### PR TITLE
Show update source warning before opt-in

### DIFF
--- a/app/src/main/res/values-v23/update_source_safety_strings.xml
+++ b/app/src/main/res/values-v23/update_source_safety_strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- The app's minimum supported API is 23, so this overrides the legacy default
+         consent text on every supported device without duplicating the resource in values/. -->
+    <string name="auto_update_check_description">NewPipe Material can periodically check GitHub Releases for new versions and notify you when one is available.
+
+If you installed NewPipe Material through IzzyOnDroid or another app store, update it through the same store whenever possible. APKs downloaded directly from GitHub bypass the review and verification performed by that store.
+
+Do you want to enable automatic update checks?</string>
+</resources>

--- a/app/src/main/res/values/update_source_safety_strings.xml
+++ b/app/src/main/res/values/update_source_safety_strings.xml
@@ -3,4 +3,5 @@
     <string name="app_update_store_source_warning">If you installed NewPipe Material through IzzyOnDroid or another app store, update it through the same store whenever possible. APKs downloaded directly from GitHub bypass the review and verification performed by your app store.</string>
     <string name="app_update_download_from_github">Download from GitHub</string>
     <string name="app_update_no_browser">No compatible browser was found. Please open the release page manually.</string>
+    <string name="app_update_check_setting_description">Check GitHub Releases for updates. If installed through IzzyOnDroid or another app store, update through the same store whenever possible; direct GitHub APKs bypass store review and verification.</string>
 </resources>

--- a/app/src/main/res/xml/update_settings.xml
+++ b/app/src/main/res/xml/update_settings.xml
@@ -35,7 +35,7 @@
     <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="@string/update_app_key"
-        android:summary="@string/updates_setting_description"
+        android:summary="@string/app_update_check_setting_description"
         android:title="@string/updates_setting_title"
         app:iconSpaceReserved="false"
         app:singleLineTitle="false" />


### PR DESCRIPTION
- Shows the IzzyOnDroid/app-store update warning in the automatic update-check consent dialog before the user opts in.
- Shows the same disclosure directly in the update-check toggle summary.
- Keeps the existing warning in the update-available dialog.