### PR TITLE
Fix playback checkbox icon rendering

### DIFF
--- a/app/src/main/res/layout/dialog_playback_parameter.xml
+++ b/app/src/main/res/layout/dialog_playback_parameter.xml
@@ -503,22 +503,20 @@
             android:layout_below="@id/separatorCheckbox"
             android:orientation="vertical">
 
-            <CheckBox
+            <com.google.android.material.checkbox.MaterialCheckBox
                 android:id="@+id/unhookCheckbox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:buttonTint="?attr/colorPrimary"
                 android:checked="false"
                 android:clickable="true"
                 android:focusable="true"
                 android:text="@string/unhook_checkbox"
                 android:textColor="?attr/colorOnSurface" />
 
-            <CheckBox
+            <com.google.android.material.checkbox.MaterialCheckBox
                 android:id="@+id/skipSilenceCheckbox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:buttonTint="?attr/colorPrimary"
                 android:checked="false"
                 android:clickable="true"
                 android:focusable="true"


### PR DESCRIPTION
- Replaced the two platform `CheckBox` controls in the playback-parameter dialog with `MaterialCheckBox`.
- Removed the direct framework `android:buttonTint` overrides.
- Kept the existing IDs, labels, checked state, and Java behavior unchanged.