### PR TITLE
Pin extractor and share reproducible build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,62 +36,33 @@ on:
 jobs:
   build-and-test-jvm:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v6
-
-      - name: Checkout latest PipePipeExtractor source
-        run: |
-          set -euo pipefail
-          mkdir -p external
-          if [ ! -d external/NewPipeExtractor/.git ]; then
-            rm -rf external/NewPipeExtractor
-            git init external/NewPipeExtractor
-            git -C external/NewPipeExtractor remote add origin https://github.com/wizdom13/PipePipeExtractor
-          fi
-          git -C external/NewPipeExtractor fetch --depth 1 origin main
-          git -C external/NewPipeExtractor checkout --detach FETCH_HEAD
-
-      - name: Verify PipePipeExtractor source
-        run: |
-          git -C external/NewPipeExtractor remote -v
-          git -C external/NewPipeExtractor remote get-url origin | grep -q "github.com/wizdom13/PipePipeExtractor"
-          git -C external/NewPipeExtractor rev-parse HEAD
-          test -d external/NewPipeExtractor/extractor
-          grep -n "JavaLanguageVersion.of(21)" external/NewPipeExtractor/build.gradle
-          grep -n "options.release = 21" external/NewPipeExtractor/build.gradle
-
-      - name: Clean PipePipeExtractor outputs
-        run: |
-          rm -rf external/NewPipeExtractor/build
-          rm -rf external/NewPipeExtractor/extractor/build
-          rm -rf external/NewPipeExtractor/timeago-parser/build
+        with:
+          submodules: recursive
 
       - uses: gradle/actions/wrapper-validation@v6
 
-      - name: create and checkout branch
+      - name: Create and checkout branch
         if: github.event_name == 'pull_request'
         env:
           BRANCH: ${{ github.head_ref }}
         run: git checkout -B "$BRANCH"
 
-      - name: set up JDK
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
           java-version: 21
-          distribution: "temurin"
-          cache: 'gradle'
+          distribution: temurin
+          cache: gradle
 
-      - name: Verify PipePipeExtractor Java bytecode
-        run: |
-          ./gradlew -p external/NewPipeExtractor :extractor:clean :extractor:compileJava --stacktrace
-          javap -verbose -classpath external/NewPipeExtractor/extractor/build/classes/java/main org.schabi.newpipe.extractor.NewPipe | grep "major version: 65"
+      - name: Verify pinned PipePipeExtractor bytecode
+        run: scripts/build.sh extractor-bytecode | grep "major version: 65"
 
-      - name: Build debug APK and run jvm tests
-        run: ./gradlew clean assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint
+      - name: Build debug APK and run JVM tests
+        run: scripts/build.sh debug
 
       - name: Verify debug APK identity
         run: |
@@ -120,39 +91,22 @@ jobs:
           - api-level: 35
             target: default
             arch: x86_64
-
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
-      - name: Checkout latest PipePipeExtractor source
-        run: |
-          set -euo pipefail
-          mkdir -p external
-          if [ ! -d external/NewPipeExtractor/.git ]; then
-            rm -rf external/NewPipeExtractor
-            git init external/NewPipeExtractor
-            git -C external/NewPipeExtractor remote add origin https://github.com/wizdom13/PipePipeExtractor
-          fi
-          git -C external/NewPipeExtractor fetch --depth 1 origin main
-          git -C external/NewPipeExtractor checkout --detach FETCH_HEAD
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
 
-      - name: Verify PipePipeExtractor source
-        run: |
-          git -C external/NewPipeExtractor remote -v
-          git -C external/NewPipeExtractor remote get-url origin | grep -q "github.com/wizdom13/PipePipeExtractor"
-          git -C external/NewPipeExtractor rev-parse HEAD
-          test -d external/NewPipeExtractor/extractor
-          grep -n "JavaLanguageVersion.of(21)" external/NewPipeExtractor/build.gradle
-          grep -n "options.release = 21" external/NewPipeExtractor/build.gradle
-
-      - name: Clean PipePipeExtractor outputs
-        run: |
-          rm -rf external/NewPipeExtractor/build
-          rm -rf external/NewPipeExtractor/extractor/build
-          rm -rf external/NewPipeExtractor/timeago-parser/build
+      - name: Prepare pinned PipePipeExtractor
+        run: scripts/prepare-extractor.sh
 
       - name: Enable KVM
         run: |
@@ -160,20 +114,13 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: set up JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: 21
-          distribution: "temurin"
-          cache: 'gradle'
-
-      - name: Run android tests
+      - name: Run Android tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
-          script: ./gradlew connectedCheck --stacktrace
+          script: scripts/build.sh connected
 
       - name: Upload test report when tests fail
         uses: actions/upload-artifact@v7

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "external/NewPipeExtractor"]
 	path = external/NewPipeExtractor
 	url = https://github.com/wizdom13/PipePipeExtractor.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/NewPipeExtractor"]
+	path = external/NewPipeExtractor
+	url = https://github.com/wizdom13/PipePipeExtractor.git
+	branch = main

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,77 @@
+# Building NewPipe Material
+
+NewPipe Material uses a pinned `PipePipeExtractor` Git submodule at `external/NewPipeExtractor`. The submodule commit recorded by each NewPipe Material commit or tag is part of the source definition and must not be replaced with the latest extractor branch tip.
+
+## Requirements
+
+- Git with submodule support
+- JDK 21
+- Android SDK with the required platform and build tools
+- Accepted Android SDK licenses
+
+## Clone the exact source
+
+```bash
+git clone --recurse-submodules https://github.com/wizdom13/NewPipe_Material.git
+cd NewPipe_Material
+```
+
+For an existing checkout or after switching tags:
+
+```bash
+git submodule sync --recursive
+git submodule update --init --recursive
+```
+
+Do not use `git submodule update --remote` for release or reproducible builds. It moves the extractor away from the commit pinned by the app repository.
+
+## Shared build entry points
+
+The same committed scripts are used locally and in GitHub Actions.
+
+Prepare and verify the pinned extractor checkout:
+
+```bash
+scripts/prepare-extractor.sh
+```
+
+Build the debug APK and run JVM checks:
+
+```bash
+scripts/build.sh debug
+```
+
+Build a release APK:
+
+```bash
+scripts/build.sh release
+```
+
+Run Android instrumented tests:
+
+```bash
+scripts/build.sh connected
+```
+
+Run style checks:
+
+```bash
+scripts/build.sh checkstyle
+```
+
+## Release signing
+
+Provide all four signing variables before running `scripts/build.sh release`:
+
+```text
+NEWPIPE_MATERIAL_RELEASE_STORE_FILE
+NEWPIPE_MATERIAL_RELEASE_STORE_PASSWORD
+NEWPIPE_MATERIAL_RELEASE_KEY_ALIAS
+NEWPIPE_MATERIAL_RELEASE_KEY_PASSWORD
+```
+
+The resulting APK is written under `app/build/outputs/apk/release/`.
+
+## Reproducible release rule
+
+Every published APK must be built from the exact commit referenced by its release tag, including the submodule commit recorded by that tag. An APK must not be replaced with one built from a newer untagged commit; publish a new version and tag instead.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+"$ROOT_DIR/scripts/prepare-extractor.sh"
+
+MODE="${1:-debug}"
+shift || true
+
+case "$MODE" in
+    debug)
+        exec ./gradlew clean assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint "$@"
+        ;;
+    release)
+        exec ./gradlew clean assembleRelease --stacktrace -DskipFormatKtlint "$@"
+        ;;
+    checkstyle)
+        exec ./gradlew runCheckstyle --stacktrace -DskipFormatKtlint "$@"
+        ;;
+    connected)
+        exec ./gradlew connectedCheck --stacktrace "$@"
+        ;;
+    extractor-bytecode)
+        ./gradlew -p external/NewPipeExtractor :extractor:clean :extractor:compileJava --stacktrace "$@"
+        exec javap -verbose -classpath external/NewPipeExtractor/extractor/build/classes/java/main org.schabi.newpipe.extractor.NewPipe
+        ;;
+    *)
+        echo "Usage: $0 {debug|release|checkstyle|connected|extractor-bytecode} [extra Gradle arguments]" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/prepare-extractor.sh
+++ b/scripts/prepare-extractor.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTRACTOR_DIR="$ROOT_DIR/external/NewPipeExtractor"
+
+cd "$ROOT_DIR"
+
+git submodule sync --recursive
+git submodule update --init --recursive
+
+if [ ! -d "$EXTRACTOR_DIR/.git" ] && [ ! -f "$EXTRACTOR_DIR/.git" ]; then
+    echo "PipePipeExtractor submodule checkout is missing at external/NewPipeExtractor" >&2
+    exit 1
+fi
+
+EXPECTED_COMMIT="$(git ls-tree HEAD external/NewPipeExtractor | awk '{print $3}')"
+ACTUAL_COMMIT="$(git -C "$EXTRACTOR_DIR" rev-parse HEAD)"
+
+if [ -z "$EXPECTED_COMMIT" ] || [ "$ACTUAL_COMMIT" != "$EXPECTED_COMMIT" ]; then
+    echo "PipePipeExtractor submodule mismatch: expected $EXPECTED_COMMIT, got $ACTUAL_COMMIT" >&2
+    exit 1
+fi
+
+test -d "$EXTRACTOR_DIR/extractor"
+grep -q "JavaLanguageVersion.of(21)" "$EXTRACTOR_DIR/build.gradle"
+grep -q "options.release = 21" "$EXTRACTOR_DIR/build.gradle"
+
+rm -rf \
+    "$EXTRACTOR_DIR/build" \
+    "$EXTRACTOR_DIR/extractor/build" \
+    "$EXTRACTOR_DIR/timeago-parser/build"
+
+echo "Using PipePipeExtractor commit $ACTUAL_COMMIT"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,24 +25,14 @@ include(":app") // androidApp
 include(":desktopApp")
 include("shared")
 
-val externalNewPipeExtractor = file("external/NewPipeExtractor")
-val adjacentNewPipeExtractor = file("../PipePipeExtractor")
-
-val newPipeExtractorDir = when {
-    externalNewPipeExtractor.isDirectory -> externalNewPipeExtractor
-    adjacentNewPipeExtractor.isDirectory -> adjacentNewPipeExtractor
-    else -> throw GradleException(
-        "PipePipeExtractor source checkout not found. " +
-            "Clone https://github.com/wizdom13/PipePipeExtractor into external/NewPipeExtractor " +
-            "or run git clone https://github.com/wizdom13/PipePipeExtractor ..\\PipePipeExtractor " +
-            "for a Windows-style adjacent checkout. The external directory name remains " +
-            "NewPipeExtractor because the app still depends on the TeamNewPipe artifact name " +
-            "while this experiment substitutes it with PipePipeExtractor source."
+val newPipeExtractorDir = file("external/NewPipeExtractor")
+if (!newPipeExtractorDir.isDirectory) {
+    throw GradleException(
+        "PipePipeExtractor submodule checkout not found. " +
+            "Run git submodule update --init --recursive or scripts/prepare-extractor.sh."
     )
 }
 
-// Temporary experiment: resolve the TeamNewPipe extractor artifact to PipePipeExtractor
-// source so local and CI builds exercise the same extractor checkout.
 includeBuild(newPipeExtractorDir) {
     dependencySubstitution {
         substitute(module("com.github.TeamNewPipe:NewPipeExtractor"))


### PR DESCRIPTION
- Added `wizdom13/PipePipeExtractor` as a Git submodule at `external/NewPipeExtractor`.
- Removed the adjacent or manually cloned extractor fallback from `settings.gradle.kts`.
- Added shared `scripts/prepare-extractor.sh` and `scripts/build.sh` entry points.
- Updated GitHub Actions to initialize the pinned submodule and call the same scripts used by local and external builders.
- Added `BUILDING.md` with exact clone, submodule, build, signing, and release rules.