### PR TITLE
Pin extractor source in stable release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,36 +24,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out release source
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
-      - name: Checkout latest PipePipeExtractor source
-        run: |
-          set -euo pipefail
-          mkdir -p external
-          if [ ! -d external/NewPipeExtractor/.git ]; then
-            rm -rf external/NewPipeExtractor
-            git init external/NewPipeExtractor
-            git -C external/NewPipeExtractor remote add origin https://github.com/wizdom13/PipePipeExtractor
-          fi
-          git -C external/NewPipeExtractor fetch --depth 1 origin main
-          git -C external/NewPipeExtractor checkout --detach FETCH_HEAD
-
-      - name: Verify PipePipeExtractor source
-        run: |
-          set -euo pipefail
-          git -C external/NewPipeExtractor remote -v
-          git -C external/NewPipeExtractor remote get-url origin | grep -q "github.com/wizdom13/PipePipeExtractor"
-          git -C external/NewPipeExtractor rev-parse HEAD
-          test -d external/NewPipeExtractor/extractor
-          grep -n "JavaLanguageVersion.of(21)" external/NewPipeExtractor/build.gradle
-          grep -n "options.release = 21" external/NewPipeExtractor/build.gradle
-
-      - name: Clean PipePipeExtractor outputs
-        run: |
-          set -euo pipefail
-          rm -rf external/NewPipeExtractor/build
-          rm -rf external/NewPipeExtractor/extractor/build
-          rm -rf external/NewPipeExtractor/timeago-parser/build
+      - name: Prepare pinned PipePipeExtractor source
+        run: scripts/prepare-extractor.sh
 
       - uses: gradle/actions/wrapper-validation@v6
 


### PR DESCRIPTION
## What changed

- initializes `external/NewPipeExtractor` as the submodule recorded by the checked-out WizeStream commit
- runs `scripts/prepare-extractor.sh` before release compilation
- removes the custom fetch of the latest `PipePipeExtractor/main`

## Why

The previous stable release workflow ignored the extractor Gitlink stored by the release tag and fetched the current branch tip instead. Re-running the same tag could therefore compile different extractor source and produce a different APK.

The shared preparation script verifies that the actual extractor HEAD exactly matches the Gitlink SHA recorded by the WizeStream commit and fails on a mismatch.

## Impact

Stable release builds now use the same pinned extractor source required by `BUILDING.md` and local build entry points. No application code, version, signing configuration, or extractor pin is changed.

## Validation

- compared the branch with `pipe`: one commit, one modified file
- confirmed `submodules: recursive` is enabled
- confirmed the release job invokes `scripts/prepare-extractor.sh`
- confirmed the floating `fetch --depth 1 origin main` and `FETCH_HEAD` checkout are absent
