### PR TITLE
Collapse feed controls while scrolling

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -45,6 +45,7 @@ import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.evernote.android.state.State
+import com.google.android.material.appbar.AppBarLayout
 import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.Item
 import com.xwray.groupie.OnItemClickListener
@@ -110,6 +111,10 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     @JvmField
     var selectedStreamFilter = StreamListFilter.NONE
 
+    @State
+    @JvmField
+    var feedHeaderExpanded = true
+
     private lateinit var groupAdapter: GroupieAdapter
 
     private var onSettingsChangeListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
@@ -117,6 +122,10 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     private var isRefreshing = false
 
     private var lastNewItemsCount = 0
+
+    private val feedHeaderOffsetListener = AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
+        feedHeaderExpanded = verticalOffset == 0
+    }
 
     init {
         setHasOptionsMenu(true)
@@ -154,6 +163,12 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         groupAdapter = GroupieAdapter().apply {
             setOnItemClickListener(listenerStreamItem)
             setOnItemLongClickListener(listenerStreamItem)
+        }
+
+        val restoreFeedHeaderExpanded = feedHeaderExpanded
+        feedBinding.feedHeader.addOnOffsetChangedListener(feedHeaderOffsetListener)
+        feedBinding.feedHeader.post {
+            _feedBinding?.feedHeader?.setExpanded(restoreFeedHeaderExpanded, false)
         }
 
         feedBinding.itemsList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
@@ -208,9 +223,13 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         super.initListeners()
         feedBinding.refreshRootView.setOnClickListener { reloadContent() }
         feedBinding.swipeRefreshLayout.setOnRefreshListener { reloadContent() }
+        feedBinding.swipeRefreshLayout.setOnChildScrollUpCallback { _, _ ->
+            !feedHeaderExpanded || feedBinding.itemsList.canScrollVertically(-1)
+        }
         feedBinding.newItemsLoadedButton.setOnClickListener {
             hideNewItemsLoaded(true)
             feedBinding.itemsList.scrollToPosition(0)
+            feedBinding.feedHeader.setExpanded(true, true)
         }
         feedBinding.streamFilterChips.streamFilterChipGroup
             .setOnCheckedStateChangeListener { _, checkedIds ->
@@ -322,6 +341,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         // Ensure that all animations are canceled
         tryGetNewItemsLoadedButton()?.clearAnimation()
 
+        feedBinding.feedHeader.removeOnOffsetChangedListener(feedHeaderOffsetListener)
         feedBinding.itemsList.adapter = null
         _feedBinding = null
         super.onDestroyView()

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -1,90 +1,106 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
 
-    <RelativeLayout
-        android:id="@+id/refresh_root_view"
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/feed_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true"
-        android:paddingTop="8dp"
-        android:visibility="gone"
-        tools:visibility="visible">
+        android:background="?attr/colorSurface"
+        app:elevation="0dp">
 
+        <!-- Keep the update status and filters together as one collapsible feed header. -->
         <LinearLayout
-            android:id="@+id/refresh_info_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:layout_toStartOf="@+id/refreshIcon"
-            android:gravity="center_vertical"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            app:layout_scrollFlags="scroll|enterAlways">
 
-            <org.schabi.newpipe.views.NewPipeTextView
-                android:id="@+id/refresh_text"
+            <RelativeLayout
+                android:id="@+id/refresh_root_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:gravity="start|center_vertical"
-                android:maxLines="2"
-                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-                android:textColor="?attr/colorOnSurface"
-                android:textSize="14sp"
-                tools:text="@tools:sample/lorem/random" />
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:paddingTop="8dp"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-            <org.schabi.newpipe.views.NewPipeTextView
-                android:id="@+id/refresh_subtitle_text"
+                <LinearLayout
+                    android:id="@+id/refresh_info_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_toStartOf="@+id/refreshIcon"
+                    android:gravity="center_vertical"
+                    android:orientation="vertical">
+
+                    <org.schabi.newpipe.views.NewPipeTextView
+                        android:id="@+id/refresh_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:gravity="start|center_vertical"
+                        android:maxLines="2"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                        android:textColor="?attr/colorOnSurface"
+                        android:textSize="14sp"
+                        tools:text="@tools:sample/lorem/random" />
+
+                    <org.schabi.newpipe.views.NewPipeTextView
+                        android:id="@+id/refresh_subtitle_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:gravity="start|center_vertical"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:textSize="12sp"
+                        tools:text="@tools:sample/lorem/random" />
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/refreshIcon"
+                    android:layout_width="24dp"
+                    android:layout_height="wrap_content"
+                    android:layout_alignTop="@+id/refresh_info_container"
+                    android:layout_alignBottom="@+id/refresh_info_container"
+                    android:layout_alignParentEnd="true"
+                    android:layout_marginStart="6dp"
+                    android:layout_marginEnd="12dp"
+                    android:src="@drawable/ic_refresh"
+                    android:tint="?attr/colorPrimary"
+                    tools:ignore="ContentDescription" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_below="@+id/refresh_info_container"
+                    android:layout_marginLeft="8dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="?attr/colorSurfaceVariant" />
+            </RelativeLayout>
+
+            <include
+                android:id="@+id/stream_filter_chips"
+                layout="@layout/list_stream_filter_chips"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:gravity="start|center_vertical"
-                android:maxLines="1"
-                android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-                android:textColor="?attr/colorOnSurfaceVariant"
-                android:textSize="12sp"
-                tools:text="@tools:sample/lorem/random" />
+                android:layout_height="wrap_content" />
         </LinearLayout>
-
-        <ImageView
-            android:id="@+id/refreshIcon"
-            android:layout_width="24dp"
-            android:layout_height="wrap_content"
-            android:layout_alignTop="@+id/refresh_info_container"
-            android:layout_alignBottom="@+id/refresh_info_container"
-            android:layout_alignParentEnd="true"
-            android:layout_marginStart="6dp"
-            android:layout_marginEnd="12dp"
-            android:src="@drawable/ic_refresh"
-            android:tint="?attr/colorPrimary"
-            tools:ignore="ContentDescription" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_below="@+id/refresh_info_container"
-            android:layout_marginLeft="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginRight="8dp"
-            android:background="?attr/colorSurfaceVariant" />
-    </RelativeLayout>
-
-    <include
-        android:id="@+id/stream_filter_chips"
-        layout="@layout/list_stream_filter_chips"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/refresh_root_view" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/stream_filter_chips">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/items_list"
@@ -101,8 +117,7 @@
         android:id="@+id/new_items_loaded_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignBottom="@id/swipeRefreshLayout"
-        android:layout_centerHorizontal="true"
+        android:layout_gravity="bottom|center_horizontal"
         android:layout_marginBottom="5sp"
         android:text="@string/feed_new_items"
         android:textSize="12sp"
@@ -113,7 +128,7 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_gravity="center"
         android:gravity="center"
         android:orientation="vertical">
 
@@ -148,7 +163,7 @@
         layout="@layout/error_panel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_gravity="center"
         android:visibility="gone"
         tools:visibility="visible" />
 
@@ -157,7 +172,7 @@
         layout="@layout/list_empty_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_gravity="center"
         android:layout_marginTop="50dp"
         android:visibility="gone"
         tools:visibility="visible" />
@@ -165,6 +180,6 @@
     <View
         android:layout_width="match_parent"
         android:layout_height="4dp"
-        android:layout_alignParentTop="true"
+        android:layout_gravity="top"
         android:background="?attr/toolbar_shadow" />
-</RelativeLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## What changed

- Groups the feed last-update panel and stream-filter chips into one Material `AppBarLayout` header.
- Collapses the header when the feed scrolls upward and restores it immediately when scrolling downward.
- Prevents pull-to-refresh from activating until both the header and feed are fully at the top.
- Restores the header when the “new items” button scrolls the feed to the first item.
- Preserves the expanded/collapsed state across view recreation.