### PR TITLE
Add secure device pairing foundation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,7 +137,9 @@ configure<ApplicationExtension> {
             excludes += setOf(
                 "META-INF/README.md",
                 "META-INF/CHANGES",
-                "META-INF/COPYRIGHT" // "COPYRIGHT" belongs to RxJava...
+                "META-INF/COPYRIGHT", // "COPYRIGHT" belongs to RxJava...
+                "META-INF/INDEX.LIST",
+                "META-INF/io.netty.versions.properties"
             )
         }
     }
@@ -260,6 +262,12 @@ dependencies {
     // HTML parser
     implementation(libs.jsoup)
 
+    // End-to-end encrypted peer-to-peer device synchronization
+    implementation(libs.jvm.libp2p) {
+        exclude(group = "io.netty", module = "netty-codec-native-quic")
+        exclude(group = "io.netty", module = "netty-tcnative-boringssl-static")
+    }
+
     // HTTP client
     implementation(libs.squareup.okhttp)
 
@@ -301,6 +309,10 @@ dependencies {
 
     // Date and time formatting
     implementation(libs.ocpsoft.prettytime)
+
+    // QR code generation and scanning for device pairing
+    implementation(libs.zxing.android.embedded)
+    implementation(libs.zxing.core)
 
     // Debugging and memory leak detection
     debugImplementation(libs.squareup.leakcanary.watcher)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -69,6 +69,11 @@
 ## SLF4J looks for an optional runtime binding class. The app does not ship one.
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
+## Netty probes for optional desktop logging and BlockHound integrations.
+-dontwarn org.apache.log4j.**
+-dontwarn org.apache.logging.log4j.**
+-dontwarn reactor.blockhound.integration.BlockHoundIntegration
+
 ## See https://github.com/TeamNewPipe/NewPipe/pull/1441
 -keepclassmembers class * implements java.io.Serializable {
     static final long serialVersionUID;

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -22,6 +23,9 @@
         </intent>
     </queries>
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />

--- a/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncSettingsFragment.kt
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.settings
+
+import android.graphics.Color
+import android.os.Bundle
+import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.zxing.BarcodeFormat
+import com.journeyapps.barcodescanner.BarcodeEncoder
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.schabi.newpipe.R
+import org.schabi.newpipe.databinding.DialogDevicePairingBinding
+import org.schabi.newpipe.sync.DeviceSyncManager
+
+class DeviceSyncSettingsFragment : BasePreferenceFragment() {
+    private val scanPairingCode = registerForActivityResult(ScanContract()) { result ->
+        result.contents?.let(::pairWithCode)
+    }
+
+    private val syncManager: DeviceSyncManager
+        get() = DeviceSyncManager.get(requireContext())
+
+    private lateinit var identityPreference: Preference
+    private lateinit var trustedDevicesPreference: Preference
+    private lateinit var showPairingCodePreference: Preference
+    private lateinit var scanPairingCodePreference: Preference
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        addPreferencesFromResourceRegistry()
+
+        identityPreference = requirePreference(R.string.device_sync_identity_key)
+        trustedDevicesPreference = requirePreference(R.string.device_sync_trusted_devices_key)
+        showPairingCodePreference = requirePreference(R.string.device_sync_show_code_key)
+        scanPairingCodePreference = requirePreference(R.string.device_sync_scan_code_key)
+
+        showPairingCodePreference.setOnPreferenceClickListener {
+            createPairingCode()
+            true
+        }
+        scanPairingCodePreference.setOnPreferenceClickListener {
+            launchScanner()
+            true
+        }
+        requirePreference<Preference>(R.string.device_sync_clear_devices_key)
+            .setOnPreferenceClickListener {
+                confirmClearTrustedDevices()
+                true
+            }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updateState()
+    }
+
+    private fun updateState() {
+        identityPreference.summary = syncManager.peerId
+        val peers = syncManager.trustedPeers
+        trustedDevicesPreference.summary = if (peers.isEmpty()) {
+            getString(R.string.device_sync_no_trusted_devices)
+        } else {
+            peers.joinToString(separator = "\n") { peer ->
+                getString(
+                    R.string.device_sync_trusted_device_summary,
+                    peer.deviceName,
+                    abbreviatePeerId(peer.peerId)
+                )
+            }
+        }
+    }
+
+    private fun createPairingCode() {
+        setPairingActionsEnabled(false)
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val code = withContext(Dispatchers.IO) {
+                    syncManager.createPairingCode()
+                }
+                showPairingCodeDialog(code)
+            } catch (error: Exception) {
+                showError(error)
+            } finally {
+                setPairingActionsEnabled(true)
+            }
+        }
+    }
+
+    private fun launchScanner() {
+        val options = ScanOptions()
+            .setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+            .setPrompt(getString(R.string.device_sync_scan_prompt))
+            .setBeepEnabled(false)
+            .setOrientationLocked(false)
+        scanPairingCode.launch(options)
+    }
+
+    private fun pairWithCode(code: String) {
+        setPairingActionsEnabled(false)
+        scanPairingCodePreference.summary = getString(R.string.device_sync_pairing_in_progress)
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val peer = withContext(Dispatchers.IO) {
+                    syncManager.pair(code)
+                }
+                updateState()
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.device_sync_pairing_succeeded, peer.deviceName),
+                    Toast.LENGTH_LONG
+                ).show()
+            } catch (error: Exception) {
+                showError(error)
+            } finally {
+                scanPairingCodePreference.setSummary(R.string.device_sync_scan_code_summary)
+                setPairingActionsEnabled(true)
+            }
+        }
+    }
+
+    private fun showPairingCodeDialog(code: String) {
+        val binding = DialogDevicePairingBinding.inflate(layoutInflater)
+        val qrSize = minOf(
+            resources.displayMetrics.widthPixels -
+                (PAIRING_DIALOG_HORIZONTAL_MARGIN_DP * resources.displayMetrics.density).toInt(),
+            (MAX_QR_SIZE_DP * resources.displayMetrics.density).toInt()
+        )
+        binding.devicePairingQr.setImageBitmap(
+            BarcodeEncoder().encodeBitmap(
+                code,
+                BarcodeFormat.QR_CODE,
+                qrSize,
+                qrSize
+            )
+        )
+        binding.devicePairingQr.setBackgroundColor(Color.WHITE)
+        binding.devicePairingPeerId.text = getString(
+            R.string.device_sync_pairing_peer_id,
+            abbreviatePeerId(syncManager.peerId)
+        )
+
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.device_sync_show_code_title)
+            .setView(binding.root)
+            .setNegativeButton(R.string.close, null)
+            .show()
+    }
+
+    private fun confirmClearTrustedDevices() {
+        if (syncManager.trustedPeers.isEmpty()) {
+            Toast.makeText(
+                requireContext(),
+                R.string.device_sync_no_trusted_devices,
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.device_sync_clear_devices_title)
+            .setMessage(R.string.device_sync_clear_devices_confirmation)
+            .setNegativeButton(R.string.cancel, null)
+            .setPositiveButton(R.string.clear) { _, _ ->
+                syncManager.clearTrustedPeers()
+                updateState()
+            }
+            .show()
+    }
+
+    private fun setPairingActionsEnabled(enabled: Boolean) {
+        showPairingCodePreference.isEnabled = enabled
+        scanPairingCodePreference.isEnabled = enabled
+    }
+
+    private fun showError(error: Exception) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.device_sync_pairing_failed)
+            .setMessage(error.message ?: getString(R.string.general_error))
+            .setPositiveButton(R.string.ok, null)
+            .show()
+    }
+
+    private fun abbreviatePeerId(peerId: String): String {
+        if (peerId.length <= ABBREVIATED_PEER_ID_LENGTH) {
+            return peerId
+        }
+        return "${peerId.take(PEER_ID_EDGE_LENGTH)}…${peerId.takeLast(PEER_ID_EDGE_LENGTH)}"
+    }
+
+    companion object {
+        private const val MAX_QR_SIZE_DP = 420
+        private const val PAIRING_DIALOG_HORIZONTAL_MARGIN_DP = 64
+        private const val PEER_ID_EDGE_LENGTH = 8
+        private const val ABBREVIATED_PEER_ID_LENGTH = PEER_ID_EDGE_LENGTH * 2
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
@@ -35,6 +35,7 @@ public final class SettingsResourceRegistry {
         add(ContentSettingsFragment.class, R.xml.content_settings);
         add(DebugSettingsFragment.class, R.xml.debug_settings).setSearchable(false);
         add(DownloadSettingsFragment.class, R.xml.download_settings);
+        add(DeviceSyncSettingsFragment.class, R.xml.device_sync_settings);
         add(HistorySettingsFragment.class, R.xml.history_settings);
         add(NotificationSettingsFragment.class, R.xml.notifications_settings);
         add(PlayerNotificationSettingsFragment.class, R.xml.player_notification_settings);

--- a/app/src/main/java/org/schabi/newpipe/sync/AndroidNetworkAddressProvider.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/AndroidNetworkAddressProvider.kt
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.Host
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+
+object AndroidNetworkAddressProvider {
+    fun addresses(host: Host): List<String> {
+        val port = host.listenAddresses()
+            .asSequence()
+            .map(MultiAddressPort::from)
+            .firstOrNull()
+            ?: throw PairingException("The synchronization listener has no TCP address")
+
+        val networkAddresses = NetworkInterface.getNetworkInterfaces()
+            ?.toList()
+            .orEmpty()
+            .asSequence()
+            .filter { it.isUp }
+            .flatMap { it.inetAddresses.toList().asSequence() }
+            .filterIsInstance<Inet4Address>()
+            .filterNot(InetAddress::isAnyLocalAddress)
+            .filterNot(InetAddress::isLinkLocalAddress)
+            .filterNot(InetAddress::isMulticastAddress)
+            .distinctBy(InetAddress::getHostAddress)
+            .map { address ->
+                "/ip4/${address.hostAddress}/tcp/$port/p2p/${host.peerId.toBase58()}"
+            }
+            .take(MAX_PAIRING_ADDRESSES)
+            .toList()
+
+        return networkAddresses.ifEmpty {
+            listOf("/ip4/127.0.0.1/tcp/$port/p2p/${host.peerId.toBase58()}")
+        }
+    }
+
+    private object MultiAddressPort {
+        private val tcpPort = Regex("(?:^|/)tcp/(\\d+)(?:/|$)")
+
+        fun from(value: Any): Int? {
+            return tcpPort.find(value.toString())?.groupValues?.get(1)?.toIntOrNull()
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/AndroidSyncStateRepository.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/AndroidSyncStateRepository.kt
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.AtomicFile
+import io.libp2p.core.crypto.KeyType
+import io.libp2p.core.crypto.generateKeyPair
+import io.libp2p.core.crypto.unmarshalPrivateKey
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.security.KeyStore
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class AndroidSyncStateRepository(context: Context) : SyncStateRepository {
+    private val stateFile = AtomicFile(context.noBackupFilesDir.resolve(STATE_FILE_NAME))
+
+    @Synchronized
+    override fun loadOrCreateIdentity(): DeviceIdentity {
+        val existingState = readState()
+        if (existingState != null) {
+            return try {
+                DeviceIdentity(
+                    unmarshalPrivateKey(Base64.getDecoder().decode(existingState.privateKey))
+                )
+            } catch (error: Exception) {
+                throw PairingException("The saved device identity is invalid", error)
+            }
+        }
+
+        val identity = DeviceIdentity(generateKeyPair(KeyType.ED25519).first)
+        writeState(
+            PersistedSyncState(
+                privateKey = Base64.getEncoder().encodeToString(identity.privateKey.bytes())
+            )
+        )
+        return identity
+    }
+
+    @Synchronized
+    override fun getTrustedPeers(): List<TrustedPeer> {
+        loadOrCreateIdentity()
+        return requireNotNull(readState()).trustedPeers.sortedBy {
+            it.deviceName.lowercase()
+        }
+    }
+
+    @Synchronized
+    override fun saveTrustedPeer(peer: TrustedPeer) {
+        loadOrCreateIdentity()
+        val state = requireNotNull(readState())
+        val peers = state.trustedPeers
+            .filterNot { it.peerId == peer.peerId }
+            .plus(peer)
+            .takeLast(MAX_TRUSTED_PEERS)
+        writeState(state.copy(trustedPeers = peers))
+    }
+
+    @Synchronized
+    override fun clearTrustedPeers() {
+        loadOrCreateIdentity()
+        val state = requireNotNull(readState())
+        writeState(state.copy(trustedPeers = emptyList()))
+    }
+
+    private fun readState(): PersistedSyncState? {
+        if (!stateFile.baseFile.exists()) {
+            return null
+        }
+        val encrypted = try {
+            stateFile.readFully()
+        } catch (error: Exception) {
+            throw PairingException("Could not read the secure synchronization state", error)
+        }
+        if (encrypted.size > MAX_STATE_FILE_BYTES) {
+            throw PairingException("The secure synchronization state is too large")
+        }
+
+        return try {
+            val input = DataInputStream(ByteArrayInputStream(encrypted))
+            val fileVersion = input.readUnsignedByte()
+            if (fileVersion != STATE_FILE_VERSION) {
+                throw PairingException(
+                    "Unsupported secure synchronization state version: $fileVersion"
+                )
+            }
+            val ivLength = input.readUnsignedByte()
+            if (ivLength !in MIN_GCM_IV_BYTES..MAX_GCM_IV_BYTES) {
+                throw PairingException("The secure synchronization state has an invalid IV")
+            }
+            val iv = ByteArray(ivLength)
+            input.readFully(iv)
+            val ciphertext = input.readBytes()
+            if (ciphertext.isEmpty()) {
+                throw PairingException("The secure synchronization state is empty")
+            }
+
+            val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateEncryptionKey(), GCMParameterSpec(128, iv))
+            val state = JSON.decodeFromString<PersistedSyncState>(
+                cipher.doFinal(ciphertext).toString(Charsets.UTF_8)
+            )
+            if (state.version != SYNC_PROTOCOL_VERSION) {
+                throw PairingException(
+                    "Unsupported synchronization state version: ${state.version}"
+                )
+            }
+            state
+        } catch (error: PairingException) {
+            throw error
+        } catch (error: Exception) {
+            throw PairingException(
+                "Could not decrypt the secure synchronization state",
+                error
+            )
+        }
+    }
+
+    private fun writeState(state: PersistedSyncState) {
+        val plaintext = JSON.encodeToString(state).toByteArray(Charsets.UTF_8)
+        val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateEncryptionKey())
+        val ciphertext = cipher.doFinal(plaintext)
+
+        val outputBytes = ByteArrayOutputStream()
+        DataOutputStream(outputBytes).use { output ->
+            output.writeByte(STATE_FILE_VERSION)
+            output.writeByte(cipher.iv.size)
+            output.write(cipher.iv)
+            output.write(ciphertext)
+        }
+
+        val stream = stateFile.startWrite()
+        try {
+            stream.write(outputBytes.toByteArray())
+            stateFile.finishWrite(stream)
+        } catch (error: Exception) {
+            stateFile.failWrite(stream)
+            throw PairingException("Could not save the secure synchronization state", error)
+        }
+    }
+
+    private fun getOrCreateEncryptionKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            ANDROID_KEY_STORE
+        )
+        keyGenerator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build()
+        )
+        return keyGenerator.generateKey()
+    }
+
+    @Serializable
+    private data class PersistedSyncState(
+        val version: Int = SYNC_PROTOCOL_VERSION,
+        val privateKey: String,
+        val trustedPeers: List<TrustedPeer> = emptyList()
+    )
+
+    companion object {
+        private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+        private const val KEY_ALIAS = "wizestream_device_sync_state_v1"
+        private const val STATE_FILE_NAME = "device_sync_state_v1"
+        private const val STATE_FILE_VERSION = 1
+        private const val CIPHER_TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val MIN_GCM_IV_BYTES = 12
+        private const val MAX_GCM_IV_BYTES = 16
+        private const val MAX_STATE_FILE_BYTES = 1024 * 1024
+        private const val MAX_TRUSTED_PEERS = 32
+        private val JSON = Json {
+            encodeDefaults = true
+            ignoreUnknownKeys = false
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/DeviceSyncManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/DeviceSyncManager.kt
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import android.content.Context
+import android.os.Build
+
+class DeviceSyncManager private constructor(context: Context) {
+    private val stateRepository = AndroidSyncStateRepository(context.applicationContext)
+    private val deviceName = listOf(Build.MANUFACTURER, Build.MODEL)
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .distinct()
+        .joinToString(" ")
+    private val node by lazy {
+        Libp2pSyncNode(
+            stateRepository = stateRepository,
+            pairingSecurity = PairingSecurity(),
+            deviceName = deviceName,
+            advertisedAddressProvider = AndroidNetworkAddressProvider::addresses
+        )
+    }
+
+    val peerId: String
+        get() = stateRepository.loadOrCreateIdentity().peerId.toBase58()
+
+    val trustedPeers: List<TrustedPeer>
+        get() = stateRepository.getTrustedPeers()
+
+    @Synchronized
+    fun createPairingCode(): String {
+        node.start()
+        return node.createPairingCode()
+    }
+
+    @Synchronized
+    fun pair(pairingCode: String): TrustedPeer {
+        node.start()
+        return node.pair(pairingCode)
+    }
+
+    fun clearTrustedPeers() {
+        stateRepository.clearTrustedPeers()
+    }
+
+    companion object {
+        @Volatile
+        private var instance: DeviceSyncManager? = null
+
+        fun get(context: Context): DeviceSyncManager {
+            return instance ?: synchronized(this) {
+                instance ?: DeviceSyncManager(context).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/Libp2pSyncNode.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/Libp2pSyncNode.kt
@@ -1,0 +1,170 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// jvm-libp2p's CompletableFuture API is backported by coreLibraryDesugaring.
+@file:android.annotation.SuppressLint("NewApi")
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.Host
+import io.libp2p.core.PeerId
+import io.libp2p.core.dsl.host
+import io.libp2p.core.multiformats.Multiaddr
+import java.util.concurrent.TimeUnit
+
+class Libp2pSyncNode(
+    private val stateRepository: SyncStateRepository,
+    private val pairingSecurity: PairingSecurity,
+    private val deviceName: String,
+    private val advertisedAddressProvider: (Host) -> List<String> = { currentHost ->
+        currentHost.listenAddresses().map(Multiaddr::toString)
+    }
+) {
+    private val identity = stateRepository.loadOrCreateIdentity()
+    private val protocol = SyncProtocolBinding(::handlePairingRequest)
+    private val host: Host = host {
+        identity {
+            factory = { this@Libp2pSyncNode.identity.privateKey }
+        }
+        protocols {
+            +protocol
+        }
+        network {
+            listen(LISTEN_ADDRESS)
+        }
+    }
+
+    @Volatile
+    private var started = false
+
+    val peerId: PeerId
+        get() = identity.peerId
+
+    @Synchronized
+    fun start() {
+        if (started) {
+            return
+        }
+        try {
+            host.start().get(START_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            started = true
+        } catch (error: Exception) {
+            throw PairingException("Could not start secure device synchronization", error)
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        if (!started) {
+            return
+        }
+        try {
+            host.stop().get(STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } finally {
+            started = false
+        }
+    }
+
+    fun advertisedAddresses(): List<String> {
+        checkStarted()
+        return advertisedAddressProvider(host)
+    }
+
+    fun createPairingCode(): String {
+        checkStarted()
+        val invitation = pairingSecurity.createInvitation(
+            identity = identity,
+            deviceName = deviceName,
+            addresses = advertisedAddresses()
+        )
+        return pairingSecurity.encodeInvitation(invitation)
+    }
+
+    @Throws(PairingException::class)
+    fun pair(pairingCode: String): TrustedPeer {
+        checkStarted()
+        val invitation = pairingSecurity.decodeAndVerifyInvitation(pairingCode)
+        if (invitation.peerId == peerId.toBase58()) {
+            throw PairingException("This pairing code belongs to this device")
+        }
+
+        val remotePeerId = try {
+            PeerId.fromBase58(invitation.peerId)
+        } catch (error: Exception) {
+            throw PairingException("The remote PeerID is invalid", error)
+        }
+        val remoteAddresses = try {
+            invitation.addresses.map(::Multiaddr).toTypedArray()
+        } catch (error: Exception) {
+            throw PairingException("The remote network addresses are invalid", error)
+        }
+
+        val streamPromise = protocol.dial(host, remotePeerId, *remoteAddresses)
+        val controller = try {
+            streamPromise.controller.get(PAIR_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (error: Exception) {
+            throw PairingException("Could not reach the other device", error)
+        }
+
+        try {
+            val request = pairingSecurity.createPairingRequest(
+                identity = identity,
+                deviceName = deviceName,
+                addresses = advertisedAddresses(),
+                invitationToken = invitation.token
+            )
+            controller.sendPairingRequest(request)
+            val response = controller.response.get(PAIR_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            if (!response.accepted) {
+                throw PairingException(response.error ?: "The other device rejected pairing")
+            }
+
+            val trustedPeer = pairingSecurity.invitationToTrustedPeer(invitation)
+            stateRepository.saveTrustedPeer(trustedPeer)
+            return trustedPeer
+        } catch (error: PairingException) {
+            throw error
+        } catch (error: Exception) {
+            throw PairingException("Secure pairing failed", error)
+        } finally {
+            controller.close()
+        }
+    }
+
+    private fun handlePairingRequest(
+        remotePeerId: PeerId,
+        request: PairingRequest,
+        controller: SyncProtocolController
+    ) {
+        try {
+            val trustedPeer = pairingSecurity.verifyAndConsumePairingRequest(
+                request,
+                remotePeerId
+            )
+            stateRepository.saveTrustedPeer(trustedPeer)
+            controller.sendPairingResponse(PairingResponse(accepted = true))
+        } catch (error: Exception) {
+            controller.sendPairingResponse(
+                PairingResponse(
+                    accepted = false,
+                    error = error.message ?: "The pairing request was rejected"
+                )
+            )
+        }
+    }
+
+    private fun checkStarted() {
+        if (!started) {
+            throw PairingException("Device synchronization is not running")
+        }
+    }
+
+    companion object {
+        private const val LISTEN_ADDRESS = "/ip4/0.0.0.0/tcp/0"
+        private const val START_TIMEOUT_SECONDS = 20L
+        private const val STOP_TIMEOUT_SECONDS = 10L
+        private const val PAIR_TIMEOUT_SECONDS = 20L
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/PairingSecurity.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/PairingSecurity.kt
@@ -1,0 +1,334 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.PeerId
+import io.libp2p.core.crypto.PrivKey
+import io.libp2p.core.crypto.PubKey
+import io.libp2p.core.crypto.marshalPublicKey
+import io.libp2p.core.crypto.unmarshalPublicKey
+import io.libp2p.core.multiformats.Multiaddr
+import java.net.URI
+import java.security.SecureRandom
+import java.time.Clock
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class PairingSecurity(
+    private val clock: Clock = Clock.systemUTC(),
+    private val secureRandom: SecureRandom = SecureRandom()
+) {
+    private val pendingInvitations = ConcurrentHashMap<String, Long>()
+
+    fun createInvitation(
+        identity: DeviceIdentity,
+        deviceName: String,
+        addresses: List<String>,
+        lifetimeMillis: Long = DEFAULT_INVITATION_LIFETIME_MILLIS
+    ): PairingInvitation {
+        require(lifetimeMillis in 1..MAX_INVITATION_LIFETIME_MILLIS)
+
+        val now = clock.millis()
+        val token = encodeBase64(ByteArray(TOKEN_SIZE_BYTES).also(secureRandom::nextBytes))
+        val unsigned = PairingInvitation(
+            version = SYNC_PROTOCOL_VERSION,
+            peerId = identity.peerId.toBase58(),
+            publicKey = encodeBase64(marshalPublicKey(identity.privateKey.publicKey())),
+            deviceName = normalizeDeviceName(deviceName),
+            addresses = validateAddresses(identity.peerId, addresses),
+            issuedAtEpochMillis = now,
+            expiresAtEpochMillis = now + lifetimeMillis,
+            token = token,
+            signature = ""
+        )
+        val invitation = unsigned.copy(
+            signature = sign(identity.privateKey, invitationSigningBytes(unsigned))
+        )
+        pendingInvitations[token] = invitation.expiresAtEpochMillis
+        pruneExpiredInvitations(now)
+        return invitation
+    }
+
+    @Throws(PairingException::class)
+    fun encodeInvitation(invitation: PairingInvitation): String {
+        verifyInvitation(invitation)
+        val encoded = encodeBase64(JSON.encodeToString(invitation).toByteArray(Charsets.UTF_8))
+        return "$PAIRING_URI_PREFIX$encoded"
+    }
+
+    @Throws(PairingException::class)
+    fun decodeAndVerifyInvitation(value: String): PairingInvitation {
+        if (value.length > MAX_PAIRING_URI_LENGTH) {
+            throw PairingException("The pairing code is too large")
+        }
+
+        val encoded = try {
+            val uri = URI(value)
+            if (
+                uri.scheme != PAIRING_URI_SCHEME ||
+                uri.host != PAIRING_URI_HOST ||
+                uri.rawQuery != null ||
+                uri.rawFragment != null ||
+                uri.userInfo != null
+            ) {
+                throw PairingException("This is not a WizeStream pairing code")
+            }
+            uri.rawPath.removePrefix("/").takeIf {
+                it.isNotEmpty() && !it.contains('/')
+            } ?: throw PairingException("The pairing code has no invitation")
+        } catch (error: PairingException) {
+            throw error
+        } catch (error: Exception) {
+            throw PairingException("This is not a valid pairing code", error)
+        }
+
+        val invitation = try {
+            JSON.decodeFromString<PairingInvitation>(
+                decodeBase64(encoded).toString(Charsets.UTF_8)
+            )
+        } catch (error: Exception) {
+            throw PairingException("The pairing invitation is malformed", error)
+        }
+        verifyInvitation(invitation)
+        return invitation
+    }
+
+    @Throws(PairingException::class)
+    fun verifyInvitation(invitation: PairingInvitation) {
+        verifyVersion(invitation.version)
+        val publicKey = verifyPeerDescriptor(
+            invitation.peerId,
+            invitation.publicKey,
+            invitation.deviceName,
+            invitation.addresses
+        )
+        val now = clock.millis()
+        if (invitation.issuedAtEpochMillis > now + MAX_CLOCK_SKEW_MILLIS) {
+            throw PairingException("The pairing invitation is not valid yet")
+        }
+        if (invitation.expiresAtEpochMillis < now) {
+            throw PairingException("The pairing invitation has expired")
+        }
+        if (
+            invitation.expiresAtEpochMillis <= invitation.issuedAtEpochMillis ||
+            invitation.expiresAtEpochMillis - invitation.issuedAtEpochMillis >
+            MAX_INVITATION_LIFETIME_MILLIS
+        ) {
+            throw PairingException("The pairing invitation has an invalid lifetime")
+        }
+        if (decodeBase64Checked(invitation.token, "invitation token").size != TOKEN_SIZE_BYTES) {
+            throw PairingException("The pairing invitation token has an invalid length")
+        }
+        verifySignature(
+            publicKey,
+            invitationSigningBytes(invitation.copy(signature = "")),
+            invitation.signature
+        )
+    }
+
+    internal fun createPairingRequest(
+        identity: DeviceIdentity,
+        deviceName: String,
+        addresses: List<String>,
+        invitationToken: String
+    ): PairingRequest {
+        val unsigned = PairingRequest(
+            version = SYNC_PROTOCOL_VERSION,
+            peerId = identity.peerId.toBase58(),
+            publicKey = encodeBase64(marshalPublicKey(identity.privateKey.publicKey())),
+            deviceName = normalizeDeviceName(deviceName),
+            addresses = validateAddresses(identity.peerId, addresses),
+            issuedAtEpochMillis = clock.millis(),
+            invitationToken = invitationToken,
+            signature = ""
+        )
+        return unsigned.copy(
+            signature = sign(identity.privateKey, requestSigningBytes(unsigned))
+        )
+    }
+
+    @Throws(PairingException::class)
+    internal fun verifyAndConsumePairingRequest(
+        request: PairingRequest,
+        remotePeerId: PeerId
+    ): TrustedPeer {
+        verifyVersion(request.version)
+        if (request.peerId != remotePeerId.toBase58()) {
+            throw PairingException("The connected device identity does not match its request")
+        }
+        val publicKey = verifyPeerDescriptor(
+            request.peerId,
+            request.publicKey,
+            request.deviceName,
+            request.addresses
+        )
+        val now = clock.millis()
+        if (kotlin.math.abs(now - request.issuedAtEpochMillis) > MAX_REQUEST_AGE_MILLIS) {
+            throw PairingException("The pairing request is stale")
+        }
+        verifySignature(
+            publicKey,
+            requestSigningBytes(request.copy(signature = "")),
+            request.signature
+        )
+        if (!consumeInvitation(request.invitationToken, now)) {
+            throw PairingException("The pairing invitation is expired or was already used")
+        }
+        return request.toTrustedPeer(now)
+    }
+
+    fun invitationToTrustedPeer(invitation: PairingInvitation): TrustedPeer {
+        verifyInvitation(invitation)
+        return invitation.toTrustedPeer(clock.millis())
+    }
+
+    private fun consumeInvitation(token: String, now: Long): Boolean {
+        val expiry = pendingInvitations.remove(token) ?: return false
+        return expiry >= now
+    }
+
+    private fun pruneExpiredInvitations(now: Long) {
+        pendingInvitations.entries.removeIf { it.value < now }
+    }
+
+    @Throws(PairingException::class)
+    private fun verifyPeerDescriptor(
+        peerIdValue: String,
+        publicKeyValue: String,
+        deviceName: String,
+        addresses: List<String>
+    ): PubKey {
+        if (deviceName.isBlank() || deviceName.length > MAX_DEVICE_NAME_LENGTH) {
+            throw PairingException("The device name is invalid")
+        }
+        val peerId = try {
+            PeerId.fromBase58(peerIdValue)
+        } catch (error: Exception) {
+            throw PairingException("The PeerID is invalid", error)
+        }
+        val publicKey = try {
+            unmarshalPublicKey(decodeBase64(publicKeyValue))
+        } catch (error: Exception) {
+            throw PairingException("The public key is invalid", error)
+        }
+        if (PeerId.fromPubKey(publicKey) != peerId) {
+            throw PairingException("The public key does not belong to the advertised PeerID")
+        }
+        try {
+            validateAddresses(peerId, addresses)
+        } catch (error: IllegalArgumentException) {
+            throw PairingException(error.message ?: "The network addresses are invalid", error)
+        }
+        return publicKey
+    }
+
+    private fun validateAddresses(peerId: PeerId, addresses: List<String>): List<String> {
+        require(addresses.isNotEmpty()) { "At least one network address is required" }
+        require(addresses.size <= MAX_PAIRING_ADDRESSES) { "Too many network addresses" }
+        return addresses.map { value ->
+            require(value.length <= MAX_MULTIADDRESS_LENGTH) { "A network address is too long" }
+            val address = Multiaddr(value)
+            require(address.getPeerId() == peerId) {
+                "Every network address must contain the advertised PeerID"
+            }
+            address.toString()
+        }.distinct()
+    }
+
+    private fun normalizeDeviceName(deviceName: String): String {
+        return deviceName.trim().replace(WHITESPACE_REGEX, " ").take(MAX_DEVICE_NAME_LENGTH)
+            .ifBlank { DEFAULT_DEVICE_NAME }
+    }
+
+    private fun verifyVersion(version: Int) {
+        if (version != SYNC_PROTOCOL_VERSION) {
+            throw PairingException("Unsupported pairing protocol version: $version")
+        }
+    }
+
+    private fun sign(privateKey: PrivKey, bytes: ByteArray): String {
+        return encodeBase64(privateKey.sign(bytes))
+    }
+
+    @Throws(PairingException::class)
+    private fun verifySignature(publicKey: PubKey, bytes: ByteArray, signatureValue: String) {
+        val signature = decodeBase64Checked(signatureValue, "signature")
+        if (!publicKey.verify(bytes, signature)) {
+            throw PairingException("The pairing signature is invalid")
+        }
+    }
+
+    private fun invitationSigningBytes(invitation: PairingInvitation): ByteArray {
+        return JSON.encodeToString(invitation).toByteArray(Charsets.UTF_8)
+    }
+
+    private fun requestSigningBytes(request: PairingRequest): ByteArray {
+        return JSON.encodeToString(request).toByteArray(Charsets.UTF_8)
+    }
+
+    private fun PairingInvitation.toTrustedPeer(pairedAt: Long) = TrustedPeer(
+        peerId = peerId,
+        publicKey = publicKey,
+        deviceName = deviceName,
+        addresses = addresses,
+        pairedAtEpochMillis = pairedAt
+    )
+
+    private fun PairingRequest.toTrustedPeer(pairedAt: Long) = TrustedPeer(
+        peerId = peerId,
+        publicKey = publicKey,
+        deviceName = deviceName,
+        addresses = addresses,
+        pairedAtEpochMillis = pairedAt
+    )
+
+    private fun decodeBase64Checked(value: String, label: String): ByteArray {
+        return try {
+            decodeBase64(value)
+        } catch (error: Exception) {
+            throw PairingException("The $label is invalid", error)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_INVITATION_LIFETIME_MILLIS = 5 * 60 * 1000L
+
+        private const val MAX_INVITATION_LIFETIME_MILLIS =
+            DEFAULT_INVITATION_LIFETIME_MILLIS
+        private const val MAX_CLOCK_SKEW_MILLIS = 60 * 1000L
+        private const val MAX_REQUEST_AGE_MILLIS = 2 * 60 * 1000L
+        private const val TOKEN_SIZE_BYTES = 32
+        private const val MAX_PAIRING_URI_LENGTH = 16 * 1024
+        private const val PAIRING_URI_SCHEME = "wizestream"
+        private const val PAIRING_URI_HOST = "pair"
+        private const val PAIRING_URI_PREFIX = "$PAIRING_URI_SCHEME://$PAIRING_URI_HOST/"
+        private const val DEFAULT_DEVICE_NAME = "Android device"
+        private val WHITESPACE_REGEX = Regex("\\s+")
+        private val JSON = Json {
+            encodeDefaults = true
+            explicitNulls = false
+            ignoreUnknownKeys = false
+        }
+
+        internal fun encodeWireMessage(message: SyncWireMessage): String {
+            return JSON.encodeToString(message)
+        }
+
+        internal fun decodeWireMessage(value: String): SyncWireMessage {
+            return JSON.decodeFromString(value)
+        }
+
+        private fun encodeBase64(value: ByteArray): String {
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(value)
+        }
+
+        private fun decodeBase64(value: String): ByteArray {
+            return Base64.getUrlDecoder().decode(value)
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/SyncModels.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SyncModels.kt
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.PeerId
+import io.libp2p.core.crypto.PrivKey
+import kotlinx.serialization.Serializable
+
+internal const val SYNC_PROTOCOL_ID = "/wizestream/sync/1.0.0"
+internal const val SYNC_PROTOCOL_VERSION = 1
+internal const val MAX_DEVICE_NAME_LENGTH = 64
+internal const val MAX_PAIRING_ADDRESSES = 8
+internal const val MAX_MULTIADDRESS_LENGTH = 256
+
+data class DeviceIdentity(
+    val privateKey: PrivKey
+) {
+    val peerId: PeerId = PeerId.fromPubKey(privateKey.publicKey())
+}
+
+@Serializable
+data class TrustedPeer(
+    val peerId: String,
+    val publicKey: String,
+    val deviceName: String,
+    val addresses: List<String>,
+    val pairedAtEpochMillis: Long
+)
+
+@Serializable
+data class PairingInvitation(
+    val version: Int,
+    val peerId: String,
+    val publicKey: String,
+    val deviceName: String,
+    val addresses: List<String>,
+    val issuedAtEpochMillis: Long,
+    val expiresAtEpochMillis: Long,
+    val token: String,
+    val signature: String
+)
+
+@Serializable
+internal data class PairingRequest(
+    val version: Int,
+    val peerId: String,
+    val publicKey: String,
+    val deviceName: String,
+    val addresses: List<String>,
+    val issuedAtEpochMillis: Long,
+    val invitationToken: String,
+    val signature: String
+)
+
+@Serializable
+internal data class PairingResponse(
+    val accepted: Boolean,
+    val error: String? = null
+)
+
+@Serializable
+internal data class SyncWireMessage(
+    val type: String,
+    val pairingRequest: PairingRequest? = null,
+    val pairingResponse: PairingResponse? = null
+) {
+    init {
+        require(
+            listOfNotNull(pairingRequest, pairingResponse).size == 1
+        ) {
+            "A sync message must contain exactly one payload"
+        }
+    }
+
+    companion object {
+        const val TYPE_PAIRING_REQUEST = "pairing_request"
+        const val TYPE_PAIRING_RESPONSE = "pairing_response"
+
+        fun pairingRequest(request: PairingRequest) = SyncWireMessage(
+            type = TYPE_PAIRING_REQUEST,
+            pairingRequest = request
+        )
+
+        fun pairingResponse(response: PairingResponse) = SyncWireMessage(
+            type = TYPE_PAIRING_RESPONSE,
+            pairingResponse = response
+        )
+    }
+}
+
+interface SyncStateRepository {
+    fun loadOrCreateIdentity(): DeviceIdentity
+
+    fun getTrustedPeers(): List<TrustedPeer>
+
+    fun saveTrustedPeer(peer: TrustedPeer)
+
+    fun clearTrustedPeers()
+}
+
+class PairingException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app/src/main/java/org/schabi/newpipe/sync/SyncProtocol.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SyncProtocol.kt
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// jvm-libp2p's CompletableFuture API is backported by coreLibraryDesugaring.
+@file:android.annotation.SuppressLint("NewApi")
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.PeerId
+import io.libp2p.core.Stream
+import io.libp2p.core.multistream.StrictProtocolBinding
+import io.libp2p.etc.types.toByteBuf
+import io.libp2p.protocol.ProtocolHandler
+import io.libp2p.protocol.ProtocolMessageHandler
+import io.netty.buffer.ByteBuf
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+
+internal typealias PairingRequestHandler =
+    (PeerId, PairingRequest, SyncProtocolController) -> Unit
+
+internal class SyncProtocolBinding(
+    requestHandler: PairingRequestHandler
+) : StrictProtocolBinding<SyncProtocolController>(
+    SYNC_PROTOCOL_ID,
+    SyncProtocol(requestHandler)
+)
+
+internal class SyncProtocol(
+    private val requestHandler: PairingRequestHandler
+) : ProtocolHandler<SyncProtocolController>(MAX_PROTOCOL_BYTES, MAX_PROTOCOL_BYTES) {
+    override fun onStartInitiator(stream: Stream): CompletableFuture<SyncProtocolController> {
+        return start(stream, true)
+    }
+
+    override fun onStartResponder(stream: Stream): CompletableFuture<SyncProtocolController> {
+        return start(stream, false)
+    }
+
+    private fun start(
+        stream: Stream,
+        initiator: Boolean
+    ): CompletableFuture<SyncProtocolController> {
+        val ready = CompletableFuture<Void>()
+        val controller = SyncProtocolController(stream, initiator, requestHandler, ready)
+        stream.pushHandler(controller)
+        return ready.thenApply { controller }
+    }
+
+    companion object {
+        private const val MAX_PROTOCOL_BYTES = 64 * 1024L
+    }
+}
+
+internal class SyncProtocolController(
+    private val stream: Stream,
+    private val initiator: Boolean,
+    private val requestHandler: PairingRequestHandler,
+    private val ready: CompletableFuture<Void>
+) : ProtocolMessageHandler<ByteBuf> {
+    val response = CompletableFuture<PairingResponse>()
+    private var pendingBytes = ByteArray(0)
+
+    override fun onActivated(stream: Stream) {
+        ready.complete(null)
+    }
+
+    override fun onMessage(stream: Stream, msg: ByteBuf) {
+        try {
+            val received = ByteArray(msg.readableBytes())
+            msg.readBytes(received)
+            pendingBytes += received
+            while (pendingBytes.size >= FRAME_LENGTH_BYTES) {
+                val frameLength = ByteBuffer.wrap(
+                    pendingBytes,
+                    0,
+                    FRAME_LENGTH_BYTES
+                ).int
+                if (frameLength !in 1..MAX_FRAME_BYTES) {
+                    throw PairingException("The pairing message has an invalid length")
+                }
+                val totalFrameLength = FRAME_LENGTH_BYTES + frameLength
+                if (pendingBytes.size < totalFrameLength) {
+                    return
+                }
+                val frame = pendingBytes.copyOfRange(FRAME_LENGTH_BYTES, totalFrameLength)
+                pendingBytes = pendingBytes.copyOfRange(totalFrameLength, pendingBytes.size)
+                handleFrame(stream.remotePeerId(), frame)
+            }
+        } catch (error: Exception) {
+            if (initiator) {
+                response.completeExceptionally(error)
+            } else {
+                sendPairingResponse(
+                    PairingResponse(accepted = false, error = "Malformed pairing request")
+                )
+            }
+        }
+    }
+
+    fun sendPairingRequest(request: PairingRequest) {
+        check(initiator) { "Only the stream initiator can send a pairing request" }
+        send(SyncWireMessage.pairingRequest(request))
+    }
+
+    fun sendPairingResponse(response: PairingResponse) {
+        check(!initiator) { "Only the stream responder can send a pairing response" }
+        send(SyncWireMessage.pairingResponse(response))
+    }
+
+    fun close() {
+        stream.close()
+    }
+
+    override fun onClosed(stream: Stream) {
+        if (initiator && !response.isDone) {
+            response.completeExceptionally(PairingException("The pairing connection closed"))
+        }
+    }
+
+    override fun onException(cause: Throwable?) {
+        if (initiator && !response.isDone) {
+            response.completeExceptionally(
+                cause ?: PairingException("The pairing connection failed")
+            )
+        }
+    }
+
+    private fun handleInitiatorMessage(message: SyncWireMessage) {
+        if (
+            message.type != SyncWireMessage.TYPE_PAIRING_RESPONSE ||
+            message.pairingResponse == null
+        ) {
+            throw PairingException("The remote device sent an unexpected response")
+        }
+        response.complete(message.pairingResponse)
+    }
+
+    private fun handleResponderMessage(remotePeerId: PeerId, message: SyncWireMessage) {
+        if (
+            message.type != SyncWireMessage.TYPE_PAIRING_REQUEST ||
+            message.pairingRequest == null
+        ) {
+            throw PairingException("The remote device sent an unexpected request")
+        }
+        requestHandler(remotePeerId, message.pairingRequest, this)
+    }
+
+    private fun send(message: SyncWireMessage) {
+        val bytes = PairingSecurity.encodeWireMessage(message).toByteArray(Charsets.UTF_8)
+        check(bytes.size <= MAX_FRAME_BYTES) { "The pairing message is too large" }
+        val frame = ByteBuffer.allocate(FRAME_LENGTH_BYTES + bytes.size)
+            .putInt(bytes.size)
+            .put(bytes)
+            .array()
+        stream.writeAndFlush(frame.toByteBuf())
+    }
+
+    private fun handleFrame(remotePeerId: PeerId, frame: ByteArray) {
+        val message = PairingSecurity.decodeWireMessage(frame.toString(Charsets.UTF_8))
+        if (initiator) {
+            handleInitiatorMessage(message)
+        } else {
+            handleResponderMessage(remotePeerId, message)
+        }
+    }
+
+    companion object {
+        private const val FRAME_LENGTH_BYTES = Int.SIZE_BYTES
+        private const val MAX_FRAME_BYTES = 32 * 1024
+    }
+}

--- a/app/src/main/res/drawable/ic_devices.xml
+++ b/app/src/main/res/drawable/ic_devices.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/defaultIconTint"
+        android:pathData="M4,6h18V4H4c-1.1,0 -2,0.9 -2,2v11H0v3h14v-3H4V6zM23,8h-6c-0.55,0 -1,0.45 -1,1v11c0,0.55 0.45,1 1,1h6c0.55,0 1,-0.45 1,-1V9c0,-0.55 -0.45,-1 -1,-1zM22,17h-4v-7h4v7z" />
+</vector>

--- a/app/src/main/res/layout/dialog_device_pairing.xml
+++ b/app/src/main/res/layout/dialog_device_pairing.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/margin_normal"
+    android:paddingTop="@dimen/margin_small"
+    android:paddingEnd="@dimen/margin_normal"
+    android:paddingBottom="@dimen/margin_small">
+
+    <ImageView
+        android:id="@+id/device_pairing_qr"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/device_sync_pairing_qr_description"
+        android:padding="@dimen/margin_small"
+        android:scaleType="fitCenter" />
+
+    <TextView
+        android:id="@+id/device_pairing_peer_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="@dimen/margin_small"
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingTop="@dimen/margin_small"
+        android:text="@string/device_sync_pairing_code_expiry"
+        android:textAppearance="?attr/textAppearanceBodySmall" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,7 @@
     <string name="settings_category_content_summary">Services, languages, regions, and content filters</string>
     <string name="settings_category_notification_summary">Notification actions, alerts, and update messages</string>
     <string name="settings_category_backup_restore_summary">Export, import, and restore app data</string>
+    <string name="settings_category_device_sync_summary">Securely pair trusted devices for private synchronization</string>
     <string name="settings_category_history_title">History and cache</string>
     <string name="settings_category_appearance_title">Appearance</string>
     <string name="settings_category_debug_title">Debug</string>
@@ -211,6 +212,33 @@
     <string name="settings_category_player_notification_title">Player notification</string>
     <string name="settings_category_player_notification_summary">Configure current playing stream notification</string>
     <string name="settings_category_backup_restore_title">Backup and restore</string>
+    <string name="settings_category_device_sync_title">Device synchronization</string>
+    <string name="device_sync_status_key" translatable="false">device_sync_status</string>
+    <string name="device_sync_identity_key" translatable="false">device_sync_identity</string>
+    <string name="device_sync_show_code_key" translatable="false">device_sync_show_pairing_code</string>
+    <string name="device_sync_scan_code_key" translatable="false">device_sync_scan_pairing_code</string>
+    <string name="device_sync_trusted_devices_key" translatable="false">device_sync_trusted_devices</string>
+    <string name="device_sync_clear_devices_key" translatable="false">device_sync_clear_trusted_devices</string>
+    <string name="device_sync_status_title">Current status</string>
+    <string name="device_sync_status_summary">Experimental secure pairing is available. Record synchronization is not enabled yet.</string>
+    <string name="device_sync_identity_title">This device PeerID</string>
+    <string name="device_sync_show_code_title">Show pairing code</string>
+    <string name="device_sync_show_code_summary">Let another WizeStream device scan this one-time QR code</string>
+    <string name="device_sync_scan_code_title">Scan pairing code</string>
+    <string name="device_sync_scan_code_summary">Scan the QR code displayed by another WizeStream device</string>
+    <string name="device_sync_scan_prompt">Scan the WizeStream pairing QR code</string>
+    <string name="device_sync_pairing_in_progress">Establishing an encrypted connection…</string>
+    <string name="device_sync_pairing_succeeded">Paired securely with %1$s</string>
+    <string name="device_sync_pairing_failed">Pairing failed</string>
+    <string name="device_sync_pairing_qr_description">One-time device pairing QR code</string>
+    <string name="device_sync_pairing_peer_id">PeerID: %1$s</string>
+    <string name="device_sync_pairing_code_expiry">Keep this screen open while the other device scans. This code expires after five minutes and can be used only once.</string>
+    <string name="device_sync_trusted_devices_title">Trusted devices</string>
+    <string name="device_sync_no_trusted_devices">No trusted devices</string>
+    <string name="device_sync_trusted_device_summary">%1$s — %2$s</string>
+    <string name="device_sync_clear_devices_title">Clear trusted devices</string>
+    <string name="device_sync_clear_devices_summary">Require every device to pair again</string>
+    <string name="device_sync_clear_devices_confirmation">Remove all trusted devices? This device’s PeerID will not change.</string>
     <string name="background_player_playing_toast">Playing in background</string>
     <string name="popup_playing_toast">Playing in popup mode</string>
     <string name="content">Content</string>

--- a/app/src/main/res/xml/device_sync_settings.xml
+++ b/app/src/main/res/xml/device_sync_settings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/settings_category_device_sync_title">
+
+    <Preference
+        android:key="@string/device_sync_status_key"
+        android:summary="@string/device_sync_status_summary"
+        android:title="@string/device_sync_status_title"
+        app:iconSpaceReserved="false"
+        app:selectable="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/device_sync_identity_key"
+        android:selectable="false"
+        android:title="@string/device_sync_identity_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/device_sync_show_code_key"
+        android:summary="@string/device_sync_show_code_summary"
+        android:title="@string/device_sync_show_code_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/device_sync_scan_code_key"
+        android:summary="@string/device_sync_scan_code_summary"
+        android:title="@string/device_sync_scan_code_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <PreferenceCategory
+        android:layout="@layout/settings_category_header_layout"
+        android:title="@string/device_sync_trusted_devices_title">
+
+        <Preference
+            android:key="@string/device_sync_trusted_devices_key"
+            android:selectable="false"
+            android:title="@string/device_sync_trusted_devices_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+
+        <Preference
+            android:key="@string/device_sync_clear_devices_key"
+            android:summary="@string/device_sync_clear_devices_summary"
+            android:title="@string/device_sync_clear_devices_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/app/src/main/res/xml/main_settings.xml
+++ b/app/src/main/res/xml/main_settings.xml
@@ -70,6 +70,13 @@
         app:iconSpaceReserved="false" />
 
     <PreferenceScreen
+        android:fragment="org.schabi.newpipe.settings.DeviceSyncSettingsFragment"
+        android:icon="@drawable/ic_devices"
+        android:title="@string/settings_category_device_sync_title"
+        android:summary="@string/settings_category_device_sync_summary"
+        app:iconSpaceReserved="false" />
+
+    <PreferenceScreen
         android:fragment="org.schabi.newpipe.settings.DebugSettingsFragment"
         android:icon="@drawable/ic_bug_report"
         android:key="@string/debug_pref_screen_key"

--- a/app/src/test/java/org/schabi/newpipe/sync/Libp2pSyncNodeTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/Libp2pSyncNodeTest.kt
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.Host
+import io.libp2p.core.crypto.KeyType
+import io.libp2p.core.crypto.generateKeyPair
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Libp2pSyncNodeTest {
+    @Test
+    fun `two nodes pair over a Noise authenticated stream`() {
+        val tabletState = InMemorySyncStateRepository()
+        val phoneState = InMemorySyncStateRepository()
+        val tablet = Libp2pSyncNode(
+            tabletState,
+            PairingSecurity(),
+            "Test tablet",
+            ::loopbackAddresses
+        )
+        val phone = Libp2pSyncNode(
+            phoneState,
+            PairingSecurity(),
+            "Test phone",
+            ::loopbackAddresses
+        )
+
+        try {
+            tablet.start()
+            phone.start()
+
+            val pairedTablet = phone.pair(tablet.createPairingCode())
+
+            assertEquals("Test tablet", pairedTablet.deviceName)
+            assertEquals(
+                listOf("Test phone"),
+                tabletState.getTrustedPeers().map(TrustedPeer::deviceName)
+            )
+            assertEquals(
+                listOf("Test tablet"),
+                phoneState.getTrustedPeers().map(TrustedPeer::deviceName)
+            )
+        } finally {
+            phone.stop()
+            tablet.stop()
+        }
+    }
+
+    private fun loopbackAddresses(host: Host): List<String> {
+        return host.listenAddresses().map { address ->
+            address.toString().replace("/ip4/0.0.0.0/", "/ip4/127.0.0.1/")
+        }
+    }
+
+    private class InMemorySyncStateRepository : SyncStateRepository {
+        private val identity = DeviceIdentity(generateKeyPair(KeyType.ED25519).first)
+        private val peers = linkedMapOf<String, TrustedPeer>()
+
+        override fun loadOrCreateIdentity() = identity
+
+        @Synchronized
+        override fun getTrustedPeers() = peers.values.toList()
+
+        @Synchronized
+        override fun saveTrustedPeer(peer: TrustedPeer) {
+            peers[peer.peerId] = peer
+        }
+
+        @Synchronized
+        override fun clearTrustedPeers() {
+            peers.clear()
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/sync/PairingSecurityTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/PairingSecurityTest.kt
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.crypto.KeyType
+import io.libp2p.core.crypto.generateKeyPair
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PairingSecurityTest {
+    private val instant = Instant.parse("2026-07-25T10:00:00Z")
+    private val clock = Clock.fixed(instant, ZoneOffset.UTC)
+
+    @Test
+    fun `signed invitation round trips through pairing URI`() {
+        val identity = newIdentity()
+        val security = PairingSecurity(clock)
+        val invitation = security.createInvitation(
+            identity,
+            "Test tablet",
+            listOf(address(identity, 32451))
+        )
+
+        val decoded = security.decodeAndVerifyInvitation(
+            security.encodeInvitation(invitation)
+        )
+
+        assertEquals(invitation, decoded)
+    }
+
+    @Test
+    fun `tampered invitation signature is rejected`() {
+        val identity = newIdentity()
+        val security = PairingSecurity(clock)
+        val invitation = security.createInvitation(
+            identity,
+            "Test tablet",
+            listOf(address(identity, 32451))
+        )
+
+        assertThrows(PairingException::class.java) {
+            security.verifyInvitation(
+                invitation.copy(signature = invitation.signature.reversed())
+            )
+        }
+    }
+
+    @Test
+    fun `invitation public key must match PeerID`() {
+        val identity = newIdentity()
+        val otherIdentity = newIdentity()
+        val security = PairingSecurity(clock)
+        val invitation = security.createInvitation(
+            identity,
+            "Test tablet",
+            listOf(address(identity, 32451))
+        )
+        val otherInvitation = security.createInvitation(
+            otherIdentity,
+            "Other device",
+            listOf(address(otherIdentity, 32452))
+        )
+
+        assertThrows(PairingException::class.java) {
+            security.verifyInvitation(
+                invitation.copy(publicKey = otherInvitation.publicKey)
+            )
+        }
+    }
+
+    @Test
+    fun `expired invitation is rejected`() {
+        val identity = newIdentity()
+        val issuer = PairingSecurity(clock)
+        val invitation = issuer.createInvitation(
+            identity,
+            "Test tablet",
+            listOf(address(identity, 32451))
+        )
+        val verifier = PairingSecurity(
+            Clock.offset(clock, java.time.Duration.ofMinutes(6))
+        )
+
+        assertThrows(PairingException::class.java) {
+            verifier.verifyInvitation(invitation)
+        }
+    }
+
+    @Test
+    fun `pairing request consumes invitation token only once`() {
+        val inviter = newIdentity()
+        val requester = newIdentity()
+        val inviterSecurity = PairingSecurity(clock)
+        val requesterSecurity = PairingSecurity(clock)
+        val invitation = inviterSecurity.createInvitation(
+            inviter,
+            "Test tablet",
+            listOf(address(inviter, 32451))
+        )
+        val request = requesterSecurity.createPairingRequest(
+            requester,
+            "Test phone",
+            listOf(address(requester, 32452)),
+            invitation.token
+        )
+
+        val peer = inviterSecurity.verifyAndConsumePairingRequest(
+            request,
+            requester.peerId
+        )
+        assertEquals(requester.peerId.toBase58(), peer.peerId)
+
+        assertThrows(PairingException::class.java) {
+            inviterSecurity.verifyAndConsumePairingRequest(request, requester.peerId)
+        }
+    }
+
+    @Test
+    fun `pairing request must match authenticated Noise peer`() {
+        val inviter = newIdentity()
+        val requester = newIdentity()
+        val differentPeer = newIdentity()
+        val inviterSecurity = PairingSecurity(clock)
+        val invitation = inviterSecurity.createInvitation(
+            inviter,
+            "Test tablet",
+            listOf(address(inviter, 32451))
+        )
+        val request = PairingSecurity(clock).createPairingRequest(
+            requester,
+            "Test phone",
+            listOf(address(requester, 32452)),
+            invitation.token
+        )
+
+        assertThrows(PairingException::class.java) {
+            inviterSecurity.verifyAndConsumePairingRequest(request, differentPeer.peerId)
+        }
+    }
+
+    private fun newIdentity(): DeviceIdentity {
+        return DeviceIdentity(generateKeyPair(KeyType.ED25519).first)
+    }
+
+    private fun address(identity: DeviceIdentity, port: Int): String {
+        return "/ip4/127.0.0.1/tcp/$port/p2p/${identity.peerId.toBase58()}"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ groupie = "2.10.1"
 jsoup = "1.22.2"
 junit = "4.13.2"
 junit-ext = "1.3.0"
+jvm-libp2p = "1.2.2-RELEASE"
 koin = "4.2.1"
 koin-plugin = "1.0.0"
 kotlin = "2.3.21"
@@ -67,6 +68,8 @@ teamnewpipe-newpipe-extractor = "v0.26.2"
 viewpager2 = "1.1.0"
 webkit = "1.15.0" # New versions require minSdk 24
 work = "2.11.2"
+zxing-android-embedded = "4.3.0"
+zxing-core = "3.5.4"
 
 [libraries]
 acra-core = { module = "ch.acra:acra-core", version.ref = "acra" }
@@ -131,6 +134,7 @@ jetbrains-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lif
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junit = { module = "junit:junit", version.ref = "junit" }
+jvm-libp2p = { module = "io.libp2p:jvm-libp2p", version.ref = "jvm-libp2p" }
 koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 kotlin-test-core = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -157,6 +161,8 @@ squareup-leakcanary-plumber = { module = "com.squareup.leakcanary:plumber-androi
 squareup-leakcanary-watcher = { module = "com.squareup.leakcanary:leakcanary-object-watcher-android", version.ref = "leakcanary" }
 squareup-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 zacsweers-autoservice-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "autoservice-zacsweers" }
+zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing-android-embedded" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://dl.cloudsmith.io/public/consensys/maven/maven/")
+        maven(url = "https://dl.cloudsmith.io/public/libp2p/jvm-libp2p/maven/")
         maven(url = "https://jitpack.io")
         maven(url = "https://repo.clojars.org")
     }


### PR DESCRIPTION
- add a persistent Ed25519 device identity and PeerID protected with Android Keystore
- add libp2p TCP transport secured by Noise under `/wizestream/sync/1.0.0`
- add signed five-minute, one-time QR pairing invitations
- verify PeerID/public-key/address consistency and bind trust to the authenticated Noise peer
- persist and manage trusted devices from a new Device synchronization settings screen
- preserve API 23 compatibility and add release/R8 support for the new networking stack
- add pairing, tamper, replay, expiry, framing, and real two-node Noise handshake tests