### PR TITLE
Add Podcasts to subscription feed fetching

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/migration/SettingMigrations.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/migration/SettingMigrations.java
@@ -239,6 +239,24 @@ public final class SettingMigrations {
         }
     };
 
+    private static final Migration MIGRATION_9_10 = new Migration(9, 10) {
+        @Override
+        protected void migrate(@NonNull final Context context) {
+            // Existing users have an explicit set of channel tabs to fetch. Enable Podcasts by
+            // default while preserving every existing selection.
+            final String fetchChannelTabsKey =
+                    context.getString(R.string.feed_fetch_channel_tabs_key);
+            final Set<String> enabledTabs = sp.getStringSet(fetchChannelTabsKey, null);
+            if (enabledTabs != null) {
+                sp.edit()
+                        .putStringSet(fetchChannelTabsKey, copyAndAdd(
+                                enabledTabs,
+                                context.getString(R.string.fetch_channel_tabs_podcasts)))
+                        .apply();
+            }
+        }
+    };
+
     static Set<String> copyAndAdd(final Set<String> values, final String value) {
         final Set<String> updatedValues = new HashSet<>(values);
         updatedValues.add(value);
@@ -261,12 +279,13 @@ public final class SettingMigrations {
             MIGRATION_6_7,
             MIGRATION_7_8,
             MIGRATION_8_9,
+            MIGRATION_9_10,
     };
 
     /**
      * Version number for preferences. Must be incremented every time a migration is necessary.
      */
-    private static final int VERSION = 9;
+    private static final int VERSION = 10;
 
 
     static void runMigrationsIfNeeded(@NonNull final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
@@ -96,6 +96,8 @@ public final class ChannelTabHelper {
                 return R.string.fetch_channel_tabs_shorts;
             case ChannelTabs.LIVESTREAMS:
                 return R.string.fetch_channel_tabs_livestreams;
+            case ChannelTabs.PODCASTS:
+                return R.string.fetch_channel_tabs_podcasts;
             case CHANNEL_TAB_LIKES:
                 return R.string.fetch_channel_tabs_likes;
             default:

--- a/app/src/main/res/raw/wizestream_default_preferences.json
+++ b/app/src/main/res/raw/wizestream_default_preferences.json
@@ -46,6 +46,7 @@
     "fetch_channel_tabs_videos",
     "fetch_channel_tabs_livestreams",
     "fetch_channel_tabs_tracks",
+    "fetch_channel_tabs_podcasts",
     "fetch_channel_tabs_likes"
   ],
   "show_thumbnail_key": true,

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -459,12 +459,14 @@
     <string name="fetch_channel_tabs_tracks">fetch_channel_tabs_tracks</string>
     <string name="fetch_channel_tabs_shorts">fetch_channel_tabs_shorts</string>
     <string name="fetch_channel_tabs_livestreams">fetch_channel_tabs_livestreams</string>
+    <string name="fetch_channel_tabs_podcasts">fetch_channel_tabs_podcasts</string>
     <string name="fetch_channel_tabs_likes">fetch_channel_tabs_likes</string>
     <string-array name="feed_fetch_channel_tabs_value_list">
         <item>@string/fetch_channel_tabs_videos</item>
         <item>@string/fetch_channel_tabs_tracks</item>
         <item>@string/fetch_channel_tabs_shorts</item>
         <item>@string/fetch_channel_tabs_livestreams</item>
+        <item>@string/fetch_channel_tabs_podcasts</item>
         <item>@string/fetch_channel_tabs_likes</item>
     </string-array>
     <string-array name="feed_fetch_channel_tabs_description_list">
@@ -472,6 +474,7 @@
         <item>@string/channel_tab_tracks</item>
         <item>@string/channel_tab_shorts</item>
         <item>@string/channel_tab_livestreams</item>
+        <item>@string/channel_tab_podcasts</item>
         <item>@string/channel_tab_likes</item>
     </string-array>
 

--- a/app/src/test/java/org/schabi/newpipe/settings/WizeStreamDefaultPreferencesTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/WizeStreamDefaultPreferencesTest.kt
@@ -121,6 +121,19 @@ class WizeStreamDefaultPreferencesTest {
                 )
             )
         )
+        verify(editor).putStringSet(
+            eq("feed_fetch_channel_tabs"),
+            eq(
+                setOf(
+                    "fetch_channel_tabs_shorts",
+                    "fetch_channel_tabs_videos",
+                    "fetch_channel_tabs_livestreams",
+                    "fetch_channel_tabs_tracks",
+                    "fetch_channel_tabs_podcasts",
+                    "fetch_channel_tabs_likes"
+                )
+            )
+        )
         verify(editor).commit()
     }
 

--- a/app/src/test/java/org/schabi/newpipe/util/ChannelTabHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ChannelTabHelperTest.java
@@ -11,7 +11,11 @@ import android.content.SharedPreferences;
 import org.junit.Test;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.linkhandler.ChannelTabs;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.search.filter.Filter;
+import org.schabi.newpipe.extractor.search.filter.FilterItem;
 
+import java.util.Collections;
 import java.util.Set;
 
 public class ChannelTabHelperTest {
@@ -29,5 +33,30 @@ public class ChannelTabHelperTest {
         assertTrue(ChannelTabHelper.showChannelTab(context, preferences, ChannelTabs.PODCASTS));
         assertEquals(R.string.channel_tab_podcasts,
                 ChannelTabHelper.getTranslationKey(ChannelTabs.PODCASTS));
+    }
+
+    @Test
+    public void podcastsCanBeSelectedForFeedFetching() {
+        final Context context = mock(Context.class);
+        final SharedPreferences preferences = mock(SharedPreferences.class);
+        when(context.getString(R.string.feed_fetch_channel_tabs_key))
+                .thenReturn("feed_fetch_channel_tabs");
+        when(context.getString(R.string.fetch_channel_tabs_podcasts))
+                .thenReturn("fetch_channel_tabs_podcasts");
+        when(preferences.getStringSet("feed_fetch_channel_tabs", null))
+                .thenReturn(Set.of("fetch_channel_tabs_podcasts"));
+
+        assertTrue(ChannelTabHelper.fetchFeedChannelTab(
+                context, preferences, handler(ChannelTabs.PODCASTS)));
+    }
+
+    private static ListLinkHandler handler(final String tab) {
+        return new ListLinkHandler(
+                "https://www.youtube.com/channel/UC123/" + tab,
+                "https://www.youtube.com/channel/UC123/" + tab,
+                "channel/UC123",
+                Collections.singletonList(
+                        new FilterItem(Filter.ITEM_IDENTIFIER_UNKNOWN, tab)),
+                null);
     }
 }


### PR DESCRIPTION
Fix what was missing for #55 

- add Podcasts to the **Fetch channel tabs** preference
- map the Podcasts tab to `fetch_channel_tabs_podcasts`
- enable Podcasts in WizeStream's bundled feed-fetch defaults
- migrate existing users from preference version 9 to 10 without changing their other tab selections
- add regression coverage for defaults and feed-tab mapping