### PR TITLE
Add subscription synchronization

### DIFF
--- a/app/schemas/org.schabi.newpipe.database.AppDatabase/10.json
+++ b/app/schemas/org.schabi.newpipe.database.AppDatabase/10.json
@@ -1,0 +1,929 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "28ef1d189fc8fc52dd2d0b043a96b5c8",
+    "entities": [
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT, `name` TEXT, `avatar_url` TEXT, `subscriber_count` INTEGER, `description` TEXT, `notification_mode` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subscriberCount",
+            "columnName": "subscriber_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notificationMode",
+            "columnName": "notification_mode",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscriptions_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_subscriptions_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`creation_date` INTEGER, `service_id` INTEGER NOT NULL, `search` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "creationDate",
+            "columnName": "creation_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "search",
+            "columnName": "search",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_search",
+            "unique": false,
+            "columnNames": [
+              "search"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_search` ON `${TABLE_NAME}` (`search`)"
+          }
+        ]
+      },
+      {
+        "tableName": "streams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `stream_type` TEXT NOT NULL, `duration` INTEGER NOT NULL, `uploader` TEXT NOT NULL, `uploader_url` TEXT, `thumbnail_url` TEXT, `view_count` INTEGER, `textual_upload_date` TEXT, `upload_date` INTEGER, `is_upload_date_approximation` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamType",
+            "columnName": "stream_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaderUrl",
+            "columnName": "uploader_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "view_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "textualUploadDate",
+            "columnName": "textual_upload_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "upload_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isUploadDateApproximation",
+            "columnName": "is_upload_date_approximation",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_streams_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_streams_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stream_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `access_date` INTEGER NOT NULL, `repeat_count` INTEGER NOT NULL, PRIMARY KEY(`stream_id`, `access_date`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "streamUid",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessDate",
+            "columnName": "access_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatCount",
+            "columnName": "repeat_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stream_id",
+            "access_date"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stream_history_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stream_history_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stream_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `progress_time` INTEGER NOT NULL, PRIMARY KEY(`stream_id`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "streamUid",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressMillis",
+            "columnName": "progress_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stream_id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `is_thumbnail_permanent` INTEGER NOT NULL, `thumbnail_stream_id` INTEGER NOT NULL, `display_index` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isThumbnailPermanent",
+            "columnName": "is_thumbnail_permanent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStreamId",
+            "columnName": "thumbnail_stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayIndex",
+            "columnName": "display_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_stream_join",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `stream_id` INTEGER NOT NULL, `join_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `join_index`), FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "playlistUid",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUid",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "join_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "join_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_stream_join_playlist_id_join_index",
+            "unique": true,
+            "columnNames": [
+              "playlist_id",
+              "join_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlist_stream_join_playlist_id_join_index` ON `${TABLE_NAME}` (`playlist_id`, `join_index`)"
+          },
+          {
+            "name": "index_playlist_stream_join_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_stream_join_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          },
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service_id` INTEGER NOT NULL, `name` TEXT, `url` TEXT, `thumbnail_url` TEXT, `uploader` TEXT, `display_index` INTEGER NOT NULL, `stream_count` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderingName",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayIndex",
+            "columnName": "display_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamCount",
+            "columnName": "stream_count",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_playlists_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_playlists_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `subscription_id` INTEGER NOT NULL, PRIMARY KEY(`stream_id`, `subscription_id`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`subscription_id`) REFERENCES `subscriptions`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stream_id",
+            "subscription_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_subscription_id",
+            "unique": false,
+            "columnNames": [
+              "subscription_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_subscription_id` ON `${TABLE_NAME}` (`subscription_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          },
+          {
+            "table": "subscriptions",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "feed_group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon_id` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_group_sort_order",
+            "unique": false,
+            "columnNames": [
+              "sort_order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_group_sort_order` ON `${TABLE_NAME}` (`sort_order`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_group_subscription_join",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`group_id` INTEGER NOT NULL, `subscription_id` INTEGER NOT NULL, PRIMARY KEY(`group_id`, `subscription_id`), FOREIGN KEY(`group_id`) REFERENCES `feed_group`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`subscription_id`) REFERENCES `subscriptions`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "feedGroupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "group_id",
+            "subscription_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_group_subscription_join_subscription_id",
+            "unique": false,
+            "columnNames": [
+              "subscription_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_group_subscription_join_subscription_id` ON `${TABLE_NAME}` (`subscription_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed_group",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "group_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          },
+          {
+            "table": "subscriptions",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "feed_last_updated",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`subscription_id` INTEGER NOT NULL, `last_updated` INTEGER, PRIMARY KEY(`subscription_id`), FOREIGN KEY(`subscription_id`) REFERENCES `subscriptions`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "subscription_id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "subscriptions",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_sync_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `lamport_version` INTEGER NOT NULL, `record_id` TEXT NOT NULL, `change_type` TEXT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `avatar_url` TEXT, `subscriber_count` INTEGER, `description` TEXT, PRIMARY KEY(`origin_peer_id`, `origin_revision`))",
+        "fields": [
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeType",
+            "columnName": "change_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subscriberCount",
+            "columnName": "subscriber_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin_peer_id",
+            "origin_revision"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_sync_changes_record_id",
+            "unique": false,
+            "columnNames": [
+              "record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_sync_changes_record_id` ON `${TABLE_NAME}` (`record_id`)"
+          },
+          {
+            "name": "index_subscription_sync_changes_lamport_version_origin_peer_id_origin_revision",
+            "unique": false,
+            "columnNames": [
+              "lamport_version",
+              "origin_peer_id",
+              "origin_revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_sync_changes_lamport_version_origin_peer_id_origin_revision` ON `${TABLE_NAME}` (`lamport_version`, `origin_peer_id`, `origin_revision`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_sync_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`record_id` TEXT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT NOT NULL, `lamport_version` INTEGER NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`record_id`))",
+        "fields": [
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_sync_records_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_subscription_sync_records_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_sync_origin_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin_peer_id` TEXT NOT NULL, `contiguous_revision` INTEGER NOT NULL, PRIMARY KEY(`origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contiguousRevision",
+            "columnName": "contiguous_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin_peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "subscription_sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peer_id` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `acknowledged_revision` INTEGER NOT NULL, PRIMARY KEY(`peer_id`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acknowledgedRevision",
+            "columnName": "acknowledged_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peer_id",
+            "origin_peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_sync_peer_state_origin_peer_id",
+            "unique": false,
+            "columnNames": [
+              "origin_peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_sync_peer_state_origin_peer_id` ON `${TABLE_NAME}` (`origin_peer_id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '28ef1d189fc8fc52dd2d0b043a96b5c8')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/database/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/database/DatabaseMigrationTest.kt
@@ -128,6 +128,13 @@ class DatabaseMigrationTest {
             Migrations.MIGRATION_8_9
         )
 
+        testHelper.runMigrationsAndValidate(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_10,
+            true,
+            Migrations.MIGRATION_9_10
+        )
+
         val migratedDatabaseV3 = getMigratedDatabase()
         val listFromDB = migratedDatabaseV3.streamDAO().getAll().blockingFirst()
 
@@ -224,6 +231,13 @@ class DatabaseMigrationTest {
             Migrations.MIGRATION_8_9
         )
 
+        testHelper.runMigrationsAndValidate(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_10,
+            true,
+            Migrations.MIGRATION_9_10
+        )
+
         val migratedDatabaseV8 = getMigratedDatabase()
         val listFromDB = migratedDatabaseV8.searchHistoryDAO().getAll().blockingFirst()
 
@@ -296,6 +310,13 @@ class DatabaseMigrationTest {
             Migrations.MIGRATION_8_9
         )
 
+        testHelper.runMigrationsAndValidate(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_10,
+            true,
+            Migrations.MIGRATION_9_10
+        )
+
         val migratedDatabaseV9 = getMigratedDatabase()
         var localListFromDB = migratedDatabaseV9.playlistDAO().getAll().blockingFirst()
         var remoteListFromDB = migratedDatabaseV9.playlistRemoteDAO().getAll().blockingFirst()
@@ -335,6 +356,21 @@ class DatabaseMigrationTest {
         assertEquals(2, remoteListFromDB.size)
         assertEquals(remoteUid3, remoteListFromDB[1].uid)
         assertEquals(-1, remoteListFromDB[1].displayIndex)
+    }
+
+    @Test
+    fun migrateDatabaseFrom9to10() {
+        testHelper.createDatabase(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_9
+        ).close()
+
+        testHelper.runMigrationsAndValidate(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_10,
+            true,
+            Migrations.MIGRATION_9_10
+        )
     }
 
     private fun getMigratedDatabase(): AppDatabase {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,14 @@
             android:label="@string/settings" />
 
         <activity
+            android:name=".settings.DeviceSyncCaptureActivity"
+            android:exported="false"
+            android:screenOrientation="sensorPortrait"
+            android:stateNotNeeded="true"
+            android:theme="@style/zxing_CaptureTheme"
+            android:windowSoftInputMode="stateAlwaysHidden" />
+
+        <activity
             android:name=".about.AboutActivity"
             android:exported="false"
             android:label="@string/title_activity_about" />

--- a/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.kt
@@ -18,6 +18,7 @@ import org.schabi.newpipe.database.Migrations.MIGRATION_5_6
 import org.schabi.newpipe.database.Migrations.MIGRATION_6_7
 import org.schabi.newpipe.database.Migrations.MIGRATION_7_8
 import org.schabi.newpipe.database.Migrations.MIGRATION_8_9
+import org.schabi.newpipe.database.Migrations.MIGRATION_9_10
 
 object NewPipeDatabase {
 
@@ -37,7 +38,8 @@ object NewPipeDatabase {
             MIGRATION_5_6,
             MIGRATION_6_7,
             MIGRATION_7_8,
-            MIGRATION_8_9
+            MIGRATION_8_9,
+            MIGRATION_9_10
         ).build()
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/AppDatabase.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/AppDatabase.kt
@@ -31,10 +31,15 @@ import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.database.subscription.SubscriptionDAO
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncChangeEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncDAO
+import org.schabi.newpipe.database.sync.SubscriptionSyncOriginStateEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncPeerStateEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncRecordEntity
 
 @TypeConverters(Converters::class)
 @Database(
-    version = Migrations.DB_VER_9,
+    version = Migrations.DB_VER_10,
     entities = [
         SubscriptionEntity::class,
         SearchHistoryEntry::class,
@@ -47,7 +52,11 @@ import org.schabi.newpipe.database.subscription.SubscriptionEntity
         FeedEntity::class,
         FeedGroupEntity::class,
         FeedGroupSubscriptionEntity::class,
-        FeedLastUpdatedEntity::class
+        FeedLastUpdatedEntity::class,
+        SubscriptionSyncChangeEntity::class,
+        SubscriptionSyncRecordEntity::class,
+        SubscriptionSyncOriginStateEntity::class,
+        SubscriptionSyncPeerStateEntity::class
     ]
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -61,6 +70,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun streamHistoryDAO(): StreamHistoryDAO
     abstract fun streamStateDAO(): StreamStateDAO
     abstract fun subscriptionDAO(): SubscriptionDAO
+    abstract fun subscriptionSyncDAO(): SubscriptionSyncDAO
 
     companion object {
         const val DATABASE_NAME: String = "newpipe.db"

--- a/app/src/main/java/org/schabi/newpipe/database/Migrations.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/Migrations.kt
@@ -29,6 +29,7 @@ object Migrations {
     const val DB_VER_7 = 7
     const val DB_VER_8 = 8
     const val DB_VER_9 = 9
+    const val DB_VER_10 = 10
 
     private val TAG = Migrations::class.java.getName()
     private val isDebug = MainActivity.DEBUG
@@ -347,5 +348,55 @@ object Migrations {
         } finally {
             db.endTransaction()
         }
+    }
+
+    val MIGRATION_9_10 = Migration(DB_VER_9, DB_VER_10) { db ->
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `subscription_sync_changes` " +
+                "(`origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, " +
+                "`lamport_version` INTEGER NOT NULL, `record_id` TEXT NOT NULL, " +
+                "`change_type` TEXT NOT NULL, `service_id` INTEGER NOT NULL, " +
+                "`url` TEXT NOT NULL, `name` TEXT, `avatar_url` TEXT, " +
+                "`subscriber_count` INTEGER, `description` TEXT, " +
+                "PRIMARY KEY(`origin_peer_id`, `origin_revision`))"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_subscription_sync_changes_record_id` " +
+                "ON `subscription_sync_changes` (`record_id`)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS " +
+                "`index_subscription_sync_changes_lamport_version_origin_peer_id_" +
+                "origin_revision` ON `subscription_sync_changes` " +
+                "(`lamport_version`, `origin_peer_id`, `origin_revision`)"
+        )
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `subscription_sync_records` " +
+                "(`record_id` TEXT NOT NULL, `service_id` INTEGER NOT NULL, " +
+                "`url` TEXT NOT NULL, `lamport_version` INTEGER NOT NULL, " +
+                "`origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, " +
+                "`is_deleted` INTEGER NOT NULL, PRIMARY KEY(`record_id`))"
+        )
+        db.execSQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS " +
+                "`index_subscription_sync_records_service_id_url` " +
+                "ON `subscription_sync_records` (`service_id`, `url`)"
+        )
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `subscription_sync_origin_state` " +
+                "(`origin_peer_id` TEXT NOT NULL, `contiguous_revision` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`origin_peer_id`))"
+        )
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `subscription_sync_peer_state` " +
+                "(`peer_id` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, " +
+                "`acknowledged_revision` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`peer_id`, `origin_peer_id`))"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS " +
+                "`index_subscription_sync_peer_state_origin_peer_id` " +
+                "ON `subscription_sync_peer_state` (`origin_peer_id`)"
+        )
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionDAO.kt
@@ -21,6 +21,9 @@ abstract class SubscriptionDAO : BasicDAO<SubscriptionEntity> {
     @Query("SELECT * FROM subscriptions ORDER BY name COLLATE NOCASE ASC")
     abstract override fun getAll(): Flowable<List<SubscriptionEntity>>
 
+    @Query("SELECT * FROM subscriptions")
+    abstract fun getAllDirect(): List<SubscriptionEntity>
+
     @Query(
         """
         SELECT * FROM subscriptions
@@ -74,6 +77,9 @@ abstract class SubscriptionDAO : BasicDAO<SubscriptionEntity> {
     @Query("SELECT * FROM subscriptions WHERE url LIKE :url AND service_id = :serviceId")
     abstract fun getSubscription(serviceId: Int, url: String): Maybe<SubscriptionEntity>
 
+    @Query("SELECT * FROM subscriptions WHERE url = :url AND service_id = :serviceId")
+    abstract fun getSubscriptionDirect(serviceId: Int, url: String): SubscriptionEntity?
+
     @Query("SELECT * FROM subscriptions WHERE uid = :subscriptionId")
     abstract fun getSubscription(subscriptionId: Long): SubscriptionEntity
 
@@ -88,6 +94,9 @@ abstract class SubscriptionDAO : BasicDAO<SubscriptionEntity> {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     internal abstract fun silentInsertAllInternal(entities: List<SubscriptionEntity>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    abstract fun insertIgnore(entity: SubscriptionEntity): Long
 
     @Transaction
     open fun upsertAll(entities: List<SubscriptionEntity>): List<SubscriptionEntity> {

--- a/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncDAO.kt
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.database.sync
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+abstract class SubscriptionSyncDAO {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    abstract fun insertChange(change: SubscriptionSyncChangeEntity): Long
+
+    @Query(
+        """
+        SELECT * FROM subscription_sync_changes
+        WHERE origin_peer_id = :originPeerId AND origin_revision > :revision
+        ORDER BY origin_revision ASC
+        LIMIT :limit
+        """
+    )
+    abstract fun getChangesAfter(
+        originPeerId: String,
+        revision: Long,
+        limit: Int
+    ): List<SubscriptionSyncChangeEntity>
+
+    @Query(
+        """
+        SELECT COUNT(*) FROM subscription_sync_changes
+        WHERE origin_peer_id = :originPeerId AND origin_revision > :revision
+        """
+    )
+    abstract fun countChangesAfter(originPeerId: String, revision: Long): Long
+
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM subscription_sync_changes
+            WHERE origin_peer_id = :originPeerId AND origin_revision = :revision
+        )
+        """
+    )
+    abstract fun hasChange(originPeerId: String, revision: Long): Boolean
+
+    @Query("SELECT DISTINCT origin_peer_id FROM subscription_sync_changes")
+    abstract fun getChangeOrigins(): List<String>
+
+    @Query("SELECT COALESCE(MAX(lamport_version), 0) FROM subscription_sync_changes")
+    abstract fun getMaximumLamportVersion(): Long
+
+    @Query("SELECT * FROM subscription_sync_records WHERE record_id = :recordId")
+    abstract fun getRecord(recordId: String): SubscriptionSyncRecordEntity?
+
+    @Query("SELECT * FROM subscription_sync_records")
+    abstract fun getAllRecords(): List<SubscriptionSyncRecordEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun upsertRecord(record: SubscriptionSyncRecordEntity)
+
+    @Query(
+        """
+        SELECT * FROM subscription_sync_origin_state
+        WHERE origin_peer_id = :originPeerId
+        """
+    )
+    abstract fun getOriginState(originPeerId: String): SubscriptionSyncOriginStateEntity?
+
+    @Query("SELECT * FROM subscription_sync_origin_state")
+    abstract fun getAllOriginStates(): List<SubscriptionSyncOriginStateEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun upsertOriginState(state: SubscriptionSyncOriginStateEntity)
+
+    @Query("SELECT * FROM subscription_sync_peer_state WHERE peer_id = :peerId")
+    abstract fun getPeerStates(peerId: String): List<SubscriptionSyncPeerStateEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun upsertPeerState(state: SubscriptionSyncPeerStateEntity)
+
+    @Query("DELETE FROM subscription_sync_peer_state")
+    abstract fun deleteAllPeerStates()
+}

--- a/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncEntities.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncEntities.kt
@@ -1,0 +1,168 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.database.sync
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = SubscriptionSyncChangeEntity.TABLE_NAME,
+    primaryKeys = [
+        SubscriptionSyncChangeEntity.ORIGIN_PEER_ID,
+        SubscriptionSyncChangeEntity.ORIGIN_REVISION
+    ],
+    indices = [
+        Index(value = [SubscriptionSyncChangeEntity.RECORD_ID]),
+        Index(
+            value = [
+                SubscriptionSyncChangeEntity.LAMPORT_VERSION,
+                SubscriptionSyncChangeEntity.ORIGIN_PEER_ID,
+                SubscriptionSyncChangeEntity.ORIGIN_REVISION
+            ]
+        )
+    ]
+)
+data class SubscriptionSyncChangeEntity(
+    @ColumnInfo(name = ORIGIN_PEER_ID)
+    val originPeerId: String,
+
+    @ColumnInfo(name = ORIGIN_REVISION)
+    val originRevision: Long,
+
+    @ColumnInfo(name = LAMPORT_VERSION)
+    val lamportVersion: Long,
+
+    @ColumnInfo(name = RECORD_ID)
+    val recordId: String,
+
+    @ColumnInfo(name = CHANGE_TYPE)
+    val changeType: String,
+
+    @ColumnInfo(name = SERVICE_ID)
+    val serviceId: Int,
+
+    @ColumnInfo(name = URL)
+    val url: String,
+
+    @ColumnInfo(name = NAME)
+    val name: String?,
+
+    @ColumnInfo(name = AVATAR_URL)
+    val avatarUrl: String?,
+
+    @ColumnInfo(name = SUBSCRIBER_COUNT)
+    val subscriberCount: Long?,
+
+    @ColumnInfo(name = DESCRIPTION)
+    val description: String?
+) {
+    companion object {
+        const val TABLE_NAME = "subscription_sync_changes"
+        const val ORIGIN_PEER_ID = "origin_peer_id"
+        const val ORIGIN_REVISION = "origin_revision"
+        const val LAMPORT_VERSION = "lamport_version"
+        const val RECORD_ID = "record_id"
+        const val CHANGE_TYPE = "change_type"
+        const val SERVICE_ID = "service_id"
+        const val URL = "url"
+        const val NAME = "name"
+        const val AVATAR_URL = "avatar_url"
+        const val SUBSCRIBER_COUNT = "subscriber_count"
+        const val DESCRIPTION = "description"
+    }
+}
+
+@Entity(
+    tableName = SubscriptionSyncRecordEntity.TABLE_NAME,
+    primaryKeys = [SubscriptionSyncRecordEntity.RECORD_ID],
+    indices = [
+        Index(
+            value = [
+                SubscriptionSyncRecordEntity.SERVICE_ID,
+                SubscriptionSyncRecordEntity.URL
+            ],
+            unique = true
+        )
+    ]
+)
+data class SubscriptionSyncRecordEntity(
+    @ColumnInfo(name = RECORD_ID)
+    val recordId: String,
+
+    @ColumnInfo(name = SERVICE_ID)
+    val serviceId: Int,
+
+    @ColumnInfo(name = URL)
+    val url: String,
+
+    @ColumnInfo(name = LAMPORT_VERSION)
+    val lamportVersion: Long,
+
+    @ColumnInfo(name = ORIGIN_PEER_ID)
+    val originPeerId: String,
+
+    @ColumnInfo(name = ORIGIN_REVISION)
+    val originRevision: Long,
+
+    @ColumnInfo(name = IS_DELETED)
+    val isDeleted: Boolean
+) {
+    companion object {
+        const val TABLE_NAME = "subscription_sync_records"
+        const val RECORD_ID = "record_id"
+        const val SERVICE_ID = "service_id"
+        const val URL = "url"
+        const val LAMPORT_VERSION = "lamport_version"
+        const val ORIGIN_PEER_ID = "origin_peer_id"
+        const val ORIGIN_REVISION = "origin_revision"
+        const val IS_DELETED = "is_deleted"
+    }
+}
+
+@Entity(
+    tableName = SubscriptionSyncOriginStateEntity.TABLE_NAME,
+    primaryKeys = [SubscriptionSyncOriginStateEntity.ORIGIN_PEER_ID]
+)
+data class SubscriptionSyncOriginStateEntity(
+    @ColumnInfo(name = ORIGIN_PEER_ID)
+    val originPeerId: String,
+
+    @ColumnInfo(name = CONTIGUOUS_REVISION)
+    val contiguousRevision: Long
+) {
+    companion object {
+        const val TABLE_NAME = "subscription_sync_origin_state"
+        const val ORIGIN_PEER_ID = "origin_peer_id"
+        const val CONTIGUOUS_REVISION = "contiguous_revision"
+    }
+}
+
+@Entity(
+    tableName = SubscriptionSyncPeerStateEntity.TABLE_NAME,
+    primaryKeys = [
+        SubscriptionSyncPeerStateEntity.PEER_ID,
+        SubscriptionSyncPeerStateEntity.ORIGIN_PEER_ID
+    ],
+    indices = [Index(value = [SubscriptionSyncPeerStateEntity.ORIGIN_PEER_ID])]
+)
+data class SubscriptionSyncPeerStateEntity(
+    @ColumnInfo(name = PEER_ID)
+    val peerId: String,
+
+    @ColumnInfo(name = ORIGIN_PEER_ID)
+    val originPeerId: String,
+
+    @ColumnInfo(name = ACKNOWLEDGED_REVISION)
+    val acknowledgedRevision: Long
+) {
+    companion object {
+        const val TABLE_NAME = "subscription_sync_peer_state"
+        const val PEER_ID = "peer_id"
+        const val ORIGIN_PEER_ID = "origin_peer_id"
+        const val ACKNOWLEDGED_REVISION = "acknowledged_revision"
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.local.subscription
 
 import android.content.Context
+import android.util.Log
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
@@ -16,6 +17,7 @@ import org.schabi.newpipe.extractor.channel.ChannelTabInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
 import org.schabi.newpipe.local.feed.service.FeedUpdateInfo
+import org.schabi.newpipe.sync.RoomSubscriptionSyncStore
 import org.schabi.newpipe.util.ExtractorHelper
 import org.schabi.newpipe.util.image.ImageStrategy
 
@@ -23,6 +25,9 @@ class SubscriptionManager(context: Context) {
     private val database = NewPipeDatabase.getInstance(context)
     private val subscriptionTable = database.subscriptionDAO()
     private val feedDatabaseManager = FeedDatabaseManager(context)
+    private val subscriptionSyncStore by lazy {
+        RoomSubscriptionSyncStore.get(context)
+    }
 
     fun subscriptionTable(): SubscriptionDAO = subscriptionTable
     fun subscriptions() = subscriptionTable.getAll()
@@ -53,6 +58,7 @@ class SubscriptionManager(context: Context) {
     fun upsertAll(infoList: List<Pair<ChannelInfo, ChannelTabInfo>>) {
         val listEntities = infoList.map { SubscriptionEntity.from(it.first) }
         subscriptionTable.upsertAll(listEntities)
+        listEntities.forEach(::recordSubscriptionUpsert)
 
         database.runInTransaction {
             infoList.forEachIndexed { index, info ->
@@ -106,17 +112,27 @@ class SubscriptionManager(context: Context) {
     }
 
     fun deleteSubscription(serviceId: Int, url: String): Completable {
-        return Completable.fromCallable { subscriptionTable.deleteSubscription(serviceId, url) }
+        return Completable.fromCallable {
+            val deleted = subscriptionTable.deleteSubscription(serviceId, url)
+            if (deleted > 0) {
+                recordSubscriptionDelete(serviceId, url)
+            }
+            deleted
+        }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
     }
 
     fun insertSubscription(subscriptionEntity: SubscriptionEntity) {
         subscriptionTable.insert(subscriptionEntity)
+        recordSubscriptionUpsert(subscriptionEntity)
     }
 
     fun deleteSubscription(subscriptionEntity: SubscriptionEntity) {
         subscriptionTable.delete(subscriptionEntity)
+        subscriptionEntity.url?.let { url ->
+            recordSubscriptionDelete(subscriptionEntity.serviceId, url)
+        }
     }
 
     /**
@@ -135,5 +151,25 @@ class SubscriptionManager(context: Context) {
                     database.streamDAO().upsertAll(entities)
                 }
             }.onErrorComplete()
+    }
+
+    private fun recordSubscriptionUpsert(subscription: SubscriptionEntity) {
+        try {
+            subscriptionSyncStore.recordLocalUpsert(subscription)
+        } catch (error: Exception) {
+            Log.e(TAG, "Could not journal a subscription addition", error)
+        }
+    }
+
+    private fun recordSubscriptionDelete(serviceId: Int, url: String) {
+        try {
+            subscriptionSyncStore.recordLocalDelete(serviceId, url)
+        } catch (error: Exception) {
+            Log.e(TAG, "Could not journal a subscription deletion", error)
+        }
+    }
+
+    companion object {
+        private const val TAG = "SubscriptionManager"
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncCaptureActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncCaptureActivity.kt
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.settings
+
+import com.journeyapps.barcodescanner.CaptureActivity
+
+class DeviceSyncCaptureActivity : CaptureActivity()

--- a/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncSettingsFragment.kt
@@ -7,6 +7,7 @@ package org.schabi.newpipe.settings
 
 import android.graphics.Color
 import android.os.Bundle
+import android.text.format.DateUtils
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
@@ -21,6 +22,8 @@ import kotlinx.coroutines.withContext
 import org.schabi.newpipe.R
 import org.schabi.newpipe.databinding.DialogDevicePairingBinding
 import org.schabi.newpipe.sync.DeviceSyncManager
+import org.schabi.newpipe.sync.DeviceSyncSummary
+import org.schabi.newpipe.sync.TrustedPeer
 
 class DeviceSyncSettingsFragment : BasePreferenceFragment() {
     private val scanPairingCode = registerForActivityResult(ScanContract()) { result ->
@@ -31,6 +34,8 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
         get() = DeviceSyncManager.get(requireContext())
 
     private lateinit var identityPreference: Preference
+    private lateinit var statusPreference: Preference
+    private lateinit var syncNowPreference: Preference
     private lateinit var trustedDevicesPreference: Preference
     private lateinit var showPairingCodePreference: Preference
     private lateinit var scanPairingCodePreference: Preference
@@ -39,10 +44,16 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
         addPreferencesFromResourceRegistry()
 
         identityPreference = requirePreference(R.string.device_sync_identity_key)
+        statusPreference = requirePreference(R.string.device_sync_status_key)
+        syncNowPreference = requirePreference(R.string.device_sync_sync_now_key)
         trustedDevicesPreference = requirePreference(R.string.device_sync_trusted_devices_key)
         showPairingCodePreference = requirePreference(R.string.device_sync_show_code_key)
         scanPairingCodePreference = requirePreference(R.string.device_sync_scan_code_key)
 
+        syncNowPreference.setOnPreferenceClickListener {
+            syncSubscriptions()
+            true
+        }
         showPairingCodePreference.setOnPreferenceClickListener {
             createPairingCode()
             true
@@ -61,26 +72,55 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
     override fun onResume() {
         super.onResume()
         updateState()
+        startListening()
     }
 
     private fun updateState() {
         identityPreference.summary = syncManager.peerId
         val peers = syncManager.trustedPeers
+        syncNowPreference.isEnabled = peers.isNotEmpty()
+        statusPreference.summary = statusSummary(peers)
         trustedDevicesPreference.summary = if (peers.isEmpty()) {
             getString(R.string.device_sync_no_trusted_devices)
         } else {
-            peers.joinToString(separator = "\n") { peer ->
-                getString(
-                    R.string.device_sync_trusted_device_summary,
-                    peer.deviceName,
-                    abbreviatePeerId(peer.peerId)
-                )
+            peers.joinToString(separator = "\n\n", transform = ::trustedPeerSummary)
+        }
+    }
+
+    private fun startListening() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    syncManager.startListening()
+                }
+            } catch (error: Exception) {
+                statusPreference.summary = error.message ?: getString(R.string.general_error)
+            }
+        }
+    }
+
+    private fun syncSubscriptions() {
+        setActionsEnabled(false)
+        syncNowPreference.summary = getString(R.string.device_sync_sync_in_progress)
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val summary = withContext(Dispatchers.IO) {
+                    syncManager.syncSubscriptions()
+                }
+                updateState()
+                showSyncSummary(summary)
+            } catch (error: Exception) {
+                showError(R.string.device_sync_sync_failed, error)
+            } finally {
+                syncNowPreference.setSummary(R.string.device_sync_sync_now_summary)
+                setActionsEnabled(true)
+                updateState()
             }
         }
     }
 
     private fun createPairingCode() {
-        setPairingActionsEnabled(false)
+        setActionsEnabled(false)
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val code = withContext(Dispatchers.IO) {
@@ -88,9 +128,9 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
                 }
                 showPairingCodeDialog(code)
             } catch (error: Exception) {
-                showError(error)
+                showError(R.string.device_sync_pairing_failed, error)
             } finally {
-                setPairingActionsEnabled(true)
+                setActionsEnabled(true)
             }
         }
     }
@@ -105,7 +145,7 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
     }
 
     private fun pairWithCode(code: String) {
-        setPairingActionsEnabled(false)
+        setActionsEnabled(false)
         scanPairingCodePreference.summary = getString(R.string.device_sync_pairing_in_progress)
         viewLifecycleOwner.lifecycleScope.launch {
             try {
@@ -119,10 +159,10 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
                     Toast.LENGTH_LONG
                 ).show()
             } catch (error: Exception) {
-                showError(error)
+                showError(R.string.device_sync_pairing_failed, error)
             } finally {
                 scanPairingCodePreference.setSummary(R.string.device_sync_scan_code_summary)
-                setPairingActionsEnabled(true)
+                setActionsEnabled(true)
             }
         }
     }
@@ -169,20 +209,121 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
             .setMessage(R.string.device_sync_clear_devices_confirmation)
             .setNegativeButton(R.string.cancel, null)
             .setPositiveButton(R.string.clear) { _, _ ->
-                syncManager.clearTrustedPeers()
-                updateState()
+                clearTrustedDevices()
             }
             .show()
     }
 
-    private fun setPairingActionsEnabled(enabled: Boolean) {
-        showPairingCodePreference.isEnabled = enabled
-        scanPairingCodePreference.isEnabled = enabled
+    private fun clearTrustedDevices() {
+        setActionsEnabled(false)
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    syncManager.clearTrustedPeers()
+                }
+            } catch (error: Exception) {
+                showError(R.string.device_sync_clear_devices_failed, error)
+            } finally {
+                setActionsEnabled(true)
+                updateState()
+            }
+        }
     }
 
-    private fun showError(error: Exception) {
+    private fun showSyncSummary(summary: DeviceSyncSummary) {
+        val details = summary.attempts.joinToString(separator = "\n") { attempt ->
+            val result = attempt.result
+            if (result != null) {
+                getString(
+                    R.string.device_sync_sync_peer_succeeded,
+                    attempt.peer.deviceName,
+                    result.sentChanges,
+                    result.receivedChanges
+                )
+            } else {
+                getString(
+                    R.string.device_sync_sync_peer_failed,
+                    attempt.peer.deviceName,
+                    attempt.error ?: getString(R.string.general_error)
+                )
+            }
+        }
+        val summaryText = getString(
+            R.string.device_sync_sync_complete_summary,
+            summary.succeeded,
+            summary.failed,
+            summary.sentChanges,
+            summary.receivedChanges
+        )
         MaterialAlertDialogBuilder(requireContext())
-            .setTitle(R.string.device_sync_pairing_failed)
+            .setTitle(R.string.device_sync_sync_complete_title)
+            .setMessage("$summaryText\n\n$details")
+            .setPositiveButton(R.string.ok, null)
+            .show()
+    }
+
+    private fun statusSummary(peers: List<TrustedPeer>): CharSequence {
+        if (peers.isEmpty()) {
+            return getString(R.string.device_sync_status_no_devices)
+        }
+        val errors = peers.count { it.lastSyncError != null }
+        if (errors > 0) {
+            return getString(R.string.device_sync_status_errors, errors)
+        }
+        val latestSync = peers.mapNotNull(TrustedPeer::lastSyncAtEpochMillis).maxOrNull()
+        return if (latestSync == null) {
+            getString(R.string.device_sync_status_ready, peers.size)
+        } else {
+            getString(
+                R.string.device_sync_status_last_sync,
+                relativeTime(latestSync)
+            )
+        }
+    }
+
+    private fun trustedPeerSummary(peer: TrustedPeer): String {
+        val identity = getString(
+            R.string.device_sync_trusted_device_summary,
+            peer.deviceName,
+            abbreviatePeerId(peer.peerId)
+        )
+        return when {
+            peer.lastSyncError != null -> getString(
+                R.string.device_sync_trusted_device_error,
+                identity,
+                peer.lastSyncError
+            )
+
+            peer.lastSyncAtEpochMillis != null -> getString(
+                R.string.device_sync_trusted_device_last_sync,
+                identity,
+                relativeTime(peer.lastSyncAtEpochMillis)
+            )
+
+            else -> getString(
+                R.string.device_sync_trusted_device_never_synced,
+                identity
+            )
+        }
+    }
+
+    private fun relativeTime(epochMillis: Long): CharSequence {
+        return DateUtils.getRelativeTimeSpanString(
+            epochMillis,
+            System.currentTimeMillis(),
+            DateUtils.MINUTE_IN_MILLIS
+        )
+    }
+
+    private fun setActionsEnabled(enabled: Boolean) {
+        showPairingCodePreference.isEnabled = enabled
+        scanPairingCodePreference.isEnabled = enabled
+        syncNowPreference.isEnabled = enabled && syncManager.trustedPeers.isNotEmpty()
+    }
+
+    private fun showError(title: Int, error: Exception) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(title)
             .setMessage(error.message ?: getString(R.string.general_error))
             .setPositiveButton(R.string.ok, null)
             .show()

--- a/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncSettingsFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/DeviceSyncSettingsFragment.kt
@@ -140,6 +140,7 @@ class DeviceSyncSettingsFragment : BasePreferenceFragment() {
             .setDesiredBarcodeFormats(ScanOptions.QR_CODE)
             .setPrompt(getString(R.string.device_sync_scan_prompt))
             .setBeepEnabled(false)
+            .setCaptureActivity(DeviceSyncCaptureActivity::class.java)
             .setOrientationLocked(false)
         scanPairingCode.launch(options)
     }

--- a/app/src/main/java/org/schabi/newpipe/sync/AndroidSyncStateRepository.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/AndroidSyncStateRepository.kt
@@ -29,52 +29,92 @@ import kotlinx.serialization.json.Json
 class AndroidSyncStateRepository(context: Context) : SyncStateRepository {
     private val stateFile = AtomicFile(context.noBackupFilesDir.resolve(STATE_FILE_NAME))
 
-    @Synchronized
     override fun loadOrCreateIdentity(): DeviceIdentity {
-        val existingState = readState()
-        if (existingState != null) {
-            return try {
-                DeviceIdentity(
-                    unmarshalPrivateKey(Base64.getDecoder().decode(existingState.privateKey))
+        return synchronized(STATE_LOCK) {
+            val existingState = readState()
+            if (existingState != null) {
+                return@synchronized try {
+                    DeviceIdentity(
+                        unmarshalPrivateKey(
+                            Base64.getDecoder().decode(existingState.privateKey)
+                        )
+                    )
+                } catch (error: Exception) {
+                    throw PairingException("The saved device identity is invalid", error)
+                }
+            }
+
+            val identity = DeviceIdentity(generateKeyPair(KeyType.ED25519).first)
+            writeState(
+                PersistedSyncState(
+                    privateKey = Base64.getEncoder()
+                        .encodeToString(identity.privateKey.bytes())
                 )
-            } catch (error: Exception) {
-                throw PairingException("The saved device identity is invalid", error)
+            )
+            identity
+        }
+    }
+
+    override fun getTrustedPeers(): List<TrustedPeer> {
+        return synchronized(STATE_LOCK) {
+            loadOrCreateIdentity()
+            requireNotNull(readState()).trustedPeers.sortedBy {
+                it.deviceName.lowercase()
             }
         }
-
-        val identity = DeviceIdentity(generateKeyPair(KeyType.ED25519).first)
-        writeState(
-            PersistedSyncState(
-                privateKey = Base64.getEncoder().encodeToString(identity.privateKey.bytes())
-            )
-        )
-        return identity
     }
 
-    @Synchronized
-    override fun getTrustedPeers(): List<TrustedPeer> {
-        loadOrCreateIdentity()
-        return requireNotNull(readState()).trustedPeers.sortedBy {
-            it.deviceName.lowercase()
+    override fun saveTrustedPeer(peer: TrustedPeer) {
+        synchronized(STATE_LOCK) {
+            loadOrCreateIdentity()
+            val state = requireNotNull(readState())
+            val existingPeer = state.trustedPeers.firstOrNull {
+                it.peerId == peer.peerId
+            }
+            val savedPeer = peer.copy(
+                lastSyncAtEpochMillis = existingPeer?.lastSyncAtEpochMillis,
+                lastSyncError = existingPeer?.lastSyncError
+            )
+            val peers = state.trustedPeers
+                .filterNot { it.peerId == peer.peerId }
+                .plus(savedPeer)
+                .takeLast(MAX_TRUSTED_PEERS)
+            writeState(state.copy(trustedPeers = peers))
         }
     }
 
-    @Synchronized
-    override fun saveTrustedPeer(peer: TrustedPeer) {
-        loadOrCreateIdentity()
-        val state = requireNotNull(readState())
-        val peers = state.trustedPeers
-            .filterNot { it.peerId == peer.peerId }
-            .plus(peer)
-            .takeLast(MAX_TRUSTED_PEERS)
-        writeState(state.copy(trustedPeers = peers))
+    override fun updateTrustedPeerSyncStatus(
+        peerId: String,
+        syncedAtEpochMillis: Long?,
+        error: String?
+    ) {
+        synchronized(STATE_LOCK) {
+            loadOrCreateIdentity()
+            val state = requireNotNull(readState())
+            if (state.trustedPeers.none { it.peerId == peerId }) {
+                return
+            }
+            val peers = state.trustedPeers.map { peer ->
+                if (peer.peerId != peerId) {
+                    peer
+                } else {
+                    peer.copy(
+                        lastSyncAtEpochMillis = syncedAtEpochMillis
+                            ?: peer.lastSyncAtEpochMillis,
+                        lastSyncError = error?.take(MAX_SYNC_ERROR_LENGTH)
+                    )
+                }
+            }
+            writeState(state.copy(trustedPeers = peers))
+        }
     }
 
-    @Synchronized
     override fun clearTrustedPeers() {
-        loadOrCreateIdentity()
-        val state = requireNotNull(readState())
-        writeState(state.copy(trustedPeers = emptyList()))
+        synchronized(STATE_LOCK) {
+            loadOrCreateIdentity()
+            val state = requireNotNull(readState())
+            writeState(state.copy(trustedPeers = emptyList()))
+        }
     }
 
     private fun readState(): PersistedSyncState? {
@@ -192,6 +232,8 @@ class AndroidSyncStateRepository(context: Context) : SyncStateRepository {
         private const val MAX_GCM_IV_BYTES = 16
         private const val MAX_STATE_FILE_BYTES = 1024 * 1024
         private const val MAX_TRUSTED_PEERS = 32
+        private const val MAX_SYNC_ERROR_LENGTH = 512
+        private val STATE_LOCK = Any()
         private val JSON = Json {
             encodeDefaults = true
             ignoreUnknownKeys = false

--- a/app/src/main/java/org/schabi/newpipe/sync/DeviceSyncManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/DeviceSyncManager.kt
@@ -9,7 +9,11 @@ import android.content.Context
 import android.os.Build
 
 class DeviceSyncManager private constructor(context: Context) {
-    private val stateRepository = AndroidSyncStateRepository(context.applicationContext)
+    private val applicationContext = context.applicationContext
+    private val stateRepository = AndroidSyncStateRepository(applicationContext)
+    private val subscriptionSyncEngine = SubscriptionSyncEngine(
+        RoomSubscriptionSyncStore.get(applicationContext)
+    )
     private val deviceName = listOf(Build.MANUFACTURER, Build.MODEL)
         .map(String::trim)
         .filter(String::isNotEmpty)
@@ -20,7 +24,8 @@ class DeviceSyncManager private constructor(context: Context) {
             stateRepository = stateRepository,
             pairingSecurity = PairingSecurity(),
             deviceName = deviceName,
-            advertisedAddressProvider = AndroidNetworkAddressProvider::addresses
+            advertisedAddressProvider = AndroidNetworkAddressProvider::addresses,
+            subscriptionSyncEngine = subscriptionSyncEngine
         )
     }
 
@@ -42,8 +47,37 @@ class DeviceSyncManager private constructor(context: Context) {
         return node.pair(pairingCode)
     }
 
+    @Synchronized
+    fun startListening() {
+        node.start()
+    }
+
+    @Synchronized
+    fun syncSubscriptions(): DeviceSyncSummary {
+        node.start()
+        val peers = trustedPeers
+        if (peers.isEmpty()) {
+            throw SubscriptionSyncException("Pair a trusted device before synchronizing")
+        }
+        val attempts = peers.map { peer ->
+            try {
+                DeviceSyncAttempt(
+                    peer = peer,
+                    result = node.syncSubscriptions(peer)
+                )
+            } catch (error: Exception) {
+                DeviceSyncAttempt(
+                    peer = peer,
+                    error = error.message ?: "Subscription synchronization failed"
+                )
+            }
+        }
+        return DeviceSyncSummary(attempts)
+    }
+
     fun clearTrustedPeers() {
         stateRepository.clearTrustedPeers()
+        subscriptionSyncEngine.clearPeerKnowledge()
     }
 
     companion object {

--- a/app/src/main/java/org/schabi/newpipe/sync/Libp2pSyncNode.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/Libp2pSyncNode.kt
@@ -20,19 +20,25 @@ class Libp2pSyncNode(
     private val deviceName: String,
     private val advertisedAddressProvider: (Host) -> List<String> = { currentHost ->
         currentHost.listenAddresses().map(Multiaddr::toString)
-    }
+    },
+    private val subscriptionSyncEngine: SubscriptionSyncEngine? = null,
+    private val listenAddress: String = LISTEN_ADDRESS
 ) {
     private val identity = stateRepository.loadOrCreateIdentity()
-    private val protocol = SyncProtocolBinding(::handlePairingRequest)
+    private val pairingProtocol = SyncProtocolBinding(::handlePairingRequest)
+    private val subscriptionProtocol = SubscriptionSyncProtocolBinding(
+        ::handleSubscriptionSyncRequest
+    )
     private val host: Host = host {
         identity {
             factory = { this@Libp2pSyncNode.identity.privateKey }
         }
         protocols {
-            +protocol
+            +pairingProtocol
+            +subscriptionProtocol
         }
         network {
-            listen(LISTEN_ADDRESS)
+            listen(listenAddress)
         }
     }
 
@@ -101,7 +107,7 @@ class Libp2pSyncNode(
             throw PairingException("The remote network addresses are invalid", error)
         }
 
-        val streamPromise = protocol.dial(host, remotePeerId, *remoteAddresses)
+        val streamPromise = pairingProtocol.dial(host, remotePeerId, *remoteAddresses)
         val controller = try {
             streamPromise.controller.get(PAIR_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         } catch (error: Exception) {
@@ -133,6 +139,104 @@ class Libp2pSyncNode(
         }
     }
 
+    @Throws(SubscriptionSyncException::class)
+    fun syncSubscriptions(peer: TrustedPeer): SubscriptionSyncResult {
+        checkStarted()
+        val engine = subscriptionSyncEngine
+            ?: throw SubscriptionSyncException("Subscription synchronization is unavailable")
+        ensureTrusted(peer.peerId)
+        val remotePeerId = parsePeerId(peer.peerId)
+        val remoteAddresses = parseAddresses(remotePeerId, peer.addresses)
+
+        var sentChanges = 0
+        var receivedChanges = 0
+        var addedSubscriptions = 0
+        var removedSubscriptions = 0
+        var rounds = 0
+
+        try {
+            while (true) {
+                if (rounds >= MAX_SYNC_ROUNDS) {
+                    throw SubscriptionSyncException(
+                        "Synchronization needs too many batches; run it again to continue"
+                    )
+                }
+                rounds += 1
+                val request = engine.createRequest(peer.peerId)
+                val streamPromise = subscriptionProtocol.dial(
+                    host,
+                    remotePeerId,
+                    *remoteAddresses
+                )
+                val controller = try {
+                    streamPromise.controller.get(
+                        SYNC_TIMEOUT_SECONDS,
+                        TimeUnit.SECONDS
+                    )
+                } catch (error: Exception) {
+                    throw SubscriptionSyncException(
+                        "Could not reach ${peer.deviceName}",
+                        error
+                    )
+                }
+
+                val response = try {
+                    controller.sendRequest(request)
+                    controller.response.get(SYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                } catch (error: Exception) {
+                    throw SubscriptionSyncException(
+                        "Subscription synchronization with ${peer.deviceName} failed",
+                        error
+                    )
+                } finally {
+                    controller.close()
+                }
+
+                val applied = engine.handleResponse(peer.peerId, response)
+                sentChanges += request.changes.size
+                receivedChanges += response.changes.size
+                addedSubscriptions += applied.addedSubscriptions
+                removedSubscriptions += applied.removedSubscriptions
+
+                if (!request.hasMore && !response.hasMore) {
+                    break
+                }
+            }
+
+            stateRepository.updateTrustedPeerSyncStatus(
+                peer.peerId,
+                System.currentTimeMillis(),
+                null
+            )
+            return SubscriptionSyncResult(
+                peer = peer,
+                sentChanges = sentChanges,
+                receivedChanges = receivedChanges,
+                addedSubscriptions = addedSubscriptions,
+                removedSubscriptions = removedSubscriptions,
+                rounds = rounds
+            )
+        } catch (error: SubscriptionSyncException) {
+            stateRepository.updateTrustedPeerSyncStatus(
+                peer.peerId,
+                null,
+                error.message ?: "Subscription synchronization failed"
+            )
+            throw error
+        } catch (error: Exception) {
+            val wrapped = SubscriptionSyncException(
+                "Subscription synchronization with ${peer.deviceName} failed",
+                error
+            )
+            stateRepository.updateTrustedPeerSyncStatus(
+                peer.peerId,
+                null,
+                wrapped.message
+            )
+            throw wrapped
+        }
+    }
+
     private fun handlePairingRequest(
         remotePeerId: PeerId,
         request: PairingRequest,
@@ -155,6 +259,74 @@ class Libp2pSyncNode(
         }
     }
 
+    private fun handleSubscriptionSyncRequest(
+        remotePeerId: PeerId,
+        request: SubscriptionSyncRequest,
+        controller: SubscriptionSyncProtocolController
+    ) {
+        val peerIdValue = remotePeerId.toBase58()
+        val response = try {
+            ensureTrusted(peerIdValue)
+            val engine = subscriptionSyncEngine
+                ?: throw SubscriptionSyncException(
+                    "Subscription synchronization is unavailable"
+                )
+            engine.handleRequest(peerIdValue, request)
+        } catch (error: Exception) {
+            SubscriptionSyncResponse(
+                accepted = false,
+                error = (
+                    error.message ?: "The synchronization request was rejected"
+                    ).take(MAX_SYNC_ERROR_LENGTH)
+            )
+        }
+        controller.sendResponse(response)
+        stateRepository.updateTrustedPeerSyncStatus(
+            peerIdValue,
+            if (response.accepted) System.currentTimeMillis() else null,
+            response.error
+        )
+    }
+
+    private fun ensureTrusted(peerIdValue: String) {
+        if (stateRepository.getTrustedPeers().none { it.peerId == peerIdValue }) {
+            throw SubscriptionSyncException("The connected device is not trusted")
+        }
+    }
+
+    private fun parsePeerId(peerIdValue: String): PeerId {
+        return try {
+            PeerId.fromBase58(peerIdValue)
+        } catch (error: Exception) {
+            throw SubscriptionSyncException("The trusted device PeerID is invalid", error)
+        }
+    }
+
+    private fun parseAddresses(
+        remotePeerId: PeerId,
+        addresses: List<String>
+    ): Array<Multiaddr> {
+        if (addresses.isEmpty() || addresses.size > MAX_PAIRING_ADDRESSES) {
+            throw SubscriptionSyncException("The trusted device has no valid network address")
+        }
+        return try {
+            addresses.map(::Multiaddr)
+                .onEach { address ->
+                    if (address.getPeerId() != remotePeerId) {
+                        throw SubscriptionSyncException(
+                            "A trusted device address has the wrong PeerID"
+                        )
+                    }
+                }
+                .toTypedArray()
+        } catch (error: Exception) {
+            throw SubscriptionSyncException(
+                "The trusted device network addresses are invalid",
+                error
+            )
+        }
+    }
+
     private fun checkStarted() {
         if (!started) {
             throw PairingException("Device synchronization is not running")
@@ -162,9 +334,12 @@ class Libp2pSyncNode(
     }
 
     companion object {
-        private const val LISTEN_ADDRESS = "/ip4/0.0.0.0/tcp/0"
+        private const val LISTEN_ADDRESS = "/ip4/0.0.0.0/tcp/48243"
         private const val START_TIMEOUT_SECONDS = 20L
         private const val STOP_TIMEOUT_SECONDS = 10L
         private const val PAIR_TIMEOUT_SECONDS = 20L
+        private const val SYNC_TIMEOUT_SECONDS = 30L
+        private const val MAX_SYNC_ROUNDS = 2048
+        private const val MAX_SYNC_ERROR_LENGTH = 512
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncEngine.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncEngine.kt
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+class SubscriptionSyncEngine internal constructor(
+    private val store: SubscriptionSyncStore
+) {
+    internal fun createRequest(peerId: String): SubscriptionSyncRequest {
+        store.reconcileLocalSubscriptions()
+        val batch = store.getPendingChanges(
+            peerId,
+            MAX_SUBSCRIPTION_CHANGES_PER_BATCH
+        )
+        return SubscriptionSyncRequest(
+            knownRevisions = store.getKnownRevisions(),
+            changes = batch.changes,
+            hasMore = batch.hasMore
+        ).also(SubscriptionSyncValidation::validateRequest)
+    }
+
+    internal fun handleRequest(
+        peerId: String,
+        request: SubscriptionSyncRequest
+    ): SubscriptionSyncResponse {
+        return try {
+            SubscriptionSyncValidation.validateRequest(request)
+            store.reconcileLocalSubscriptions()
+            store.applyChanges(request.changes)
+            store.acknowledgePeer(peerId, request.knownRevisions)
+            val batch = store.getPendingChanges(
+                peerId,
+                MAX_SUBSCRIPTION_CHANGES_PER_BATCH
+            )
+            SubscriptionSyncResponse(
+                accepted = true,
+                knownRevisions = store.getKnownRevisions(),
+                changes = batch.changes,
+                hasMore = batch.hasMore
+            ).also(SubscriptionSyncValidation::validateResponse)
+        } catch (error: Exception) {
+            SubscriptionSyncResponse(
+                accepted = false,
+                error = (
+                    error.message ?: "The subscription changes were rejected"
+                    ).take(MAX_RESPONSE_ERROR_LENGTH)
+            )
+        }
+    }
+
+    internal fun handleResponse(
+        peerId: String,
+        response: SubscriptionSyncResponse
+    ): SubscriptionApplyResult {
+        SubscriptionSyncValidation.validateResponse(response)
+        if (!response.accepted) {
+            throw SubscriptionSyncException(
+                response.error ?: "The remote device rejected synchronization"
+            )
+        }
+        store.acknowledgePeer(peerId, response.knownRevisions)
+        return store.applyChanges(response.changes)
+    }
+
+    internal fun clearPeerKnowledge() {
+        store.clearPeerKnowledge()
+    }
+
+    companion object {
+        private const val MAX_RESPONSE_ERROR_LENGTH = 512
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncModels.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncModels.kt
@@ -1,0 +1,300 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.PeerId
+import java.security.MessageDigest
+import kotlinx.serialization.Serializable
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
+
+internal const val SUBSCRIPTION_SYNC_PROTOCOL_ID = "/wizestream/subscriptions/1.0.0"
+internal const val SUBSCRIPTION_SYNC_VERSION = 1
+internal const val MAX_SUBSCRIPTION_CHANGES_PER_BATCH = 8
+internal const val MAX_SYNC_ORIGINS = 128
+internal const val MAX_SUBSCRIPTION_URL_LENGTH = 4096
+internal const val MAX_SUBSCRIPTION_NAME_LENGTH = 512
+internal const val MAX_SUBSCRIPTION_AVATAR_URL_LENGTH = 4096
+internal const val MAX_SUBSCRIPTION_DESCRIPTION_LENGTH = 4 * 1024
+internal const val MAX_SYNC_REVISION = 1_000_000_000_000L
+
+@Serializable
+internal enum class SubscriptionChangeType {
+    UPSERT,
+    DELETE
+}
+
+@Serializable
+internal data class SyncedSubscription(
+    val serviceId: Int,
+    val url: String,
+    val name: String? = null,
+    val avatarUrl: String? = null,
+    val subscriberCount: Long? = null,
+    val description: String? = null
+) {
+    internal fun toEntity() = SubscriptionEntity(
+        serviceId = serviceId,
+        url = url,
+        name = name,
+        avatarUrl = avatarUrl,
+        subscriberCount = subscriberCount,
+        description = description
+    )
+
+    companion object {
+        internal fun from(entity: SubscriptionEntity): SyncedSubscription {
+            return SyncedSubscription(
+                serviceId = entity.serviceId,
+                url = requireNotNull(entity.url).trim(),
+                name = entity.name?.take(MAX_SUBSCRIPTION_NAME_LENGTH),
+                avatarUrl = entity.avatarUrl?.take(MAX_SUBSCRIPTION_AVATAR_URL_LENGTH),
+                subscriberCount = entity.subscriberCount,
+                description = entity.description?.take(MAX_SUBSCRIPTION_DESCRIPTION_LENGTH)
+            )
+        }
+    }
+}
+
+@Serializable
+internal data class SubscriptionChange(
+    val originPeerId: String,
+    val originRevision: Long,
+    val lamportVersion: Long,
+    val recordId: String,
+    val serviceId: Int,
+    val url: String,
+    val type: SubscriptionChangeType,
+    val subscription: SyncedSubscription? = null
+) {
+    internal val versionStamp: SubscriptionVersionStamp
+        get() = SubscriptionVersionStamp(
+            lamportVersion,
+            originPeerId,
+            originRevision
+        )
+}
+
+@Serializable
+internal data class SubscriptionSyncRequest(
+    val version: Int = SUBSCRIPTION_SYNC_VERSION,
+    val knownRevisions: Map<String, Long>,
+    val changes: List<SubscriptionChange>,
+    val hasMore: Boolean
+)
+
+@Serializable
+internal data class SubscriptionSyncResponse(
+    val accepted: Boolean,
+    val error: String? = null,
+    val knownRevisions: Map<String, Long> = emptyMap(),
+    val changes: List<SubscriptionChange> = emptyList(),
+    val hasMore: Boolean = false
+)
+
+data class SubscriptionSyncResult(
+    val peer: TrustedPeer,
+    val sentChanges: Int,
+    val receivedChanges: Int,
+    val addedSubscriptions: Int,
+    val removedSubscriptions: Int,
+    val rounds: Int
+)
+
+data class DeviceSyncAttempt(
+    val peer: TrustedPeer,
+    val result: SubscriptionSyncResult? = null,
+    val error: String? = null
+)
+
+data class DeviceSyncSummary(
+    val attempts: List<DeviceSyncAttempt>
+) {
+    val succeeded: Int
+        get() = attempts.count { it.result != null }
+
+    val failed: Int
+        get() = attempts.size - succeeded
+
+    val sentChanges: Int
+        get() = attempts.sumOf { it.result?.sentChanges ?: 0 }
+
+    val receivedChanges: Int
+        get() = attempts.sumOf { it.result?.receivedChanges ?: 0 }
+}
+
+internal data class SubscriptionVersionStamp(
+    val lamportVersion: Long,
+    val originPeerId: String,
+    val originRevision: Long
+) : Comparable<SubscriptionVersionStamp> {
+    override fun compareTo(other: SubscriptionVersionStamp): Int {
+        return compareValuesBy(
+            this,
+            other,
+            SubscriptionVersionStamp::lamportVersion,
+            SubscriptionVersionStamp::originPeerId,
+            SubscriptionVersionStamp::originRevision
+        )
+    }
+}
+
+internal data class SubscriptionChangeBatch(
+    val changes: List<SubscriptionChange>,
+    val hasMore: Boolean
+)
+
+internal data class SubscriptionApplyResult(
+    val acceptedChanges: Int,
+    val addedSubscriptions: Int,
+    val removedSubscriptions: Int
+)
+
+internal object SubscriptionSyncValidation {
+    fun validateRequest(request: SubscriptionSyncRequest) {
+        if (request.version != SUBSCRIPTION_SYNC_VERSION) {
+            throw SubscriptionSyncException(
+                "Unsupported subscription synchronization version: ${request.version}"
+            )
+        }
+        validateKnownRevisions(request.knownRevisions)
+        validateChanges(request.changes)
+    }
+
+    fun validateResponse(response: SubscriptionSyncResponse) {
+        if (!response.accepted) {
+            if (response.error.isNullOrBlank()) {
+                throw SubscriptionSyncException("The remote device rejected synchronization")
+            }
+            if (response.error.length > MAX_SYNC_ERROR_LENGTH) {
+                throw SubscriptionSyncException("The synchronization error is too large")
+            }
+            return
+        }
+        if (response.error != null) {
+            throw SubscriptionSyncException("A successful synchronization response has an error")
+        }
+        validateKnownRevisions(response.knownRevisions)
+        validateChanges(response.changes)
+    }
+
+    fun validateKnownRevisions(knownRevisions: Map<String, Long>) {
+        if (knownRevisions.size > MAX_SYNC_ORIGINS) {
+            throw SubscriptionSyncException("The synchronization clock has too many origins")
+        }
+        knownRevisions.forEach { (peerId, revision) ->
+            validatePeerId(peerId)
+            if (revision !in 0..MAX_SYNC_REVISION) {
+                throw SubscriptionSyncException(
+                    "A synchronization revision is outside the supported range"
+                )
+            }
+        }
+    }
+
+    fun validateChanges(changes: List<SubscriptionChange>) {
+        if (changes.size > MAX_SUBSCRIPTION_CHANGES_PER_BATCH) {
+            throw SubscriptionSyncException("Too many subscription changes were sent")
+        }
+        val revisions = hashSetOf<Pair<String, Long>>()
+        changes.forEach { change ->
+            validatePeerId(change.originPeerId)
+            if (
+                change.originRevision !in 1..MAX_SYNC_REVISION ||
+                change.lamportVersion !in 1..MAX_SYNC_REVISION
+            ) {
+                throw SubscriptionSyncException("A subscription change has an invalid version")
+            }
+            if (!revisions.add(change.originPeerId to change.originRevision)) {
+                throw SubscriptionSyncException("A subscription change was sent more than once")
+            }
+            if (
+                change.url.isBlank() ||
+                change.url != change.url.trim() ||
+                change.url.length > MAX_SUBSCRIPTION_URL_LENGTH ||
+                change.serviceId < 0
+            ) {
+                throw SubscriptionSyncException("A subscription change has an invalid identity")
+            }
+            if (
+                change.recordId != SubscriptionRecordId.from(
+                    change.serviceId,
+                    change.url
+                )
+            ) {
+                throw SubscriptionSyncException("A subscription record identity is invalid")
+            }
+            when (change.type) {
+                SubscriptionChangeType.UPSERT -> {
+                    val subscription = change.subscription
+                        ?: throw SubscriptionSyncException(
+                            "A subscription addition has no subscription data"
+                        )
+                    validateSubscription(subscription)
+                    if (
+                        subscription.serviceId != change.serviceId ||
+                        subscription.url != change.url
+                    ) {
+                        throw SubscriptionSyncException(
+                            "Subscription data does not match its record identity"
+                        )
+                    }
+                }
+
+                SubscriptionChangeType.DELETE -> {
+                    if (change.subscription != null) {
+                        throw SubscriptionSyncException(
+                            "A subscription deletion contains unexpected data"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun validateSubscription(subscription: SyncedSubscription) {
+        if (
+            (subscription.name?.length ?: 0) > MAX_SUBSCRIPTION_NAME_LENGTH ||
+            (subscription.avatarUrl?.length ?: 0) >
+            MAX_SUBSCRIPTION_AVATAR_URL_LENGTH ||
+            (subscription.description?.length ?: 0) >
+            MAX_SUBSCRIPTION_DESCRIPTION_LENGTH
+        ) {
+            throw SubscriptionSyncException("Subscription metadata is too large")
+        }
+    }
+
+    private fun validatePeerId(peerId: String) {
+        try {
+            PeerId.fromBase58(peerId)
+        } catch (error: Exception) {
+            throw SubscriptionSyncException("A synchronization PeerID is invalid", error)
+        }
+    }
+
+    private const val MAX_SYNC_ERROR_LENGTH = 512
+}
+
+internal object SubscriptionRecordId {
+    fun from(serviceId: Int, url: String): String {
+        val canonicalUrl = url.trim()
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest("$serviceId\u0000$canonicalUrl".toByteArray(Charsets.UTF_8))
+        return buildString(digest.size * 2) {
+            digest.forEach { byte ->
+                val value = byte.toInt() and 0xff
+                append(HEX_DIGITS[value ushr 4])
+                append(HEX_DIGITS[value and 0x0f])
+            }
+        }
+    }
+
+    private const val HEX_DIGITS = "0123456789abcdef"
+}
+
+class SubscriptionSyncException(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)

--- a/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncProtocol.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncProtocol.kt
@@ -1,0 +1,240 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// jvm-libp2p's CompletableFuture API is backported by coreLibraryDesugaring.
+@file:android.annotation.SuppressLint("NewApi")
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.PeerId
+import io.libp2p.core.Stream
+import io.libp2p.core.multistream.StrictProtocolBinding
+import io.libp2p.etc.types.toByteBuf
+import io.libp2p.protocol.ProtocolHandler
+import io.libp2p.protocol.ProtocolMessageHandler
+import io.netty.buffer.ByteBuf
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal typealias SubscriptionSyncRequestHandler =
+    (PeerId, SubscriptionSyncRequest, SubscriptionSyncProtocolController) -> Unit
+
+internal class SubscriptionSyncProtocolBinding(
+    requestHandler: SubscriptionSyncRequestHandler
+) : StrictProtocolBinding<SubscriptionSyncProtocolController>(
+    SUBSCRIPTION_SYNC_PROTOCOL_ID,
+    SubscriptionSyncProtocol(requestHandler)
+)
+
+internal class SubscriptionSyncProtocol(
+    private val requestHandler: SubscriptionSyncRequestHandler
+) : ProtocolHandler<SubscriptionSyncProtocolController>(
+    MAX_PROTOCOL_BYTES,
+    MAX_PROTOCOL_BYTES
+) {
+    override fun onStartInitiator(
+        stream: Stream
+    ): CompletableFuture<SubscriptionSyncProtocolController> {
+        return start(stream, true)
+    }
+
+    override fun onStartResponder(
+        stream: Stream
+    ): CompletableFuture<SubscriptionSyncProtocolController> {
+        return start(stream, false)
+    }
+
+    private fun start(
+        stream: Stream,
+        initiator: Boolean
+    ): CompletableFuture<SubscriptionSyncProtocolController> {
+        val ready = CompletableFuture<Void>()
+        val controller = SubscriptionSyncProtocolController(
+            stream,
+            initiator,
+            requestHandler,
+            ready
+        )
+        stream.pushHandler(controller)
+        return ready.thenApply { controller }
+    }
+
+    companion object {
+        private const val MAX_PROTOCOL_BYTES = 2 * 1024 * 1024L
+    }
+}
+
+internal class SubscriptionSyncProtocolController(
+    private val stream: Stream,
+    private val initiator: Boolean,
+    private val requestHandler: SubscriptionSyncRequestHandler,
+    private val ready: CompletableFuture<Void>
+) : ProtocolMessageHandler<ByteBuf> {
+    val response = CompletableFuture<SubscriptionSyncResponse>()
+    private var pendingBytes = ByteArray(0)
+    private var handledFrame = false
+
+    override fun onActivated(stream: Stream) {
+        ready.complete(null)
+    }
+
+    override fun onMessage(stream: Stream, msg: ByteBuf) {
+        try {
+            val received = ByteArray(msg.readableBytes())
+            msg.readBytes(received)
+            pendingBytes += received
+            while (pendingBytes.size >= FRAME_LENGTH_BYTES) {
+                val frameLength = ByteBuffer.wrap(
+                    pendingBytes,
+                    0,
+                    FRAME_LENGTH_BYTES
+                ).int
+                if (frameLength !in 1..MAX_FRAME_BYTES) {
+                    throw SubscriptionSyncException(
+                        "The subscription synchronization message has an invalid length"
+                    )
+                }
+                val totalFrameLength = FRAME_LENGTH_BYTES + frameLength
+                if (pendingBytes.size < totalFrameLength) {
+                    return
+                }
+                if (handledFrame) {
+                    throw SubscriptionSyncException(
+                        "The synchronization stream sent an unexpected extra message"
+                    )
+                }
+                val frame = pendingBytes.copyOfRange(
+                    FRAME_LENGTH_BYTES,
+                    totalFrameLength
+                )
+                pendingBytes = pendingBytes.copyOfRange(
+                    totalFrameLength,
+                    pendingBytes.size
+                )
+                handledFrame = true
+                handleFrame(stream.remotePeerId(), frame)
+            }
+        } catch (error: Exception) {
+            handleFailure(error)
+        }
+    }
+
+    fun sendRequest(request: SubscriptionSyncRequest) {
+        check(initiator) { "Only the stream initiator can send a sync request" }
+        send(SubscriptionSyncCodec.encodeRequest(request))
+    }
+
+    fun sendResponse(response: SubscriptionSyncResponse) {
+        check(!initiator) { "Only the stream responder can send a sync response" }
+        send(SubscriptionSyncCodec.encodeResponse(response))
+    }
+
+    fun close() {
+        stream.close()
+    }
+
+    override fun onClosed(stream: Stream) {
+        if (initiator && !response.isDone) {
+            response.completeExceptionally(
+                SubscriptionSyncException("The synchronization connection closed")
+            )
+        }
+    }
+
+    override fun onException(cause: Throwable?) {
+        if (initiator && !response.isDone) {
+            response.completeExceptionally(
+                cause ?: SubscriptionSyncException("The synchronization connection failed")
+            )
+        }
+    }
+
+    private fun handleFrame(remotePeerId: PeerId, frame: ByteArray) {
+        val value = frame.toString(Charsets.UTF_8)
+        if (initiator) {
+            response.complete(SubscriptionSyncCodec.decodeResponse(value))
+        } else {
+            requestHandler(
+                remotePeerId,
+                SubscriptionSyncCodec.decodeRequest(value),
+                this
+            )
+        }
+    }
+
+    private fun handleFailure(error: Exception) {
+        if (initiator) {
+            response.completeExceptionally(error)
+            return
+        }
+        runCatching {
+            sendResponse(
+                SubscriptionSyncResponse(
+                    accepted = false,
+                    error = "Malformed subscription synchronization request"
+                )
+            )
+        }
+    }
+
+    private fun send(value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        if (bytes.size > MAX_FRAME_BYTES) {
+            throw SubscriptionSyncException(
+                "The subscription synchronization message is too large"
+            )
+        }
+        val frame = ByteBuffer.allocate(FRAME_LENGTH_BYTES + bytes.size)
+            .putInt(bytes.size)
+            .put(bytes)
+            .array()
+        stream.writeAndFlush(frame.toByteBuf())
+    }
+
+    companion object {
+        private const val FRAME_LENGTH_BYTES = Int.SIZE_BYTES
+        private const val MAX_FRAME_BYTES = 1024 * 1024
+    }
+}
+
+private object SubscriptionSyncCodec {
+    private val json = Json {
+        encodeDefaults = true
+        explicitNulls = false
+        ignoreUnknownKeys = false
+    }
+
+    fun encodeRequest(request: SubscriptionSyncRequest): String {
+        return json.encodeToString(request)
+    }
+
+    fun decodeRequest(value: String): SubscriptionSyncRequest {
+        return try {
+            json.decodeFromString(value)
+        } catch (error: Exception) {
+            throw SubscriptionSyncException(
+                "The subscription synchronization request is malformed",
+                error
+            )
+        }
+    }
+
+    fun encodeResponse(response: SubscriptionSyncResponse): String {
+        return json.encodeToString(response)
+    }
+
+    fun decodeResponse(value: String): SubscriptionSyncResponse {
+        return try {
+            json.decodeFromString(value)
+        } catch (error: Exception) {
+            throw SubscriptionSyncException(
+                "The subscription synchronization response is malformed",
+                error
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncStore.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncStore.kt
@@ -1,0 +1,408 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import android.content.Context
+import java.util.concurrent.Callable
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncChangeEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncOriginStateEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncPeerStateEntity
+import org.schabi.newpipe.database.sync.SubscriptionSyncRecordEntity
+
+internal interface SubscriptionSyncStore {
+    val localPeerId: String
+
+    fun reconcileLocalSubscriptions()
+
+    fun recordLocalUpsert(subscription: SubscriptionEntity)
+
+    fun recordLocalDelete(serviceId: Int, url: String)
+
+    fun getKnownRevisions(): Map<String, Long>
+
+    fun getPendingChanges(peerId: String, limit: Int): SubscriptionChangeBatch
+
+    fun acknowledgePeer(peerId: String, knownRevisions: Map<String, Long>)
+
+    fun applyChanges(changes: List<SubscriptionChange>): SubscriptionApplyResult
+
+    fun clearPeerKnowledge()
+}
+
+internal class RoomSubscriptionSyncStore private constructor(
+    private val database: AppDatabase,
+    override val localPeerId: String
+) : SubscriptionSyncStore {
+    private val syncDao = database.subscriptionSyncDAO()
+    private val subscriptionDao = database.subscriptionDAO()
+
+    override fun reconcileLocalSubscriptions() {
+        database.runInTransaction {
+            val subscriptions = subscriptionDao.getAllDirect()
+                .filter(::isSynchronizable)
+            val liveRecords = subscriptions.associateBy { subscription ->
+                SubscriptionRecordId.from(
+                    subscription.serviceId,
+                    requireNotNull(subscription.url)
+                )
+            }
+            val syncRecords = syncDao.getAllRecords().associateBy(
+                SubscriptionSyncRecordEntity::recordId
+            )
+
+            subscriptions.forEach { subscription ->
+                val recordId = SubscriptionRecordId.from(
+                    subscription.serviceId,
+                    requireNotNull(subscription.url)
+                )
+                val record = syncRecords[recordId]
+                if (record == null || record.isDeleted) {
+                    recordLocalUpsertInTransaction(subscription)
+                }
+            }
+
+            syncRecords.values
+                .filterNot(SubscriptionSyncRecordEntity::isDeleted)
+                .filterNot { record -> liveRecords.containsKey(record.recordId) }
+                .forEach { record ->
+                    recordLocalDeleteInTransaction(record.serviceId, record.url)
+                }
+        }
+    }
+
+    override fun recordLocalUpsert(subscription: SubscriptionEntity) {
+        database.runInTransaction {
+            recordLocalUpsertInTransaction(subscription)
+        }
+    }
+
+    override fun recordLocalDelete(serviceId: Int, url: String) {
+        database.runInTransaction {
+            recordLocalDeleteInTransaction(serviceId, url)
+        }
+    }
+
+    override fun getKnownRevisions(): Map<String, Long> {
+        return syncDao.getAllOriginStates()
+            .filter { it.contiguousRevision > 0 }
+            .associate { it.originPeerId to it.contiguousRevision }
+    }
+
+    override fun getPendingChanges(
+        peerId: String,
+        limit: Int
+    ): SubscriptionChangeBatch {
+        require(limit in 1..MAX_SUBSCRIPTION_CHANGES_PER_BATCH)
+        val peerKnowledge = syncDao.getPeerStates(peerId)
+            .associate { it.originPeerId to it.acknowledgedRevision }
+        val origins = syncDao.getChangeOrigins().sorted()
+        val candidates = origins.flatMap { origin ->
+            syncDao.getChangesAfter(
+                origin,
+                peerKnowledge[origin] ?: 0,
+                limit
+            )
+        }.map { it.toModel() }
+            .sortedBy(SubscriptionChange::versionStamp)
+            .take(limit)
+
+        val pendingCount = origins.sumOf { origin ->
+            syncDao.countChangesAfter(origin, peerKnowledge[origin] ?: 0)
+        }
+        return SubscriptionChangeBatch(
+            changes = candidates,
+            hasMore = pendingCount > candidates.size.toLong()
+        )
+    }
+
+    override fun acknowledgePeer(
+        peerId: String,
+        knownRevisions: Map<String, Long>
+    ) {
+        SubscriptionSyncValidation.validateKnownRevisions(knownRevisions)
+        database.runInTransaction {
+            val localKnowledge = getKnownRevisions()
+            val existing = syncDao.getPeerStates(peerId)
+                .associate { it.originPeerId to it.acknowledgedRevision }
+            knownRevisions.forEach { (origin, claimedRevision) ->
+                val safeRevision = minOf(claimedRevision, localKnowledge[origin] ?: 0)
+                val acknowledgedRevision = maxOf(existing[origin] ?: 0, safeRevision)
+                if (acknowledgedRevision > 0) {
+                    syncDao.upsertPeerState(
+                        SubscriptionSyncPeerStateEntity(
+                            peerId = peerId,
+                            originPeerId = origin,
+                            acknowledgedRevision = acknowledgedRevision
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    override fun applyChanges(changes: List<SubscriptionChange>): SubscriptionApplyResult {
+        SubscriptionSyncValidation.validateChanges(changes)
+        return database.runInTransaction(
+            Callable {
+                val maximumAcceptedLamport = minOf(
+                    syncDao.getMaximumLamportVersion() + MAX_REMOTE_LAMPORT_ADVANCE,
+                    MAX_SYNC_REVISION
+                )
+                if (changes.any { it.lamportVersion > maximumAcceptedLamport }) {
+                    throw SubscriptionSyncException(
+                        "A subscription change advances the logical clock too far"
+                    )
+                }
+                var accepted = 0
+                var added = 0
+                var removed = 0
+
+                changes.forEach { change ->
+                    if (syncDao.insertChange(change.toEntity()) == -1L) {
+                        return@forEach
+                    }
+                    accepted += 1
+                    advanceContiguousRevision(change.originPeerId)
+
+                    val currentRecord = syncDao.getRecord(change.recordId)
+                    if (
+                        currentRecord != null &&
+                        change.versionStamp <= currentRecord.versionStamp
+                    ) {
+                        return@forEach
+                    }
+
+                    when (change.type) {
+                        SubscriptionChangeType.UPSERT -> {
+                            val inserted = subscriptionDao.insertIgnore(
+                                requireNotNull(change.subscription).toEntity()
+                            )
+                            if (inserted != -1L) {
+                                added += 1
+                            }
+                        }
+
+                        SubscriptionChangeType.DELETE -> {
+                            if (subscriptionDao.deleteSubscription(change.serviceId, change.url) > 0) {
+                                removed += 1
+                            }
+                        }
+                    }
+                    syncDao.upsertRecord(change.toRecordEntity())
+                }
+
+                SubscriptionApplyResult(
+                    acceptedChanges = accepted,
+                    addedSubscriptions = added,
+                    removedSubscriptions = removed
+                )
+            }
+        )
+    }
+
+    override fun clearPeerKnowledge() {
+        syncDao.deleteAllPeerStates()
+    }
+
+    private fun recordLocalUpsertInTransaction(subscription: SubscriptionEntity) {
+        val syncedSubscription = SyncedSubscription.from(subscription)
+        validateLocalIdentity(syncedSubscription.serviceId, syncedSubscription.url)
+        val recordId = SubscriptionRecordId.from(
+            syncedSubscription.serviceId,
+            syncedSubscription.url
+        )
+        val currentRecord = syncDao.getRecord(recordId)
+        if (currentRecord != null && !currentRecord.isDeleted) {
+            return
+        }
+        saveLocalChange(
+            recordId = recordId,
+            serviceId = syncedSubscription.serviceId,
+            url = syncedSubscription.url,
+            type = SubscriptionChangeType.UPSERT,
+            subscription = syncedSubscription,
+            currentRecord = currentRecord
+        )
+    }
+
+    private fun recordLocalDeleteInTransaction(serviceId: Int, url: String) {
+        val canonicalUrl = url.trim()
+        validateLocalIdentity(serviceId, canonicalUrl)
+        val recordId = SubscriptionRecordId.from(serviceId, canonicalUrl)
+        val currentRecord = syncDao.getRecord(recordId)
+        if (currentRecord?.isDeleted == true) {
+            return
+        }
+        saveLocalChange(
+            recordId = recordId,
+            serviceId = serviceId,
+            url = canonicalUrl,
+            type = SubscriptionChangeType.DELETE,
+            subscription = null,
+            currentRecord = currentRecord
+        )
+    }
+
+    private fun saveLocalChange(
+        recordId: String,
+        serviceId: Int,
+        url: String,
+        type: SubscriptionChangeType,
+        subscription: SyncedSubscription?,
+        currentRecord: SubscriptionSyncRecordEntity?
+    ) {
+        val originState = syncDao.getOriginState(localPeerId)
+        val originRevision = incrementVersion(
+            originState?.contiguousRevision ?: 0
+        )
+        val lamportVersion = incrementVersion(
+            maxOf(
+                syncDao.getMaximumLamportVersion(),
+                currentRecord?.lamportVersion ?: 0
+            )
+        )
+        val change = SubscriptionChange(
+            originPeerId = localPeerId,
+            originRevision = originRevision,
+            lamportVersion = lamportVersion,
+            recordId = recordId,
+            serviceId = serviceId,
+            url = url,
+            type = type,
+            subscription = subscription
+        )
+        SubscriptionSyncValidation.validateChanges(listOf(change))
+        check(syncDao.insertChange(change.toEntity()) != -1L) {
+            "The local subscription revision already exists"
+        }
+        syncDao.upsertOriginState(
+            SubscriptionSyncOriginStateEntity(localPeerId, originRevision)
+        )
+        syncDao.upsertRecord(change.toRecordEntity())
+    }
+
+    private fun incrementVersion(value: Long): Long {
+        if (value >= MAX_SYNC_REVISION) {
+            throw SubscriptionSyncException("The subscription journal version is exhausted")
+        }
+        return value + 1
+    }
+
+    private fun advanceContiguousRevision(originPeerId: String) {
+        var contiguous = syncDao.getOriginState(originPeerId)?.contiguousRevision ?: 0
+        while (
+            contiguous < MAX_SYNC_REVISION &&
+            syncDao.hasChange(originPeerId, contiguous + 1)
+        ) {
+            contiguous += 1
+        }
+        syncDao.upsertOriginState(
+            SubscriptionSyncOriginStateEntity(originPeerId, contiguous)
+        )
+    }
+
+    private fun validateLocalIdentity(serviceId: Int, url: String) {
+        if (
+            serviceId < 0 ||
+            url.isBlank() ||
+            url.length > MAX_SUBSCRIPTION_URL_LENGTH
+        ) {
+            throw SubscriptionSyncException(
+                "This subscription does not have a synchronizable service and URL"
+            )
+        }
+    }
+
+    private fun isSynchronizable(subscription: SubscriptionEntity): Boolean {
+        val url = subscription.url
+        return subscription.serviceId >= 0 &&
+            !url.isNullOrBlank() &&
+            url.length <= MAX_SUBSCRIPTION_URL_LENGTH
+    }
+
+    private fun SubscriptionSyncChangeEntity.toModel() = SubscriptionChange(
+        originPeerId = originPeerId,
+        originRevision = originRevision,
+        lamportVersion = lamportVersion,
+        recordId = recordId,
+        serviceId = serviceId,
+        url = url,
+        type = try {
+            SubscriptionChangeType.valueOf(changeType)
+        } catch (error: IllegalArgumentException) {
+            throw SubscriptionSyncException(
+                "The local subscription journal contains an invalid change",
+                error
+            )
+        },
+        subscription = if (changeType == SubscriptionChangeType.UPSERT.name) {
+            SyncedSubscription(
+                serviceId = serviceId,
+                url = url,
+                name = name,
+                avatarUrl = avatarUrl,
+                subscriberCount = subscriberCount,
+                description = description
+            )
+        } else {
+            null
+        }
+    )
+
+    private fun SubscriptionChange.toEntity() = SubscriptionSyncChangeEntity(
+        originPeerId = originPeerId,
+        originRevision = originRevision,
+        lamportVersion = lamportVersion,
+        recordId = recordId,
+        changeType = type.name,
+        serviceId = serviceId,
+        url = url,
+        name = subscription?.name,
+        avatarUrl = subscription?.avatarUrl,
+        subscriberCount = subscription?.subscriberCount,
+        description = subscription?.description
+    )
+
+    private fun SubscriptionChange.toRecordEntity() = SubscriptionSyncRecordEntity(
+        recordId = recordId,
+        serviceId = serviceId,
+        url = url,
+        lamportVersion = lamportVersion,
+        originPeerId = originPeerId,
+        originRevision = originRevision,
+        isDeleted = type == SubscriptionChangeType.DELETE
+    )
+
+    private val SubscriptionSyncRecordEntity.versionStamp: SubscriptionVersionStamp
+        get() = SubscriptionVersionStamp(
+            lamportVersion,
+            originPeerId,
+            originRevision
+        )
+
+    companion object {
+        private const val MAX_REMOTE_LAMPORT_ADVANCE = 1_000_000L
+
+        @Volatile
+        private var instance: RoomSubscriptionSyncStore? = null
+
+        fun get(context: Context): RoomSubscriptionSyncStore {
+            return instance ?: synchronized(this) {
+                instance ?: run {
+                    val applicationContext = context.applicationContext
+                    val stateRepository = AndroidSyncStateRepository(applicationContext)
+                    RoomSubscriptionSyncStore(
+                        database = NewPipeDatabase.getInstance(applicationContext),
+                        localPeerId = stateRepository.loadOrCreateIdentity().peerId.toBase58()
+                    )
+                }.also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/sync/SyncModels.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SyncModels.kt
@@ -27,7 +27,9 @@ data class TrustedPeer(
     val publicKey: String,
     val deviceName: String,
     val addresses: List<String>,
-    val pairedAtEpochMillis: Long
+    val pairedAtEpochMillis: Long,
+    val lastSyncAtEpochMillis: Long? = null,
+    val lastSyncError: String? = null
 )
 
 @Serializable
@@ -97,6 +99,12 @@ interface SyncStateRepository {
     fun getTrustedPeers(): List<TrustedPeer>
 
     fun saveTrustedPeer(peer: TrustedPeer)
+
+    fun updateTrustedPeerSyncStatus(
+        peerId: String,
+        syncedAtEpochMillis: Long?,
+        error: String?
+    )
 
     fun clearTrustedPeers()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,13 +214,25 @@
     <string name="settings_category_backup_restore_title">Backup and restore</string>
     <string name="settings_category_device_sync_title">Device synchronization</string>
     <string name="device_sync_status_key" translatable="false">device_sync_status</string>
+    <string name="device_sync_sync_now_key" translatable="false">device_sync_sync_now</string>
     <string name="device_sync_identity_key" translatable="false">device_sync_identity</string>
     <string name="device_sync_show_code_key" translatable="false">device_sync_show_pairing_code</string>
     <string name="device_sync_scan_code_key" translatable="false">device_sync_scan_pairing_code</string>
     <string name="device_sync_trusted_devices_key" translatable="false">device_sync_trusted_devices</string>
     <string name="device_sync_clear_devices_key" translatable="false">device_sync_clear_trusted_devices</string>
     <string name="device_sync_status_title">Current status</string>
-    <string name="device_sync_status_summary">Experimental secure pairing is available. Record synchronization is not enabled yet.</string>
+    <string name="device_sync_status_no_devices">Pair another device to synchronize subscriptions</string>
+    <string name="device_sync_status_ready">Ready to synchronize. Trusted devices: %1$d</string>
+    <string name="device_sync_status_last_sync">Last successful synchronization: %1$s</string>
+    <string name="device_sync_status_errors">Trusted devices needing attention: %1$d</string>
+    <string name="device_sync_sync_now_title">Sync subscriptions now</string>
+    <string name="device_sync_sync_now_summary">Exchange subscription additions and deletions with trusted devices</string>
+    <string name="device_sync_sync_in_progress">Synchronizing subscriptions…</string>
+    <string name="device_sync_sync_complete_title">Subscription synchronization complete</string>
+    <string name="device_sync_sync_complete_summary">Successful devices: %1$d. Failed devices: %2$d. Changes sent: %3$d; received: %4$d.</string>
+    <string name="device_sync_sync_peer_succeeded">%1$s — sent %2$d, received %3$d</string>
+    <string name="device_sync_sync_peer_failed">%1$s — failed: %2$s</string>
+    <string name="device_sync_sync_failed">Subscription synchronization failed</string>
     <string name="device_sync_identity_title">This device PeerID</string>
     <string name="device_sync_show_code_title">Show pairing code</string>
     <string name="device_sync_show_code_summary">Let another WizeStream device scan this one-time QR code</string>
@@ -236,9 +248,13 @@
     <string name="device_sync_trusted_devices_title">Trusted devices</string>
     <string name="device_sync_no_trusted_devices">No trusted devices</string>
     <string name="device_sync_trusted_device_summary">%1$s — %2$s</string>
+    <string name="device_sync_trusted_device_never_synced">%1$s\nNot synchronized yet</string>
+    <string name="device_sync_trusted_device_last_sync">%1$s\nLast sync: %2$s</string>
+    <string name="device_sync_trusted_device_error">%1$s\nLast attempt failed: %2$s</string>
     <string name="device_sync_clear_devices_title">Clear trusted devices</string>
     <string name="device_sync_clear_devices_summary">Require every device to pair again</string>
     <string name="device_sync_clear_devices_confirmation">Remove all trusted devices? This device’s PeerID will not change.</string>
+    <string name="device_sync_clear_devices_failed">Could not clear trusted devices</string>
     <string name="background_player_playing_toast">Playing in background</string>
     <string name="popup_playing_toast">Playing in popup mode</string>
     <string name="content">Content</string>

--- a/app/src/main/res/xml/device_sync_settings.xml
+++ b/app/src/main/res/xml/device_sync_settings.xml
@@ -5,10 +5,16 @@
 
     <Preference
         android:key="@string/device_sync_status_key"
-        android:summary="@string/device_sync_status_summary"
         android:title="@string/device_sync_status_title"
         app:iconSpaceReserved="false"
         app:selectable="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/device_sync_sync_now_key"
+        android:summary="@string/device_sync_sync_now_summary"
+        android:title="@string/device_sync_sync_now_title"
+        app:iconSpaceReserved="false"
         app:singleLineTitle="false" />
 
     <Preference

--- a/app/src/test/java/org/schabi/newpipe/sync/Libp2pSyncNodeTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/Libp2pSyncNodeTest.kt
@@ -20,13 +20,15 @@ class Libp2pSyncNodeTest {
             tabletState,
             PairingSecurity(),
             "Test tablet",
-            ::loopbackAddresses
+            ::loopbackAddresses,
+            listenAddress = TEST_LISTEN_ADDRESS
         )
         val phone = Libp2pSyncNode(
             phoneState,
             PairingSecurity(),
             "Test phone",
-            ::loopbackAddresses
+            ::loopbackAddresses,
+            listenAddress = TEST_LISTEN_ADDRESS
         )
 
         try {
@@ -50,10 +52,70 @@ class Libp2pSyncNodeTest {
         }
     }
 
+    @Test
+    fun `paired nodes exchange subscriptions over a Noise authenticated stream`() {
+        val tabletState = InMemorySyncStateRepository()
+        val phoneState = InMemorySyncStateRepository()
+        val tabletSubscriptions = TestSubscriptionSyncStore(
+            tabletState.loadOrCreateIdentity().peerId.toBase58()
+        )
+        val phoneSubscriptions = TestSubscriptionSyncStore(
+            phoneState.loadOrCreateIdentity().peerId.toBase58()
+        )
+        val tablet = Libp2pSyncNode(
+            tabletState,
+            PairingSecurity(),
+            "Test tablet",
+            ::loopbackAddresses,
+            SubscriptionSyncEngine(tabletSubscriptions),
+            TEST_LISTEN_ADDRESS
+        )
+        val phone = Libp2pSyncNode(
+            phoneState,
+            PairingSecurity(),
+            "Test phone",
+            ::loopbackAddresses,
+            SubscriptionSyncEngine(phoneSubscriptions),
+            TEST_LISTEN_ADDRESS
+        )
+        tabletSubscriptions.add(0, TABLET_SUBSCRIPTION_URL)
+        phoneSubscriptions.add(0, PHONE_SUBSCRIPTION_URL)
+
+        try {
+            tablet.start()
+            phone.start()
+            val trustedTablet = phone.pair(tablet.createPairingCode())
+
+            val result = phone.syncSubscriptions(trustedTablet)
+
+            assertEquals(1, result.sentChanges)
+            assertEquals(1, result.receivedChanges)
+            assertEquals(
+                setOf(TABLET_SUBSCRIPTION_URL, PHONE_SUBSCRIPTION_URL),
+                tabletSubscriptions.subscriptionUrls
+            )
+            assertEquals(
+                tabletSubscriptions.subscriptionUrls,
+                phoneSubscriptions.subscriptionUrls
+            )
+        } finally {
+            phone.stop()
+            tablet.stop()
+        }
+    }
+
     private fun loopbackAddresses(host: Host): List<String> {
         return host.listenAddresses().map { address ->
             address.toString().replace("/ip4/0.0.0.0/", "/ip4/127.0.0.1/")
         }
+    }
+
+    companion object {
+        private const val TEST_LISTEN_ADDRESS = "/ip4/127.0.0.1/tcp/0"
+        private const val TABLET_SUBSCRIPTION_URL =
+            "https://example.com/channel/tablet"
+        private const val PHONE_SUBSCRIPTION_URL =
+            "https://example.com/channel/phone"
     }
 
     private class InMemorySyncStateRepository : SyncStateRepository {
@@ -68,6 +130,21 @@ class Libp2pSyncNodeTest {
         @Synchronized
         override fun saveTrustedPeer(peer: TrustedPeer) {
             peers[peer.peerId] = peer
+        }
+
+        @Synchronized
+        override fun updateTrustedPeerSyncStatus(
+            peerId: String,
+            syncedAtEpochMillis: Long?,
+            error: String?
+        ) {
+            peers[peerId]?.let { peer ->
+                peers[peerId] = peer.copy(
+                    lastSyncAtEpochMillis = syncedAtEpochMillis
+                        ?: peer.lastSyncAtEpochMillis,
+                    lastSyncError = error
+                )
+            }
         }
 
         @Synchronized

--- a/app/src/test/java/org/schabi/newpipe/sync/SubscriptionSyncEngineTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/SubscriptionSyncEngineTest.kt
@@ -1,0 +1,203 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import io.libp2p.core.crypto.KeyType
+import io.libp2p.core.crypto.generateKeyPair
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubscriptionSyncEngineTest {
+    @Test
+    fun `subscription additions synchronize in both directions and are idempotent`() {
+        val phoneStore = newStore()
+        val tabletStore = newStore()
+        val phone = SubscriptionSyncEngine(phoneStore)
+        val tablet = SubscriptionSyncEngine(tabletStore)
+        phoneStore.add(SERVICE_ID, PHONE_URL)
+        tabletStore.add(SERVICE_ID, TABLET_URL)
+
+        val rounds = synchronize(phone, phoneStore, tablet, tabletStore)
+
+        assertEquals(setOf(PHONE_URL, TABLET_URL), phoneStore.subscriptionUrls)
+        assertEquals(setOf(PHONE_URL, TABLET_URL), tabletStore.subscriptionUrls)
+        assertTrue(rounds >= 1)
+
+        val repeatRounds = synchronize(phone, phoneStore, tablet, tabletStore)
+        assertEquals(1, repeatRounds)
+        val request = phone.createRequest(tabletStore.localPeerId)
+        assertTrue(request.changes.isEmpty())
+        assertFalse(request.hasMore)
+    }
+
+    @Test
+    fun `subscription deletion propagates as a tombstone`() {
+        val phoneStore = newStore()
+        val tabletStore = newStore()
+        val phone = SubscriptionSyncEngine(phoneStore)
+        val tablet = SubscriptionSyncEngine(tabletStore)
+        phoneStore.add(SERVICE_ID, PHONE_URL)
+        synchronize(phone, phoneStore, tablet, tabletStore)
+
+        tabletStore.delete(SERVICE_ID, PHONE_URL)
+        synchronize(tablet, tabletStore, phone, phoneStore)
+
+        assertTrue(phoneStore.subscriptionUrls.isEmpty())
+        assertTrue(tabletStore.subscriptionUrls.isEmpty())
+        synchronize(tablet, tabletStore, phone, phoneStore)
+        assertTrue(phoneStore.subscriptionUrls.isEmpty())
+    }
+
+    @Test
+    fun `more than one batch is exchanged in a single manual sync`() {
+        val phoneStore = newStore()
+        val tabletStore = newStore()
+        val phone = SubscriptionSyncEngine(phoneStore)
+        val tablet = SubscriptionSyncEngine(tabletStore)
+        repeat(MAX_SUBSCRIPTION_CHANGES_PER_BATCH + 9) { index ->
+            phoneStore.add(SERVICE_ID, "https://example.com/channel/$index")
+        }
+
+        val rounds = synchronize(phone, phoneStore, tablet, tabletStore)
+
+        assertTrue(rounds >= 2)
+        assertEquals(phoneStore.subscriptionUrls, tabletStore.subscriptionUrls)
+    }
+
+    @Test
+    fun `equal Lamport conflicts resolve identically regardless of arrival order`() {
+        val firstStore = newStore()
+        val secondStore = newStore()
+        val firstOrigin = newPeerId()
+        val secondOrigin = newPeerId()
+        val recordId = SubscriptionRecordId.from(SERVICE_ID, PHONE_URL)
+        val addition = SubscriptionChange(
+            originPeerId = firstOrigin,
+            originRevision = 1,
+            lamportVersion = 7,
+            recordId = recordId,
+            serviceId = SERVICE_ID,
+            url = PHONE_URL,
+            type = SubscriptionChangeType.UPSERT,
+            subscription = SyncedSubscription(SERVICE_ID, PHONE_URL, "Channel")
+        )
+        val deletion = SubscriptionChange(
+            originPeerId = secondOrigin,
+            originRevision = 1,
+            lamportVersion = 7,
+            recordId = recordId,
+            serviceId = SERVICE_ID,
+            url = PHONE_URL,
+            type = SubscriptionChangeType.DELETE
+        )
+
+        firstStore.applyChanges(listOf(addition, deletion))
+        secondStore.applyChanges(listOf(deletion, addition))
+
+        assertEquals(firstStore.subscriptionUrls, secondStore.subscriptionUrls)
+        val additionWins = addition.versionStamp > deletion.versionStamp
+        assertEquals(additionWins, PHONE_URL in firstStore.subscriptionUrls)
+    }
+
+    @Test
+    fun `malformed record identity is rejected without applying changes`() {
+        val phoneStore = newStore()
+        val tabletStore = newStore()
+        val tablet = SubscriptionSyncEngine(tabletStore)
+        val malformed = SubscriptionChange(
+            originPeerId = phoneStore.localPeerId,
+            originRevision = 1,
+            lamportVersion = 1,
+            recordId = "not-the-record-hash",
+            serviceId = SERVICE_ID,
+            url = PHONE_URL,
+            type = SubscriptionChangeType.UPSERT,
+            subscription = SyncedSubscription(SERVICE_ID, PHONE_URL, "Channel")
+        )
+
+        val response = tablet.handleRequest(
+            phoneStore.localPeerId,
+            SubscriptionSyncRequest(
+                knownRevisions = emptyMap(),
+                changes = listOf(malformed),
+                hasMore = false
+            )
+        )
+
+        assertFalse(response.accepted)
+        assertTrue(tabletStore.subscriptionUrls.isEmpty())
+    }
+
+    @Test
+    fun `noncanonical subscription URL is rejected without applying changes`() {
+        val phoneStore = newStore()
+        val tabletStore = newStore()
+        val tablet = SubscriptionSyncEngine(tabletStore)
+        val paddedUrl = " $PHONE_URL "
+        val noncanonical = SubscriptionChange(
+            originPeerId = phoneStore.localPeerId,
+            originRevision = 1,
+            lamportVersion = 1,
+            recordId = SubscriptionRecordId.from(SERVICE_ID, paddedUrl),
+            serviceId = SERVICE_ID,
+            url = paddedUrl,
+            type = SubscriptionChangeType.UPSERT,
+            subscription = SyncedSubscription(
+                SERVICE_ID,
+                paddedUrl,
+                "Channel"
+            )
+        )
+
+        val response = tablet.handleRequest(
+            phoneStore.localPeerId,
+            SubscriptionSyncRequest(
+                knownRevisions = emptyMap(),
+                changes = listOf(noncanonical),
+                hasMore = false
+            )
+        )
+
+        assertFalse(response.accepted)
+        assertTrue(tabletStore.subscriptionUrls.isEmpty())
+    }
+
+    private fun synchronize(
+        initiator: SubscriptionSyncEngine,
+        initiatorStore: TestSubscriptionSyncStore,
+        responder: SubscriptionSyncEngine,
+        responderStore: TestSubscriptionSyncStore
+    ): Int {
+        var rounds = 0
+        while (true) {
+            rounds += 1
+            val request = initiator.createRequest(responderStore.localPeerId)
+            val response = responder.handleRequest(
+                initiatorStore.localPeerId,
+                request
+            )
+            initiator.handleResponse(responderStore.localPeerId, response)
+            if (!request.hasMore && !response.hasMore) {
+                return rounds
+            }
+        }
+    }
+
+    private fun newStore() = TestSubscriptionSyncStore(newPeerId())
+
+    private fun newPeerId(): String {
+        val privateKey = generateKeyPair(KeyType.ED25519).first
+        return DeviceIdentity(privateKey).peerId.toBase58()
+    }
+
+    companion object {
+        private const val SERVICE_ID = 0
+        private const val PHONE_URL = "https://example.com/channel/phone"
+        private const val TABLET_URL = "https://example.com/channel/tablet"
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/sync/TestSubscriptionSyncStore.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/TestSubscriptionSyncStore.kt
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
+
+internal class TestSubscriptionSyncStore(
+    override val localPeerId: String
+) : SubscriptionSyncStore {
+    private val journal = linkedMapOf<Pair<String, Long>, SubscriptionChange>()
+    private val knownRevisions = linkedMapOf<String, Long>()
+    private val peerKnowledge = linkedMapOf<String, MutableMap<String, Long>>()
+    private val records = linkedMapOf<String, SubscriptionChange>()
+    private val subscriptions = linkedMapOf<String, SyncedSubscription>()
+    private var localRevision = 0L
+    private var lamportVersion = 0L
+
+    val subscriptionUrls: Set<String>
+        get() = subscriptions.values.map(SyncedSubscription::url).toSet()
+
+    override fun reconcileLocalSubscriptions() = Unit
+
+    override fun recordLocalUpsert(subscription: SubscriptionEntity) {
+        val synced = SyncedSubscription.from(subscription)
+        subscriptions[recordId(synced.serviceId, synced.url)] = synced
+        recordLocalChange(
+            synced.serviceId,
+            synced.url,
+            SubscriptionChangeType.UPSERT,
+            synced
+        )
+    }
+
+    override fun recordLocalDelete(serviceId: Int, url: String) {
+        subscriptions.remove(recordId(serviceId, url))
+        recordLocalChange(
+            serviceId,
+            url,
+            SubscriptionChangeType.DELETE,
+            null
+        )
+    }
+
+    fun add(serviceId: Int, url: String, name: String = url) {
+        recordLocalUpsert(
+            SubscriptionEntity(
+                serviceId = serviceId,
+                url = url,
+                name = name
+            )
+        )
+    }
+
+    fun delete(serviceId: Int, url: String) {
+        recordLocalDelete(serviceId, url)
+    }
+
+    override fun getKnownRevisions(): Map<String, Long> {
+        return knownRevisions.toMap()
+    }
+
+    override fun getPendingChanges(
+        peerId: String,
+        limit: Int
+    ): SubscriptionChangeBatch {
+        val acknowledged = peerKnowledge[peerId].orEmpty()
+        val pending = journal.values
+            .filter { change ->
+                change.originRevision > (acknowledged[change.originPeerId] ?: 0)
+            }
+            .sortedBy(SubscriptionChange::versionStamp)
+        return SubscriptionChangeBatch(
+            changes = pending.take(limit),
+            hasMore = pending.size > limit
+        )
+    }
+
+    override fun acknowledgePeer(
+        peerId: String,
+        knownRevisions: Map<String, Long>
+    ) {
+        val knowledge = peerKnowledge.getOrPut(peerId) { linkedMapOf() }
+        knownRevisions.forEach { (origin, revision) ->
+            val safeRevision = minOf(revision, this.knownRevisions[origin] ?: 0)
+            knowledge[origin] = maxOf(knowledge[origin] ?: 0, safeRevision)
+        }
+    }
+
+    override fun applyChanges(changes: List<SubscriptionChange>): SubscriptionApplyResult {
+        SubscriptionSyncValidation.validateChanges(changes)
+        var accepted = 0
+        var added = 0
+        var removed = 0
+        changes.forEach { change ->
+            val changeId = change.originPeerId to change.originRevision
+            if (journal.containsKey(changeId)) {
+                return@forEach
+            }
+            journal[changeId] = change
+            accepted += 1
+            lamportVersion = maxOf(lamportVersion, change.lamportVersion)
+            advanceKnownRevision(change.originPeerId)
+            val existing = records[change.recordId]
+            if (existing != null && change.versionStamp <= existing.versionStamp) {
+                return@forEach
+            }
+            when (change.type) {
+                SubscriptionChangeType.UPSERT -> {
+                    if (subscriptions.put(change.recordId, requireNotNull(change.subscription)) == null) {
+                        added += 1
+                    }
+                }
+
+                SubscriptionChangeType.DELETE -> {
+                    if (subscriptions.remove(change.recordId) != null) {
+                        removed += 1
+                    }
+                }
+            }
+            records[change.recordId] = change
+        }
+        return SubscriptionApplyResult(accepted, added, removed)
+    }
+
+    override fun clearPeerKnowledge() {
+        peerKnowledge.clear()
+    }
+
+    private fun recordLocalChange(
+        serviceId: Int,
+        url: String,
+        type: SubscriptionChangeType,
+        subscription: SyncedSubscription?
+    ) {
+        val recordId = recordId(serviceId, url)
+        val existing = records[recordId]
+        if (
+            existing != null &&
+            existing.type == type &&
+            type == SubscriptionChangeType.UPSERT
+        ) {
+            return
+        }
+        localRevision += 1
+        lamportVersion = maxOf(
+            lamportVersion,
+            existing?.lamportVersion ?: 0
+        ) + 1
+        val change = SubscriptionChange(
+            originPeerId = localPeerId,
+            originRevision = localRevision,
+            lamportVersion = lamportVersion,
+            recordId = recordId,
+            serviceId = serviceId,
+            url = url,
+            type = type,
+            subscription = subscription
+        )
+        journal[localPeerId to localRevision] = change
+        knownRevisions[localPeerId] = localRevision
+        records[recordId] = change
+    }
+
+    private fun advanceKnownRevision(originPeerId: String) {
+        var revision = knownRevisions[originPeerId] ?: 0
+        while (journal.containsKey(originPeerId to revision + 1)) {
+            revision += 1
+        }
+        knownRevisions[originPeerId] = revision
+    }
+
+    private fun recordId(serviceId: Int, url: String): String {
+        return SubscriptionRecordId.from(serviceId, url)
+    }
+}


### PR DESCRIPTION
Relates to #47.

- add incremental bidirectional subscription synchronization between trusted devices
- persist a versioned Room change journal with tombstones, Lamport conflict resolution, and per-peer acknowledgements
- exchange bounded, idempotent change batches over the existing Noise-authenticated connection
- add manual sync controls, last-sync status, and per-device error reporting
- keep the QR scanning camera in portrait through a dedicated internal `sensorPortrait` capture activity
