### PR TITLE
Add YouTube Shorts destination

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/KioskTranslator.kt
@@ -28,6 +28,7 @@ object KioskTranslator {
             "trending_music" -> context.getString(R.string.trending_music)
             "trending_movies_and_shows" -> context.getString(R.string.trending_movies)
             "trending_podcasts_episodes" -> context.getString(R.string.trending_podcasts)
+            "youtube_shorts" -> context.getString(R.string.youtube_shorts)
             else -> kioskId
         }
     }
@@ -46,6 +47,7 @@ object KioskTranslator {
             "trending_music" -> R.drawable.ic_music_note
             "trending_movies_and_shows" -> R.drawable.ic_movie
             "trending_podcasts_episodes" -> R.drawable.ic_podcasts
+            "youtube_shorts" -> R.drawable.ic_smart_display
             else -> 0
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1109,6 +1109,7 @@
     <string name="trending_podcasts">Trending podcasts</string>
     <string name="trending_movies">Trending movies and shows</string>
     <string name="trending_music">Trending music</string>
+    <string name="youtube_shorts">YouTube Shorts</string>
     <string name="entry_deleted">Entry deleted</string>
     <string name="player_http_403">HTTP error 403 received from server while playing, likely caused by streaming URL expiration or an IP ban</string>
     <string name="player_http_invalid_status">HTTP error %1$s received from server while playing</string>


### PR DESCRIPTION
Closes #69

- updates the WizeStreamExtractor gitlink to the Shorts kiosk implementation in wizdom13/WizeStreamExtractor#4
- labels the destination as **YouTube Shorts**
- assigns the existing smart-display icon in the drawer and home-tab chooser
- pins the locale fallback that uses public `#shorts` search results when YouTube omits the Trending Shorts shelf

The new destination appears in YouTube's drawer kiosks and can be added as a home tab through **Settings → Content → Content of main page**. It is separate from the existing Shorts filter, which continues to filter already-loaded lists.


