### PR TITLE
Add built-in audio equalizer

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
@@ -33,7 +33,7 @@ class ChannelHeaderLayoutTest {
         context: Context,
         widthPixels: Int,
         heightPixels: Int,
-        showBanner: Boolean,
+        showBanner: Boolean
     ) {
         val root = LayoutInflater.from(context)
             .inflate(R.layout.fragment_channel, FrameLayout(context), false)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2085,6 +2085,14 @@ public final class Player implements PlaybackListener, Listener {
     //////////////////////////////////////////////////////////////////////////*/
     //region ExoPlayer listeners (that didn't fit in other categories)
 
+    @Override
+    public void onAudioSessionIdChanged(final int audioSessionId) {
+        equalizerController.attachAudioSession(audioSessionId);
+        applyPlayerVolume();
+        UIs.call(playerUi -> playerUi.onEqualizerStateChanged(
+                equalizerController.getState(), equalizerController.isOperational()));
+    }
+
     /**
      * <p>Listens for event or state changes on ExoPlayer. When any event happens, we check for
      * changes in the currently-playing metadata and update the encapsulating
@@ -2098,14 +2106,6 @@ public final class Player implements PlaybackListener, Listener {
      * @param events The {@link com.google.android.exoplayer2.Player.Events} that has triggered
      *               the player state changes.
      **/
-    @Override
-    public void onAudioSessionIdChanged(final int audioSessionId) {
-        equalizerController.attachAudioSession(audioSessionId);
-        applyPlayerVolume();
-        UIs.call(playerUi -> playerUi.onEqualizerStateChanged(
-                equalizerController.getState(), equalizerController.isOperational()));
-    }
-
     @Override
     public void onEvents(@NonNull final com.google.android.exoplayer2.Player player,
                          @NonNull final com.google.android.exoplayer2.Player.Events events) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -105,6 +105,8 @@ import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.learning.LearningSessionTracker;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.player.equalizer.EqualizerController;
+import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.event.PlayerEventListener;
 import org.schabi.newpipe.player.event.PlayerServiceEventListener;
 import org.schabi.newpipe.player.helper.AudioReactor;
@@ -243,6 +245,8 @@ public final class Player implements PlaybackListener, Listener {
 
     private ExoPlayer simpleExoPlayer;
     private AudioReactor audioReactor;
+    @NonNull
+    private final EqualizerController equalizerController;
 
     @NonNull
     private final DefaultTrackSelector trackSelector;
@@ -340,6 +344,7 @@ public final class Player implements PlaybackListener, Listener {
         this.service = service;
         context = service;
         prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        equalizerController = new EqualizerController(context);
         recordManager = new HistoryRecordManager(context);
         learningSessionTracker = new LearningSessionTracker(context);
 
@@ -701,6 +706,7 @@ public final class Player implements PlaybackListener, Listener {
         simpleExoPlayer.setSeekParameters(PlayerHelper.getSeekParameters(context));
         simpleExoPlayer.setWakeMode(C.WAKE_MODE_NETWORK);
         simpleExoPlayer.setHandleAudioBecomingNoisy(true);
+        equalizerController.attachAudioSession(simpleExoPlayer.getAudioSessionId());
 
         audioReactor = new AudioReactor(context, simpleExoPlayer);
 
@@ -709,12 +715,7 @@ public final class Player implements PlaybackListener, Listener {
         // Setup UIs
         UIs.call(PlayerUi::initPlayer);
 
-        // Disable media tunneling if requested by the user from ExoPlayer settings
-        if (!PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.disable_media_tunneling_key), false)) {
-            trackSelector.setParameters(trackSelector.buildUponParameters()
-                    .setTunnelingEnabled(true));
-        }
+        updateAudioTunneling();
     }
     //endregion
 
@@ -731,6 +732,7 @@ public final class Player implements PlaybackListener, Listener {
         }
         learningSessionTracker.stop();
         UIs.call(PlayerUi::destroyPlayer);
+        equalizerController.releaseAudioSession();
 
         if (!exoPlayerIsNull()) {
             simpleExoPlayer.removeListener(this);
@@ -1735,9 +1737,57 @@ public final class Player implements PlaybackListener, Listener {
         return muted;
     }
 
+    @NonNull
+    public EqualizerState getEqualizerState() {
+        return equalizerController.getState();
+    }
+
+    public boolean isEqualizerAvailable() {
+        return equalizerController.isAvailable();
+    }
+
+    public boolean isEqualizerOperational() {
+        return equalizerController.isOperational();
+    }
+
+    public void previewEqualizerState(@NonNull final EqualizerState state) {
+        applyEqualizerState(state, false);
+    }
+
+    public void updateEqualizerState(@NonNull final EqualizerState state) {
+        applyEqualizerState(state, true);
+    }
+
+    private void applyEqualizerState(@NonNull final EqualizerState state,
+                                     final boolean persist) {
+        final boolean enabledChanged =
+                equalizerController.getState().isEnabled() != state.isEnabled();
+        if (persist) {
+            equalizerController.updateState(state);
+        } else {
+            equalizerController.previewState(state);
+        }
+        applyPlayerVolume();
+        if (enabledChanged) {
+            updateAudioTunneling();
+        }
+        UIs.call(playerUi -> playerUi.onEqualizerStateChanged(
+                state, equalizerController.isOperational()));
+    }
+
+    private void updateAudioTunneling() {
+        final boolean tunnelingEnabled = !prefs.getBoolean(
+                context.getString(R.string.disable_media_tunneling_key), false)
+                && !equalizerController.getState().isEnabled();
+        trackSelector.setParameters(trackSelector.buildUponParameters()
+                .setTunnelingEnabled(tunnelingEnabled));
+    }
+
     private void applyPlayerVolume() {
         if (!exoPlayerIsNull()) {
-            simpleExoPlayer.setVolume(muted ? 0.0f : sleepTimerVolumeMultiplier);
+            final float equalizerHeadroom = equalizerController.getHeadroomMultiplier();
+            simpleExoPlayer.setVolume(muted
+                    ? 0.0f : sleepTimerVolumeMultiplier * equalizerHeadroom);
         }
     }
     //endregion
@@ -2048,6 +2098,14 @@ public final class Player implements PlaybackListener, Listener {
      * @param events The {@link com.google.android.exoplayer2.Player.Events} that has triggered
      *               the player state changes.
      **/
+    @Override
+    public void onAudioSessionIdChanged(final int audioSessionId) {
+        equalizerController.attachAudioSession(audioSessionId);
+        applyPlayerVolume();
+        UIs.call(playerUi -> playerUi.onEqualizerStateChanged(
+                equalizerController.getState(), equalizerController.isOperational()));
+    }
+
     @Override
     public void onEvents(@NonNull final com.google.android.exoplayer2.Player player,
                          @NonNull final com.google.android.exoplayer2.Player.Events events) {

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/AndroidEqualizerEngine.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/AndroidEqualizerEngine.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import android.media.audiofx.Equalizer;
+
+import androidx.annotation.NonNull;
+
+final class AndroidEqualizerEngine implements EqualizerEngine {
+    @NonNull
+    private final Equalizer equalizer;
+    @NonNull
+    private final int[] centerFrequenciesMilliHertz;
+    private final short minimumMillibels;
+    private final short maximumMillibels;
+    private boolean released;
+
+    AndroidEqualizerEngine(final int audioSessionId) {
+        equalizer = new Equalizer(0, audioSessionId);
+        final short bandCount = equalizer.getNumberOfBands();
+        final short[] range = equalizer.getBandLevelRange();
+        centerFrequenciesMilliHertz = new int[bandCount];
+        for (short band = 0; band < bandCount; band++) {
+            centerFrequenciesMilliHertz[band] = equalizer.getCenterFreq(band);
+        }
+        minimumMillibels = range[0];
+        maximumMillibels = range[1];
+    }
+
+    @Override
+    public void apply(@NonNull final int[] canonicalGainSteps) {
+        ensureOpen();
+        final short[] levels = EqualizerCurveMapper.mapToDeviceBands(
+                centerFrequenciesMilliHertz,
+                minimumMillibels,
+                maximumMillibels,
+                canonicalGainSteps);
+        for (short band = 0; band < levels.length; band++) {
+            equalizer.setBandLevel(band, levels[band]);
+        }
+    }
+
+    @Override
+    public void setEnabled(final boolean enabled) {
+        ensureOpen();
+        equalizer.setEnabled(enabled);
+    }
+
+    @Override
+    public void release() {
+        if (!released) {
+            released = true;
+            equalizer.release();
+        }
+    }
+
+    private void ensureOpen() {
+        if (released) {
+            throw new IllegalStateException("Equalizer engine has already been released");
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/AndroidEqualizerEngineFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/AndroidEqualizerEngineFactory.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import android.media.audiofx.AudioEffect;
+
+import androidx.annotation.NonNull;
+
+import java.util.Arrays;
+
+final class AndroidEqualizerEngineFactory implements EqualizerEngineFactory {
+    @Override
+    public boolean isAvailable() {
+        try {
+            final AudioEffect.Descriptor[] effects = AudioEffect.queryEffects();
+            return effects != null && Arrays.stream(effects)
+                    .anyMatch(effect -> AudioEffect.EFFECT_TYPE_EQUALIZER.equals(effect.type));
+        } catch (final RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    @NonNull
+    @Override
+    public EqualizerEngine create(final int audioSessionId) {
+        return new AndroidEqualizerEngine(audioSessionId);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerController.java
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Owns one native equalizer engine at a time and follows the ExoPlayer audio-session lifecycle.
+ */
+public final class EqualizerController {
+    private static final String TAG = EqualizerController.class.getSimpleName();
+    private static final int NO_AUDIO_SESSION = -1;
+
+    @NonNull
+    private final EqualizerStateStore stateStore;
+    @NonNull
+    private final EqualizerEngineFactory engineFactory;
+    @NonNull
+    private EqualizerState state;
+    @Nullable
+    private EqualizerEngine engine;
+    private int audioSessionId = NO_AUDIO_SESSION;
+
+    public EqualizerController(@NonNull final Context context) {
+        this(new EqualizerPreferences(context), new AndroidEqualizerEngineFactory());
+    }
+
+    EqualizerController(@NonNull final EqualizerStateStore stateStore,
+                        @NonNull final EqualizerEngineFactory engineFactory) {
+        this.stateStore = Objects.requireNonNull(stateStore);
+        this.engineFactory = Objects.requireNonNull(engineFactory);
+        state = stateStore.load();
+    }
+
+    @NonNull
+    public EqualizerState getState() {
+        return state;
+    }
+
+    public boolean isAvailable() {
+        return engine != null || engineFactory.isAvailable();
+    }
+
+    public boolean isOperational() {
+        return engine != null;
+    }
+
+    public void attachAudioSession(final int newAudioSessionId) {
+        if (audioSessionId == newAudioSessionId && (engine != null || !state.isEnabled())) {
+            return;
+        }
+        releaseAudioSession();
+        audioSessionId = newAudioSessionId;
+        ensureEngine();
+    }
+
+    public void releaseAudioSession() {
+        releaseEngine();
+        audioSessionId = NO_AUDIO_SESSION;
+    }
+
+    public void previewState(@NonNull final EqualizerState newState) {
+        applyNewState(newState);
+    }
+
+    public void updateState(@NonNull final EqualizerState newState) {
+        applyNewState(newState);
+        stateStore.save(state);
+    }
+
+    private void applyNewState(@NonNull final EqualizerState newState) {
+        state = Objects.requireNonNull(newState);
+        if (!state.isEnabled()) {
+            releaseEngine();
+            return;
+        }
+        ensureEngine();
+        applyState();
+    }
+
+    public float getHeadroomMultiplier() {
+        return engine != null && state.isEnabled() ? state.getHeadroomMultiplier() : 1.0f;
+    }
+
+    private void ensureEngine() {
+        if (engine != null || !state.isEnabled() || audioSessionId <= 0) {
+            return;
+        }
+        try {
+            if (!engineFactory.isAvailable()) {
+                return;
+            }
+            engine = engineFactory.create(audioSessionId);
+            applyState();
+        } catch (final RuntimeException error) {
+            Log.w(TAG, "Equalizer is unavailable for audio session " + audioSessionId, error);
+            releaseEngine();
+        }
+    }
+
+    private void applyState() {
+        if (engine == null) {
+            return;
+        }
+        try {
+            engine.apply(state.getGains());
+            engine.setEnabled(state.isEnabled());
+        } catch (final RuntimeException error) {
+            Log.w(TAG, "Could not apply equalizer state", error);
+            releaseEngine();
+        }
+    }
+
+    private void releaseEngine() {
+        if (engine == null) {
+            return;
+        }
+        try {
+            engine.setEnabled(false);
+        } catch (final RuntimeException ignored) {
+            // Release below remains mandatory even when a vendor engine is already dead.
+        }
+        try {
+            engine.release();
+        } catch (final RuntimeException error) {
+            Log.w(TAG, "Could not release equalizer engine cleanly", error);
+        } finally {
+            engine = null;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerCurveMapper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerCurveMapper.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Maps WizeStream's fixed curve to an Android device's native bands.
+ */
+public final class EqualizerCurveMapper {
+    private static final int MILLIBELS_PER_HALF_DECIBEL = 50;
+
+    private EqualizerCurveMapper() {
+    }
+
+    @NonNull
+    public static short[] mapToDeviceBands(@NonNull final int[] centerFrequenciesMilliHertz,
+                                           final short minimumMillibels,
+                                           final short maximumMillibels,
+                                           @NonNull final int[] canonicalGainSteps) {
+        if (canonicalGainSteps.length != EqualizerState.BAND_COUNT) {
+            throw new IllegalArgumentException("Canonical equalizer curve must have ten bands");
+        }
+        final short[] levels = new short[centerFrequenciesMilliHertz.length];
+        for (int index = 0; index < centerFrequenciesMilliHertz.length; index++) {
+            final double frequencyHertz = centerFrequenciesMilliHertz[index] / 1_000.0;
+            final double gainStep = interpolateGainStep(frequencyHertz, canonicalGainSteps);
+            final int millibels = (int) Math.round(gainStep * MILLIBELS_PER_HALF_DECIBEL);
+            levels[index] = (short) Math.max(
+                    minimumMillibels,
+                    Math.min(maximumMillibels, millibels));
+        }
+        return levels;
+    }
+
+    static double interpolateGainStep(final double frequencyHertz,
+                                      @NonNull final int[] gains) {
+        final int[] frequencies = EqualizerState.BAND_FREQUENCIES_HZ;
+        if (frequencyHertz <= frequencies[0]) {
+            return gains[0];
+        }
+        if (frequencyHertz >= frequencies[frequencies.length - 1]) {
+            return gains[gains.length - 1];
+        }
+        for (int upper = 1; upper < frequencies.length; upper++) {
+            if (frequencyHertz <= frequencies[upper]) {
+                final int lower = upper - 1;
+                final double logarithmicLower = Math.log(frequencies[lower]);
+                final double logarithmicUpper = Math.log(frequencies[upper]);
+                final double position = (Math.log(frequencyHertz) - logarithmicLower)
+                        / (logarithmicUpper - logarithmicLower);
+                return gains[lower] + position * (gains[upper] - gains[lower]);
+            }
+        }
+        return gains[gains.length - 1];
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerDialog.java
@@ -1,0 +1,447 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import android.content.Context;
+import android.graphics.Typeface;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.switchmaterial.SwitchMaterial;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.Player;
+
+import java.util.Locale;
+
+/**
+ * Shared responsive equalizer editor used by player controls and settings.
+ */
+public final class EqualizerDialog {
+    private static final EqualizerPreset[] DISPLAYED_PRESETS = {
+        EqualizerPreset.FLAT,
+        EqualizerPreset.BASS_BOOST,
+        EqualizerPreset.VOCAL,
+        EqualizerPreset.ACOUSTIC,
+        EqualizerPreset.ROCK,
+        EqualizerPreset.CUSTOM
+    };
+
+    private EqualizerDialog() {
+    }
+
+    public interface StateAdapter {
+        @NonNull
+        EqualizerState getState();
+
+        boolean isAvailable();
+
+        boolean isOperational();
+
+        boolean appliesLive();
+
+        void preview(@NonNull EqualizerState state);
+
+        void commit(@NonNull EqualizerState state);
+    }
+
+    @NonNull
+    public static StateAdapter forPlayer(@NonNull final Player player) {
+        return new StateAdapter() {
+            @NonNull
+            @Override
+            public EqualizerState getState() {
+                return player.getEqualizerState();
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return player.isEqualizerAvailable();
+            }
+
+            @Override
+            public boolean isOperational() {
+                return player.isEqualizerOperational();
+            }
+
+            @Override
+            public boolean appliesLive() {
+                return true;
+            }
+
+            @Override
+            public void preview(@NonNull final EqualizerState state) {
+                player.previewEqualizerState(state);
+            }
+
+            @Override
+            public void commit(@NonNull final EqualizerState state) {
+                player.updateEqualizerState(state);
+            }
+        };
+    }
+
+    @NonNull
+    public static StateAdapter forPreferences(@NonNull final Context context) {
+        final EqualizerPreferences preferences = new EqualizerPreferences(context);
+        final EqualizerState initialState = preferences.load();
+        final boolean available = new AndroidEqualizerEngineFactory().isAvailable();
+        return new StateAdapter() {
+            private EqualizerState state = initialState;
+
+            @NonNull
+            @Override
+            public EqualizerState getState() {
+                return state;
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return available;
+            }
+
+            @Override
+            public boolean isOperational() {
+                return false;
+            }
+
+            @Override
+            public boolean appliesLive() {
+                return false;
+            }
+
+            @Override
+            public void preview(@NonNull final EqualizerState newState) {
+                state = newState;
+            }
+
+            @Override
+            public void commit(@NonNull final EqualizerState newState) {
+                state = newState;
+                preferences.save(state);
+            }
+        };
+    }
+
+    public static void show(@NonNull final Context context,
+                            @NonNull final StateAdapter adapter) {
+        show(context, adapter, () -> {
+        });
+    }
+
+    public static void show(@NonNull final Context context,
+                            @NonNull final StateAdapter adapter,
+                            @NonNull final Runnable onDismiss) {
+        final Editor editor = new Editor(context, adapter);
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.equalizer)
+                .setView(editor.getView())
+                .setPositiveButton(R.string.close, null)
+                .setOnDismissListener(dialog -> {
+                    adapter.commit(editor.getState());
+                    onDismiss.run();
+                })
+                .show();
+    }
+
+    @NonNull
+    public static String getPresetDisplayName(@NonNull final Context context,
+                                               @NonNull final EqualizerPreset preset) {
+        switch (preset) {
+            case FLAT:
+                return context.getString(R.string.equalizer_preset_flat);
+            case BASS_BOOST:
+                return context.getString(R.string.equalizer_preset_bass_boost);
+            case VOCAL:
+                return context.getString(R.string.equalizer_preset_vocal);
+            case ACOUSTIC:
+                return context.getString(R.string.equalizer_preset_acoustic);
+            case ROCK:
+                return context.getString(R.string.equalizer_preset_rock);
+            case CUSTOM:
+            default:
+                return context.getString(R.string.equalizer_preset_custom);
+        }
+    }
+
+    private static final class Editor {
+        @NonNull
+        private final Context context;
+        @NonNull
+        private final StateAdapter adapter;
+        @NonNull
+        private final LinearLayout content;
+        @NonNull
+        private final Spinner presetSpinner;
+        @NonNull
+        private final TextView statusText;
+        @NonNull
+        private final TextView headroomText;
+        @NonNull
+        private final SeekBar[] seekBars = new SeekBar[EqualizerState.BAND_COUNT];
+        @NonNull
+        private final TextView[] gainLabels = new TextView[EqualizerState.BAND_COUNT];
+        @NonNull
+        private EqualizerState state;
+        private boolean updatingControls;
+
+        Editor(@NonNull final Context context, @NonNull final StateAdapter adapter) {
+            this.context = context;
+            this.adapter = adapter;
+            state = adapter.getState();
+
+            content = new LinearLayout(context);
+            content.setOrientation(LinearLayout.VERTICAL);
+            final int padding = dp(20);
+            content.setPadding(padding, dp(4), padding, dp(8));
+
+            final SwitchMaterial enabledSwitch = new SwitchMaterial(context);
+            enabledSwitch.setText(R.string.equalizer_enable);
+            enabledSwitch.setChecked(state.isEnabled());
+            enabledSwitch.setEnabled(adapter.isAvailable());
+            content.addView(enabledSwitch, matchWrap());
+
+            statusText = new TextView(context);
+            statusText.setPadding(0, dp(4), 0, dp(12));
+            content.addView(statusText, matchWrap());
+
+            final TextView presetLabel = sectionLabel(R.string.equalizer_preset);
+            content.addView(presetLabel, matchWrap());
+
+            presetSpinner = new Spinner(context);
+            final String[] presetNames = new String[DISPLAYED_PRESETS.length];
+            for (int index = 0; index < DISPLAYED_PRESETS.length; index++) {
+                presetNames[index] = getPresetDisplayName(context, DISPLAYED_PRESETS[index]);
+            }
+            final ArrayAdapter<String> presetAdapter = new ArrayAdapter<>(
+                    context, android.R.layout.simple_spinner_dropdown_item, presetNames);
+            presetSpinner.setAdapter(presetAdapter);
+            content.addView(presetSpinner, matchWrap());
+
+            final TextView curveDescription = new TextView(context);
+            curveDescription.setText(R.string.equalizer_curve_description);
+            curveDescription.setPadding(0, dp(12), 0, dp(8));
+            content.addView(curveDescription, matchWrap());
+
+            for (int band = 0; band < EqualizerState.BAND_COUNT; band++) {
+                addBand(band);
+            }
+
+            headroomText = new TextView(context);
+            headroomText.setPadding(0, dp(12), 0, 0);
+            content.addView(headroomText, matchWrap());
+
+            enabledSwitch.setOnCheckedChangeListener((button, checked) -> {
+                state = state.withEnabled(checked);
+                adapter.commit(state);
+                refreshStatus();
+            });
+            presetSpinner.setOnItemSelectedListener(new SimpleItemSelectedListener(position -> {
+                if (updatingControls) {
+                    return;
+                }
+                final EqualizerPreset preset = DISPLAYED_PRESETS[position];
+                if (preset == EqualizerPreset.CUSTOM) {
+                    return;
+                }
+                state = state.withPreset(preset);
+                updateBandControls();
+                adapter.commit(state);
+                refreshStatus();
+            }));
+
+            updateBandControls();
+            refreshStatus();
+        }
+
+        @NonNull
+        View getView() {
+            final android.widget.ScrollView scrollView =
+                    new android.widget.ScrollView(context);
+            scrollView.addView(content);
+            return scrollView;
+        }
+
+        @NonNull
+        EqualizerState getState() {
+            return state;
+        }
+
+        private void addBand(final int band) {
+            final LinearLayout header = new LinearLayout(context);
+            header.setOrientation(LinearLayout.HORIZONTAL);
+            header.setPadding(0, dp(8), 0, 0);
+
+            final TextView frequency = new TextView(context);
+            frequency.setText(formatFrequency(EqualizerState.BAND_FREQUENCIES_HZ[band]));
+            frequency.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+            header.addView(frequency, weightedWrap());
+
+            gainLabels[band] = new TextView(context);
+            header.addView(gainLabels[band], wrapWrap());
+            content.addView(header, matchWrap());
+
+            final SeekBar seekBar = new SeekBar(context);
+            seekBar.setMax(EqualizerState.MAX_GAIN_STEP - EqualizerState.MIN_GAIN_STEP);
+            seekBar.setKeyProgressIncrement(1);
+            seekBar.setContentDescription(formatFrequency(
+                    EqualizerState.BAND_FREQUENCIES_HZ[band]));
+            seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(final SeekBar bar,
+                                              final int progress,
+                                              final boolean fromUser) {
+                    if (!fromUser || updatingControls) {
+                        return;
+                    }
+                    final int gain = progress + EqualizerState.MIN_GAIN_STEP;
+                    state = state.withBandGain(band, gain);
+                    gainLabels[band].setText(formatGain(gain));
+                    selectPreset(EqualizerPreset.CUSTOM);
+                    adapter.preview(state);
+                    refreshStatus();
+                }
+
+                @Override
+                public void onStartTrackingTouch(final SeekBar bar) {
+                }
+
+                @Override
+                public void onStopTrackingTouch(final SeekBar bar) {
+                    adapter.commit(state);
+                }
+            });
+            seekBars[band] = seekBar;
+            content.addView(seekBar, matchWrap());
+        }
+
+        private void updateBandControls() {
+            updatingControls = true;
+            final int[] gains = state.getGains();
+            for (int band = 0; band < gains.length; band++) {
+                seekBars[band].setProgress(gains[band] - EqualizerState.MIN_GAIN_STEP);
+                gainLabels[band].setText(formatGain(gains[band]));
+            }
+            selectPreset(state.getPreset());
+            updatingControls = false;
+            refreshHeadroom();
+        }
+
+        private void selectPreset(@NonNull final EqualizerPreset preset) {
+            for (int index = 0; index < DISPLAYED_PRESETS.length; index++) {
+                if (DISPLAYED_PRESETS[index] == preset) {
+                    updatingControls = true;
+                    presetSpinner.setSelection(index);
+                    updatingControls = false;
+                    return;
+                }
+            }
+        }
+
+        private void refreshStatus() {
+            if (!adapter.isAvailable()) {
+                statusText.setText(R.string.equalizer_unavailable);
+            } else if (!state.isEnabled()) {
+                statusText.setText(R.string.equalizer_disabled);
+            } else if (!adapter.appliesLive()) {
+                statusText.setText(R.string.equalizer_applies_next_playback);
+            } else if (adapter.isOperational()) {
+                statusText.setText(R.string.equalizer_active);
+            } else {
+                statusText.setText(R.string.equalizer_waiting_for_audio_session);
+            }
+            refreshHeadroom();
+        }
+
+        private void refreshHeadroom() {
+            final int maximumGainStep =
+                    java.util.Arrays.stream(state.getGains()).max().orElse(0);
+            final double headroom =
+                    state.isEnabled() ? Math.max(0, maximumGainStep) / 2.0 : 0.0;
+            headroomText.setText(context.getString(
+                    R.string.equalizer_headroom, headroom));
+        }
+
+        @NonNull
+        private TextView sectionLabel(final int textResource) {
+            final TextView view = new TextView(context);
+            view.setText(textResource);
+            view.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
+            return view;
+        }
+
+        @NonNull
+        private String formatFrequency(final int frequencyHertz) {
+            if (frequencyHertz >= 1_000) {
+                return context.getString(
+                        R.string.equalizer_frequency_khz, frequencyHertz / 1_000);
+            }
+            return context.getString(R.string.equalizer_frequency_hz, frequencyHertz);
+        }
+
+        @NonNull
+        private String formatGain(final int gainStep) {
+            return String.format(Locale.getDefault(), "%+.1f dB", gainStep / 2.0);
+        }
+
+        private int dp(final int value) {
+            return Math.round(value * context.getResources().getDisplayMetrics().density);
+        }
+
+        @NonNull
+        private LinearLayout.LayoutParams matchWrap() {
+            return new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT);
+        }
+
+        @NonNull
+        private LinearLayout.LayoutParams wrapWrap() {
+            return new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT);
+        }
+
+        @NonNull
+        private LinearLayout.LayoutParams weightedWrap() {
+            return new LinearLayout.LayoutParams(
+                    0, LinearLayout.LayoutParams.WRAP_CONTENT, 1.0f);
+        }
+    }
+
+    private interface PositionConsumer {
+        void accept(int position);
+    }
+
+    private static final class SimpleItemSelectedListener
+            implements android.widget.AdapterView.OnItemSelectedListener {
+        @NonNull
+        private final PositionConsumer consumer;
+
+        SimpleItemSelectedListener(@NonNull final PositionConsumer consumer) {
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void onItemSelected(final android.widget.AdapterView<?> parent,
+                                   final View view,
+                                   final int position,
+                                   final long id) {
+            consumer.accept(position);
+        }
+
+        @Override
+        public void onNothingSelected(final android.widget.AdapterView<?> parent) {
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerEngine.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerEngine.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.annotation.NonNull;
+
+interface EqualizerEngine {
+    void apply(@NonNull int[] canonicalGainSteps);
+
+    void setEnabled(boolean enabled);
+
+    void release();
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerEngineFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerEngineFactory.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.annotation.NonNull;
+
+interface EqualizerEngineFactory {
+    boolean isAvailable();
+
+    @NonNull
+    EqualizerEngine create(int audioSessionId);
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerPreferences.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerPreferences.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Objects;
+
+/**
+ * Versioned local persistence for the Release 1 equalizer state.
+ */
+public final class EqualizerPreferences implements EqualizerStateStore {
+    public static final String PREFERENCE_KEY = "equalizer_state_v1";
+
+    @NonNull
+    private final SharedPreferences preferences;
+
+    public EqualizerPreferences(@NonNull final Context context) {
+        this(PreferenceManager.getDefaultSharedPreferences(context));
+    }
+
+    EqualizerPreferences(@NonNull final SharedPreferences preferences) {
+        this.preferences = Objects.requireNonNull(preferences);
+    }
+
+    @NonNull
+    @Override
+    public EqualizerState load() {
+        final String stored = preferences.getString(PREFERENCE_KEY, null);
+        if (stored == null) {
+            return EqualizerState.flat();
+        }
+        try {
+            final JSONObject object = new JSONObject(stored);
+            if (object.getInt("version") != EqualizerState.VERSION) {
+                return EqualizerState.flat();
+            }
+            final JSONArray array = object.getJSONArray("gains");
+            if (array.length() != EqualizerState.BAND_COUNT) {
+                return EqualizerState.flat();
+            }
+            final int[] gains = new int[EqualizerState.BAND_COUNT];
+            for (int index = 0; index < gains.length; index++) {
+                gains[index] = array.getInt(index);
+                if (gains[index] < EqualizerState.MIN_GAIN_STEP
+                        || gains[index] > EqualizerState.MAX_GAIN_STEP) {
+                    return EqualizerState.flat();
+                }
+            }
+            return new EqualizerState(
+                    object.getBoolean("enabled"),
+                    EqualizerPreset.fromId(object.getString("selectedPreset")),
+                    gains);
+        } catch (final JSONException | ClassCastException ignored) {
+            return EqualizerState.flat();
+        }
+    }
+
+    @Override
+    public void save(@NonNull final EqualizerState state) {
+        final JSONObject object = new JSONObject();
+        final JSONArray gains = new JSONArray();
+        for (final int gain : state.getGains()) {
+            gains.put(gain);
+        }
+        try {
+            object.put("version", EqualizerState.VERSION);
+            object.put("enabled", state.isEnabled());
+            object.put("selectedPreset", state.getPreset().getId());
+            object.put("gains", gains);
+            preferences.edit().putString(PREFERENCE_KEY, object.toString()).apply();
+        } catch (final JSONException error) {
+            throw new IllegalStateException("Could not serialize equalizer state", error);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerPreset.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerPreset.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Application-owned equalizer presets. Values use half-decibel steps so they are deterministic
+ * across Android devices and synchronization formats.
+ */
+public enum EqualizerPreset {
+    FLAT("flat", new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+    BASS_BOOST("bass_boost", new int[]{10, 8, 6, 2, 0, -2, -2, 0, 2, 4}),
+    VOCAL("vocal", new int[]{-4, -2, 0, 2, 4, 6, 6, 4, 2, 0}),
+    ACOUSTIC("acoustic", new int[]{4, 2, 0, -2, 2, 4, 4, 2, 2, 4}),
+    ROCK("rock", new int[]{6, 4, 2, 0, -2, 2, 4, 6, 6, 4}),
+    CUSTOM("custom", null);
+
+    @NonNull
+    private final String id;
+    @Nullable
+    private final int[] gains;
+
+    EqualizerPreset(@NonNull final String id, @Nullable final int[] gains) {
+        this.id = id;
+        this.gains = gains == null ? null : Arrays.copyOf(gains, gains.length);
+    }
+
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    @NonNull
+    public int[] getGains() {
+        if (gains == null) {
+            throw new IllegalStateException("The custom preset has no fixed curve");
+        }
+        return Arrays.copyOf(gains, gains.length);
+    }
+
+    @NonNull
+    public static EqualizerPreset fromId(@Nullable final String id) {
+        if (id != null) {
+            for (final EqualizerPreset preset : values()) {
+                if (preset.id.equals(id)) {
+                    return preset;
+                }
+            }
+        }
+        return FLAT;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerState.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerState.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.annotation.NonNull;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Portable ten-band equalizer state. Gains are stored in half-decibel units.
+ */
+public final class EqualizerState {
+    public static final int VERSION = 1;
+    public static final int BAND_COUNT = 10;
+    public static final int MIN_GAIN_STEP = -24;
+    public static final int MAX_GAIN_STEP = 24;
+    public static final int[] BAND_FREQUENCIES_HZ = {
+        32, 64, 125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000
+    };
+
+    private final boolean enabled;
+    @NonNull
+    private final EqualizerPreset preset;
+    @NonNull
+    private final int[] gains;
+
+    public EqualizerState(final boolean enabled,
+                          @NonNull final EqualizerPreset preset,
+                          @NonNull final int[] gains) {
+        if (gains.length != BAND_COUNT) {
+            throw new IllegalArgumentException("An equalizer curve must contain ten bands");
+        }
+        this.enabled = enabled;
+        this.preset = Objects.requireNonNull(preset);
+        this.gains = Arrays.stream(gains)
+                .map(EqualizerState::clampGain)
+                .toArray();
+    }
+
+    @NonNull
+    public static EqualizerState flat() {
+        return new EqualizerState(false, EqualizerPreset.FLAT, EqualizerPreset.FLAT.getGains());
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @NonNull
+    public EqualizerPreset getPreset() {
+        return preset;
+    }
+
+    @NonNull
+    public int[] getGains() {
+        return Arrays.copyOf(gains, gains.length);
+    }
+
+    @NonNull
+    public EqualizerState withEnabled(final boolean newEnabled) {
+        return new EqualizerState(newEnabled, preset, gains);
+    }
+
+    @NonNull
+    public EqualizerState withPreset(@NonNull final EqualizerPreset newPreset) {
+        if (newPreset == EqualizerPreset.CUSTOM) {
+            return new EqualizerState(enabled, EqualizerPreset.CUSTOM, gains);
+        }
+        return new EqualizerState(enabled, newPreset, newPreset.getGains());
+    }
+
+    @NonNull
+    public EqualizerState withBandGain(final int band, final int gainStep) {
+        if (band < 0 || band >= BAND_COUNT) {
+            throw new IllegalArgumentException("Equalizer band index is outside the curve");
+        }
+        final int[] updated = getGains();
+        updated[band] = clampGain(gainStep);
+        return new EqualizerState(enabled, EqualizerPreset.CUSTOM, updated);
+    }
+
+    public float getHeadroomMultiplier() {
+        final int maximumGainStep = Arrays.stream(gains).max().orElse(0);
+        if (!enabled || maximumGainStep <= 0) {
+            return 1.0f;
+        }
+        final double maximumGainDecibels = maximumGainStep / 2.0;
+        return (float) Math.pow(10.0, -maximumGainDecibels / 20.0);
+    }
+
+    public static int clampGain(final int gainStep) {
+        return Math.max(MIN_GAIN_STEP, Math.min(MAX_GAIN_STEP, gainStep));
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof EqualizerState)) {
+            return false;
+        }
+        final EqualizerState that = (EqualizerState) other;
+        return enabled == that.enabled
+                && preset == that.preset
+                && Arrays.equals(gains, that.gains);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hash(enabled, preset) + Arrays.hashCode(gains);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerStateStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/EqualizerStateStore.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.annotation.NonNull;
+
+interface EqualizerStateStore {
+    @NonNull
+    EqualizerState load();
+
+    void save(@NonNull EqualizerState state);
+}

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -61,6 +61,8 @@ import org.schabi.newpipe.learning.LearningNoteDialog;
 import org.schabi.newpipe.learning.LearningNoteManager;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.equalizer.EqualizerDialog;
+import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.event.PlayerServiceEventListener;
 import org.schabi.newpipe.player.gesture.BasePlayerGestureListener;
 import org.schabi.newpipe.player.gesture.MainPlayerGestureListener;
@@ -174,6 +176,9 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.segmentsButton.setOnClickListener(v -> onSegmentsClicked());
         binding.sleepTimerButton.setOnClickListener(v ->
                 getParentActivity().ifPresent(activity -> SleepTimerDialog.show(activity, player)));
+        binding.equalizerButton.setOnClickListener(v ->
+                getParentActivity().ifPresent(activity -> EqualizerDialog.show(
+                        activity, EqualizerDialog.forPlayer(player))));
         binding.learningNoteButton.setOnClickListener(v -> showLearningNoteDialog());
 
         binding.addToPlaylistButton.setOnClickListener(v ->
@@ -202,6 +207,13 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         });
     }
 
+
+    @Override
+    public void onEqualizerStateChanged(@NonNull final EqualizerState state,
+                                        final boolean operational) {
+        binding.equalizerButton.setActivated(state.isEnabled());
+        binding.equalizerButton.setAlpha(state.isEnabled() && operational ? 1.0f : 0.7f);
+    }
 
     @Override
     public void showSponsorBlockSkipButton(@NonNull final String label,
@@ -242,6 +254,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.queueButton.setOnClickListener(null);
         binding.segmentsButton.setOnClickListener(null);
         binding.sleepTimerButton.setOnClickListener(null);
+        binding.equalizerButton.setOnClickListener(null);
         binding.addToPlaylistButton.setOnClickListener(null);
         hideSponsorBlockSkipButton();
         clearSponsorBlockSeekBarMarkers();
@@ -334,6 +347,8 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.share.setVisibility(View.VISIBLE);
         binding.openInBrowser.setVisibility(View.VISIBLE);
         binding.sleepTimerButton.setVisibility(View.VISIBLE);
+        binding.equalizerButton.setVisibility(View.VISIBLE);
+        binding.equalizerButton.setActivated(player.getEqualizerState().isEnabled());
         updateLearningNoteButtonVisibility(player.getCurrentStreamInfo().orElse(null));
         binding.switchMute.setVisibility(View.VISIBLE);
         binding.playerCloseButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -16,6 +16,7 @@ import com.google.android.exoplayer2.video.VideoSize;
 import org.schabi.newpipe.extractor.sponsorblock.SponsorBlockSegment;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.helper.SleepTimer;
 
 import java.util.List;
@@ -188,6 +189,10 @@ public abstract class PlayerUi {
     }
 
     public void onMuteUnmuteChanged(final boolean isMuted) {
+    }
+
+    public void onEqualizerStateChanged(@NonNull final EqualizerState state,
+                                        final boolean operational) {
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PopupPlayerUi.java
@@ -178,6 +178,7 @@ public final class PopupPlayerUi extends VideoPlayerUi {
         binding.playWithKodi.setVisibility(View.GONE);
         binding.openInBrowser.setVisibility(View.GONE);
         binding.sleepTimerButton.setVisibility(View.GONE);
+        binding.equalizerButton.setVisibility(View.GONE);
         binding.sleepTimerCountdown.setVisibility(View.GONE);
         binding.switchMute.setVisibility(View.GONE);
         binding.playerCloseButton.setVisibility(View.GONE);

--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -8,10 +8,14 @@ import android.text.format.DateUtils;
 import android.widget.Toast;
 
 import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 
 import com.google.android.material.snackbar.Snackbar;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.equalizer.EqualizerDialog;
+import org.schabi.newpipe.player.equalizer.EqualizerPreferences;
+import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.PermissionHelper;
 
@@ -27,6 +31,7 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
 
         updateSeekOptions();
         updateResolutionOptions();
+        setupEqualizerPreference();
         listener = (sharedPreferences, key) -> {
 
             // on M and above, if user chooses to minimise to popup player on exit
@@ -51,6 +56,29 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
                 updateResolutionOptions();
             }
         };
+    }
+
+    private void setupEqualizerPreference() {
+        final Preference preference = requirePreference(R.string.equalizer_settings_key);
+        updateEqualizerPreferenceSummary(preference);
+        preference.setOnPreferenceClickListener(clicked -> {
+            EqualizerDialog.show(
+                    requireContext(),
+                    EqualizerDialog.forPreferences(requireContext()),
+                    () -> updateEqualizerPreferenceSummary(preference));
+            return true;
+        });
+    }
+
+    private void updateEqualizerPreferenceSummary(final Preference preference) {
+        final EqualizerState state = new EqualizerPreferences(requireContext()).load();
+        if (!state.isEnabled()) {
+            preference.setSummary(R.string.equalizer_settings_summary_disabled);
+            return;
+        }
+        preference.setSummary(getString(
+                R.string.equalizer_settings_summary_enabled,
+                EqualizerDialog.getPresetDisplayName(requireContext(), state.getPreset())));
     }
 
     /**

--- a/app/src/main/res/drawable/ic_equalizer.xml
+++ b/app/src/main/res/drawable/ic_equalizer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,18h2v-2H4v2zM4,14h2V6H4v8zM9,18h2v-7H9v7zM9,9h2V6H9v3zM14,18h2v-4h-2v4zM14,12h2V6h-2v6zM19,18h2V9h-2v9zM19,7h2V6h-2v1z" />
+</vector>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -396,6 +396,20 @@
                         app:tint="@color/white" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/equalizerButton"
+                        android:layout_width="35dp"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:clickable="true"
+                        android:contentDescription="@string/equalizer"
+                        android:focusable="true"
+                        android:padding="@dimen/player_main_buttons_padding"
+                        android:scaleType="fitCenter"
+                        android:src="@drawable/ic_equalizer"
+                        app:tint="@color/white" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/switchMute"
                         android:layout_width="wrap_content"
                         android:layout_height="37dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1282,4 +1282,26 @@
     <string name="sponsor_block_skip_sponsor">Skip sponsor</string>
     <string name="sponsor_block_skip_segment">Skip segment</string>
     <string name="sponsor_block_skip_button_content_description">Skip SponsorBlock segment</string>
+    <!-- Equalizer -->
+    <string name="equalizer">Equalizer</string>
+    <string name="equalizer_settings_key" translatable="false">equalizer_settings</string>
+    <string name="equalizer_enable">Enable equalizer</string>
+    <string name="equalizer_preset">Preset</string>
+    <string name="equalizer_preset_flat">Flat</string>
+    <string name="equalizer_preset_bass_boost">Bass boost</string>
+    <string name="equalizer_preset_vocal">Vocal</string>
+    <string name="equalizer_preset_acoustic">Acoustic</string>
+    <string name="equalizer_preset_rock">Rock</string>
+    <string name="equalizer_preset_custom">Custom</string>
+    <string name="equalizer_curve_description">The fixed 10-band curve is adapted to the audio bands supported by this device.</string>
+    <string name="equalizer_unavailable">The Android equalizer effect is unavailable on this device.</string>
+    <string name="equalizer_disabled">Equalizer is off.</string>
+    <string name="equalizer_active">Active for this playback session.</string>
+    <string name="equalizer_waiting_for_audio_session">Waiting for a playback audio session.</string>
+    <string name="equalizer_applies_next_playback">Changes apply to the next playback session.</string>
+    <string name="equalizer_headroom">Automatic clipping headroom: −%1$.1f dB</string>
+    <string name="equalizer_frequency_hz">%1$d Hz</string>
+    <string name="equalizer_frequency_khz">%1$d kHz</string>
+    <string name="equalizer_settings_summary_disabled">Off · Five presets and one custom curve</string>
+    <string name="equalizer_settings_summary_enabled">On · %1$s</string>
 </resources>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -91,6 +91,13 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false">
 
+        <Preference
+            android:key="@string/equalizer_settings_key"
+            android:summary="@string/equalizer_settings_summary_disabled"
+            android:title="@string/equalizer"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/use_external_video_player_key"

--- a/app/src/test/java/org/schabi/newpipe/player/equalizer/EqualizerControllerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/equalizer/EqualizerControllerTest.java
@@ -1,0 +1,157 @@
+package org.schabi.newpipe.player.equalizer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import androidx.annotation.NonNull;
+
+import org.junit.Test;
+
+public class EqualizerControllerTest {
+    @Test
+    public void enablingCreatesOneSessionEngineAndPersistsState() {
+        final FakeStore store = new FakeStore(EqualizerState.flat());
+        final FakeFactory factory = new FakeFactory(true);
+        final EqualizerController controller = new EqualizerController(store, factory);
+        controller.attachAudioSession(41);
+
+        assertEquals(0, factory.createCount);
+
+        final EqualizerState enabled =
+                EqualizerState.flat().withEnabled(true).withPreset(EqualizerPreset.ROCK);
+        controller.updateState(enabled);
+
+        assertEquals(1, factory.createCount);
+        assertEquals(41, factory.lastSessionId);
+        assertTrue(factory.lastEngine.enabled);
+        assertArrayEquals(enabled.getGains(), factory.lastEngine.gains);
+        assertSame(enabled, store.saved);
+        assertTrue(controller.isOperational());
+        assertEquals(enabled.getHeadroomMultiplier(),
+                controller.getHeadroomMultiplier(), 0.0f);
+    }
+
+    @Test
+    public void audioSessionChangeReleasesOldEngineAndReappliesCurve() {
+        final FakeStore store = new FakeStore(
+                EqualizerState.flat().withEnabled(true).withPreset(EqualizerPreset.VOCAL));
+        final FakeFactory factory = new FakeFactory(true);
+        final EqualizerController controller = new EqualizerController(store, factory);
+
+        controller.attachAudioSession(10);
+        final FakeEngine first = factory.lastEngine;
+        controller.attachAudioSession(11);
+
+        assertTrue(first.released);
+        assertFalse(first.enabled);
+        assertEquals(2, factory.createCount);
+        assertEquals(11, factory.lastSessionId);
+        assertArrayEquals(store.initial.getGains(), factory.lastEngine.gains);
+    }
+
+    @Test
+    public void previewIsLiveButOnlyCommitPersists() {
+        final FakeStore store = new FakeStore(EqualizerState.flat());
+        final FakeFactory factory = new FakeFactory(true);
+        final EqualizerController controller = new EqualizerController(store, factory);
+        controller.attachAudioSession(7);
+
+        final EqualizerState preview =
+                EqualizerState.flat().withEnabled(true).withBandGain(0, 8);
+        controller.previewState(preview);
+
+        assertEquals(0, store.saveCount);
+        assertArrayEquals(preview.getGains(), factory.lastEngine.gains);
+
+        controller.updateState(preview);
+        assertEquals(1, store.saveCount);
+        assertSame(preview, store.saved);
+    }
+
+    @Test
+    public void unavailableBackendNeverAppliesHeadroom() {
+        final FakeStore store = new FakeStore(
+                EqualizerState.flat().withEnabled(true).withPreset(EqualizerPreset.ROCK));
+        final FakeFactory factory = new FakeFactory(false);
+        final EqualizerController controller = new EqualizerController(store, factory);
+
+        controller.attachAudioSession(9);
+
+        assertFalse(controller.isOperational());
+        assertEquals(0, factory.createCount);
+        assertEquals(1.0f, controller.getHeadroomMultiplier(), 0.0f);
+    }
+
+    private static final class FakeStore implements EqualizerStateStore {
+        @NonNull
+        private final EqualizerState initial;
+        private EqualizerState saved;
+        private int saveCount;
+
+        FakeStore(@NonNull final EqualizerState initial) {
+            this.initial = initial;
+        }
+
+        @NonNull
+        @Override
+        public EqualizerState load() {
+            return initial;
+        }
+
+        @Override
+        public void save(@NonNull final EqualizerState state) {
+            saved = state;
+            saveCount++;
+        }
+    }
+
+    private static final class FakeFactory implements EqualizerEngineFactory {
+        private final boolean available;
+        private int createCount;
+        private int lastSessionId;
+        private FakeEngine lastEngine;
+
+        FakeFactory(final boolean available) {
+            this.available = available;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return available;
+        }
+
+        @NonNull
+        @Override
+        public EqualizerEngine create(final int audioSessionId) {
+            createCount++;
+            lastSessionId = audioSessionId;
+            lastEngine = new FakeEngine();
+            return lastEngine;
+        }
+    }
+
+    private static final class FakeEngine implements EqualizerEngine {
+        private int[] gains;
+        private boolean enabled;
+        private boolean released;
+
+        @Override
+        public void apply(@NonNull final int[] canonicalGainSteps) {
+            gains = java.util.Arrays.copyOf(
+                    canonicalGainSteps, canonicalGainSteps.length);
+        }
+
+        @Override
+        public void setEnabled(final boolean newEnabled) {
+            enabled = newEnabled;
+        }
+
+        @Override
+        public void release() {
+            released = true;
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/equalizer/EqualizerCurveMapperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/equalizer/EqualizerCurveMapperTest.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.player.equalizer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class EqualizerCurveMapperTest {
+    @Test
+    public void canonicalCentersMapToExactNativeLevels() {
+        final int[] centersMilliHertz = new int[EqualizerState.BAND_COUNT];
+        final int[] gains = new int[EqualizerState.BAND_COUNT];
+        final short[] expected = new short[EqualizerState.BAND_COUNT];
+        for (int index = 0; index < EqualizerState.BAND_COUNT; index++) {
+            centersMilliHertz[index] =
+                    EqualizerState.BAND_FREQUENCIES_HZ[index] * 1_000;
+            gains[index] = index - 5;
+            expected[index] = (short) (gains[index] * 50);
+        }
+
+        assertArrayEquals(expected, EqualizerCurveMapper.mapToDeviceBands(
+                centersMilliHertz, (short) -1_500, (short) 1_500, gains));
+    }
+
+    @Test
+    public void interpolationUsesLogFrequencySpacing() {
+        final int[] gains = EqualizerPreset.FLAT.getGains();
+        gains[5] = 0;
+        gains[6] = 10;
+
+        final double logarithmicMidpoint = Math.sqrt(1_000.0 * 2_000.0);
+        assertEquals(5.0,
+                EqualizerCurveMapper.interpolateGainStep(logarithmicMidpoint, gains),
+                0.00001);
+    }
+
+    @Test
+    public void mappedLevelsRespectVendorRange() {
+        final int[] gains = new int[EqualizerState.BAND_COUNT];
+        java.util.Arrays.fill(gains, EqualizerState.MAX_GAIN_STEP);
+
+        assertArrayEquals(new short[]{300}, EqualizerCurveMapper.mapToDeviceBands(
+                new int[]{1_000_000}, (short) -300, (short) 300, gains));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/equalizer/EqualizerStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/equalizer/EqualizerStateTest.java
@@ -1,0 +1,56 @@
+package org.schabi.newpipe.player.equalizer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class EqualizerStateTest {
+    @Test
+    public void fixedPresetsHavePortableTenBandCurves() {
+        for (final EqualizerPreset preset : EqualizerPreset.values()) {
+            if (preset == EqualizerPreset.CUSTOM) {
+                continue;
+            }
+            final int[] gains = preset.getGains();
+            assertEquals(EqualizerState.BAND_COUNT, gains.length);
+            for (final int gain : gains) {
+                assertTrue(gain >= EqualizerState.MIN_GAIN_STEP);
+                assertTrue(gain <= EqualizerState.MAX_GAIN_STEP);
+            }
+        }
+    }
+
+    @Test
+    public void editingABandCreatesTheSingleCustomCurveAndClampsGain() {
+        final EqualizerState edited = EqualizerState.flat()
+                .withEnabled(true)
+                .withBandGain(2, EqualizerState.MAX_GAIN_STEP + 10);
+
+        assertEquals(EqualizerPreset.CUSTOM, edited.getPreset());
+        assertEquals(EqualizerState.MAX_GAIN_STEP, edited.getGains()[2]);
+        assertEquals(EqualizerState.BAND_COUNT, edited.getGains().length);
+    }
+
+    @Test
+    public void selectingPresetReplacesTheWholeCurve() {
+        final EqualizerState state = EqualizerState.flat()
+                .withBandGain(0, 8)
+                .withPreset(EqualizerPreset.ROCK);
+
+        assertEquals(EqualizerPreset.ROCK, state.getPreset());
+        assertArrayEquals(EqualizerPreset.ROCK.getGains(), state.getGains());
+    }
+
+    @Test
+    public void positiveBoostCreatesMatchingAutomaticHeadroom() {
+        final int[] gains = EqualizerPreset.FLAT.getGains();
+        gains[5] = 12;
+        final EqualizerState state =
+                new EqualizerState(true, EqualizerPreset.CUSTOM, gains);
+
+        assertEquals(0.501187f, state.getHeadroomMultiplier(), 0.00001f);
+        assertEquals(1.0f, state.withEnabled(false).getHeadroomMultiplier(), 0.0f);
+    }
+}


### PR DESCRIPTION
- adds a fixed, portable 10-band WizeStream curve with five built-in presets and one persistent unnamed custom curve
- adapts the curve logarithmically to each device's Android native equalizer bands
- follows ExoPlayer audio-session changes and releases native effects safely
- applies automatic clipping headroom only while the native effect is operational
- disables media tunneling while EQ is enabled to avoid bypass/incompatibility
- adds one shared responsive editor from the player controls and Video & audio settings
- keeps Release 1 state local-only; named presets, paired-device sync, and software DSP remain deferred
- adds unit coverage for curves, interpolation, headroom, persistence boundaries, and session lifecycle