### PR TITLE
Recover device sync after hotspot changes

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/sync/AndroidPeerDiscovery.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/AndroidPeerDiscovery.kt
@@ -143,12 +143,9 @@ internal class AndroidPeerDiscovery(context: Context) {
     }
 
     fun addressesFor(peer: TrustedPeer): List<String> {
-        val peerId = peer.peerId
-        val discoveredAddresses = mdnsAddressesFor(peerId)
-        if (discoveredAddresses.isNotEmpty()) {
-            return discoveredAddresses
-        }
-        return subnetAddressesFor(peer)
+        val mdnsAddresses = mdnsAddressesFor(peer.peerId)
+        val subnetAddresses = subnetAddressesFor(peer)
+        return combinePeerDiscoveryCandidates(mdnsAddresses, subnetAddresses)
     }
 
     private fun mdnsAddressesFor(peerId: String): List<String> {
@@ -214,7 +211,7 @@ internal class AndroidPeerDiscovery(context: Context) {
             return emptyList()
         }
 
-        Log.i(TAG, "mDNS did not find the trusted peer; scanning its saved sync port")
+        Log.i(TAG, "Scanning the local subnet for refreshed trusted-peer addresses")
         val probes = targets.flatMap { target ->
             subnetHostAddresses(target.linkAddress).flatMap { address ->
                 ports.map { port -> SubnetProbe(target.network, address, port) }
@@ -350,6 +347,21 @@ internal class AndroidPeerDiscovery(context: Context) {
         private const val MIN_PORT = 1
         private const val MAX_PORT = 65_535
     }
+}
+
+internal fun combinePeerDiscoveryCandidates(
+    mdnsAddresses: List<String>,
+    subnetAddresses: List<String>
+): List<String> {
+    return sequence {
+        // Preserve mDNS as the first choice, but reserve room for subnet recovery. A stale,
+        // non-empty mDNS cache must not prevent dialing a peer that moved to a hotspot subnet.
+        mdnsAddresses.firstOrNull()?.let { yield(it) }
+        yieldAll(subnetAddresses)
+        yieldAll(mdnsAddresses.drop(1))
+    }.distinct()
+        .take(MAX_PAIRING_ADDRESSES)
+        .toList()
 }
 
 private data class SubnetScanTarget(

--- a/app/src/test/java/org/schabi/newpipe/sync/AndroidNetworkAddressProviderTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/AndroidNetworkAddressProviderTest.kt
@@ -81,6 +81,39 @@ class AndroidNetworkAddressProviderTest {
         )
     }
 
+    @Test
+    fun `stale mdns candidates do not block hotspot subnet recovery`() {
+        val staleMdns = "/ip4/10.113.36.244/tcp/44065/p2p/trusted-peer"
+        val currentHotspot = "/ip4/10.197.178.244/tcp/44065/p2p/trusted-peer"
+        val secondMdns = "/ip4/192.168.0.244/tcp/44065/p2p/trusted-peer"
+
+        assertEquals(
+            listOf(staleMdns, currentHotspot, secondMdns),
+            combinePeerDiscoveryCandidates(
+                mdnsAddresses = listOf(staleMdns, secondMdns),
+                subnetAddresses = listOf(currentHotspot)
+            )
+        )
+    }
+
+    @Test
+    fun `discovery candidates are deduplicated and bounded without starving subnet recovery`() {
+        val mdns = (1..MAX_PAIRING_ADDRESSES).map { index ->
+            "/ip4/10.0.0.$index/tcp/44065/p2p/trusted-peer"
+        }
+        val recovered = "/ip4/10.197.178.244/tcp/44065/p2p/trusted-peer"
+
+        val candidates = combinePeerDiscoveryCandidates(
+            mdnsAddresses = mdns,
+            subnetAddresses = listOf(recovered, recovered)
+        )
+
+        assertEquals(MAX_PAIRING_ADDRESSES, candidates.size)
+        assertEquals(mdns.first(), candidates.first())
+        assertEquals(recovered, candidates[1])
+        assertEquals(candidates.size, candidates.distinct().size)
+    }
+
     private fun candidate(
         address: String,
         wifiOrEthernet: Boolean,

--- a/docs/device-synchronization.md
+++ b/docs/device-synchronization.md
@@ -6,8 +6,9 @@ devices. It does not require a platform login or a WizeStream cloud account.
 ## Pair two devices
 
 Both devices must have a WizeStream version that supports device
-synchronization and must be able to reach each other on the same Wi-Fi or
-Ethernet network.
+synchronization and must be able to reach each other on the same Wi-Fi,
+Ethernet, or local hotspot network. Synchronization does not use the public
+internet.
 
 1. Open **Settings > Device synchronization** on both devices.
 2. On the first device, select **Show pairing code** and keep the code visible.
@@ -34,7 +35,7 @@ hour when:
 
 - The device has sufficient battery.
 - The device is connected through Wi-Fi or Ethernet.
-- A trusted device is reachable on the same network.
+- A trusted device is reachable on the same Wi-Fi, Ethernet, or hotspot network.
 
 A trusted device being temporarily unavailable does not remove the pairing.
 Use **Sync now** when both devices are available if an immediate update is


### PR DESCRIPTION
- combines refreshed mDNS and bounded local-subnet candidates after a reachability failure
- keeps mDNS as the first dial choice while reserving candidate capacity for subnet recovery
- deduplicates and caps candidates at the existing pairing-address limit
- preserves trusted PeerID validation and saves refreshed addresses only after an authenticated successful sync
- documents support for same-network local hotspots and clarifies that public-internet sync is not added
- adds regression tests based on the stale `10.113.36.x` versus current `10.197.178.x` addresses reported in #105 