### PR TITLE
Retarget Desktop workflows to pipe

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -4,14 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - desktop-electron
+      - pipe
     paths:
       - 'desktop/**'
       - 'app/src/main/java/org/schabi/newpipe/extractor/**'
-      - 'app/src/main/java/org/schabi/newpipe/sync/SyncModels.kt'
-      - 'app/src/main/java/org/schabi/newpipe/sync/PairingSecurity.kt'
-      - 'app/src/main/java/org/schabi/newpipe/sync/SyncProtocol.kt'
+      - 'app/src/main/java/org/schabi/newpipe/sync/**'
       - '.github/workflows/desktop-ci.yml'
+      - '.github/workflows/desktop-preview-release.yml'
       - '.github/workflows/desktop-release.yml'
   pull_request:
     branches:
@@ -21,6 +20,7 @@ on:
       - 'app/src/main/java/org/schabi/newpipe/extractor/**'
       - 'app/src/main/java/org/schabi/newpipe/sync/**'
       - '.github/workflows/desktop-ci.yml'
+      - '.github/workflows/desktop-preview-release.yml'
       - '.github/workflows/desktop-release.yml'
 
 concurrency:

--- a/.github/workflows/desktop-preview-release.yml
+++ b/.github/workflows/desktop-preview-release.yml
@@ -2,11 +2,11 @@ name: Desktop unsigned preview release
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - desktop-electron
-    paths:
-      - '.github/workflows/desktop-preview-release.yml'
+    inputs:
+      release_tag:
+        description: Type v0.6.0-beta.1-unsigned-preview to authorize this immutable preview
+        required: true
+        type: string
 
 concurrency:
   group: desktop-unsigned-preview-v0.6.0-beta.1
@@ -29,6 +29,17 @@ jobs:
         working-directory: desktop
     steps:
       - uses: actions/checkout@v6
+      - name: Require pipe and refuse to overwrite the published preview
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          test "$GITHUB_REF" = 'refs/heads/pipe'
+          test "$RELEASE_TAG" = 'v0.6.0-beta.1-unsigned-preview'
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Release tag $RELEASE_TAG already exists and is immutable"
+            exit 1
+          fi
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,7 +19,17 @@ permissions:
   artifact-metadata: write
 
 jobs:
+  source:
+    name: Verify pipe release source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require the integrated release branch
+        shell: bash
+        run: test "$GITHUB_REF" = 'refs/heads/pipe'
+
   gate:
+    needs: source
     name: Verify protected release gate
     runs-on: ubuntu-24.04
     environment: desktop-release

--- a/desktop/docs/releasing.md
+++ b/desktop/docs/releasing.md
@@ -17,7 +17,7 @@ policy and configure protected, trusted signing identities.
 1. Create the public `wizdom13/WizeStream_Desktop` repository with a `main` branch. Its README must
    link to `wizdom13/WizeStream` as the corresponding GPL source repository.
 2. Create the `desktop-release` environment in the source repository. Require an explicit reviewer,
-   limit deployment branches to `desktop-electron`, and prevent administrators from bypassing the
+   limit deployment branches to `pipe`, and prevent administrators from bypassing the
    gate where the organization policy permits it.
 3. Create a fine-grained GitHub token with Contents read/write access only to
    `wizdom13/WizeStream_Desktop`. Store it as `WIZESTREAM_DESKTOP_RELEASE_TOKEN` in the protected
@@ -47,7 +47,7 @@ downloaded because Apple only offers it once.
 
 ## Credential-free validation
 
-Every push to `desktop-electron` runs the unsigned five-target Desktop CI matrix. It checks the
+Every push to `pipe` runs the unsigned five-target Desktop CI matrix. It checks the
 release contract, builds updater metadata with architecture-distinct filenames, executes unit and
 native-media tests, smoke-tests the unpacked app, audits production dependencies, and uploads
 short-lived workflow artifacts. It never reads the protected release environment.
@@ -63,7 +63,7 @@ npm test
 
 ## Future signed beta release (postponed)
 
-1. Confirm `desktop-electron` is green and points at the intended source commit.
+1. Confirm `pipe` is green and points at the intended source commit.
 2. Open **Desktop signed beta release** in Actions and enter exactly `v0.6.0-beta.1`.
 3. Approve the `desktop-release` environment deployment.
 4. The gate verifies every protected credential and the separate release repository before any


### PR DESCRIPTION
- run Desktop CI on direct `pipe` pushes instead of the retired integration branch
- watch all shared synchronization sources and both Desktop release workflows
- make the existing unsigned Beta 1 publisher manual-only, `pipe`-only, and unable to overwrite its published immutable tag
- reject future signed-release dispatches from any branch other than `pipe` before requesting protected-environment access
- update release-operation documentation and protected-environment branch guidance