### PR TITLE
Document WizeStream multi-platform Desktop support

### DIFF
--- a/.github/ISSUE_TEMPLATE/desktop_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/desktop_bug_report.yml
@@ -1,0 +1,129 @@
+name: Desktop preview bug report
+description: Report a problem with an unsigned WizeStream Desktop preview
+labels: [bug, needs triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for testing WizeStream Desktop.
+
+        Download previews only from the official `wizdom13/WizeStream` GitHub Releases page and verify the supplied `SHA256SUMS` before testing. These packages are explicitly unsigned, so Windows unknown-publisher or SmartScreen warnings and macOS Gatekeeper approval are expected.
+
+        Never paste access tokens, private keys, pairing invitations, signed media URLs, or other secrets into an issue or log.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: "I can reproduce the problem with the latest WizeStream Desktop preview from the official repository."
+          required: true
+        - label: "I verified the downloaded package against the release's `SHA256SUMS`."
+          required: true
+        - label: "I checked the open and closed issues for an existing report."
+          required: true
+        - label: "I removed secrets, pairing invitations, signed media URLs, and private information from this report."
+          required: true
+
+  - type: input
+    id: release-tag
+    attributes:
+      label: Preview release tag
+      description: Enter the exact GitHub release tag you tested.
+      placeholder: v0.6.0-beta.1-unsigned-preview
+    validations:
+      required: true
+
+  - type: input
+    id: package-name
+    attributes:
+      label: Package filename
+      description: Enter the complete filename from GitHub Releases.
+      placeholder: WizeStream Desktop-0.6.0-beta.1-windows-x64-setup.exe
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      options:
+        - x64
+        - arm64
+    validations:
+      required: true
+
+  - type: input
+    id: system-version
+    attributes:
+      label: Operating-system version and device
+      description: Include the exact OS version and computer model or relevant hardware details.
+      placeholder: Windows 11 23H2, desktop PC with Intel x64 processor
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      options:
+        - Installation or first launch
+        - Startup or navigation
+        - Search or browsing
+        - Playback or track selection
+        - Downloads or recovery
+        - Pairing or synchronization
+        - Subscriptions, playlists, history, or notes
+        - Packaging or platform integration
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Include the exact error text when one is shown.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Redacted logs or screenshots
+      description: Attach useful evidence after removing secrets, pairing invitations, signed media URLs, usernames, and private filesystem paths.
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional information
+      description: Include package type, network conditions, media service, and whether the problem is consistently reproducible.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -86,8 +86,11 @@ change the release policy and configure trusted signing identities.
 
 Phase 8 synchronizes the WizeStream 1.6.0 Android changes from `pipe`, reconciles the release
 documentation with the unsigned-preview policy, reruns Android regression checks and the complete
-five-platform Desktop matrix, and prepares `desktop-electron` for review before integration into
-`pipe`.
+five-platform Desktop matrix, and integrates WizeStream Desktop into `pipe`.
+
+Phase 9 stabilizes that integrated preview. It adds a dedicated Desktop bug-report path and a
+repeatable five-platform manual acceptance checklist, while keeping the first unsigned preview
+immutable. Another preview is published only when material fixes justify a higher beta version.
 
 ## Requirements
 
@@ -135,6 +138,7 @@ omitted, so preview upgrades are installed manually. Windows signing and macOS
 signing/notarization are postponed future release gates, not requirements for architecture CI or
 the current preview channel.
 
+See [docs/preview-testing.md](docs/preview-testing.md) for the Phase 9 manual acceptance checklist.
 See [docs/releasing.md](docs/releasing.md) for the current unsigned-preview policy and the postponed
 future signing, updater-validation and rollback procedures.
 
@@ -154,7 +158,9 @@ future signing, updater-validation and rollback procedures.
 
 ## Next milestone
 
-Complete Phase 8 validation, collect feedback from the explicitly unsigned preview, and review the
-`desktop-electron` to `pipe` pull request. Publish another unsigned preview only when fixes
-materially change the existing beta. Signed public releases and production automatic updates remain
-postponed until the maintainers explicitly adopt a new release policy.
+Complete the Phase 9 five-platform manual acceptance checklist and triage reports submitted through
+the Desktop preview issue form. Fix reproducible preview regressions from dedicated branches based
+on `pipe`, and require the Android and complete Desktop CI matrices before merging them. Publish a
+higher unsigned beta only when material fixes change the tested binaries. Signed public releases
+and production automatic updates remain postponed until the maintainers explicitly adopt a new
+release policy.

--- a/desktop/docs/preview-testing.md
+++ b/desktop/docs/preview-testing.md
@@ -1,0 +1,75 @@
+# Desktop unsigned-preview testing
+
+This checklist defines the Phase 9 manual acceptance pass for WizeStream Desktop. It supplements
+the automated five-target Desktop CI matrix; it does not replace it.
+
+## Safety and authenticity
+
+1. Download the preview and `SHA256SUMS` only from the official
+   [`wizdom13/WizeStream` releases page](https://github.com/wizdom13/WizeStream/releases).
+2. Confirm that the release tag ends in `-unsigned-preview` and that the release notes identify the
+   packages as explicitly unsigned.
+3. Verify the downloaded package before opening it:
+
+   - Windows PowerShell: `Get-FileHash -Algorithm SHA256 '<package>'`
+   - macOS: `shasum -a 256 '<package>'`
+   - Linux: `sha256sum '<package>'`
+
+   Compare the complete result with the matching line in `SHA256SUMS`.
+4. Treat an unexpected hash, unexpected publisher identity, or download from any other location as
+   a failed test. Do not run the package.
+
+Windows unknown-publisher or SmartScreen warnings and macOS Gatekeeper approval are expected for
+the current unsigned preview. They are not evidence of a broken download when the SHA-256 value
+matches the official manifest.
+
+## Supported test matrix
+
+| Platform | Architecture | Packages | Expected unsigned behavior |
+| --- | --- | --- | --- |
+| Windows | x64 | setup `.exe`, portable `.exe` | Unknown-publisher or SmartScreen warning may appear |
+| macOS | x64 | `.dmg`, `.zip` | Gatekeeper approval may be required |
+| macOS | arm64 | `.dmg`, `.zip` | Gatekeeper approval may be required |
+| Linux | x64 | `.AppImage`, `.deb` | No publisher identity is provided |
+| Linux | arm64 | `.AppImage`, `.deb` | No publisher identity is provided |
+
+Use a clean user profile or virtual machine when practical. Record the release tag, exact package
+filename, OS version, architecture, device model and SHA-256 result for every test pass.
+
+## Acceptance checklist
+
+For each platform and architecture:
+
+- [ ] The package installs or extracts without corrupt or missing-file errors.
+- [ ] WizeStream Desktop starts and presents a usable window rather than a blank screen.
+- [ ] Closing and reopening the application preserves local data.
+- [ ] Search returns results and opening a result loads its details.
+- [ ] Video and audio playback start, pause, seek and stop correctly.
+- [ ] Available audio and subtitle tracks can be selected without restarting the application.
+- [ ] A progressive download completes to a valid playable file.
+- [ ] An adaptive video-only download requires an audio choice, combines both components, and
+      produces a valid playable file.
+- [ ] Cancelling and retrying a download does not create a false completed state.
+- [ ] Subscriptions, playlists, history and Learning Mode notes survive a restart.
+- [ ] Pairing accepts only a valid, unexpired invitation and synchronization works with a trusted
+      peer on the private local network.
+- [ ] A stale hotspot address can recover the saved peer without trusting an unknown device.
+- [ ] The application does not offer, download or install a production automatic update.
+
+## Reporting a failure
+
+Open a **Desktop preview bug report** in this repository and complete every required field. One
+issue should describe one reproducible problem.
+
+Never attach access tokens, private keys, pairing invitations, signed media URLs, or unredacted
+private filesystem paths. Include the smallest useful redacted log or screenshot, the exact package
+filename and exact reproduction steps.
+
+## Phase 9 release gate
+
+The existing `v0.6.0-beta.1-unsigned-preview` tag and assets are immutable. A second unsigned
+preview is justified only when one or more material fixes change the tested binaries. A new preview
+must use a higher beta version and a new tag; existing release assets must never be overwritten.
+
+Signed public releases and production automatic updates remain postponed until maintainers adopt a
+new release policy and configure trusted Windows and Apple signing identities.

--- a/desktop/docs/releasing.md
+++ b/desktop/docs/releasing.md
@@ -12,6 +12,12 @@ unsigned packages. Signed public releases and production automatic updates are p
 future signing procedures below remain inactive unless the maintainers explicitly change this
 policy and configure protected, trusted signing identities.
 
+Phase 9 feedback and manual acceptance use the checklist in
+[`preview-testing.md`](preview-testing.md). Preview failures must be reported through the dedicated
+Desktop issue form with the exact release tag, package filename, platform and architecture. The
+existing `v0.6.0-beta.1-unsigned-preview` release is immutable; publish a higher beta only after
+material fixes pass the Android regression checks and the complete five-target Desktop matrix.
+
 ## Future signed-release setup (postponed)
 
 1. Create the public `wizdom13/WizeStream_Desktop` repository with a `main` branch. Its README must


### PR DESCRIPTION
## Summary

- present WizeStream as one multi-platform application for Android, Windows, macOS and Linux
- add a clear platform and package table to the main README
- add simple Desktop installation, safety, testing and maintenance guidance
- add a dedicated Desktop preview bug-report form
- update the FAQ, privacy policy, build guide and contributor guide for Desktop support
- remove the old numbered development history from public documentation

## Release status

Android releases remain signed. Windows, macOS and Linux packages remain explicitly unsigned previews with manual updates. The existing `v0.6.0-beta.1-unsigned-preview` release is immutable. This pull request does not publish a release, enable signing, or enable production automatic updates.

## Validation

- issue-template YAML parsed successfully
- Desktop release contract passed
- Desktop unit tests: 3 files and 10 tests passed
- `git diff --check` passed
- no obsolete `desktop-electron` references remain in the documentation
- no numbered development-phase references remain in the Markdown documentation

The Android and complete five-target Desktop GitHub Actions matrices validate the branch on normal runners.