### PR TITLE
Document WizeStream multi-platform support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 Thank you for your interest in contributing to WizeStream.
 
-WizeStream is an independent, NewPipe-based streaming client for Android. It combines Material 3
-Expressive design with privacy-friendly playback, local-first features, multiple streaming
-platforms, and its own integrated extractor changes while preserving the strengths of the core
-NewPipe experience.
+WizeStream is an independent, NewPipe-based, multi-platform streaming application for Android,
+Windows, macOS and Linux. It combines Material 3 Expressive Android design with a dedicated Desktop
+interface, privacy-friendly playback, local-first features, multiple streaming services, and its
+own integrated extractor changes while preserving the strengths of the core NewPipe experience.
 
 This project welcomes focused contributions, but changes must respect the project direction and avoid unnecessary behavior changes.
 
@@ -21,8 +21,9 @@ WizeStream focuses on:
 * Privacy-friendly playback and downloads
 * Useful local-first features
 * Reliable support for multiple streaming platforms
+* Consistent Android, Windows, macOS and Linux project identity
 * Maintained, integrated extractor and service compatibility
-* Release-ready signed builds
+* Release-ready signed Android builds and verified Desktop previews
 * Clear fork attribution
 * Preserving compatible NewPipe behavior and data migration where practical
 * Safe, reviewable, well-scoped changes
@@ -54,6 +55,7 @@ Good contribution types include:
 * Release-readiness fixes
 * Accessibility improvements
 * Build, CI, and signing workflow fixes
+* Desktop preview testing and platform-specific fixes
 * Small refactors that reduce risk or improve maintainability
 * QA reports with screenshots, device info, and reproduction steps
 
@@ -170,6 +172,11 @@ git diff --check
 
 For Android/device-sensitive changes, also run or request device QA.
 
+For Desktop changes, run the checks documented in
+[`desktop/README.md`](../desktop/README.md#validate) and request platform QA using the
+[`desktop/docs/preview-testing.md`](../desktop/docs/preview-testing.md) checklist. Desktop changes
+must pass the complete Windows x64, macOS x64/arm64 and Linux x64/arm64 CI matrix.
+
 Recommended manual QA for UI changes:
 
 * Light theme
@@ -193,7 +200,8 @@ For visual changes, include screenshots when possible.
 A useful QA report includes:
 
 * Device model
-* Android version
+* Platform and operating-system version
+* Architecture for Desktop reports
 * App build type
 * Theme mode
 * Theme color
@@ -218,7 +226,7 @@ When opening an issue, include:
 
 * Clear title
 * App version
-* Device and Android version
+* Platform, device and operating-system version
 * Steps to reproduce
 * Expected behavior
 * Actual behavior

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,11 +1,13 @@
 # Building WizeStream
 
-WizeStream includes the complete extractor and timeago-parser sources directly in the `app`
-module. Java sources live under `app/src/main/java`, protocol definitions under
-`app/src/main/proto`, and their unit tests under `app/src/test/java`. Every WizeStream commit and
-release tag therefore records and builds the application and service extraction logic together.
+WizeStream is a multi-platform application for Android, Windows, macOS and Linux. It includes the
+complete extractor and timeago-parser sources directly in the Android `app` module and reuses the
+integrated sources in the Desktop backend. Java sources live under `app/src/main/java`, protocol
+definitions under `app/src/main/proto`, and their unit tests under `app/src/test/java`. Every
+WizeStream commit and release tag therefore records the application and service extraction logic
+together.
 
-## Requirements
+## Android requirements
 
 - Git
 - JDK 21
@@ -21,7 +23,7 @@ cd WizeStream
 
 No submodule initialization, separate extractor checkout, or separate extractor build is required.
 
-## Shared build entry points
+## Android build entry points
 
 The same committed scripts are used locally and in GitHub Actions.
 
@@ -66,6 +68,9 @@ Keep `MINOR` and `PATCH` between 0 and 999. Add the release notes at
 as `vMAJOR.MINOR.PATCH`. The release workflow rejects a tag that does not match Gradle's
 `versionName`.
 
+Desktop preview versions are defined in `desktop/package.json` and use distinct tags ending in
+`-unsigned-preview`. Desktop preview assets are immutable and must not reuse an existing tag.
+
 ## Release signing
 
 Provide all four WizeStream signing variables before running `scripts/build.sh release`:
@@ -81,8 +86,27 @@ The legacy `NEWPIPE_MATERIAL_RELEASE_*` names remain accepted as fallbacks so ex
 
 The resulting APK is written under `app/build/outputs/apk/release/`.
 
+## Desktop builds
+
+Desktop development requires Node.js 24 and JDK 21. From `desktop/`:
+
+```bash
+npm ci
+npm run dev
+```
+
+Run `npm run dist` on the target operating system to create a native package. The complete Desktop
+CI matrix builds Windows x64, macOS x64/arm64 and Linux x64/arm64. See
+[`desktop/README.md`](desktop/README.md) for architecture and validation details and
+[`desktop/docs/releasing.md`](desktop/docs/releasing.md) for the current explicitly unsigned
+preview policy.
+
 ## Reproducible release rule
 
 Every published WizeStream APK must be built from the exact commit referenced by its release tag.
 That commit includes the integrated extractor source under `app/src/main/java`. An APK must not be
 replaced with one built from a newer untagged commit; publish a new version and tag instead.
+
+The same immutability rule applies to Desktop preview packages: build every asset from the tagged
+source commit, publish checksums and attestations, and use a higher preview version for any changed
+binary. Never overwrite an existing preview asset.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,20 +1,26 @@
 # WizeStream Privacy Policy
 
-Last updated: July 27, 2026
+Last updated: August 14, 2026
 
-WizeStream is an independently maintained, open-source Android streaming application. It does not require a WizeStream account and does not include advertising, analytics, or tracking SDKs.
+WizeStream is an independently maintained, open-source, multi-platform streaming application for
+Android, Windows, macOS and Linux. It does not require a WizeStream account and does not include
+advertising, analytics, or tracking SDKs.
 
 ## Network requests
 
 WizeStream connects directly to the media services you choose to use. Those services and your network provider can receive ordinary connection information such as your IP address, request details, and cookies required for the selected service. Their own privacy policies apply to that activity.
 
-When update checks are enabled or manually requested, WizeStream contacts the GitHub Releases API for `wizdom13/WizeStream`. The app does not add a WizeStream account identifier or advertising identifier to those requests.
+On Android, WizeStream contacts the GitHub Releases API for `wizdom13/WizeStream` when update checks
+are enabled or manually requested. The app does not add a WizeStream account identifier or
+advertising identifier to those requests. Production automatic updates are disabled in the current
+Desktop preview; Desktop updates are downloaded manually.
 
 ## Device synchronization
 
 Device synchronization is optional and does not require a WizeStream cloud account. After you pair
-two devices with a one-time QR code, WizeStream can exchange supported records directly through an
-encrypted peer-to-peer connection between those trusted device identities.
+two devices with a one-time invitation (shown as a QR code where supported), WizeStream can exchange
+supported records directly through an encrypted peer-to-peer connection between those trusted
+device identities.
 
 Synchronized records can include subscriptions, feed groups, playlists, watch history, playback
 progress, home tabs, content-filter selections, channel playback profiles, allowlisted settings, and
@@ -26,23 +32,39 @@ original content URL, media type, filename, MIME type, file size, and completion
 device can identify the item and offer to download it again from the original media service.
 
 Trusted-device identities and synchronization state are stored locally. Automatic synchronization
-periodically attempts to reach paired devices when the device has sufficient battery and is
-connected through Wi-Fi or Ethernet. Clearing trusted devices removes their authorization and
-requires them to pair again.
+periodically attempts to reach paired devices through Wi-Fi or Ethernet. Android observes its
+battery and background-execution conditions; Desktop synchronization runs while WizeStream Desktop
+is open. Clearing trusted devices removes their authorization and requires them to pair again.
 
 ## Crash and error reports
 
-WizeStream does not upload crash reports automatically. The error screen lets you copy a report or explicitly choose to send it through an email application or GitHub. Before sending, you can review and edit your comment. A report can include the requested URL, service, app language, content country and language, package and app version, Android version, timestamp, exception details, and your comment.
+WizeStream does not upload crash reports automatically. On Android, the error screen lets you copy
+a report or explicitly choose to send it through an email application or GitHub. Before sending,
+you can review and edit your comment. A report can include the requested URL, service, app language,
+content country and language, package and app version, Android version, timestamp, exception
+details, and your comment. Desktop preview reports are submitted manually through the repository's
+Desktop issue form after you review and redact any attached logs.
 
 Email providers and GitHub process information according to their own privacy policies. GitHub issue reports can be public, so do not include passwords, authentication cookies, private links, or other sensitive information.
 
 ## Data stored on your device
 
-Subscriptions, playlists, history, settings, cookies, downloads, and backups are stored locally on your device or in a location you select. WizeStream only exports data when you choose an export action. Removing the app or clearing its storage removes app-private data, subject to Android and your backup provider's behavior.
+Subscriptions, playlists, history, settings, cookies, downloads, and backups are stored locally on
+your device or in a location you select. WizeStream only exports data when you choose an export
+action. Removing the application or clearing its storage removes app-private data, subject to the
+operating system and any backup provider you use.
 
 ## Permissions
 
-WizeStream requests Android permissions only for features you use, such as notifications, background playback, overlay playback, network access, camera access for scanning a device-pairing QR code, and legacy file access on supported older Android versions. Android settings can be used to revoke optional permissions.
+On Android, WizeStream requests permissions only for features you use, such as notifications,
+background playback, overlay playback, network access, camera access for scanning a device-pairing
+QR code, and legacy file access on supported older Android versions. Android settings can revoke
+optional permissions.
+
+On Desktop, WizeStream uses ordinary operating-system access needed for network playback,
+user-selected downloads and local peer-to-peer synchronization. Browser-style navigation, popups
+and renderer permission requests are denied by default. Operating-system settings can revoke any
+permission granted to the Desktop application.
 
 ## Changes and contact
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 <h1 align="center">WizeStream</h1>
 
-<p align="center"><b>An independent, privacy-friendly NewPipe-based streaming client for Android.</b></p>
+<p align="center"><b>An independent, privacy-friendly, multi-platform streaming application for Android, Windows, macOS and Linux.</b></p>
 
-> **Desktop development preview:** A native Windows, macOS and Linux architecture is being built
-> with Electron, TypeScript, React, WizeStreamExtractor, SQLite and mpv on the
-> [`desktop-electron`](https://github.com/wizdom13/WizeStream/tree/desktop-electron) branch. See the
-> [desktop implementation guide](desktop/README.md). This is separate from the experimental ATL
-> Flatpak and is not yet a stable end-user release.
+WizeStream combines its established Android application with a real Desktop client built for
+Windows, macOS and Linux. Desktop is integrated into the `pipe` branch and available as an
+**explicitly unsigned preview**; it is not an Android compatibility wrapper. See the
+[Desktop implementation guide](desktop/README.md) and
+[Desktop preview testing guide](desktop/docs/preview-testing.md).
+
+| Platform | Availability | Packages |
+| --- | --- | --- |
+| Android | Signed application releases | APK / IzzyOnDroid |
+| Windows x64 | Unsigned Desktop preview | Installer and portable `.exe` |
+| macOS x64 and arm64 | Unsigned Desktop preview | `.dmg` and `.zip` |
+| Linux x64 and arm64 | Unsigned Desktop preview | `.AppImage` and `.deb` |
 
 <p align="center">
   <a href="https://apt.izzysoft.de/packages/org.wisso.newpipematerial"><img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" height="80" alt="Get it on IzzyOnDroid"></a>
@@ -20,6 +27,7 @@
 <p align="center">
   <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPL%20v3-blue.svg" alt="License: GPLv3"></a>
   <a href="https://github.com/wizdom13/WizeStream/actions"><img src="https://github.com/wizdom13/WizeStream/actions/workflows/ci.yml/badge.svg?branch=pipe" alt="Build status"></a>
+  <a href="https://github.com/wizdom13/WizeStream/actions/workflows/desktop-ci.yml"><img src="https://github.com/wizdom13/WizeStream/actions/workflows/desktop-ci.yml/badge.svg?branch=pipe" alt="Desktop build status"></a>
   <a href="https://apt.izzysoft.de/packages/org.wisso.newpipematerial"><img src="https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/org.wisso.newpipematerial&amp;label=IzzyOnDroid" alt="Latest version on IzzyOnDroid"></a>
   <a href="https://shields.rbtlog.dev/org.wisso.newpipematerial"><img src="https://shields.rbtlog.dev/simple/org.wisso.newpipematerial" alt="Reproducible build status"></a>
 </p>
@@ -64,9 +72,10 @@
 
 ## Important project notice
 
-WizeStream is an independent, NewPipe-based streaming client for Android. It combines a modern
-Material 3 Expressive interface with privacy-friendly playback, useful local-first features, and
-support for multiple streaming platforms.
+WizeStream is an independent, NewPipe-based, multi-platform streaming application for Android,
+Windows, macOS and Linux. It combines privacy-friendly playback, useful local-first features,
+support for multiple streaming services, an expressive Android interface, and a dedicated Desktop
+experience.
 
 WizeStream maintains its own application and integrated extractor changes. It is **not affiliated
 with, sponsored by, or endorsed by** the official NewPipe project, TeamNewPipe, or NewPipe e.V.
@@ -103,10 +112,13 @@ baseline is recorded in [UPSTREAM.md](UPSTREAM.md).
 WizeStream keeps the lightweight, privacy-friendly NewPipe experience while developing its own
 interface, playback, discovery, synchronization, and service-support features. Material 3
 Expressive design remains an important project goal, but it is one part of a broader independent
-client rather than the project's only purpose.
+application rather than the project's only purpose. Android and Desktop use platform-appropriate
+interfaces while sharing WizeStream's integrated extractor sources and compatible synchronization
+protocol.
 
 Project highlights:
 
+- Android, Windows, macOS and Linux support in one open-source project
 - Material 3-inspired design with Material You colors, manual color presets, and customizable navigation
 - Account-free playback, subscriptions, feeds, playlists, downloads, and history across supported services
 - Dedicated YouTube Music and YouTube Shorts destinations, advanced search filters, and channel sorting
@@ -181,6 +193,11 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
 ---
 
 ## Features
+
+Feature availability differs between the Android and Desktop interfaces. Android provides the full
+mobile feature set documented below. The Desktop preview provides native Desktop browsing,
+playback, downloads, libraries, Learning Mode notes and trusted-device synchronization; see the
+[Desktop implementation guide](desktop/README.md) for its exact current scope.
 
 ### Streaming and discovery
 
@@ -261,11 +278,12 @@ See [Device synchronization](#device-synchronization) for behavior, limitations,
 
 ### Updates and releases
 
-- Manual and optional background checks for signed WizeStream releases
-- In-app changelog preview, APK download progress, and installation handoff
-- Update validation for checksum, package identity, version, and signing certificate
-- Independent semantic versioning, release signing, stable builds, and separately installable nightly
-  builds
+- Android supports manual and optional background checks for signed WizeStream releases, with
+  changelog preview, APK download progress, installation handoff, and update validation.
+- Desktop preview packages are downloaded and updated manually. Production automatic updates are
+  disabled, and Windows/macOS packages are currently unsigned.
+- Independent semantic versioning, signed Android releases, and separately installable Android
+  nightly builds
 
 ---
 
@@ -307,7 +325,7 @@ data details, background behavior, and privacy notes.
 
 Install WizeStream through an F-Droid-compatible client from the IzzyOnDroid repository.
 
-### Release APK
+### Android release APK
 
 <a href="https://github.com/wizdom13/WizeStream/releases"><img src="https://i.ibb.co/q0mdc4Z/get-it-on-github.png" height="80" alt="Get it on GitHub"></a>
 
@@ -321,6 +339,18 @@ WizeStream uses a different application ID from official NewPipe, so both apps c
 WizeStream:        org.wisso.newpipematerial
 Debug build:       org.wisso.newpipematerial.debug
 ```
+
+### Desktop unsigned preview
+
+Download Windows, macOS or Linux packages from the
+[`v0.6.0-beta.1-unsigned-preview`](https://github.com/wizdom13/WizeStream/releases/tag/v0.6.0-beta.1-unsigned-preview)
+release. Verify the supplied `SHA256SUMS` before opening a package.
+
+The Desktop preview is explicitly unsigned. Windows may show an unknown-publisher or SmartScreen
+warning, and macOS Gatekeeper may require deliberate approval. Production automatic updates are
+disabled, so Desktop preview upgrades are installed manually. See the
+[Desktop preview testing guide](desktop/docs/preview-testing.md) for package and verification
+details.
 
 ### GitHub Store
 
@@ -360,7 +390,8 @@ Do not publish WizeStream or forks of NewPipe to Google Play without first revie
 
 ## Building from source
 
-WizeStream includes its extractor source directly in the `app` module:
+WizeStream includes its extractor source directly in the Android `app` module and reuses those
+sources in the Desktop backend:
 
 ```bash
 git clone https://github.com/wizdom13/WizeStream.git
@@ -392,9 +423,24 @@ See [BUILDING.md](BUILDING.md) for complete build, signing, and reproducible-rel
 
 The debug APK uses the app label **WizeStream Debug** and package `org.wisso.newpipematerial.debug`.
 
+To develop the Desktop application, install Node.js 24 and JDK 21, then run from `desktop/`:
+
+```bash
+npm ci
+npm run dev
+```
+
+Desktop packages must be built on their target operating system with `npm run dist`. See the
+[Desktop implementation guide](desktop/README.md) for architecture, validation and packaging
+details.
+
 ---
 
 ## Release signing
+
+The environment variables below sign Android releases. Desktop Windows signing and macOS
+signing/notarization are postponed; the current Desktop preview remains explicitly unsigned. See
+[Desktop release operations](desktop/docs/releasing.md) for that policy.
 
 Configure release signing with the WizeStream environment-variable names:
 
@@ -426,9 +472,10 @@ extractor source stored in that commit.
 
 ## Development status
 
-WizeStream is under active development as an independent NewPipe-based client. Current priorities
-include Material 3 Expressive polish, playback reliability, local-first features, service
-compatibility, and release readiness.
+WizeStream is under active maintenance as an independent, multi-platform NewPipe-based
+application. The Desktop application is integrated into the main project and future work is normal
+maintenance and improvement. Ongoing work focuses on Android and Desktop reliability, user
+feedback, local-first features, service compatibility, security and release readiness.
 
 Completed or in-progress areas include:
 
@@ -445,6 +492,8 @@ Completed or in-progress areas include:
 - Multi-audio selection and clearer audio-track labels
 - Dialog, snackbar, settings, video-detail, and download UI polish
 - Release-signing workflow support
+- Integrated Windows, macOS and Linux Desktop application with five-target CI
+- Explicitly unsigned Desktop preview distribution with checksums and artifact attestations
 
 High-risk areas receive dedicated QA before broad behavior changes.
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,7 +1,9 @@
 # WizeStream Desktop
 
-WizeStream Desktop is an experimental, real desktop client for Windows, macOS and Linux. It is
-not an Android compatibility wrapper and does not share the Android user interface.
+WizeStream is a multi-platform application for Android, Windows, macOS and Linux. WizeStream
+Desktop is its real desktop client for Windows, macOS and Linux, currently distributed as an
+explicitly unsigned preview. It is not an Android compatibility wrapper and does not share the
+Android user interface.
 
 The desktop architecture contains:
 
@@ -17,80 +19,25 @@ The desktop architecture contains:
 - Native preview packages produced on native Windows, Intel/Apple Silicon macOS, and
   x86_64/aarch64 Linux runners, plus a protected signed-beta release path.
 
-## Current scope
+## What the Desktop app can do
 
-Phase 1 established the application shell, extractor-backed search, stream resolution, external
-mpv playback, persistent desktop identity, encrypted pairing and native preview packages.
+- Search and browse supported streaming services.
+- Play video and audio inside the application.
+- Choose available audio tracks and captions.
+- Download video, audio and captions, with pause and resume support.
+- Manage subscriptions, playlists, history and Learning Mode notes.
+- Pair with trusted WizeStream devices and synchronize selected data over the local network.
+- Keep user data locally without requiring a WizeStream account.
 
-Phase 2 enables manual, category-selectable synchronization with Android devices for:
+Synchronization can run manually or automatically while WizeStream Desktop is open. It works only
+with devices you deliberately pair and trust. If a trusted device changes address after using a
+hotspot, WizeStream can find it again but still verifies the saved device identity before syncing.
 
-- subscriptions and local/remote playlists;
-- watch history, playback progress and search history;
-- Learning Mode notes;
-- feed groups, home tabs, channel playback profiles and filters;
-- portable settings and completed-download metadata.
+Downloads are checked before they are marked complete. When separate video and audio tracks are
+needed, WizeStream combines them without lowering their quality.
 
-The desktop compiles the same v1 synchronization models, validation, engines and libp2p protocol
-bindings used by Android. JDBC adapters use immutable change journals, per-origin revision clocks,
-per-peer acknowledgements, Lamport conflict resolution and tombstones. Structured records without
-a desktop editing surface are retained losslessly so round trips do not discard Android data.
-
-Phase 3 adds native desktop library editors for subscriptions, local playlists and their items,
-watch and search history, and Learning Mode notes. Successful searches and playback starts create
-history events, and local edits are reconciled into the same Phase 2 journals before the next
-device synchronization.
-
-Phase 4 added semantic original/dubbed/descriptive audio labels, caption selection, embedded libmpv
-rendering, and resumable video, audio and caption downloads.
-
-The Windows packaging workflow pins the Shinchiro libmpv development archive and verifies its
-SHA-256 digest before compiling or staging native code.
-
-Phase 5 adds opt-in automatic synchronization while WizeStream Desktop is running. The JVM
-backend persists a user-selected interval, categories and explicit trusted-device allowlist,
-checks for a private local IPv4 network, and reuses the Phase 2 engines without changing their
-journals or conflict rules. Runs are serialized with manual synchronization, recover after an
-overdue application restart, and use per-device 5-minute-to-6-hour exponential retry backoff.
-Search history remains excluded until explicitly selected. Recent manual, automatic, skipped and
-failed attempts are shown on the Devices screen without recording synchronized payloads, pairing
-codes, private keys or media URLs.
-
-Automatic synchronization is not an operating-system daemon: closing WizeStream stops its JVM
-backend and scheduler. The next launch performs a jittered catch-up when a persisted run is overdue.
-
-Phase 6 packages an Electron-ABI-matched embedded libmpv renderer on Windows x64, Linux x64/arm64,
-and macOS x64/arm64. Windows and macOS prefer shared textures; Linux uses the software/WebGL
-pipeline. Selected external audio and captions now remain inside the embedded player and can be
-switched through narrow typed operations. The shell-free external mpv controller remains an
-explicit recovery option on every platform.
-
-Adaptive video-only downloads require an audio selection and are represented as one recoverable
-job. WizeStream downloads both components, refreshes expired URLs only when the saved stream
-fingerprint resolves unambiguously, and uses packaged checksum-verified FFmpeg/FFprobe tools to
-stream-copy and validate MP4, WebM or Matroska output before an atomic final rename. It never
-transcodes, silently changes quality/language, logs signed media URLs, or records completion before
-the final file is valid. Legacy Phase 4 download state migrates to schema version 2 without deleting
-partial files.
-
-When a trusted device's saved IP address is stale, desktop scans the local IPv4 subnet only on the
-previously trusted sync port and then authenticates the discovered endpoint against the saved
-libp2p PeerID. Discovery never establishes trust by itself.
-
-Phase 7 adds the `0.6.0-beta.1-unsigned-preview` release contract. Preview packages are produced by
-GitHub Actions for all five target architectures and published with `SHA256SUMS` plus GitHub
-artifact attestations. Production automatic updates are hard-disabled, updater metadata is omitted,
-and preview upgrades are installed manually. Windows unknown-publisher or SmartScreen warnings and
-macOS Gatekeeper approval are expected for these unsigned packages. The protected signed-release
-workflow is retained as a postponed future path and remains inactive unless maintainers explicitly
-change the release policy and configure trusted signing identities.
-
-Phase 8 synchronizes the WizeStream 1.6.0 Android changes from `pipe`, reconciles the release
-documentation with the unsigned-preview policy, reruns Android regression checks and the complete
-five-platform Desktop matrix, and integrates WizeStream Desktop into `pipe`.
-
-Phase 9 stabilizes that integrated preview. It adds a dedicated Desktop bug-report path and a
-repeatable five-platform manual acceptance checklist, while keeping the first unsigned preview
-immutable. Another preview is published only when material fixes justify a higher beta version.
+The current Desktop packages are explicitly unsigned previews. They are built and tested for
+Windows x64, macOS x64/arm64 and Linux x64/arm64. Updates are installed manually.
 
 ## Requirements
 
@@ -138,7 +85,7 @@ omitted, so preview upgrades are installed manually. Windows signing and macOS
 signing/notarization are postponed future release gates, not requirements for architecture CI or
 the current preview channel.
 
-See [docs/preview-testing.md](docs/preview-testing.md) for the Phase 9 manual acceptance checklist.
+See [docs/preview-testing.md](docs/preview-testing.md) for the manual acceptance checklist.
 See [docs/releasing.md](docs/releasing.md) for the current unsigned-preview policy and the postponed
 future signing, updater-validation and rollback procedures.
 
@@ -156,11 +103,10 @@ future signing, updater-validation and rollback procedures.
 - Pairing invitations retain WizeStream's protocol version, peer identity signature checks,
   expiration, one-time token and libp2p authenticated transport.
 
-## Next milestone
+## Maintenance status
 
-Complete the Phase 9 five-platform manual acceptance checklist and triage reports submitted through
-the Desktop preview issue form. Fix reproducible preview regressions from dedicated branches based
-on `pipe`, and require the Android and complete Desktop CI matrices before merging them. Publish a
-higher unsigned beta only when material fixes change the tested binaries. Signed public releases
-and production automatic updates remain postponed until the maintainers explicitly adopt a new
-release policy.
+WizeStream Desktop is integrated into the main project. Ongoing work is regular maintenance:
+testing the supported platforms, reviewing preview reports and fixing reproducible problems.
+Changes must pass the Android and complete Desktop test matrices before they are merged. A higher
+unsigned beta is published only when important fixes change the application. Signed public
+releases and production automatic updates remain postponed.

--- a/desktop/docs/preview-testing.md
+++ b/desktop/docs/preview-testing.md
@@ -1,7 +1,7 @@
 # Desktop unsigned-preview testing
 
-This checklist defines the Phase 9 manual acceptance pass for WizeStream Desktop. It supplements
-the automated five-target Desktop CI matrix; it does not replace it.
+This checklist helps testers confirm that the WizeStream Desktop preview works on every supported
+platform. It supplements automated testing; it does not replace it.
 
 ## Safety and authenticity
 
@@ -65,7 +65,7 @@ Never attach access tokens, private keys, pairing invitations, signed media URLs
 private filesystem paths. Include the smallest useful redacted log or screenshot, the exact package
 filename and exact reproduction steps.
 
-## Phase 9 release gate
+## Release gate
 
 The existing `v0.6.0-beta.1-unsigned-preview` tag and assets are immutable. A second unsigned
 preview is justified only when one or more material fixes change the tested binaries. A new preview

--- a/desktop/docs/releasing.md
+++ b/desktop/docs/releasing.md
@@ -12,11 +12,11 @@ unsigned packages. Signed public releases and production automatic updates are p
 future signing procedures below remain inactive unless the maintainers explicitly change this
 policy and configure protected, trusted signing identities.
 
-Phase 9 feedback and manual acceptance use the checklist in
-[`preview-testing.md`](preview-testing.md). Preview failures must be reported through the dedicated
-Desktop issue form with the exact release tag, package filename, platform and architecture. The
-existing `v0.6.0-beta.1-unsigned-preview` release is immutable; publish a higher beta only after
-material fixes pass the Android regression checks and the complete five-target Desktop matrix.
+Use the checklist in [`preview-testing.md`](preview-testing.md) for feedback and manual testing.
+Preview failures must be reported through the dedicated Desktop issue form with the exact release
+tag, package filename, platform and architecture. The existing
+`v0.6.0-beta.1-unsigned-preview` release is immutable; publish a higher beta only after important
+fixes pass the Android regression checks and the complete five-target Desktop matrix.
 
 ## Future signed-release setup (postponed)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,10 +2,17 @@
 
 ## What is WizeStream?
 
-WizeStream is an independent, NewPipe-based streaming client for Android. It combines a modern
-Material 3 Expressive interface with privacy-friendly playback, useful local-first features, and
-support for multiple streaming platforms. Material 3 is an important design goal, not the
-project's only purpose.
+WizeStream is an independent, NewPipe-based, multi-platform streaming application for Android,
+Windows, macOS and Linux. It combines privacy-friendly playback, useful local-first features,
+support for multiple streaming services, an expressive Android interface and a dedicated Desktop
+experience. Material 3 is an important Android design goal, not the project's only purpose.
+
+## Which operating systems are supported?
+
+WizeStream provides signed Android application releases. Its integrated Desktop client supports
+Windows x64, macOS x64/arm64 and Linux x64/arm64. Desktop packages are currently explicitly
+unsigned previews, and production automatic updates are disabled. Download them only from the
+official repository and verify `SHA256SUMS` before opening them.
 
 ## Is WizeStream an official NewPipe release?
 
@@ -44,7 +51,13 @@ shown as **Not local** and can be fetched from its original source with **Downlo
 
 ## How should I update WizeStream?
 
-Use the same source from which you installed it whenever possible. IzzyOnDroid users should update through their F-Droid-compatible client. Direct installations can use signed WizeStream GitHub releases or the in-app GitHub release checker.
+On Android, use the same source from which you installed WizeStream whenever possible.
+IzzyOnDroid users should update through their F-Droid-compatible client. Direct Android
+installations can use signed WizeStream GitHub releases or the in-app GitHub release checker.
+
+Desktop preview updates are manual. Download a higher preview only from the official GitHub release,
+verify its checksum, and install it over or alongside the existing package as appropriate for the
+operating system. Production automatic Desktop updates remain disabled.
 
 ## Which services are supported?
 


### PR DESCRIPTION
- present WizeStream as one application for Android, Windows, macOS and Linux
- add a simple platform and package table to the main README
- explain that Android releases are signed while Desktop packages are unsigned previews
- add clear Desktop download, safety, testing and maintenance guidance
- update the FAQ, privacy policy, build guide and contributor guide
- replace the old numbered development history with a short list of current Desktop capabilities