### PR TITLE
Add Android-aligned desktop settings

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -27,6 +27,8 @@ The desktop architecture contains:
 - Download video, audio and captions, with pause and resume support.
 - Manage subscriptions, playlists, history and Learning Mode notes.
 - Pair with trusted WizeStream devices and synchronize selected data over the local network.
+- Adjust applicable playback, download, appearance, history, content, device and Learning Mode
+  settings using the same familiar sections as the Android app.
 - Keep user data locally without requiring a WizeStream account.
 
 Synchronization can run manually or automatically while WizeStream Desktop is open. It works only

--- a/desktop/scripts/verify-build.mjs
+++ b/desktop/scripts/verify-build.mjs
@@ -66,6 +66,9 @@ assert.equal(typeof exposedApi?.player?.stop, 'function');
 assert.equal(typeof exposedApi?.player?.status, 'function');
 assert.equal(typeof exposedApi?.downloads?.start, 'function');
 assert.equal(typeof exposedApi?.downloads?.onChanged, 'function');
+assert.equal(typeof exposedApi?.settings?.get, 'function');
+assert.equal(typeof exposedApi?.settings?.update, 'function');
+assert.equal(typeof exposedApi?.settings?.reset, 'function');
 await exposedApi.backend.invoke('health');
 const healthCall = ipcCalls.find((call) => call.channel === 'backend:invoke');
 assert.equal(healthCall?.payload?.method, 'health');
@@ -92,5 +95,8 @@ assert.match(rendererJavaScript, /Play embedded/, 'renderer must include Phase 4
 assert.match(rendererJavaScript, /Download current stream/, 'renderer must include Phase 4 downloads');
 assert.match(rendererJavaScript, /Combining tracks/, 'renderer must report Phase 6 adaptive muxing');
 assert.match(rendererJavaScript, /Open with external mpv/, 'renderer must preserve explicit external-player recovery');
+assert.match(rendererJavaScript, /Video and audio/, 'renderer must include Android-aligned desktop settings');
+assert.match(rendererJavaScript, /History and cache/, 'renderer must include applicable history settings');
+assert.match(rendererJavaScript, /Device synchronization/, 'renderer must link settings to Devices');
 
 console.log('Packaged Electron startup boundary verified.');

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -10,6 +10,7 @@ import { BackendClient } from './backend-client.js';
 import { DownloadManager } from './download-manager.js';
 import { embeddedMpvAddonPath, embeddedMpvAvailable } from './embedded-mpv.js';
 import { MpvController } from './mpv-controller.js';
+import { SettingsManager } from './settings-manager.js';
 import { UpdateManager } from './update-manager.js';
 
 declare const __WIZESTREAM_UPDATES_ENABLED__: boolean;
@@ -21,6 +22,7 @@ const player = new MpvController();
 let embeddedPlayer: MpvMain | undefined;
 let downloads: DownloadManager | undefined;
 let updates: UpdateManager | undefined;
+let settings: SettingsManager | undefined;
 let embeddedAddonPath = '';
 let shutdownStarted = false;
 const backendMethods = new Set<BackendMethod>([
@@ -119,6 +121,8 @@ function createWindow(): BrowserWindow {
 
 app.whenReady().then(async () => {
   session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false));
+  settings = new SettingsManager(path.join(app.getPath('userData'), 'settings.json'));
+  await settings.initialize();
   embeddedAddonPath = embeddedMpvAddonPath(process.resourcesPath, app.getAppPath(), app.isPackaged);
   embeddedPlayer = createMpvMain({ addonPath: embeddedAddonPath });
   downloads = new DownloadManager(
@@ -181,6 +185,9 @@ app.whenReady().then(async () => {
     if (filePath) shell.showItemInFolder(filePath);
   });
   ipcMain.handle('downloads:open-folder', () => shell.openPath(path.join(app.getPath('downloads'), 'WizeStream')));
+  ipcMain.handle('settings:get', () => settings?.get());
+  ipcMain.handle('settings:update', (_event, input: unknown) => settings?.update(input));
+  ipcMain.handle('settings:reset', () => settings?.reset());
   updates = await createUpdateManager();
   updates.initialize();
   ipcMain.handle('updates:state', () => updates?.state());

--- a/desktop/src/main/settings-manager.test.ts
+++ b/desktop/src/main/settings-manager.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defaultDesktopSettings } from '../shared/contracts.js';
+import { SettingsManager } from './settings-manager.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+async function fixture() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'wizestream-settings-'));
+  temporaryDirectories.push(directory);
+  return path.join(directory, 'settings.json');
+}
+
+describe('SettingsManager', () => {
+  it('uses the Android-aligned desktop defaults when no file exists', async () => {
+    const manager = new SettingsManager(await fixture());
+    expect(await manager.initialize()).toEqual(defaultDesktopSettings);
+  });
+
+  it('persists a validated partial update', async () => {
+    const filePath = await fixture();
+    const manager = new SettingsManager(filePath);
+    await manager.initialize();
+    await manager.update({ theme: 'dark', enableSearchHistory: false });
+
+    const restored = new SettingsManager(filePath);
+    expect(await restored.initialize()).toMatchObject({ theme: 'dark', enableSearchHistory: false });
+    expect(JSON.parse(await readFile(filePath, 'utf8'))).toMatchObject({ theme: 'dark' });
+  });
+
+  it('rejects unknown or invalid settings', async () => {
+    const manager = new SettingsManager(await fixture());
+    await manager.initialize();
+    await expect(manager.update({ theme: 'neon' })).rejects.toThrow();
+    await expect(manager.update({ unexpected: true })).rejects.toThrow();
+  });
+
+  it('recovers from a corrupt file without exposing malformed values', async () => {
+    const filePath = await fixture();
+    await writeFile(filePath, '{broken');
+    const manager = new SettingsManager(filePath);
+    expect(await manager.initialize()).toEqual(defaultDesktopSettings);
+  });
+});

--- a/desktop/src/main/settings-manager.ts
+++ b/desktop/src/main/settings-manager.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { z } from 'zod';
+import { defaultDesktopSettings, type DesktopSettings } from '../shared/contracts.js';
+
+const settingsSchema = z.object({
+  theme: z.enum(['system', 'light', 'dark']),
+  defaultServiceId: z.number().int().nonnegative().nullable(),
+  defaultResolution: z.enum([
+    'best_resolution', '1080p60', '1080p', '720p60', '720p', '480p', '360p', '240p', '144p',
+  ]),
+  defaultVideoFormat: z.enum(['video_mp4', 'video_webm', 'video_3gp']),
+  defaultAudioFormat: z.enum(['audio_m4a', 'audio_webm']),
+  preferOriginalAudio: z.boolean(),
+  preferDescriptiveAudio: z.boolean(),
+  enableWatchHistory: z.boolean(),
+  enableSearchHistory: z.boolean(),
+  learningMode: z.boolean(),
+  learningNotes: z.boolean(),
+}).strict();
+
+const settingsPatchSchema = settingsSchema.partial();
+
+export class SettingsManager {
+  private value: DesktopSettings = { ...defaultDesktopSettings };
+
+  constructor(private readonly filePath: string) {}
+
+  async initialize(): Promise<DesktopSettings> {
+    try {
+      const parsed = JSON.parse(await readFile(this.filePath, 'utf8')) as unknown;
+      const migrated = settingsPatchSchema.parse(parsed);
+      this.value = settingsSchema.parse({ ...defaultDesktopSettings, ...migrated });
+    } catch (error) {
+      const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined;
+      if (code !== 'ENOENT') console.warn('Desktop settings could not be read; defaults will be used', error);
+      this.value = { ...defaultDesktopSettings };
+    }
+    return this.get();
+  }
+
+  get(): DesktopSettings {
+    return { ...this.value };
+  }
+
+  async update(input: unknown): Promise<DesktopSettings> {
+    const patch = settingsPatchSchema.parse(input);
+    this.value = settingsSchema.parse({ ...this.value, ...patch });
+    await this.save();
+    return this.get();
+  }
+
+  async reset(): Promise<DesktopSettings> {
+    this.value = { ...defaultDesktopSettings };
+    await this.save();
+    return this.get();
+  }
+
+  private async save(): Promise<void> {
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    const temporaryPath = `${this.filePath}.tmp`;
+    await writeFile(temporaryPath, `${JSON.stringify(this.value, null, 2)}\n`, { mode: 0o600 });
+    await rename(temporaryPath, this.filePath);
+  }
+}

--- a/desktop/src/preload/index.cts
+++ b/desktop/src/preload/index.cts
@@ -39,6 +39,11 @@ const api: DesktopApi = {
       return () => ipcRenderer.off('updates:changed', wrapped);
     },
   },
+  settings: {
+    get: () => ipcRenderer.invoke('settings:get') as ReturnType<DesktopApi['settings']['get']>,
+    update: (patch) => ipcRenderer.invoke('settings:update', patch) as ReturnType<DesktopApi['settings']['update']>,
+    reset: () => ipcRenderer.invoke('settings:reset') as ReturnType<DesktopApi['settings']['reset']>,
+  },
 };
 
 contextBridge.exposeInMainWorld('wizestream', api);

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import {
   ListItem, ListItemAvatar, ListItemButton, ListItemIcon, ListItemText, MenuItem,
   Slider, Stack, Switch, TextField, Toolbar, Tooltip, Typography,
 } from '@mui/material';
+import { useColorScheme } from '@mui/material/styles';
 import { defineMpvVideoElement, type MpvVideoElement } from 'electron-mpv-video/renderer';
 import AddRounded from '@mui/icons-material/AddRounded';
 import DeleteOutlineRounded from '@mui/icons-material/DeleteOutlineRounded';
@@ -23,19 +24,24 @@ import PlayArrowRounded from '@mui/icons-material/PlayArrowRounded';
 import ReplayRounded from '@mui/icons-material/ReplayRounded';
 import SchoolRounded from '@mui/icons-material/SchoolRounded';
 import SearchRounded from '@mui/icons-material/SearchRounded';
+import SettingsRounded from '@mui/icons-material/SettingsRounded';
 import StopRounded from '@mui/icons-material/StopRounded';
 import SubscriptionsRounded from '@mui/icons-material/SubscriptionsRounded';
 import SystemUpdateAltRounded from '@mui/icons-material/SystemUpdateAltRounded';
+import { defaultDesktopSettings } from '../shared/contracts';
 import type {
-  DownloadJob, DownloadSource, EmbeddedPlayerRequest, HistoryItem, LearningNote, LibraryStream, PlayerStatus, PlaylistItem, PlaylistSummary,
+  DesktopSettings, DownloadJob, DownloadSource, EmbeddedPlayerRequest,
+  HistoryItem, LearningNote, LibraryStream, PlayerStatus, PlaylistItem, PlaylistSummary,
   SearchHistoryItem, SearchItem, ServiceSummary, StreamDetails, StreamVariant, SubtitleVariant,
   AutomaticSyncPolicy, SubscriptionItem, SyncRunLog, SyncRunResult, SyncStatus,
   UpdateState,
 } from '../shared/contracts';
+import { SettingsPanel } from './SettingsPanel';
+import { preferredAudioIndex, preferredVideoIndex } from './stream-preferences';
 
 defineMpvVideoElement();
 
-type Section = 'discover' | 'subscriptions' | 'playlists' | 'history' | 'learning' | 'downloads' | 'sync';
+type Section = 'discover' | 'subscriptions' | 'playlists' | 'history' | 'learning' | 'downloads' | 'sync' | 'settings';
 
 const navigation: Array<{ id: Section; label: string; icon: React.ReactNode }> = [
   { id: 'discover', label: 'Discover', icon: <HomeRounded /> },
@@ -45,9 +51,11 @@ const navigation: Array<{ id: Section; label: string; icon: React.ReactNode }> =
   { id: 'learning', label: 'Learning', icon: <SchoolRounded /> },
   { id: 'downloads', label: 'Downloads', icon: <DownloadRounded /> },
   { id: 'sync', label: 'Devices', icon: <DevicesRounded /> },
+  { id: 'settings', label: 'Settings', icon: <SettingsRounded /> },
 ];
 
 export function App() {
+  const { setMode } = useColorScheme();
   const [section, setSection] = useState<Section>('discover');
   const [services, setServices] = useState<ServiceSummary[]>([]);
   const [serviceId, setServiceId] = useState(0);
@@ -64,19 +72,25 @@ export function App() {
   const [embeddedRequest, setEmbeddedRequest] = useState<EmbeddedPlayerRequest & { title: string; nonce: number }>();
   const [updateState, setUpdateState] = useState<UpdateState>();
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+  const [settings, setSettings] = useState<DesktopSettings>(defaultDesktopSettings);
 
   useEffect(() => {
     Promise.all([
       window.wizestream.backend.invoke<ServiceSummary[]>('services.list'),
       window.wizestream.backend.invoke<SyncStatus>('sync.status'),
       window.wizestream.player.status(),
-    ]).then(([availableServices, syncStatus, playerStatus]) => {
+      window.wizestream.settings.get(),
+    ]).then(([availableServices, syncStatus, playerStatus, savedSettings]) => {
       setServices(availableServices);
-      setServiceId(availableServices[0]?.id ?? 0);
+      setServiceId(availableServices.some((service) => service.id === savedSettings.defaultServiceId)
+        ? savedSettings.defaultServiceId! : availableServices[0]?.id ?? 0);
       setSync(syncStatus);
       setMpv(playerStatus);
+      setSettings(savedSettings);
     }).catch((reason: unknown) => setError(errorMessage(reason)));
   }, []);
+
+  useEffect(() => { setMode(settings.theme); }, [setMode, settings.theme]);
 
   useEffect(() => {
     void window.wizestream.updates.state().then((state) => {
@@ -119,18 +133,25 @@ export function App() {
       setResults(await window.wizestream.backend.invoke<SearchItem[]>('search', {
         serviceId, query: searchQuery,
       }));
-      await window.wizestream.backend.invoke('library.search-history.record', { serviceId, query: searchQuery });
+      if (settings.enableSearchHistory) {
+        await window.wizestream.backend.invoke('library.search-history.record', { serviceId, query: searchQuery });
+      }
     } catch (reason) { setError(errorMessage(reason)); } finally { setLoading(false); }
   }
 
   const resolveStream = useCallback(async (url: string) => {
     setLoading(true); setError(undefined);
     try {
-      setSelected(await window.wizestream.backend.invoke<StreamDetails>('stream.resolve', { url }));
-      setVideoChoice('auto'); setAudioChoice('auto'); setSubtitleChoice('none'); setEmbeddedRequest(undefined);
+      const details = await window.wizestream.backend.invoke<StreamDetails>('stream.resolve', { url });
+      setSelected(details);
+      const videoIndex = preferredVideoIndex(details, settings);
+      const audioIndex = preferredAudioIndex(details, settings);
+      setVideoChoice(videoIndex === undefined ? 'auto' : String(videoIndex));
+      setAudioChoice(audioIndex === undefined ? 'auto' : String(audioIndex));
+      setSubtitleChoice('none'); setEmbeddedRequest(undefined);
       setSection('discover');
     } catch (reason) { setError(errorMessage(reason)); } finally { setLoading(false); }
-  }, []);
+  }, [settings]);
 
   async function openResult(item: SearchItem) {
     if (item.type === 'STREAM') await resolveStream(item.url);
@@ -153,7 +174,9 @@ export function App() {
           subtitleUrl: selectedSubtitle?.url,
         });
       }
-      await window.wizestream.backend.invoke('library.history.record', { ...selectedLibraryStream });
+      if (settings.enableWatchHistory) {
+        await window.wizestream.backend.invoke('library.history.record', { ...selectedLibraryStream });
+      }
       setMpv(await window.wizestream.player.status());
     } catch (reason) { setError(errorMessage(reason)); }
   }
@@ -171,12 +194,27 @@ export function App() {
     }
   }
 
+  async function saveSettings(patch: Partial<DesktopSettings>) {
+    const saved = await window.wizestream.settings.update(patch);
+    setSettings(saved);
+    if (patch.defaultServiceId !== undefined) {
+      const preferred = services.find((service) => service.id === saved.defaultServiceId);
+      if (preferred) setServiceId(preferred.id);
+    }
+  }
+
+  async function resetSettings() {
+    const saved = await window.wizestream.settings.reset();
+    setSettings(saved);
+    setServiceId(services[0]?.id ?? 0);
+  }
+
   return (
     <Box className="app-shell">
       <Box component="nav" className="navigation-rail">
         <Avatar sx={{ width: 48, height: 48, mb: 2, bgcolor: 'primary.main' }}>W</Avatar>
         <List sx={{ width: '100%' }}>
-          {navigation.map((item) => (
+          {navigation.filter((item) => item.id !== 'learning' || settings.learningMode).map((item) => (
             <ListItemButton key={item.id} selected={section === item.id} onClick={() => setSection(item.id)}>
               <ListItemIcon>{item.icon}</ListItemIcon><ListItemText primary={item.label} />
             </ListItemButton>
@@ -249,7 +287,7 @@ export function App() {
                       || (!embeddedSelection && !mpv?.externalAvailable)} onClick={() => void playSelected()}>{embeddedSelection ? 'Play embedded' : 'Play with mpv'}</Button>
                   <Button startIcon={<DownloadRounded />} variant="outlined" size="large" onClick={() => setSection('downloads')}>Download</Button>
                   <Button startIcon={<PlaylistAddRounded />} variant="outlined" size="large" onClick={() => setSection('playlists')}>Add to playlist</Button>
-                  <Button startIcon={<NoteAddRounded />} variant="outlined" size="large" onClick={() => setSection('learning')}>Add note</Button>
+                  {settings.learningMode && settings.learningNotes && <Button startIcon={<NoteAddRounded />} variant="outlined" size="large" onClick={() => setSection('learning')}>Add note</Button>}
                 </Stack>
               </CardContent>
             </Box></Card>}
@@ -259,7 +297,11 @@ export function App() {
               : section === 'history' ? <HistoryPanel onOpen={resolveStream} />
                 : section === 'learning' ? <LearningPanel currentStream={selectedLibraryStream} onOpen={resolveStream} />
                   : section === 'downloads' ? <DownloadsPanel currentStream={selected} />
-                    : <SyncPanel sync={sync} onRefresh={() => void window.wizestream.backend.invoke<SyncStatus>('sync.status').then(setSync)} />}
+                    : section === 'sync' ? <SyncPanel sync={sync} onRefresh={() => void window.wizestream.backend.invoke<SyncStatus>('sync.status').then(setSync)} />
+                      : <SettingsPanel settings={settings} services={services} currentVersion={updateState?.currentVersion}
+                        onUpdate={saveSettings} onReset={resetSettings}
+                        onOpenDownloads={() => void window.wizestream.downloads.openFolder()} onOpenDevices={() => setSection('sync')}
+                        onOpenUpdates={() => void openUpdates()} />}
         </Container>
       </Box>
       <Dialog open={updateDialogOpen} onClose={() => setUpdateDialogOpen(false)} fullWidth maxWidth="sm">

--- a/desktop/src/renderer/SettingsPanel.tsx
+++ b/desktop/src/renderer/SettingsPanel.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import {
+  Alert, Box, Button, Card, CardActionArea, CardContent, Divider, FormControlLabel,
+  IconButton, List, ListItem, ListItemIcon, ListItemText, MenuItem, Stack, Switch,
+  TextField, Tooltip, Typography,
+} from '@mui/material';
+import ArrowBackRounded from '@mui/icons-material/ArrowBackRounded';
+import CleaningServicesRounded from '@mui/icons-material/CleaningServicesRounded';
+import DevicesRounded from '@mui/icons-material/DevicesRounded';
+import DownloadRounded from '@mui/icons-material/DownloadRounded';
+import HistoryRounded from '@mui/icons-material/HistoryRounded';
+import HomeRounded from '@mui/icons-material/HomeRounded';
+import PaletteRounded from '@mui/icons-material/PaletteRounded';
+import SchoolRounded from '@mui/icons-material/SchoolRounded';
+import SystemUpdateAltRounded from '@mui/icons-material/SystemUpdateAltRounded';
+import VideoSettingsRounded from '@mui/icons-material/VideoSettingsRounded';
+import type { DesktopSettings, ServiceSummary } from '../shared/contracts';
+
+type Category = 'video' | 'download' | 'appearance' | 'history' | 'content' | 'sync' | 'learning' | 'updates';
+
+const categories: Array<{ id: Category; title: string; summary: string; icon: React.ReactNode }> = [
+  { id: 'video', title: 'Video and audio', summary: 'Playback, resolution, formats, and audio behavior', icon: <VideoSettingsRounded /> },
+  { id: 'download', title: 'Download', summary: 'Download folders, file names, and download options', icon: <DownloadRounded /> },
+  { id: 'appearance', title: 'Appearance', summary: 'Theme, colors, tabs, and layout', icon: <PaletteRounded /> },
+  { id: 'history', title: 'History and cache', summary: 'Watch history, search history, and cached data', icon: <HistoryRounded /> },
+  { id: 'content', title: 'Content', summary: 'Services, languages, regions, and content filters', icon: <HomeRounded /> },
+  { id: 'sync', title: 'Device synchronization', summary: 'Securely pair trusted devices for private synchronization', icon: <DevicesRounded /> },
+  { id: 'learning', title: 'Learning Mode', summary: 'Optional notes, progress, dashboard, and study statistics', icon: <SchoolRounded /> },
+  { id: 'updates', title: 'Updates', summary: 'Version, changelog, and update checks', icon: <SystemUpdateAltRounded /> },
+];
+
+export function SettingsPanel({ settings, services, currentVersion, onUpdate, onReset, onOpenDownloads,
+  onOpenDevices, onOpenUpdates }: {
+  settings: DesktopSettings;
+  services: ServiceSummary[];
+  currentVersion?: string;
+  onUpdate(patch: Partial<DesktopSettings>): Promise<void>;
+  onReset(): Promise<void>;
+  onOpenDownloads(): void;
+  onOpenDevices(): void;
+  onOpenUpdates(): void;
+}) {
+  const [category, setCategory] = useState<Category>();
+  const [message, setMessage] = useState<string>();
+
+  async function update(patch: Partial<DesktopSettings>) {
+    setMessage(undefined);
+    try { await onUpdate(patch); }
+    catch (reason) { setMessage(reason instanceof Error ? reason.message : String(reason)); }
+  }
+
+  async function clear(method: 'library.history.clear' | 'library.search-history.clear', confirmation: string) {
+    if (!window.confirm(confirmation)) return;
+    setMessage(undefined);
+    try {
+      await window.wizestream.backend.invoke(method);
+      setMessage(method === 'library.history.clear' ? 'Watch history cleared.' : 'Search history cleared.');
+    } catch (reason) { setMessage(reason instanceof Error ? reason.message : String(reason)); }
+  }
+
+  if (!category) return <Stack spacing={3}>
+    <Box><Typography variant="h4">Settings</Typography><Typography color="text.secondary">Choose how WizeStream Desktop works for you.</Typography></Box>
+    {message && <Alert severity="info">{message}</Alert>}
+    <Box className="settings-category-grid">{categories.map((item) => <Card key={item.id} variant="outlined">
+      <CardActionArea onClick={() => setCategory(item.id)} sx={{ height: '100%' }}><CardContent sx={{ p: 3 }}>
+        <Stack direction="row" sx={{ gap: 2, alignItems: 'center' }}><Box color="primary.main">{item.icon}</Box><Box>
+          <Typography variant="h6">{item.title}</Typography><Typography color="text.secondary" variant="body2">{item.summary}</Typography>
+        </Box></Stack>
+      </CardContent></CardActionArea>
+    </Card>)}</Box>
+    <Box><Button color="inherit" startIcon={<CleaningServicesRounded />} onClick={() => {
+      if (window.confirm('Reset all desktop settings to their defaults?')) void onReset();
+    }}>Reset settings</Button></Box>
+  </Stack>;
+
+  const metadata = categories.find((item) => item.id === category)!;
+  return <Stack spacing={3}>
+    <Stack direction="row" sx={{ gap: 1, alignItems: 'center' }}>
+      <Tooltip title="Back to Settings"><IconButton onClick={() => { setCategory(undefined); setMessage(undefined); }}><ArrowBackRounded /></IconButton></Tooltip>
+      <Box><Typography variant="h4">{metadata.title}</Typography><Typography color="text.secondary">{metadata.summary}</Typography></Box>
+    </Stack>
+    {message && <Alert severity={message.endsWith('cleared.') ? 'success' : 'error'}>{message}</Alert>}
+    <Card variant="outlined"><CardContent sx={{ p: 0 }}>
+      {category === 'video' && <List disablePadding>
+        <SettingSelect title="Default resolution" value={settings.defaultResolution} onChange={(value) => void update({ defaultResolution: value as DesktopSettings['defaultResolution'] })}
+          options={[['best_resolution', 'Best available'], ['1080p60', '1080p60'], ['1080p', '1080p'], ['720p60', '720p60'], ['720p', '720p'], ['480p', '480p'], ['360p', '360p'], ['240p', '240p'], ['144p', '144p']]} />
+        <Divider component="li" /><SettingSelect title="Default video format" value={settings.defaultVideoFormat} onChange={(value) => void update({ defaultVideoFormat: value as DesktopSettings['defaultVideoFormat'] })}
+          options={[['video_mp4', 'MPEG-4'], ['video_webm', 'WebM'], ['video_3gp', '3GP']]} />
+        <Divider component="li" /><SettingSelect title="Default audio format" value={settings.defaultAudioFormat} onChange={(value) => void update({ defaultAudioFormat: value as DesktopSettings['defaultAudioFormat'] })}
+          options={[['audio_m4a', 'M4A'], ['audio_webm', 'WebM']]} />
+        <Divider component="li" /><SettingSwitch title="Prefer original audio" summary="Select the original audio track regardless of the language" checked={settings.preferOriginalAudio} onChange={(checked) => void update({ preferOriginalAudio: checked })} />
+        <Divider component="li" /><SettingSwitch title="Prefer descriptive audio" summary="Select an audio track with descriptions for visually impaired people if available" checked={settings.preferDescriptiveAudio} onChange={(checked) => void update({ preferDescriptiveAudio: checked })} />
+      </List>}
+      {category === 'download' && <SettingAction icon={<DownloadRounded />} title="Download folder" summary="Media and captions are stored in the WizeStream folder inside your system Downloads folder." action="Open folder" onClick={onOpenDownloads} />}
+      {category === 'appearance' && <List disablePadding><SettingSelect title="Theme" value={settings.theme} onChange={(value) => void update({ theme: value as DesktopSettings['theme'] })}
+        options={[['light', 'Light'], ['dark', 'Dark'], ['system', 'Follow the system']]} /></List>}
+      {category === 'history' && <List disablePadding>
+        <SettingSwitch title="Watch history" summary="Keep track of watched videos" checked={settings.enableWatchHistory} onChange={(checked) => void update({ enableWatchHistory: checked })} />
+        <Divider component="li" /><SettingSwitch title="Search history" summary="Store search queries locally" checked={settings.enableSearchHistory} onChange={(checked) => void update({ enableSearchHistory: checked })} />
+        <Divider component="li" /><SettingAction icon={<CleaningServicesRounded />} title="Clear watch history" summary="Deletes the history of played streams and the playback positions" action="Clear" onClick={() => void clear('library.history.clear', 'Clear all watch history?')} />
+        <Divider component="li" /><SettingAction icon={<CleaningServicesRounded />} title="Clear search history" summary="Deletes history of search keywords" action="Clear" onClick={() => void clear('library.search-history.clear', 'Clear all search history?')} />
+      </List>}
+      {category === 'content' && <List disablePadding><SettingSelect title="Default content service" value={settings.defaultServiceId === null ? 'automatic' : String(settings.defaultServiceId)}
+        onChange={(value) => void update({ defaultServiceId: value === 'automatic' ? null : Number(value) })}
+        options={[['automatic', 'First available'], ...services.map((service) => [String(service.id), service.name] as [string, string])]} /></List>}
+      {category === 'sync' && <SettingAction icon={<DevicesRounded />} title="Device synchronization" summary="Pair devices, choose data categories, and manage automatic local-network synchronization in Devices." action="Open Devices" onClick={onOpenDevices} />}
+      {category === 'learning' && <List disablePadding>
+        <SettingSwitch title="Enable Learning Mode" summary="Show optional learning tools without changing the normal WizeStream experience" checked={settings.learningMode} onChange={(checked) => void update({ learningMode: checked })} />
+        <Divider component="li" /><SettingSwitch title="Timestamped notes" summary="Create notes linked to exact positions in videos" checked={settings.learningNotes} disabled={!settings.learningMode} onChange={(checked) => void update({ learningNotes: checked })} />
+      </List>}
+      {category === 'updates' && <Box sx={{ p: 4 }}><Typography variant="h6">WizeStream Desktop {currentVersion ?? ''}</Typography>
+        <Alert severity="info" sx={{ my: 2 }}>Preview builds are explicitly unsigned. Updates remain manual until signed public releases are available.</Alert>
+        <Button startIcon={<SystemUpdateAltRounded />} variant="outlined" onClick={onOpenUpdates}>Check for updates</Button>
+      </Box>}
+    </CardContent></Card>
+  </Stack>;
+}
+
+function SettingSelect({ title, value, options, onChange }: { title: string; value: string; options: Array<[string, string]>; onChange(value: string): void }) {
+  return <ListItem sx={{ py: 2.5 }}><ListItemText primary={title} /><TextField select size="small" value={value} onChange={(event) => onChange(event.target.value)} sx={{ minWidth: 210 }}>
+    {options.map(([option, label]) => <MenuItem key={option} value={option}>{label}</MenuItem>)}</TextField></ListItem>;
+}
+
+function SettingSwitch({ title, summary, checked, disabled, onChange }: { title: string; summary: string; checked: boolean; disabled?: boolean; onChange(value: boolean): void }) {
+  return <ListItem sx={{ py: 2 }}><ListItemText primary={title} secondary={summary} /><FormControlLabel sx={{ ml: 2 }} label={checked ? 'On' : 'Off'} control={<Switch checked={checked} disabled={disabled} onChange={(event) => onChange(event.target.checked)} />} /></ListItem>;
+}
+
+function SettingAction({ icon, title, summary, action, onClick }: { icon: React.ReactNode; title: string; summary: string; action: string; onClick(): void }) {
+  return <ListItem sx={{ py: 2.5 }}><ListItemIcon>{icon}</ListItemIcon><ListItemText primary={title} secondary={summary} /><Button sx={{ ml: 2 }} variant="outlined" onClick={onClick}>{action}</Button></ListItem>;
+}

--- a/desktop/src/renderer/stream-preferences.test.ts
+++ b/desktop/src/renderer/stream-preferences.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { defaultDesktopSettings, type StreamDetails } from '../shared/contracts';
+import { preferredAudioIndex, preferredVideoIndex } from './stream-preferences';
+
+const details: StreamDetails = {
+  serviceId: 0, url: 'https://example.test/watch', name: 'Example', duration: 10, streamType: 'VIDEO_STREAM',
+  videoStreams: [
+    { id: 'low', url: 'https://example.test/low', resolution: '480p', format: 'MPEG-4' },
+    { id: 'webm', url: 'https://example.test/high', resolution: '720p60', format: 'WebM' },
+    { id: 'mp4', url: 'https://example.test/preferred', resolution: '720p60', format: 'MPEG-4' },
+  ],
+  audioStreams: [
+    { id: 'dubbed', url: 'https://example.test/dubbed', format: 'M4A', audioTrackType: 'DUBBED' },
+    { id: 'original', url: 'https://example.test/original', format: 'WebM', audioTrackType: 'ORIGINAL' },
+    { id: 'descriptive', url: 'https://example.test/descriptive', format: 'M4A', audioTrackType: 'DESCRIPTIVE' },
+  ],
+  subtitles: [],
+};
+
+describe('desktop stream preferences', () => {
+  it('prefers the configured resolution and format', () => {
+    expect(preferredVideoIndex(details, defaultDesktopSettings)).toBe(2);
+  });
+
+  it('prefers descriptive audio when requested', () => {
+    expect(preferredAudioIndex(details, { ...defaultDesktopSettings, preferDescriptiveAudio: true })).toBe(2);
+  });
+
+  it('uses the original audio preference before the format preference', () => {
+    expect(preferredAudioIndex(details, defaultDesktopSettings)).toBe(1);
+  });
+});

--- a/desktop/src/renderer/stream-preferences.ts
+++ b/desktop/src/renderer/stream-preferences.ts
@@ -1,0 +1,50 @@
+import type { DesktopSettings, StreamDetails, StreamVariant } from '../shared/contracts';
+
+const videoFormats: Record<DesktopSettings['defaultVideoFormat'], string[]> = {
+  video_mp4: ['mp4', 'mpeg-4', 'mpeg4'],
+  video_webm: ['webm'],
+  video_3gp: ['3gp'],
+};
+
+const audioFormats: Record<DesktopSettings['defaultAudioFormat'], string[]> = {
+  audio_m4a: ['m4a', 'mp4', 'mpeg-4', 'mpeg4'],
+  audio_webm: ['webm'],
+};
+
+function formatMatches(stream: StreamVariant, formats: string[]): boolean {
+  const value = stream.format?.toLowerCase() ?? '';
+  return formats.some((format) => value.includes(format));
+}
+
+export function preferredVideoIndex(details: StreamDetails, settings: DesktopSettings): number | undefined {
+  const formats = videoFormats[settings.defaultVideoFormat];
+  const preferredResolution = settings.defaultResolution.toLowerCase();
+  const preferredHeight = preferredResolution.match(/\d+p/)?.[0];
+  let bestScore = 0;
+  let bestIndex: number | undefined;
+  details.videoStreams.forEach((stream, index) => {
+    const resolution = stream.resolution?.toLowerCase() ?? '';
+    const exactResolution = resolution.includes(preferredResolution);
+    const sameHeight = preferredHeight !== undefined && resolution.includes(preferredHeight);
+    const height = Number(resolution.match(/\d+(?=p)/)?.[0] ?? 0);
+    const resolutionScore = preferredResolution === 'best_resolution' ? height / 100
+      : exactResolution ? 8 : sameHeight ? 6 : 0;
+    const score = resolutionScore
+      + (formatMatches(stream, formats) ? 3 : 0) + (!stream.videoOnly ? 1 : 0);
+    if (score > bestScore) { bestScore = score; bestIndex = index; }
+  });
+  return bestIndex;
+}
+
+export function preferredAudioIndex(details: StreamDetails, settings: DesktopSettings): number | undefined {
+  const formats = audioFormats[settings.defaultAudioFormat];
+  let bestScore = 0;
+  let bestIndex: number | undefined;
+  details.audioStreams.forEach((stream, index) => {
+    const score = (settings.preferDescriptiveAudio && stream.audioTrackType === 'DESCRIPTIVE' ? 8 : 0)
+      + (settings.preferOriginalAudio && stream.audioTrackType === 'ORIGINAL' ? 5 : 0)
+      + (formatMatches(stream, formats) ? 2 : 0);
+    if (score > bestScore) { bestScore = score; bestIndex = index; }
+  });
+  return bestIndex;
+}

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -19,4 +19,5 @@ body { overflow-x: hidden; }
 .sync-category-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
 .library-split { display: grid; grid-template-columns: minmax(260px, 32%) 1fr; gap: 20px; align-items: start; }
 .note-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 20px; }
+.settings-category-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 18px; }
 @media (max-width: 1050px) { .navigation-rail { width: 92px; } .navigation-rail .MuiListItemText-root { display: none; } .content-column { margin-left: 92px; width: calc(100% - 92px); } .details-card, .library-split { grid-template-columns: 1fr; } .stream-selectors { grid-template-columns: 1fr; } }

--- a/desktop/src/shared/contracts.ts
+++ b/desktop/src/shared/contracts.ts
@@ -324,6 +324,39 @@ export interface UpdateState {
   message?: string;
 }
 
+export type DesktopTheme = 'system' | 'light' | 'dark';
+export type PreferredVideoFormat = 'video_mp4' | 'video_webm' | 'video_3gp';
+export type PreferredAudioFormat = 'audio_m4a' | 'audio_webm';
+
+export interface DesktopSettings {
+  theme: DesktopTheme;
+  defaultServiceId: number | null;
+  defaultResolution: 'best_resolution' | '1080p60' | '1080p' | '720p60' | '720p'
+    | '480p' | '360p' | '240p' | '144p';
+  defaultVideoFormat: PreferredVideoFormat;
+  defaultAudioFormat: PreferredAudioFormat;
+  preferOriginalAudio: boolean;
+  preferDescriptiveAudio: boolean;
+  enableWatchHistory: boolean;
+  enableSearchHistory: boolean;
+  learningMode: boolean;
+  learningNotes: boolean;
+}
+
+export const defaultDesktopSettings: DesktopSettings = {
+  theme: 'system',
+  defaultServiceId: null,
+  defaultResolution: '720p60',
+  defaultVideoFormat: 'video_mp4',
+  defaultAudioFormat: 'audio_m4a',
+  preferOriginalAudio: true,
+  preferDescriptiveAudio: false,
+  enableWatchHistory: true,
+  enableSearchHistory: true,
+  learningMode: false,
+  learningNotes: true,
+};
+
 export interface DesktopApi {
   backend: {
     invoke<T>(method: BackendMethod, params?: Record<string, unknown>): Promise<T>;
@@ -349,6 +382,11 @@ export interface DesktopApi {
     download(): Promise<UpdateState>;
     install(): Promise<void>;
     onChanged(listener: (state: UpdateState) => void): () => void;
+  };
+  settings: {
+    get(): Promise<DesktopSettings>;
+    update(patch: Partial<DesktopSettings>): Promise<DesktopSettings>;
+    reset(): Promise<DesktopSettings>;
   };
 }
 


### PR DESCRIPTION
- add **Settings** directly below **Devices** in WizeStream Desktop
- reuse the applicable Android settings structure and wording
- persist validated Desktop preferences locally with an atomic settings store
- apply playback, audio-track, theme, history, content-service, and Learning Mode preferences
- link Download and Device synchronization settings to their existing Desktop screens
- keep the unsigned-preview and manual-update policy unchanged