### PR TITLE
Add desktop backup and improve subscription library

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -29,6 +29,8 @@ The desktop architecture contains:
 - Pair with trusted WizeStream devices and synchronize selected data over the local network.
 - Adjust applicable playback, download, appearance, history, content, device and Learning Mode
   settings using the same familiar sections as the Android app.
+- Export and restore versioned Desktop ZIP backups. Subscription-only JSON exports use Android's
+  schema, and Desktop can import subscriptions from Android JSON exports or Android full-backup ZIPs.
 - Keep user data locally without requiring a WizeStream account.
 
 Synchronization can run manually or automatically while WizeStream Desktop is open. It works only

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
@@ -22,11 +22,13 @@ public final class DesktopBackend implements AutoCloseable {
     private final DesktopDatabase database;
     private final Connection syncConnection;
     private final DesktopLibrary library;
+    private final DesktopBackupManager backups;
     private final DesktopSyncService sync;
 
     private DesktopBackend(final Path dataDirectory) throws Exception {
         database = new DesktopDatabase(dataDirectory);
         library = new DesktopLibrary(database.connection());
+        backups = new DesktopBackupManager(database.connection(), library);
         syncConnection = database.openConnection();
         sync = new DesktopSyncService(syncConnection, "WizeStream Desktop");
         sync.start();
@@ -120,6 +122,14 @@ public final class DesktopBackend implements AutoCloseable {
                         requiredLong(params, "sizeBytes"),
                         requiredLong(params, "completedAt"),
                         requiredText(params, "mediaKind"));
+                case "backup.export" -> backups.exportBackup(
+                        Path.of(requiredText(params, "path")), params.path("settings"));
+                case "backup.inspect" -> backups.inspectBackup(Path.of(requiredText(params, "path")));
+                case "backup.restore" -> backups.restoreBackup(Path.of(requiredText(params, "path")));
+                case "subscriptions.import" -> backups.importSubscriptions(
+                        Path.of(requiredText(params, "path")));
+                case "subscriptions.export" -> backups.exportSubscriptions(
+                        Path.of(requiredText(params, "path")), requiredText(params, "appVersion"));
                 case "sync.status" -> sync.status();
                 case "sync.invitation" -> Map.of("pairingCode", sync.createPairingCode());
                 case "sync.pair" -> sync.pair(requiredText(params, "pairingCode"));

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackupManager.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackupManager.java
@@ -76,10 +76,10 @@ final class DesktopBackupManager {
             manifest.put("createdTimestamp", root.path("createdTimestamp").longValue());
             manifest.put("includesDatabase", true);
             manifest.put("includesPreferences", true);
-            JSON.writeValue(zip, manifest);
+            zip.write(JSON.writeValueAsBytes(manifest));
             zip.closeEntry();
             zip.putNextEntry(new ZipEntry(DATA_ENTRY));
-            JSON.writeValue(zip, root);
+            zip.write(JSON.writeValueAsBytes(root));
             zip.closeEntry();
         }
         atomicReplace(temporary, target);

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackupManager.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackupManager.java
@@ -1,0 +1,420 @@
+package org.wisso.wizestream.desktop.backend;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+final class DesktopBackupManager {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String DATA_ENTRY = "wizestream-desktop-backup.json";
+    private static final String MANIFEST_ENTRY = "backup_manifest.json";
+    private static final String ANDROID_DATABASE_ENTRY = "newpipe.db";
+    private static final int FORMAT_VERSION = 1;
+    private static final long MAX_INPUT_BYTES = 512L * 1024L * 1024L;
+    private static final int MAX_JSON_BYTES = 32 * 1024 * 1024;
+    private static final int MAX_ANDROID_DATABASE_BYTES = 256 * 1024 * 1024;
+    private static final int MAX_RECORDS = 20_000;
+
+    private final Connection connection;
+    private final DesktopLibrary library;
+
+    DesktopBackupManager(final Connection connection, final DesktopLibrary library) {
+        this.connection = connection;
+        this.library = library;
+    }
+
+    Map<String, Object> exportBackup(final Path output, final JsonNode settings) throws Exception {
+        if (!settings.isObject()) throw new IllegalArgumentException("Desktop settings are missing");
+        final ObjectNode root = JSON.createObjectNode();
+        root.put("appName", "WizeStream Desktop");
+        root.put("backupFormatVersion", FORMAT_VERSION);
+        root.put("createdTimestamp", System.currentTimeMillis());
+        root.set("settings", settings.deepCopy());
+        final ObjectNode data = root.putObject("data");
+        data.set("subscriptions", JSON.valueToTree(library.subscriptions()));
+        final ArrayNode playlists = data.putArray("playlists");
+        for (final Map<String, Object> playlist : library.playlists()) {
+            final ObjectNode item = JSON.valueToTree(playlist);
+            item.set("items", JSON.valueToTree(library.playlistItems((String) playlist.get("id"))));
+            playlists.add(item);
+        }
+        data.set("history", JSON.valueToTree(library.history()));
+        data.set("searchHistory", JSON.valueToTree(library.searchHistory()));
+        data.set("learningNotes", JSON.valueToTree(library.learningNotes()));
+
+        final Path target = output.toAbsolutePath().normalize();
+        if (target.getParent() != null) Files.createDirectories(target.getParent());
+        final Path temporary = target.resolveSibling(target.getFileName() + ".tmp");
+        try (OutputStream file = Files.newOutputStream(temporary);
+             ZipOutputStream zip = new ZipOutputStream(file)) {
+            zip.putNextEntry(new ZipEntry(MANIFEST_ENTRY));
+            final ObjectNode manifest = JSON.createObjectNode();
+            manifest.put("appName", "WizeStream Desktop");
+            manifest.put("backupFormatVersion", FORMAT_VERSION);
+            manifest.put("createdTimestamp", root.path("createdTimestamp").longValue());
+            manifest.put("includesDatabase", true);
+            manifest.put("includesPreferences", true);
+            JSON.writeValue(zip, manifest);
+            zip.closeEntry();
+            zip.putNextEntry(new ZipEntry(DATA_ENTRY));
+            JSON.writeValue(zip, root);
+            zip.closeEntry();
+        }
+        atomicReplace(temporary, target);
+        return summary(root, "exported");
+    }
+
+    Map<String, Object> inspectBackup(final Path input) throws Exception {
+        return summary(readDesktopBackup(input), "ready");
+    }
+
+    Map<String, Object> restoreBackup(final Path input) throws Exception {
+        final JsonNode root = readDesktopBackup(input);
+        final BackupRecords records = validateBackup(root);
+        synchronized (connection) {
+            final boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                try (Statement statement = connection.createStatement()) {
+                    statement.executeUpdate("DELETE FROM playlist_items");
+                    statement.executeUpdate("DELETE FROM playlists");
+                    statement.executeUpdate("DELETE FROM subscriptions");
+                    statement.executeUpdate("DELETE FROM history");
+                    statement.executeUpdate("DELETE FROM search_history");
+                    statement.executeUpdate("DELETE FROM learning_notes");
+                }
+                for (final SubscriptionRecord subscription : records.subscriptions()) {
+                    library.saveSubscription(subscription.serviceId(), subscription.url(),
+                            subscription.name(), subscription.avatarUrl());
+                }
+                for (final PlaylistRecord playlist : records.playlists()) {
+                    final String id = (String) library.createPlaylist(playlist.name()).get("id");
+                    for (final DesktopLibrary.StreamInput item : playlist.items()) {
+                        library.addPlaylistItem(id, item);
+                    }
+                }
+                for (final StreamRecord item : records.history()) library.recordHistory(item.stream());
+                for (final SearchRecord item : records.searchHistory()) {
+                    library.recordSearch(item.serviceId(), item.query());
+                }
+                for (final NoteRecord item : records.learningNotes()) {
+                    library.saveLearningNote(null, item.stream(), item.positionSeconds(), item.note());
+                }
+                connection.commit();
+            } catch (final Exception error) {
+                connection.rollback();
+                throw error;
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        }
+        return summary(root, "restored");
+    }
+
+    Map<String, Object> importSubscriptions(final Path input) throws Exception {
+        final Path source = checkedInput(input);
+        final List<SubscriptionRecord> subscriptions;
+        if (looksLikeZip(source)) subscriptions = subscriptionsFromZip(source);
+        else subscriptions = subscriptionsFromAndroidJson(Files.readAllBytes(source));
+        if (subscriptions.isEmpty()) throw new IllegalArgumentException("No subscriptions were found");
+        synchronized (connection) {
+            final boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                for (final SubscriptionRecord subscription : subscriptions) {
+                    library.saveSubscription(subscription.serviceId(), subscription.url(),
+                            subscription.name(), subscription.avatarUrl());
+                }
+                connection.commit();
+            } catch (final Exception error) {
+                connection.rollback();
+                throw error;
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        }
+        return Map.of("imported", subscriptions.size(), "source", "Android-compatible export");
+    }
+
+    Map<String, Object> exportSubscriptions(final Path output, final String appVersion) throws Exception {
+        final ObjectNode root = JSON.createObjectNode();
+        final ArrayNode items = root.putArray("subscriptions");
+        for (final Map<String, Object> subscription : library.subscriptions()) {
+            final ObjectNode item = items.addObject();
+            item.put("service_id", ((Number) subscription.get("serviceId")).intValue());
+            item.put("url", (String) subscription.get("url"));
+            item.put("name", (String) subscription.get("name"));
+        }
+        root.put("app_version", appVersion);
+        root.put("app_version_int", 0);
+        final Path target = output.toAbsolutePath().normalize();
+        if (target.getParent() != null) Files.createDirectories(target.getParent());
+        final Path temporary = target.resolveSibling(target.getFileName() + ".tmp");
+        JSON.writerWithDefaultPrettyPrinter().writeValue(temporary.toFile(), root);
+        atomicReplace(temporary, target);
+        return Map.of("exported", items.size());
+    }
+
+    private JsonNode readDesktopBackup(final Path input) throws Exception {
+        final Path source = checkedInput(input);
+        if (!looksLikeZip(source)) throw new IllegalArgumentException("Select a WizeStream Desktop ZIP backup");
+        try (ZipInputStream zip = new ZipInputStream(Files.newInputStream(source))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (DATA_ENTRY.equals(entry.getName())) {
+                    final JsonNode root = JSON.readTree(readLimited(zip, MAX_JSON_BYTES));
+                    if (!"WizeStream Desktop".equals(root.path("appName").asText())
+                            || root.path("backupFormatVersion").asInt(-1) != FORMAT_VERSION
+                            || !root.path("settings").isObject()) {
+                        throw new IllegalArgumentException("Unsupported WizeStream Desktop backup");
+                    }
+                    validateBackup(root);
+                    return root;
+                }
+            }
+        }
+        throw new IllegalArgumentException("This ZIP is not a WizeStream Desktop full backup");
+    }
+
+    private List<SubscriptionRecord> subscriptionsFromZip(final Path source) throws Exception {
+        try (ZipInputStream zip = new ZipInputStream(Files.newInputStream(source))) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (DATA_ENTRY.equals(entry.getName())) {
+                    final JsonNode root = JSON.readTree(readLimited(zip, MAX_JSON_BYTES));
+                    return parseSubscriptions(root.path("data").path("subscriptions"), false);
+                }
+                if (entry.getName().toLowerCase().endsWith(".json")) {
+                    try {
+                        final List<SubscriptionRecord> records = subscriptionsFromAndroidJson(
+                                readLimited(zip, MAX_JSON_BYTES));
+                        if (!records.isEmpty()) return records;
+                    } catch (final IllegalArgumentException ignored) {
+                        // Continue to the Android database entry when this is preferences/manifest JSON.
+                    }
+                }
+                if (ANDROID_DATABASE_ENTRY.equals(entry.getName())) {
+                    final Path database = Files.createTempFile("wizestream-android-backup-", ".db");
+                    try {
+                        try (OutputStream output = Files.newOutputStream(database)) {
+                            copyLimited(zip, output, MAX_ANDROID_DATABASE_BYTES);
+                        }
+                        return subscriptionsFromAndroidDatabase(database);
+                    } finally {
+                        Files.deleteIfExists(database);
+                    }
+                }
+            }
+        }
+        throw new IllegalArgumentException("The ZIP does not contain Android subscription data");
+    }
+
+    private List<SubscriptionRecord> subscriptionsFromAndroidJson(final byte[] bytes) throws Exception {
+        if (bytes.length > MAX_JSON_BYTES) throw new IllegalArgumentException("Subscription file is too large");
+        final JsonNode root = JSON.readTree(bytes);
+        return parseSubscriptions(root.path("subscriptions"), true);
+    }
+
+    private List<SubscriptionRecord> subscriptionsFromAndroidDatabase(final Path database) throws Exception {
+        final List<SubscriptionRecord> result = new ArrayList<>();
+        try (Connection android = DriverManager.getConnection("jdbc:sqlite:" + database.toAbsolutePath());
+             Statement statement = android.createStatement();
+             ResultSet rows = statement.executeQuery(
+                     "SELECT service_id, url, name, avatar_url FROM subscriptions")) {
+            while (rows.next()) {
+                result.add(subscription(rows.getInt(1), rows.getString(2), rows.getString(3),
+                        plainHttpUrl(rows.getString(4))));
+                if (result.size() > MAX_RECORDS) throw new IllegalArgumentException("Too many subscriptions");
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private BackupRecords validateBackup(final JsonNode root) {
+        final JsonNode data = root.path("data");
+        final List<SubscriptionRecord> subscriptions = parseSubscriptions(data.path("subscriptions"), false);
+        final List<PlaylistRecord> playlists = new ArrayList<>();
+        for (final JsonNode playlist : requiredArray(data, "playlists")) {
+            final List<DesktopLibrary.StreamInput> items = new ArrayList<>();
+            for (final JsonNode item : requiredArray(playlist, "items")) items.add(stream(item));
+            playlists.add(new PlaylistRecord(text(playlist, "name", 200), List.copyOf(items)));
+        }
+        final List<StreamRecord> history = new ArrayList<>();
+        for (final JsonNode item : requiredArray(data, "history")) history.add(new StreamRecord(stream(item)));
+        final List<SearchRecord> searches = new ArrayList<>();
+        for (final JsonNode item : requiredArray(data, "searchHistory")) {
+            searches.add(new SearchRecord(nonNegativeInt(item, "serviceId"), text(item, "query", 500)));
+        }
+        final List<NoteRecord> notes = new ArrayList<>();
+        for (final JsonNode item : requiredArray(data, "learningNotes")) {
+            final DesktopLibrary.StreamInput stream = stream(item);
+            final long position = nonNegativeLong(item, "positionSeconds");
+            if (position > Math.max(stream.duration(), 86_400L)) {
+                throw new IllegalArgumentException("Invalid learning note position");
+            }
+            notes.add(new NoteRecord(stream, position, text(item, "note", 10_000)));
+        }
+        final int total = subscriptions.size() + playlists.size() + history.size() + searches.size() + notes.size();
+        if (total > MAX_RECORDS) throw new IllegalArgumentException("Backup contains too many records");
+        return new BackupRecords(subscriptions, List.copyOf(playlists), List.copyOf(history),
+                List.copyOf(searches), List.copyOf(notes));
+    }
+
+    private List<SubscriptionRecord> parseSubscriptions(final JsonNode node, final boolean androidNames) {
+        if (!node.isArray()) throw new IllegalArgumentException("Subscriptions are missing");
+        final List<SubscriptionRecord> result = new ArrayList<>();
+        for (final JsonNode item : node) {
+            final String serviceKey = androidNames ? "service_id" : "serviceId";
+            result.add(subscription(nonNegativeInt(item, serviceKey), text(item, "url", 2_000),
+                    text(item, "name", 500), plainHttpUrl(optionalText(item, "avatarUrl"))));
+            if (result.size() > MAX_RECORDS) throw new IllegalArgumentException("Too many subscriptions");
+        }
+        return List.copyOf(result);
+    }
+
+    private SubscriptionRecord subscription(final int serviceId, final String url, final String name,
+                                              final String avatarUrl) {
+        final String safeName = name == null || name.isBlank()
+                ? url : name.substring(0, Math.min(200, name.length()));
+        final DesktopLibrary.StreamInput validated = DesktopLibrary.stream(serviceId, url, safeName,
+                0, "VIDEO_STREAM", "", null, null);
+        return new SubscriptionRecord(serviceId, validated.url(), safeName, avatarUrl);
+    }
+
+    private DesktopLibrary.StreamInput stream(final JsonNode item) {
+        return DesktopLibrary.stream(nonNegativeInt(item, "serviceId"), text(item, "url", 2_000),
+                text(item, "title", 500), nonNegativeLong(item, "duration"),
+                text(item, "streamType", 80), optionalText(item, "uploader"),
+                plainHttpUrl(optionalText(item, "uploaderUrl")),
+                plainHttpUrl(optionalText(item, "thumbnailUrl")));
+    }
+
+    private Map<String, Object> summary(final JsonNode root, final String status) {
+        final JsonNode data = root.path("data");
+        final Map<String, Object> result = new LinkedHashMap<>();
+        result.put("status", status);
+        result.put("subscriptions", data.path("subscriptions").size());
+        result.put("playlists", data.path("playlists").size());
+        result.put("history", data.path("history").size());
+        result.put("searchHistory", data.path("searchHistory").size());
+        result.put("learningNotes", data.path("learningNotes").size());
+        result.put("settings", JSON.convertValue(root.path("settings"), Map.class));
+        return result;
+    }
+
+    private Path checkedInput(final Path input) throws IOException {
+        final Path source = input.toAbsolutePath().normalize();
+        if (!Files.isRegularFile(source)) throw new IllegalArgumentException("Backup file was not found");
+        if (Files.size(source) > MAX_INPUT_BYTES) throw new IllegalArgumentException("Backup file is too large");
+        return source;
+    }
+
+    private static boolean looksLikeZip(final Path input) throws IOException {
+        try (InputStream stream = Files.newInputStream(input)) {
+            return stream.read() == 'P' && stream.read() == 'K';
+        }
+    }
+
+    private static byte[] readLimited(final InputStream input, final int limit) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        copyLimited(input, output, limit);
+        return output.toByteArray();
+    }
+
+    private static void copyLimited(final InputStream input, final OutputStream output, final int limit)
+            throws IOException {
+        final byte[] buffer = new byte[16 * 1024];
+        int total = 0;
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+            total += count;
+            if (total > limit) throw new IllegalArgumentException("Backup entry is too large");
+            output.write(buffer, 0, count);
+        }
+    }
+
+    private static void atomicReplace(final Path temporary, final Path target) throws IOException {
+        try {
+            Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (final AtomicMoveNotSupportedException ignored) {
+            Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private static Iterable<JsonNode> requiredArray(final JsonNode parent, final String name) {
+        final JsonNode value = parent.path(name);
+        if (!value.isArray()) throw new IllegalArgumentException("Backup is missing " + name);
+        return value;
+    }
+
+    private static int nonNegativeInt(final JsonNode node, final String name) {
+        final JsonNode value = node.path(name);
+        if (!value.canConvertToInt() || value.intValue() < 0) throw new IllegalArgumentException("Invalid " + name);
+        return value.intValue();
+    }
+
+    private static long nonNegativeLong(final JsonNode node, final String name) {
+        final JsonNode value = node.path(name);
+        if (!value.canConvertToLong() || value.longValue() < 0) throw new IllegalArgumentException("Invalid " + name);
+        return value.longValue();
+    }
+
+    private static String text(final JsonNode node, final String name, final int max) {
+        final JsonNode value = node.path(name);
+        if (!value.isTextual() || value.textValue().isBlank() || value.textValue().length() > max) {
+            throw new IllegalArgumentException("Invalid " + name);
+        }
+        return value.textValue();
+    }
+
+    private static String optionalText(final JsonNode node, final String name) {
+        final JsonNode value = node.path(name);
+        return value.isTextual() ? value.textValue() : null;
+    }
+
+    private static String plainHttpUrl(final String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            final URI uri = URI.create(value);
+            return ("https".equalsIgnoreCase(uri.getScheme()) || "http".equalsIgnoreCase(uri.getScheme()))
+                    && uri.getHost() != null ? uri.toString() : null;
+        } catch (final IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private record SubscriptionRecord(int serviceId, String url, String name, String avatarUrl) { }
+    private record PlaylistRecord(String name, List<DesktopLibrary.StreamInput> items) { }
+    private record StreamRecord(DesktopLibrary.StreamInput stream) { }
+    private record SearchRecord(int serviceId, String query) { }
+    private record NoteRecord(DesktopLibrary.StreamInput stream, long positionSeconds, String note) { }
+    private record BackupRecords(
+            List<SubscriptionRecord> subscriptions,
+            List<PlaylistRecord> playlists,
+            List<StreamRecord> history,
+            List<SearchRecord> searchHistory,
+            List<NoteRecord> learningNotes
+    ) { }
+}

--- a/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopBackupManagerTest.kt
+++ b/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopBackupManagerTest.kt
@@ -1,0 +1,147 @@
+package org.wisso.wizestream.desktop.backend
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.nio.file.Files
+import java.sql.DriverManager
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class DesktopBackupManagerTest {
+    private val json = ObjectMapper()
+
+    @Test
+    fun `full desktop backup restores libraries and settings transactionally`() {
+        val directory = createTempDirectory("wizestream-backup-test")
+        try {
+            DesktopDatabase(directory).use { database ->
+                val library = DesktopLibrary(database.connection())
+                val manager = DesktopBackupManager(database.connection(), library)
+                val stream = DesktopLibrary.stream(
+                    0, "https://www.youtube.com/watch?v=backup", "Backup stream", 300,
+                    "VIDEO_STREAM", "WizeStream", null, null
+                )
+                library.saveSubscription(0, "https://www.youtube.com/@wizestream", "WizeStream", null)
+                val playlistId = library.createPlaylist("Study").getValue("id") as String
+                library.addPlaylistItem(playlistId, stream)
+                library.recordHistory(stream)
+                library.recordSearch(0, "backup")
+                library.saveLearningNote(null, stream, 42, "Restore this note")
+
+                val backup = directory.resolve("WizeStreamData.zip")
+                val settings = json.createObjectNode().put("theme", "dark")
+                val exported = manager.exportBackup(backup, settings)
+                assertEquals(1, exported["subscriptions"])
+
+                library.deleteSubscription(0, "https://www.youtube.com/@wizestream")
+                library.deletePlaylist(playlistId)
+                library.clearHistory()
+                library.clearSearchHistory()
+                database.connection().createStatement().use { it.executeUpdate("DELETE FROM learning_notes") }
+
+                val restored = manager.restoreBackup(backup)
+                assertEquals("dark", (restored["settings"] as Map<*, *>)["theme"])
+                assertEquals("WizeStream", library.subscriptions().single()["name"])
+                assertEquals("Study", library.playlists().single()["name"])
+                assertEquals("Backup stream", library.history().single()["title"])
+                assertEquals("backup", library.searchHistory().single()["query"])
+                assertEquals("Restore this note", library.learningNotes().single()["note"])
+            }
+        } finally {
+            directory.toFile().deleteRecursively()
+            assertTrue(Files.notExists(directory))
+        }
+    }
+
+    @Test
+    fun `imports and exports the Android subscription JSON schema`() {
+        val directory = createTempDirectory("wizestream-subscription-json-test")
+        try {
+            DesktopDatabase(directory).use { database ->
+                val library = DesktopLibrary(database.connection())
+                val manager = DesktopBackupManager(database.connection(), library)
+                val input = directory.resolve("subscriptions.json")
+                Files.writeString(input, """
+                    {"subscriptions":[{"service_id":0,"url":"https://www.youtube.com/@android","name":"Android export"}],"app_version":"1.6.0","app_version_int":1600000}
+                """.trimIndent())
+
+                assertEquals(1, manager.importSubscriptions(input)["imported"])
+                assertEquals("Android export", library.subscriptions().single()["name"])
+
+                val output = directory.resolve("desktop-subscriptions.json")
+                manager.exportSubscriptions(output, "0.6.0-beta.1")
+                val exported = json.readTree(output.toFile())
+                assertEquals(0, exported.path("subscriptions").first().path("service_id").intValue())
+                assertEquals("https://www.youtube.com/@android", exported.path("subscriptions").first().path("url").textValue())
+            }
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `imports subscriptions from an Android full backup database`() {
+        val directory = createTempDirectory("wizestream-android-backup-test")
+        try {
+            val androidDatabase = directory.resolve("newpipe.db")
+            DriverManager.getConnection("jdbc:sqlite:$androidDatabase").use { connection ->
+                connection.createStatement().use { statement ->
+                    statement.executeUpdate("""
+                        CREATE TABLE subscriptions (
+                          uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, url TEXT,
+                          name TEXT, avatar_url TEXT
+                        )
+                    """.trimIndent())
+                    statement.executeUpdate("""
+                        INSERT INTO subscriptions(service_id, url, name, avatar_url)
+                        VALUES (0, 'https://www.youtube.com/@fullbackup', 'Full backup', NULL)
+                    """.trimIndent())
+                }
+            }
+            val zip = directory.resolve("WizeStreamData.zip")
+            ZipOutputStream(Files.newOutputStream(zip)).use { output ->
+                output.putNextEntry(ZipEntry("backup_manifest.json"))
+                output.write("{\"appName\":\"WizeStream\"}".toByteArray())
+                output.closeEntry()
+                output.putNextEntry(ZipEntry("newpipe.db"))
+                Files.copy(androidDatabase, output)
+                output.closeEntry()
+            }
+
+            DesktopDatabase(directory.resolve("desktop")).use { database ->
+                val library = DesktopLibrary(database.connection())
+                val manager = DesktopBackupManager(database.connection(), library)
+                assertEquals(1, manager.importSubscriptions(zip)["imported"])
+                assertEquals("Full backup", library.subscriptions().single()["name"])
+            }
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `invalid full backup leaves current data untouched`() {
+        val directory = createTempDirectory("wizestream-invalid-backup-test")
+        try {
+            DesktopDatabase(directory).use { database ->
+                val library = DesktopLibrary(database.connection())
+                val manager = DesktopBackupManager(database.connection(), library)
+                library.saveSubscription(0, "https://www.youtube.com/@safe", "Keep me", null)
+                val invalid = directory.resolve("invalid.zip")
+                ZipOutputStream(Files.newOutputStream(invalid)).use { output ->
+                    output.putNextEntry(ZipEntry("unrelated.txt"))
+                    output.write("not a backup".toByteArray())
+                    output.closeEntry()
+                }
+                assertFailsWith<IllegalArgumentException> { manager.restoreBackup(invalid) }
+                assertEquals("Keep me", library.subscriptions().single()["name"])
+            }
+        } finally {
+            directory.toFile().deleteRecursively()
+        }
+    }
+}

--- a/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopBackupManagerTest.kt
+++ b/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopBackupManagerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import java.nio.file.Files
 import java.sql.DriverManager
 import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
@@ -36,6 +37,10 @@ class DesktopBackupManagerTest {
                 val settings = json.createObjectNode().put("theme", "dark")
                 val exported = manager.exportBackup(backup, settings)
                 assertEquals(1, exported["subscriptions"])
+                ZipFile(backup.toFile()).use { zip ->
+                    assertTrue(zip.getEntry("backup_manifest.json") != null)
+                    assertTrue(zip.getEntry("wizestream-desktop-backup.json") != null)
+                }
 
                 library.deleteSubscription(0, "https://www.youtube.com/@wizestream")
                 library.deletePlaylist(playlistId)

--- a/desktop/scripts/verify-build.mjs
+++ b/desktop/scripts/verify-build.mjs
@@ -69,6 +69,10 @@ assert.equal(typeof exposedApi?.downloads?.onChanged, 'function');
 assert.equal(typeof exposedApi?.settings?.get, 'function');
 assert.equal(typeof exposedApi?.settings?.update, 'function');
 assert.equal(typeof exposedApi?.settings?.reset, 'function');
+assert.equal(typeof exposedApi?.backup?.exportFull, 'function');
+assert.equal(typeof exposedApi?.backup?.restoreFull, 'function');
+assert.equal(typeof exposedApi?.backup?.importSubscriptions, 'function');
+assert.equal(typeof exposedApi?.backup?.exportSubscriptions, 'function');
 await exposedApi.backend.invoke('health');
 const healthCall = ipcCalls.find((call) => call.channel === 'backend:invoke');
 assert.equal(healthCall?.payload?.method, 'health');
@@ -98,5 +102,7 @@ assert.match(rendererJavaScript, /Open with external mpv/, 'renderer must preser
 assert.match(rendererJavaScript, /Video and audio/, 'renderer must include Android-aligned desktop settings');
 assert.match(rendererJavaScript, /History and cache/, 'renderer must include applicable history settings');
 assert.match(rendererJavaScript, /Device synchronization/, 'renderer must link settings to Devices');
+assert.match(rendererJavaScript, /Backup and restore/, 'renderer must include Desktop backup tools');
+assert.match(rendererJavaScript, /Android JSON subscription export/, 'renderer must explain Android subscription compatibility');
 
 console.log('Packaged Electron startup boundary verified.');

--- a/desktop/src/main/backend-client.ts
+++ b/desktop/src/main/backend-client.ts
@@ -72,7 +72,8 @@ export class BackendClient {
       const timeout = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`Backend request timed out: ${method}`));
-      }, method === 'sync.run' ? 10 * 60_000 : 45_000);
+      }, method === 'sync.run' ? 10 * 60_000
+        : method.startsWith('backup.') || method.startsWith('subscriptions.') ? 2 * 60_000 : 45_000);
       this.pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timeout });
       this.process?.stdin.write(`${request}\n`, (error) => {
         if (error) {

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -2,10 +2,10 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { access } from 'node:fs/promises';
-import { app, BrowserWindow, ipcMain, session, shell } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, session, shell } from 'electron';
 import { createMpvMain, type MpvMain } from 'electron-mpv-video/main';
 import { z } from 'zod';
-import type { BackendMethod, DownloadKind, DownloadSource, StreamDetails } from '../shared/contracts.js';
+import type { BackupOperationResult, BackendMethod, DownloadKind, DownloadSource, StreamDetails } from '../shared/contracts.js';
 import { BackendClient } from './backend-client.js';
 import { DownloadManager } from './download-manager.js';
 import { embeddedMpvAddonPath, embeddedMpvAvailable } from './embedded-mpv.js';
@@ -188,6 +188,70 @@ app.whenReady().then(async () => {
   ipcMain.handle('settings:get', () => settings?.get());
   ipcMain.handle('settings:update', (_event, input: unknown) => settings?.update(input));
   ipcMain.handle('settings:reset', () => settings?.reset());
+  ipcMain.handle('backup:export-full', async () => {
+    const selection = await dialog.showSaveDialog({
+      title: 'Export full backup',
+      defaultPath: path.join(app.getPath('documents'), `WizeStreamData-${backupTimestamp()}.zip`),
+      filters: [{ name: 'WizeStream ZIP backup', extensions: ['zip'] }],
+    });
+    if (selection.canceled || !selection.filePath) return { cancelled: true };
+    const result = await backend.invoke<BackupOperationResult>('backup.export', {
+      path: selection.filePath,
+      settings: settings?.get(),
+    });
+    return { ...result, fileName: path.basename(selection.filePath) };
+  });
+  ipcMain.handle('backup:restore-full', async () => {
+    const selection = await dialog.showOpenDialog({
+      title: 'Import full backup', properties: ['openFile'],
+      filters: [{ name: 'WizeStream ZIP backup', extensions: ['zip'] }],
+    });
+    const filePath = selection.filePaths[0];
+    if (selection.canceled || !filePath) return { cancelled: true };
+    const inspected = await backend.invoke<BackupOperationResult>('backup.inspect', { path: filePath });
+    const restoredSettings = settings?.validate(inspected.settings);
+    const details = [
+      `${inspected.subscriptions ?? 0} subscriptions`, `${inspected.playlists ?? 0} playlists`,
+      `${inspected.history ?? 0} watch-history entries`, `${inspected.searchHistory ?? 0} searches`,
+      `${inspected.learningNotes ?? 0} Learning Mode notes`, 'desktop settings',
+    ].join(', ');
+    const confirmation = await dialog.showMessageBox({
+      type: 'warning', title: 'Import full backup?',
+      message: 'Current local data and settings may be replaced.',
+      detail: `Detected contents: ${details}\n\nThe selected file is validated before any current data is changed.`,
+      buttons: ['Cancel', 'Import'], defaultId: 1, cancelId: 0, noLink: true,
+    });
+    if (confirmation.response !== 1) return { cancelled: true };
+    const result = await backend.invoke<BackupOperationResult>('backup.restore', { path: filePath });
+    const savedSettings = restoredSettings ? await settings?.replace(restoredSettings) : undefined;
+    return { ...result, settings: savedSettings, fileName: path.basename(filePath) };
+  });
+  ipcMain.handle('backup:import-subscriptions', async () => {
+    const selection = await dialog.showOpenDialog({
+      title: 'Import subscriptions only', properties: ['openFile'],
+      filters: [
+        { name: 'WizeStream Android exports', extensions: ['json', 'zip'] },
+        { name: 'JSON subscription export', extensions: ['json'] },
+        { name: 'Android full backup', extensions: ['zip'] },
+      ],
+    });
+    const filePath = selection.filePaths[0];
+    if (selection.canceled || !filePath) return { cancelled: true };
+    const result = await backend.invoke<BackupOperationResult>('subscriptions.import', { path: filePath });
+    return { ...result, fileName: path.basename(filePath) };
+  });
+  ipcMain.handle('backup:export-subscriptions', async () => {
+    const selection = await dialog.showSaveDialog({
+      title: 'Export subscriptions only',
+      defaultPath: path.join(app.getPath('documents'), `WizeStreamSubscriptions-${backupTimestamp()}.json`),
+      filters: [{ name: 'Android-compatible subscription JSON', extensions: ['json'] }],
+    });
+    if (selection.canceled || !selection.filePath) return { cancelled: true };
+    const result = await backend.invoke<BackupOperationResult>('subscriptions.export', {
+      path: selection.filePath, appVersion: app.getVersion(),
+    });
+    return { ...result, fileName: path.basename(selection.filePath) };
+  });
   updates = await createUpdateManager();
   updates.initialize();
   ipcMain.handle('updates:state', () => updates?.state());
@@ -268,6 +332,10 @@ async function createUpdateManager(): Promise<UpdateManager> {
   return new UpdateManager(updater, app.getVersion(), (state) => {
     for (const window of BrowserWindow.getAllWindows()) window.webContents.send('updates:changed', state);
   });
+}
+
+function backupTimestamp(): string {
+  return new Date().toISOString().replace(/[-:]/g, '').replace('T', '_').slice(0, 15);
 }
 
 function downloadSources(details: StreamDetails): DownloadSource[] {

--- a/desktop/src/main/settings-manager.test.ts
+++ b/desktop/src/main/settings-manager.test.ts
@@ -47,4 +47,14 @@ describe('SettingsManager', () => {
     const manager = new SettingsManager(filePath);
     expect(await manager.initialize()).toEqual(defaultDesktopSettings);
   });
+
+  it('validates and atomically replaces settings restored from a backup', async () => {
+    const filePath = await fixture();
+    const manager = new SettingsManager(filePath);
+    await manager.initialize();
+    const restored = { ...defaultDesktopSettings, theme: 'dark' as const, learningMode: true };
+    expect(manager.validate(restored)).toEqual(restored);
+    expect(await manager.replace(restored)).toEqual(restored);
+    await expect(manager.replace({ theme: 'dark' })).rejects.toThrow();
+  });
 });

--- a/desktop/src/main/settings-manager.ts
+++ b/desktop/src/main/settings-manager.ts
@@ -43,6 +43,10 @@ export class SettingsManager {
     return { ...this.value };
   }
 
+  validate(input: unknown): DesktopSettings {
+    return settingsSchema.parse(input);
+  }
+
   async update(input: unknown): Promise<DesktopSettings> {
     const patch = settingsPatchSchema.parse(input);
     this.value = settingsSchema.parse({ ...this.value, ...patch });
@@ -52,6 +56,12 @@ export class SettingsManager {
 
   async reset(): Promise<DesktopSettings> {
     this.value = { ...defaultDesktopSettings };
+    await this.save();
+    return this.get();
+  }
+
+  async replace(input: unknown): Promise<DesktopSettings> {
+    this.value = this.validate(input);
     await this.save();
     return this.get();
   }

--- a/desktop/src/preload/index.cts
+++ b/desktop/src/preload/index.cts
@@ -44,6 +44,12 @@ const api: DesktopApi = {
     update: (patch) => ipcRenderer.invoke('settings:update', patch) as ReturnType<DesktopApi['settings']['update']>,
     reset: () => ipcRenderer.invoke('settings:reset') as ReturnType<DesktopApi['settings']['reset']>,
   },
+  backup: {
+    exportFull: () => ipcRenderer.invoke('backup:export-full') as ReturnType<DesktopApi['backup']['exportFull']>,
+    restoreFull: () => ipcRenderer.invoke('backup:restore-full') as ReturnType<DesktopApi['backup']['restoreFull']>,
+    importSubscriptions: () => ipcRenderer.invoke('backup:import-subscriptions') as ReturnType<DesktopApi['backup']['importSubscriptions']>,
+    exportSubscriptions: () => ipcRenderer.invoke('backup:export-subscriptions') as ReturnType<DesktopApi['backup']['exportSubscriptions']>,
+  },
 };
 
 contextBridge.exposeInMainWorld('wizestream', api);

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -301,7 +301,11 @@ export function App() {
                       : <SettingsPanel settings={settings} services={services} currentVersion={updateState?.currentVersion}
                         onUpdate={saveSettings} onReset={resetSettings}
                         onOpenDownloads={() => void window.wizestream.downloads.openFolder()} onOpenDevices={() => setSection('sync')}
-                        onOpenUpdates={() => void openUpdates()} />}
+                        onOpenUpdates={() => void openUpdates()} onSettingsRestored={(restored) => {
+                          setSettings(restored);
+                          const preferred = services.find((service) => service.id === restored.defaultServiceId);
+                          setServiceId(preferred?.id ?? services[0]?.id ?? 0);
+                        }} />}
         </Container>
       </Box>
       <Dialog open={updateDialogOpen} onClose={() => setUpdateDialogOpen(false)} fullWidth maxWidth="sm">

--- a/desktop/src/renderer/SettingsPanel.tsx
+++ b/desktop/src/renderer/SettingsPanel.tsx
@@ -5,6 +5,7 @@ import {
   TextField, Tooltip, Typography,
 } from '@mui/material';
 import ArrowBackRounded from '@mui/icons-material/ArrowBackRounded';
+import BackupRounded from '@mui/icons-material/BackupRounded';
 import CleaningServicesRounded from '@mui/icons-material/CleaningServicesRounded';
 import DevicesRounded from '@mui/icons-material/DevicesRounded';
 import DownloadRounded from '@mui/icons-material/DownloadRounded';
@@ -14,9 +15,9 @@ import PaletteRounded from '@mui/icons-material/PaletteRounded';
 import SchoolRounded from '@mui/icons-material/SchoolRounded';
 import SystemUpdateAltRounded from '@mui/icons-material/SystemUpdateAltRounded';
 import VideoSettingsRounded from '@mui/icons-material/VideoSettingsRounded';
-import type { DesktopSettings, ServiceSummary } from '../shared/contracts';
+import type { BackupOperationResult, DesktopSettings, ServiceSummary } from '../shared/contracts';
 
-type Category = 'video' | 'download' | 'appearance' | 'history' | 'content' | 'sync' | 'learning' | 'updates';
+type Category = 'video' | 'download' | 'appearance' | 'history' | 'content' | 'updates' | 'backup' | 'sync' | 'learning';
 
 const categories: Array<{ id: Category; title: string; summary: string; icon: React.ReactNode }> = [
   { id: 'video', title: 'Video and audio', summary: 'Playback, resolution, formats, and audio behavior', icon: <VideoSettingsRounded /> },
@@ -24,13 +25,14 @@ const categories: Array<{ id: Category; title: string; summary: string; icon: Re
   { id: 'appearance', title: 'Appearance', summary: 'Theme, colors, tabs, and layout', icon: <PaletteRounded /> },
   { id: 'history', title: 'History and cache', summary: 'Watch history, search history, and cached data', icon: <HistoryRounded /> },
   { id: 'content', title: 'Content', summary: 'Services, languages, regions, and content filters', icon: <HomeRounded /> },
+  { id: 'updates', title: 'Updates', summary: 'Version, changelog, and update checks', icon: <SystemUpdateAltRounded /> },
+  { id: 'backup', title: 'Backup and restore', summary: 'Export, import, and restore app data', icon: <BackupRounded /> },
   { id: 'sync', title: 'Device synchronization', summary: 'Securely pair trusted devices for private synchronization', icon: <DevicesRounded /> },
   { id: 'learning', title: 'Learning Mode', summary: 'Optional notes, progress, dashboard, and study statistics', icon: <SchoolRounded /> },
-  { id: 'updates', title: 'Updates', summary: 'Version, changelog, and update checks', icon: <SystemUpdateAltRounded /> },
 ];
 
 export function SettingsPanel({ settings, services, currentVersion, onUpdate, onReset, onOpenDownloads,
-  onOpenDevices, onOpenUpdates }: {
+  onOpenDevices, onOpenUpdates, onSettingsRestored }: {
   settings: DesktopSettings;
   services: ServiceSummary[];
   currentVersion?: string;
@@ -39,14 +41,17 @@ export function SettingsPanel({ settings, services, currentVersion, onUpdate, on
   onOpenDownloads(): void;
   onOpenDevices(): void;
   onOpenUpdates(): void;
+  onSettingsRestored(settings: DesktopSettings): void;
 }) {
   const [category, setCategory] = useState<Category>();
   const [message, setMessage] = useState<string>();
+  const [messageSeverity, setMessageSeverity] = useState<'success' | 'error' | 'info'>('info');
+  const [busy, setBusy] = useState(false);
 
   async function update(patch: Partial<DesktopSettings>) {
     setMessage(undefined);
     try { await onUpdate(patch); }
-    catch (reason) { setMessage(reason instanceof Error ? reason.message : String(reason)); }
+    catch (reason) { setMessageSeverity('error'); setMessage(reason instanceof Error ? reason.message : String(reason)); }
   }
 
   async function clear(method: 'library.history.clear' | 'library.search-history.clear', confirmation: string) {
@@ -54,13 +59,32 @@ export function SettingsPanel({ settings, services, currentVersion, onUpdate, on
     setMessage(undefined);
     try {
       await window.wizestream.backend.invoke(method);
+      setMessageSeverity('success');
       setMessage(method === 'library.history.clear' ? 'Watch history cleared.' : 'Search history cleared.');
-    } catch (reason) { setMessage(reason instanceof Error ? reason.message : String(reason)); }
+    } catch (reason) { setMessageSeverity('error'); setMessage(reason instanceof Error ? reason.message : String(reason)); }
+  }
+
+  async function backupAction(operation: 'exportFull' | 'restoreFull' | 'importSubscriptions' | 'exportSubscriptions') {
+    setBusy(true); setMessage(undefined);
+    try {
+      const result: BackupOperationResult = await window.wizestream.backup[operation]();
+      if (result.cancelled) return;
+      if (result.settings) onSettingsRestored(result.settings);
+      const descriptions: Record<typeof operation, string> = {
+        exportFull: `Backup exported: ${result.fileName ?? 'WizeStream backup'}`,
+        restoreFull: `Backup restored from ${result.fileName ?? 'the selected file'}.`,
+        importSubscriptions: `Imported ${result.imported ?? 0} subscriptions from ${result.fileName ?? 'the selected file'}.`,
+        exportSubscriptions: `Exported ${result.exported ?? 0} subscriptions to ${result.fileName ?? 'the selected file'}.`,
+      };
+      setMessageSeverity('success'); setMessage(descriptions[operation]);
+    } catch (reason) {
+      setMessageSeverity('error'); setMessage(reason instanceof Error ? reason.message : String(reason));
+    } finally { setBusy(false); }
   }
 
   if (!category) return <Stack spacing={3}>
     <Box><Typography variant="h4">Settings</Typography><Typography color="text.secondary">Choose how WizeStream Desktop works for you.</Typography></Box>
-    {message && <Alert severity="info">{message}</Alert>}
+    {message && <Alert severity={messageSeverity}>{message}</Alert>}
     <Box className="settings-category-grid">{categories.map((item) => <Card key={item.id} variant="outlined">
       <CardActionArea onClick={() => setCategory(item.id)} sx={{ height: '100%' }}><CardContent sx={{ p: 3 }}>
         <Stack direction="row" sx={{ gap: 2, alignItems: 'center' }}><Box color="primary.main">{item.icon}</Box><Box>
@@ -68,9 +92,6 @@ export function SettingsPanel({ settings, services, currentVersion, onUpdate, on
         </Box></Stack>
       </CardContent></CardActionArea>
     </Card>)}</Box>
-    <Box><Button color="inherit" startIcon={<CleaningServicesRounded />} onClick={() => {
-      if (window.confirm('Reset all desktop settings to their defaults?')) void onReset();
-    }}>Reset settings</Button></Box>
   </Stack>;
 
   const metadata = categories.find((item) => item.id === category)!;
@@ -79,7 +100,7 @@ export function SettingsPanel({ settings, services, currentVersion, onUpdate, on
       <Tooltip title="Back to Settings"><IconButton onClick={() => { setCategory(undefined); setMessage(undefined); }}><ArrowBackRounded /></IconButton></Tooltip>
       <Box><Typography variant="h4">{metadata.title}</Typography><Typography color="text.secondary">{metadata.summary}</Typography></Box>
     </Stack>
-    {message && <Alert severity={message.endsWith('cleared.') ? 'success' : 'error'}>{message}</Alert>}
+    {message && <Alert severity={messageSeverity}>{message}</Alert>}
     <Card variant="outlined"><CardContent sx={{ p: 0 }}>
       {category === 'video' && <List disablePadding>
         <SettingSelect title="Default resolution" value={settings.defaultResolution} onChange={(value) => void update({ defaultResolution: value as DesktopSettings['defaultResolution'] })}
@@ -112,6 +133,20 @@ export function SettingsPanel({ settings, services, currentVersion, onUpdate, on
         <Alert severity="info" sx={{ my: 2 }}>Preview builds are explicitly unsigned. Updates remain manual until signed public releases are available.</Alert>
         <Button startIcon={<SystemUpdateAltRounded />} variant="outlined" onClick={onOpenUpdates}>Check for updates</Button>
       </Box>}
+      {category === 'backup' && <List disablePadding>
+        <ListItem sx={{ py: 2.5 }}><ListItemIcon><BackupRounded /></ListItemIcon><ListItemText primary="What full backup includes" secondary="Full backup includes subscriptions, playlists, app settings, history, search history, and Learning Mode notes." /></ListItem>
+        <Divider component="li" /><SettingAction icon={<BackupRounded />} title="Import full backup" summary="Restore subscriptions, playlists, app settings, and local data from a ZIP backup." action="Import" disabled={busy} onClick={() => void backupAction('restoreFull')} />
+        <Divider component="li" /><SettingAction icon={<BackupRounded />} title="Export full backup" summary="Create a ZIP backup with subscriptions, playlists, app settings, and local data." action="Export" disabled={busy} onClick={() => void backupAction('exportFull')} />
+        <Divider component="li" /><SettingAction icon={<CleaningServicesRounded />} title="Reset settings" summary="Reset all settings to their default values" action="Reset" disabled={busy} onClick={() => {
+          if (!window.confirm('Do you want to restore defaults?')) return;
+          setBusy(true); setMessage(undefined);
+          void onReset().then(() => { setMessageSeverity('success'); setMessage('Settings restored to defaults.'); })
+            .catch((reason: unknown) => { setMessageSeverity('error'); setMessage(reason instanceof Error ? reason.message : String(reason)); })
+            .finally(() => setBusy(false));
+        }} />
+        <Divider component="li" /><SettingAction icon={<BackupRounded />} title="Export subscriptions only" summary="Use this for Android-compatible JSON subscription migration only. Full backup already includes subscriptions." action="Export" disabled={busy} onClick={() => void backupAction('exportSubscriptions')} />
+        <Divider component="li" /><SettingAction icon={<BackupRounded />} title="Import subscriptions only" summary="Import an Android JSON subscription export or subscriptions from an Android full-backup ZIP. Existing subscriptions are merged." action="Import" disabled={busy} onClick={() => void backupAction('importSubscriptions')} />
+      </List>}
     </CardContent></Card>
   </Stack>;
 }
@@ -125,6 +160,6 @@ function SettingSwitch({ title, summary, checked, disabled, onChange }: { title:
   return <ListItem sx={{ py: 2 }}><ListItemText primary={title} secondary={summary} /><FormControlLabel sx={{ ml: 2 }} label={checked ? 'On' : 'Off'} control={<Switch checked={checked} disabled={disabled} onChange={(event) => onChange(event.target.checked)} />} /></ListItem>;
 }
 
-function SettingAction({ icon, title, summary, action, onClick }: { icon: React.ReactNode; title: string; summary: string; action: string; onClick(): void }) {
-  return <ListItem sx={{ py: 2.5 }}><ListItemIcon>{icon}</ListItemIcon><ListItemText primary={title} secondary={summary} /><Button sx={{ ml: 2 }} variant="outlined" onClick={onClick}>{action}</Button></ListItem>;
+function SettingAction({ icon, title, summary, action, disabled, onClick }: { icon: React.ReactNode; title: string; summary: string; action: string; disabled?: boolean; onClick(): void }) {
+  return <ListItem sx={{ py: 2.5 }}><ListItemIcon>{icon}</ListItemIcon><ListItemText primary={title} secondary={summary} /><Button sx={{ ml: 2 }} variant="outlined" disabled={disabled} onClick={onClick}>{action}</Button></ListItem>;
 }

--- a/desktop/src/shared/contracts.ts
+++ b/desktop/src/shared/contracts.ts
@@ -31,7 +31,12 @@ export type BackendMethod =
   | 'sync.pair'
   | 'sync.policy.update'
   | 'sync.runs.list'
-  | 'sync.run';
+  | 'sync.run'
+  | 'backup.export'
+  | 'backup.inspect'
+  | 'backup.restore'
+  | 'subscriptions.import'
+  | 'subscriptions.export';
 
 export interface ServiceSummary {
   id: number;
@@ -343,6 +348,21 @@ export interface DesktopSettings {
   learningNotes: boolean;
 }
 
+export interface BackupOperationResult {
+  cancelled?: boolean;
+  status?: 'ready' | 'exported' | 'restored';
+  fileName?: string;
+  subscriptions?: number;
+  playlists?: number;
+  history?: number;
+  searchHistory?: number;
+  learningNotes?: number;
+  settings?: DesktopSettings;
+  imported?: number;
+  exported?: number;
+  source?: string;
+}
+
 export const defaultDesktopSettings: DesktopSettings = {
   theme: 'system',
   defaultServiceId: null,
@@ -387,6 +407,12 @@ export interface DesktopApi {
     get(): Promise<DesktopSettings>;
     update(patch: Partial<DesktopSettings>): Promise<DesktopSettings>;
     reset(): Promise<DesktopSettings>;
+  };
+  backup: {
+    exportFull(): Promise<BackupOperationResult>;
+    restoreFull(): Promise<BackupOperationResult>;
+    importSubscriptions(): Promise<BackupOperationResult>;
+    exportSubscriptions(): Promise<BackupOperationResult>;
   };
 }
 


### PR DESCRIPTION
## What changed

- add **Backup and restore** to WizeStream Desktop settings
- export and restore a versioned full Desktop backup ZIP
- validate backups before confirmation and restore transactionally with rollback
- export and import subscriptions using the Android-compatible JSON format
- import subscriptions from Android full-backup ZIP files containing `newpipe.db`
- merge subscription-only imports with existing Desktop subscriptions
- display subscriptions in a responsive channel-card grid
- fetch missing channel avatars through WizeStreamExtractor and cache them locally
- provide a manual **Refresh channel images** retry action
- make the sticky Desktop toolbar opaque so scrolled content cannot overlap it
- use native file dialogs so renderer code never receives local filesystem paths
- enforce backup size and item-count limits

## Why

Desktop users need a safe way to preserve local data and move subscriptions between Android and Desktop without requiring an account. Android JSON exports do not include channel images, so Desktop now retrieves and caches them after import.

## User impact

Users can back up and restore Desktop data from **Settings → Backup and restore**. They can move subscriptions in either direction using the Android-compatible JSON file, or import subscriptions directly from an Android full backup.

Imported subscriptions appear in a responsive grid. Channel images fill in automatically when the service provides them; the normal placeholder remains if an image is unavailable.

The unsigned-preview and manual-update policy is unchanged.

## Validation

- 18 Desktop unit tests passed
- renderer production build passed
- Electron main/preload bundle passed
- packaged startup boundary verification passed
- `git diff --check` passed
- backend tests cover Desktop restore, Android JSON compatibility, Android full-backup ZIP import, invalid-backup safety, and cached avatar persistence

The GitHub Actions matrix compiles and tests the Java 21 backend and builds all supported Desktop targets.