### PR TITLE
Improve the Desktop subscription library

### DIFF
--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
@@ -61,11 +61,14 @@ public final class DesktopBackend implements AutoCloseable {
                 case "library.subscriptions.save" -> library.saveSubscription(
                         requiredInt(params, "serviceId"), requiredText(params, "url"),
                         requiredText(params, "name"), optionalText(params, "avatarUrl"));
-                case "library.subscriptions.refresh-avatar" -> {
+                case "library.subscriptions.refresh-metadata" -> {
                     final int serviceId = requiredInt(params, "serviceId");
                     final String url = requiredText(params, "url");
-                    yield library.updateSubscriptionAvatar(
-                            serviceId, url, extractor.channelAvatar(serviceId, url));
+                    final Map<String, Object> metadata = extractor.channelMetadata(serviceId, url);
+                    final Number subscriberCount = (Number) metadata.get("subscriberCount");
+                    yield library.updateSubscriptionMetadata(
+                            serviceId, url, (String) metadata.get("avatarUrl"),
+                            subscriberCount == null ? null : subscriberCount.longValue());
                 }
                 case "library.subscriptions.delete" -> {
                     library.deleteSubscription(

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
@@ -61,6 +61,12 @@ public final class DesktopBackend implements AutoCloseable {
                 case "library.subscriptions.save" -> library.saveSubscription(
                         requiredInt(params, "serviceId"), requiredText(params, "url"),
                         requiredText(params, "name"), optionalText(params, "avatarUrl"));
+                case "library.subscriptions.refresh-avatar" -> {
+                    final int serviceId = requiredInt(params, "serviceId");
+                    final String url = requiredText(params, "url");
+                    yield library.updateSubscriptionAvatar(
+                            serviceId, url, extractor.channelAvatar(serviceId, url));
+                }
                 case "library.subscriptions.delete" -> {
                     library.deleteSubscription(
                             requiredInt(params, "serviceId"), requiredText(params, "url"));

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopLibrary.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopLibrary.java
@@ -63,28 +63,37 @@ final class DesktopLibrary {
                 "avatarUrl", safeAvatar);
     }
 
-    Map<String, Object> updateSubscriptionAvatar(
+    Map<String, Object> updateSubscriptionMetadata(
             final int serviceId,
             final String url,
-            final String avatarUrl
+            final String avatarUrl,
+            final Long subscriberCount
     ) throws SQLException {
         if (serviceId < 0) throw new IllegalArgumentException("Invalid serviceId");
         final String safeUrl = httpUrl(url, "url");
         final String safeAvatar = optionalHttpUrl(avatarUrl, "avatarUrl");
-        if (safeAvatar == null) throw new IllegalArgumentException("Invalid avatarUrl");
+        if (subscriberCount != null && subscriberCount < 0) {
+            throw new IllegalArgumentException("Invalid subscriberCount");
+        }
+        if (safeAvatar == null && subscriberCount == null) {
+            throw new IllegalArgumentException("Channel metadata is missing");
+        }
         final int updated;
         synchronized (connection) {
             try (PreparedStatement statement = connection.prepareStatement("""
-                    UPDATE subscriptions SET avatar_url=? WHERE service_id=? AND url=?
+                    UPDATE subscriptions SET avatar_url=COALESCE(?, avatar_url),
+                    subscriber_count=COALESCE(?, subscriber_count) WHERE service_id=? AND url=?
                     """)) {
                 statement.setString(1, safeAvatar);
-                statement.setInt(2, serviceId);
-                statement.setString(3, safeUrl);
+                statement.setObject(2, subscriberCount);
+                statement.setInt(3, serviceId);
+                statement.setString(4, safeUrl);
                 updated = statement.executeUpdate();
             }
         }
         if (updated == 0) throw new IllegalArgumentException("Subscription was not found");
-        return row("serviceId", serviceId, "url", safeUrl, "avatarUrl", safeAvatar);
+        return row("serviceId", serviceId, "url", safeUrl, "avatarUrl", safeAvatar,
+                "subscriberCount", subscriberCount);
     }
 
     void deleteSubscription(final int serviceId, final String url) throws SQLException {

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopLibrary.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopLibrary.java
@@ -63,6 +63,30 @@ final class DesktopLibrary {
                 "avatarUrl", safeAvatar);
     }
 
+    Map<String, Object> updateSubscriptionAvatar(
+            final int serviceId,
+            final String url,
+            final String avatarUrl
+    ) throws SQLException {
+        if (serviceId < 0) throw new IllegalArgumentException("Invalid serviceId");
+        final String safeUrl = httpUrl(url, "url");
+        final String safeAvatar = optionalHttpUrl(avatarUrl, "avatarUrl");
+        if (safeAvatar == null) throw new IllegalArgumentException("Invalid avatarUrl");
+        final int updated;
+        synchronized (connection) {
+            try (PreparedStatement statement = connection.prepareStatement("""
+                    UPDATE subscriptions SET avatar_url=? WHERE service_id=? AND url=?
+                    """)) {
+                statement.setString(1, safeAvatar);
+                statement.setInt(2, serviceId);
+                statement.setString(3, safeUrl);
+                updated = statement.executeUpdate();
+            }
+        }
+        if (updated == 0) throw new IllegalArgumentException("Subscription was not found");
+        return row("serviceId", serviceId, "url", safeUrl, "avatarUrl", safeAvatar);
+    }
+
     void deleteSubscription(final int serviceId, final String url) throws SQLException {
         if (serviceId < 0) throw new IllegalArgumentException("Invalid serviceId");
         execute("DELETE FROM subscriptions WHERE service_id=? AND url=?", statement -> {

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/ExtractorFacade.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/ExtractorFacade.java
@@ -88,15 +88,21 @@ final class ExtractorFacade {
         return value;
     }
 
-    String channelAvatar(final int serviceId, final String url) throws Exception {
+    Map<String, Object> channelMetadata(final int serviceId, final String url) throws Exception {
         if (serviceId < 0 || url == null || url.length() > 4_096
                 || !(url.startsWith("https://") || url.startsWith("http://"))) {
             throw new IllegalArgumentException("Invalid channel URL");
         }
         final ChannelInfo info = ChannelInfo.getInfo(NewPipe.getService(serviceId), url);
         final String avatarUrl = blankToNull(info.getAvatarUrl());
-        if (avatarUrl == null) throw new IllegalArgumentException("Channel image is unavailable");
-        return avatarUrl;
+        final Long subscriberCount = info.getSubscriberCount() < 0 ? null : info.getSubscriberCount();
+        if (avatarUrl == null && subscriberCount == null) {
+            throw new IllegalArgumentException("Channel details are unavailable");
+        }
+        final Map<String, Object> value = new LinkedHashMap<>();
+        value.put("avatarUrl", avatarUrl);
+        value.put("subscriberCount", subscriberCount);
+        return value;
     }
 
     private Map<String, Object> searchItem(final InfoItem item) {

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/ExtractorFacade.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/ExtractorFacade.java
@@ -3,6 +3,7 @@ package org.wisso.wizestream.desktop.backend;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
+import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
 import org.schabi.newpipe.extractor.search.SearchInfo;
@@ -85,6 +86,17 @@ final class ExtractorFacade {
         value.put("audioStreams", audioStreams(info));
         value.put("subtitles", subtitles(info));
         return value;
+    }
+
+    String channelAvatar(final int serviceId, final String url) throws Exception {
+        if (serviceId < 0 || url == null || url.length() > 4_096
+                || !(url.startsWith("https://") || url.startsWith("http://"))) {
+            throw new IllegalArgumentException("Invalid channel URL");
+        }
+        final ChannelInfo info = ChannelInfo.getInfo(NewPipe.getService(serviceId), url);
+        final String avatarUrl = blankToNull(info.getAvatarUrl());
+        if (avatarUrl == null) throw new IllegalArgumentException("Channel image is unavailable");
+        return avatarUrl;
     }
 
     private Map<String, Object> searchItem(final InfoItem item) {

--- a/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopLibraryTest.kt
+++ b/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopLibraryTest.kt
@@ -31,15 +31,17 @@ class DesktopLibraryTest {
                     "https://example.com/avatar.png"
                 )
                 assertEquals("WizeStream", library.subscriptions().single()["name"])
-                library.updateSubscriptionAvatar(
+                library.updateSubscriptionMetadata(
                     0,
                     "https://www.youtube.com/@wizestream",
-                    "https://example.com/refreshed-avatar.png"
+                    "https://example.com/refreshed-avatar.png",
+                    144_000L
                 )
                 assertEquals(
                     "https://example.com/refreshed-avatar.png",
                     library.subscriptions().single()["avatarUrl"]
                 )
+                assertEquals(144_000L, library.subscriptions().single()["subscriberCount"])
 
                 val playlist = library.createPlaylist("Study")
                 val playlistId = playlist.getValue("id") as String

--- a/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopLibraryTest.kt
+++ b/desktop/backend/src/test/kotlin/org/wisso/wizestream/desktop/backend/DesktopLibraryTest.kt
@@ -31,6 +31,15 @@ class DesktopLibraryTest {
                     "https://example.com/avatar.png"
                 )
                 assertEquals("WizeStream", library.subscriptions().single()["name"])
+                library.updateSubscriptionAvatar(
+                    0,
+                    "https://www.youtube.com/@wizestream",
+                    "https://example.com/refreshed-avatar.png"
+                )
+                assertEquals(
+                    "https://example.com/refreshed-avatar.png",
+                    library.subscriptions().single()["avatarUrl"]
+                )
 
                 val playlist = library.createPlaylist("Study")
                 val playlistId = playlist.getValue("id") as String

--- a/desktop/scripts/verify-build.mjs
+++ b/desktop/scripts/verify-build.mjs
@@ -102,6 +102,8 @@ assert.match(rendererJavaScript, /Open with external mpv/, 'renderer must preser
 assert.match(rendererJavaScript, /Video and audio/, 'renderer must include Android-aligned desktop settings');
 assert.match(rendererJavaScript, /History and cache/, 'renderer must include applicable history settings');
 assert.match(rendererJavaScript, /Device synchronization/, 'renderer must link settings to Devices');
+assert.match(rendererJavaScript, /Refresh channel images/, 'renderer must offer subscription avatar refresh');
+assert.match(rendererJavaScript, /subscription-grid/, 'renderer must display subscriptions in a grid');
 assert.match(rendererJavaScript, /Backup and restore/, 'renderer must include Desktop backup tools');
 assert.match(rendererJavaScript, /Android JSON subscription export/, 'renderer must explain Android subscription compatibility');
 

--- a/desktop/scripts/verify-build.mjs
+++ b/desktop/scripts/verify-build.mjs
@@ -102,7 +102,7 @@ assert.match(rendererJavaScript, /Open with external mpv/, 'renderer must preser
 assert.match(rendererJavaScript, /Video and audio/, 'renderer must include Android-aligned desktop settings');
 assert.match(rendererJavaScript, /History and cache/, 'renderer must include applicable history settings');
 assert.match(rendererJavaScript, /Device synchronization/, 'renderer must link settings to Devices');
-assert.match(rendererJavaScript, /Refresh channel images/, 'renderer must offer subscription avatar refresh');
+assert.match(rendererJavaScript, /Refresh channel details/, 'renderer must offer subscription metadata refresh');
 assert.match(rendererJavaScript, /subscription-grid/, 'renderer must display subscriptions in a grid');
 assert.match(rendererJavaScript, /Backup and restore/, 'renderer must include Desktop backup tools');
 assert.match(rendererJavaScript, /Android JSON subscription export/, 'renderer must explain Android subscription compatibility');

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -27,7 +27,8 @@ let embeddedAddonPath = '';
 let shutdownStarted = false;
 const backendMethods = new Set<BackendMethod>([
   'health', 'services.list', 'search', 'stream.resolve', 'library.summary',
-  'library.subscriptions.list', 'library.subscriptions.save', 'library.subscriptions.delete',
+  'library.subscriptions.list', 'library.subscriptions.save',
+  'library.subscriptions.refresh-avatar', 'library.subscriptions.delete',
   'library.playlists.list', 'library.playlists.create', 'library.playlists.rename',
   'library.playlists.delete', 'library.playlists.items', 'library.playlists.add-item',
   'library.playlists.delete-item', 'library.history.list', 'library.history.record',

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -28,7 +28,7 @@ let shutdownStarted = false;
 const backendMethods = new Set<BackendMethod>([
   'health', 'services.list', 'search', 'stream.resolve', 'library.summary',
   'library.subscriptions.list', 'library.subscriptions.save',
-  'library.subscriptions.refresh-avatar', 'library.subscriptions.delete',
+  'library.subscriptions.refresh-metadata', 'library.subscriptions.delete',
   'library.playlists.list', 'library.playlists.create', 'library.playlists.rename',
   'library.playlists.delete', 'library.playlists.items', 'library.playlists.add-item',
   'library.playlists.delete-item', 'library.history.list', 'library.history.record',

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -54,6 +54,8 @@ const navigation: Array<{ id: Section; label: string; icon: React.ReactNode }> =
   { id: 'settings', label: 'Settings', icon: <SettingsRounded /> },
 ];
 
+const attemptedSubscriptionAvatars = new Set<string>();
+
 export function App() {
   const { setMode } = useColorScheme();
   const [section, setSection] = useState<Section>('discover');
@@ -222,7 +224,8 @@ export function App() {
         </List>
       </Box>
       <Box component="main" className="content-column">
-        <AppBar position="sticky" color="transparent" elevation={0}>
+        <AppBar position="sticky" color="inherit" elevation={0}
+          sx={{ bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider' }}>
           <Toolbar sx={{ gap: 2 }}>
             <Typography variant="h6" sx={{ flexGrow: 1 }}>WizeStream Desktop</Typography>
             <Chip color={mpv?.embeddedAvailable || mpv?.externalAvailable ? 'success' : 'default'}
@@ -410,8 +413,43 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
   const [url, setUrl] = useState('');
   const [avatarUrl, setAvatarUrl] = useState('');
   const [error, setError] = useState<string>();
+  const [refreshingImages, setRefreshingImages] = useState(false);
+  const refreshRunning = useRef(false);
   const load = useCallback(() => window.wizestream.backend.invoke<SubscriptionItem[]>('library.subscriptions.list').then(setItems).catch((reason: unknown) => setError(errorMessage(reason))), []);
   useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    if (refreshRunning.current) return;
+    const missing = items.filter((item) => !item.avatarUrl
+      && !attemptedSubscriptionAvatars.has(`${item.serviceId}:${item.url}`));
+    if (missing.length === 0) return;
+    refreshRunning.current = true;
+    setRefreshingImages(true);
+    void (async () => {
+      for (const item of missing) {
+        const key = `${item.serviceId}:${item.url}`;
+        attemptedSubscriptionAvatars.add(key);
+        try {
+          const refreshed = await window.wizestream.backend.invoke<Pick<SubscriptionItem, 'serviceId' | 'url' | 'avatarUrl'>>(
+            'library.subscriptions.refresh-avatar', { serviceId: item.serviceId, url: item.url },
+          );
+          setItems((current) => current.map((candidate) => candidate.serviceId === refreshed.serviceId
+            && candidate.url === refreshed.url ? { ...candidate, avatarUrl: refreshed.avatarUrl } : candidate));
+        } catch {
+          // Keep the standard channel placeholder when a service cannot provide an image.
+        }
+      }
+      refreshRunning.current = false;
+      setRefreshingImages(false);
+    })();
+  }, [items]);
+
+  function retryMissingImages() {
+    for (const item of items) {
+      if (!item.avatarUrl) attemptedSubscriptionAvatars.delete(`${item.serviceId}:${item.url}`);
+    }
+    setItems((current) => [...current]);
+  }
 
   function showEditor(item?: SubscriptionItem) {
     setEditing(item); setServiceId(item?.serviceId ?? services[0]?.id ?? 0); setName(item?.name ?? '');
@@ -428,9 +466,24 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
     try { await window.wizestream.backend.invoke('library.subscriptions.delete', { serviceId: item.serviceId, url: item.url }); await load(); }
     catch (reason) { setError(errorMessage(reason)); }
   }
-  return <Stack spacing={3}><PanelHeader title="Subscriptions" description="Manage channels synchronized with your Android devices." action={<Button startIcon={<AddRounded />} variant="contained" onClick={() => showEditor()}>Add channel</Button>} />
+  return <Stack spacing={3}><PanelHeader title="Subscriptions" description="Manage channels synchronized with your Android devices." action={<Stack direction="row" spacing={1}>
+    <Button startIcon={refreshingImages ? <CircularProgress size={18} /> : <ReplayRounded />} variant="outlined"
+      disabled={refreshingImages || items.length === 0 || items.every((item) => item.avatarUrl)}
+      onClick={retryMissingImages}>{refreshingImages ? 'Loading images…' : 'Refresh channel images'}</Button>
+    <Button startIcon={<AddRounded />} variant="contained" onClick={() => showEditor()}>Add channel</Button>
+  </Stack>} />
     {error && <Alert severity="error">{error}</Alert>}
-    {items.length === 0 ? <LibraryEmpty text="No subscriptions yet." /> : <Card variant="outlined"><List disablePadding>{items.map((item, index) => <Box key={`${item.serviceId}:${item.url}`}>{index > 0 && <Divider />}<ListItem secondaryAction={<Stack direction="row"><IconButton aria-label="Edit subscription" onClick={() => showEditor(item)}><EditRounded /></IconButton><IconButton aria-label="Delete subscription" onClick={() => void remove(item)}><DeleteOutlineRounded /></IconButton></Stack>}><ListItemAvatar><Avatar src={item.avatarUrl}><SubscriptionsRounded /></Avatar></ListItemAvatar><ListItemText primary={item.name} secondary={item.url} /></ListItem></Box>)}</List></Card>}
+    {items.length === 0 ? <LibraryEmpty text="No subscriptions yet." /> : <Box className="subscription-grid">{items.map((item) => <Card key={`${item.serviceId}:${item.url}`} variant="outlined">
+      <CardContent sx={{ p: 3, textAlign: 'center', height: '100%', boxSizing: 'border-box' }}>
+        <Avatar src={item.avatarUrl} alt="" sx={{ width: 88, height: 88, mx: 'auto', mb: 2 }}><SubscriptionsRounded sx={{ fontSize: 38 }} /></Avatar>
+        <Typography variant="h6" className="two-lines" sx={{ minHeight: '3em' }}>{item.name}</Typography>
+        <Typography color="text.secondary" variant="body2" className="two-lines" sx={{ mt: 1, overflowWrap: 'anywhere' }}>{item.url}</Typography>
+        <Stack direction="row" sx={{ justifyContent: 'center', mt: 2 }}>
+          <Tooltip title="Edit"><IconButton aria-label="Edit subscription" onClick={() => showEditor(item)}><EditRounded /></IconButton></Tooltip>
+          <Tooltip title="Remove"><IconButton aria-label="Delete subscription" onClick={() => void remove(item)}><DeleteOutlineRounded /></IconButton></Tooltip>
+        </Stack>
+      </CardContent>
+    </Card>)}</Box>}
     <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="sm"><DialogTitle>{editing ? 'Edit subscription' : 'Add subscription'}</DialogTitle><DialogContent><Stack spacing={2} sx={{ pt: 1 }}><TextField select label="Service" value={serviceId} disabled={Boolean(editing)} onChange={(event) => setServiceId(Number(event.target.value))}>{services.map((service) => <MenuItem key={service.id} value={service.id}>{service.name}</MenuItem>)}</TextField><TextField label="Channel name" value={name} onChange={(event) => setName(event.target.value)} /><TextField label="Channel URL" value={url} disabled={Boolean(editing)} onChange={(event) => setUrl(event.target.value)} /><TextField label="Avatar URL (optional)" value={avatarUrl} onChange={(event) => setAvatarUrl(event.target.value)} />{error && <Alert severity="error">{error}</Alert>}</Stack></DialogContent><DialogActions><Button onClick={() => setOpen(false)}>Cancel</Button><Button variant="contained" disabled={!name.trim() || !url.trim()} onClick={() => void save()}>Save</Button></DialogActions></Dialog>
   </Stack>;
 }

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -37,6 +37,7 @@ import type {
   UpdateState,
 } from '../shared/contracts';
 import { SettingsPanel } from './SettingsPanel';
+import { subscriberCountLabel } from './subscriber-count';
 import { preferredAudioIndex, preferredVideoIndex } from './stream-preferences';
 
 defineMpvVideoElement();
@@ -54,7 +55,7 @@ const navigation: Array<{ id: Section; label: string; icon: React.ReactNode }> =
   { id: 'settings', label: 'Settings', icon: <SettingsRounded /> },
 ];
 
-const attemptedSubscriptionAvatars = new Set<string>();
+const attemptedSubscriptionMetadata = new Set<string>();
 
 export function App() {
   const { setMode } = useColorScheme();
@@ -413,40 +414,46 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
   const [url, setUrl] = useState('');
   const [avatarUrl, setAvatarUrl] = useState('');
   const [error, setError] = useState<string>();
-  const [refreshingImages, setRefreshingImages] = useState(false);
+  const [refreshingDetails, setRefreshingDetails] = useState(false);
   const refreshRunning = useRef(false);
   const load = useCallback(() => window.wizestream.backend.invoke<SubscriptionItem[]>('library.subscriptions.list').then(setItems).catch((reason: unknown) => setError(errorMessage(reason))), []);
   useEffect(() => { void load(); }, [load]);
 
   useEffect(() => {
     if (refreshRunning.current) return;
-    const missing = items.filter((item) => !item.avatarUrl
-      && !attemptedSubscriptionAvatars.has(`${item.serviceId}:${item.url}`));
+    const missing = items.filter((item) => (!item.avatarUrl || item.subscriberCount == null
+      || item.subscriberCount < 0) && !attemptedSubscriptionMetadata.has(`${item.serviceId}:${item.url}`));
     if (missing.length === 0) return;
     refreshRunning.current = true;
-    setRefreshingImages(true);
+    setRefreshingDetails(true);
     void (async () => {
       for (const item of missing) {
         const key = `${item.serviceId}:${item.url}`;
-        attemptedSubscriptionAvatars.add(key);
+        attemptedSubscriptionMetadata.add(key);
         try {
-          const refreshed = await window.wizestream.backend.invoke<Pick<SubscriptionItem, 'serviceId' | 'url' | 'avatarUrl'>>(
-            'library.subscriptions.refresh-avatar', { serviceId: item.serviceId, url: item.url },
+          const refreshed = await window.wizestream.backend.invoke<Pick<SubscriptionItem, 'serviceId' | 'url' | 'avatarUrl' | 'subscriberCount'>>(
+            'library.subscriptions.refresh-metadata', { serviceId: item.serviceId, url: item.url },
           );
           setItems((current) => current.map((candidate) => candidate.serviceId === refreshed.serviceId
-            && candidate.url === refreshed.url ? { ...candidate, avatarUrl: refreshed.avatarUrl } : candidate));
+            && candidate.url === refreshed.url ? {
+              ...candidate,
+              avatarUrl: refreshed.avatarUrl ?? candidate.avatarUrl,
+              subscriberCount: refreshed.subscriberCount ?? candidate.subscriberCount,
+            } : candidate));
         } catch {
           // Keep the standard channel placeholder when a service cannot provide an image.
         }
       }
       refreshRunning.current = false;
-      setRefreshingImages(false);
+      setRefreshingDetails(false);
     })();
   }, [items]);
 
-  function retryMissingImages() {
+  function retryMissingDetails() {
     for (const item of items) {
-      if (!item.avatarUrl) attemptedSubscriptionAvatars.delete(`${item.serviceId}:${item.url}`);
+      if (!item.avatarUrl || item.subscriberCount == null || item.subscriberCount < 0) {
+        attemptedSubscriptionMetadata.delete(`${item.serviceId}:${item.url}`);
+      }
     }
     setItems((current) => [...current]);
   }
@@ -467,9 +474,10 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
     catch (reason) { setError(errorMessage(reason)); }
   }
   return <Stack spacing={3}><PanelHeader title="Subscriptions" description="Manage channels synchronized with your Android devices." action={<Stack direction="row" spacing={1}>
-    <Button startIcon={refreshingImages ? <CircularProgress size={18} /> : <ReplayRounded />} variant="outlined"
-      disabled={refreshingImages || items.length === 0 || items.every((item) => item.avatarUrl)}
-      onClick={retryMissingImages}>{refreshingImages ? 'Loading images…' : 'Refresh channel images'}</Button>
+    <Button startIcon={refreshingDetails ? <CircularProgress size={18} /> : <ReplayRounded />} variant="outlined"
+      disabled={refreshingDetails || items.length === 0 || items.every((item) => item.avatarUrl
+        && item.subscriberCount != null && item.subscriberCount >= 0)}
+      onClick={retryMissingDetails}>{refreshingDetails ? 'Loading channel details…' : 'Refresh channel details'}</Button>
     <Button startIcon={<AddRounded />} variant="contained" onClick={() => showEditor()}>Add channel</Button>
   </Stack>} />
     {error && <Alert severity="error">{error}</Alert>}
@@ -477,6 +485,7 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
       <CardContent sx={{ p: 3, textAlign: 'center', height: '100%', boxSizing: 'border-box' }}>
         <Avatar src={item.avatarUrl} alt="" sx={{ width: 88, height: 88, mx: 'auto', mb: 2 }}><SubscriptionsRounded sx={{ fontSize: 38 }} /></Avatar>
         <Typography variant="h6" className="two-lines" sx={{ minHeight: '3em' }}>{item.name}</Typography>
+        {subscriberCountLabel(item.subscriberCount) && <Typography color="text.secondary" sx={{ mt: 0.5 }}>{subscriberCountLabel(item.subscriberCount)}</Typography>}
         <Typography color="text.secondary" variant="body2" className="two-lines" sx={{ mt: 1, overflowWrap: 'anywhere' }}>{item.url}</Typography>
         <Stack direction="row" sx={{ justifyContent: 'center', mt: 2 }}>
           <Tooltip title="Edit"><IconButton aria-label="Edit subscription" onClick={() => showEditor(item)}><EditRounded /></IconButton></Tooltip>

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -8,6 +8,7 @@ body { overflow-x: hidden; }
 .content-column { margin-left: 228px; width: calc(100% - 228px); }
 .search-row { display: flex; gap: 12px; align-items: center; }
 .result-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 20px; }
+.subscription-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 18px; }
 .result-thumbnail { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; background: #201c24; }
 .details-card { display: grid; grid-template-columns: minmax(360px, 48%) 1fr; }
 .details-thumbnail { width: 100%; height: 100%; min-height: 340px; object-fit: cover; }

--- a/desktop/src/renderer/subscriber-count.test.ts
+++ b/desktop/src/renderer/subscriber-count.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { subscriberCountLabel } from './subscriber-count';
+
+describe('subscriber count labels', () => {
+  it('uses a compact channel-card label', () => {
+    expect(subscriberCountLabel(144_000)).toBe('144k subscribers');
+    expect(subscriberCountLabel(1_250_000)).toBe('1.3m subscribers');
+  });
+
+  it('uses the singular label for one subscriber', () => {
+    expect(subscriberCountLabel(1)).toBe('1 subscriber');
+  });
+
+  it('omits unavailable counts', () => {
+    expect(subscriberCountLabel(null)).toBeUndefined();
+    expect(subscriberCountLabel(-1)).toBeUndefined();
+  });
+});

--- a/desktop/src/renderer/subscriber-count.ts
+++ b/desktop/src/renderer/subscriber-count.ts
@@ -1,0 +1,10 @@
+const compactNumber = new Intl.NumberFormat('en', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+export function subscriberCountLabel(value?: number | null): string | undefined {
+  if (value === undefined || value === null || !Number.isSafeInteger(value) || value < 0) return undefined;
+  const count = compactNumber.format(value).replace('K', 'k').replace('M', 'm').replace('B', 'b');
+  return `${count} ${value === 1 ? 'subscriber' : 'subscribers'}`;
+}

--- a/desktop/src/shared/contracts.ts
+++ b/desktop/src/shared/contracts.ts
@@ -6,7 +6,7 @@ export type BackendMethod =
   | 'library.summary'
   | 'library.subscriptions.list'
   | 'library.subscriptions.save'
-  | 'library.subscriptions.refresh-avatar'
+  | 'library.subscriptions.refresh-metadata'
   | 'library.subscriptions.delete'
   | 'library.playlists.list'
   | 'library.playlists.create'
@@ -192,7 +192,7 @@ export interface SubscriptionItem {
   url: string;
   name: string;
   avatarUrl?: string;
-  subscriberCount?: number;
+  subscriberCount?: number | null;
   description?: string;
   youtubeModeMask?: number;
 }

--- a/desktop/src/shared/contracts.ts
+++ b/desktop/src/shared/contracts.ts
@@ -6,6 +6,7 @@ export type BackendMethod =
   | 'library.summary'
   | 'library.subscriptions.list'
   | 'library.subscriptions.save'
+  | 'library.subscriptions.refresh-avatar'
   | 'library.subscriptions.delete'
   | 'library.playlists.list'
   | 'library.playlists.create'


### PR DESCRIPTION
- display subscriptions in a responsive channel-card grid
- fetch missing channel avatars and subscriber counts through WizeStreamExtractor
- cache refreshed channel metadata in the local Desktop database
- format subscriber totals compactly, such as `144k subscribers`
- provide a manual **Refresh channel details** retry action
- keep the normal placeholder and omit the count when a service cannot provide metadata
- make the sticky Desktop toolbar opaque so scrolled content cannot overlap it