### PR TITLE
Open subscriptions in an internal channel view

### DIFF
--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/DesktopBackend.java
@@ -56,6 +56,8 @@ public final class DesktopBackend implements AutoCloseable {
                 case "services.list" -> extractor.services();
                 case "search" -> extractor.search(requiredInt(params, "serviceId"), requiredText(params, "query"));
                 case "stream.resolve" -> extractor.resolve(requiredText(params, "url"));
+                case "channel.resolve" -> extractor.channel(
+                        requiredInt(params, "serviceId"), requiredText(params, "url"));
                 case "library.summary" -> database.summary();
                 case "library.subscriptions.list" -> library.subscriptions();
                 case "library.subscriptions.save" -> library.saveSubscription(

--- a/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/ExtractorFacade.java
+++ b/desktop/backend/src/main/java/org/wisso/wizestream/desktop/backend/ExtractorFacade.java
@@ -89,11 +89,7 @@ final class ExtractorFacade {
     }
 
     Map<String, Object> channelMetadata(final int serviceId, final String url) throws Exception {
-        if (serviceId < 0 || url == null || url.length() > 4_096
-                || !(url.startsWith("https://") || url.startsWith("http://"))) {
-            throw new IllegalArgumentException("Invalid channel URL");
-        }
-        final ChannelInfo info = ChannelInfo.getInfo(NewPipe.getService(serviceId), url);
+        final ChannelInfo info = channelInfo(serviceId, url);
         final String avatarUrl = blankToNull(info.getAvatarUrl());
         final Long subscriberCount = info.getSubscriberCount() < 0 ? null : info.getSubscriberCount();
         if (avatarUrl == null && subscriberCount == null) {
@@ -103,6 +99,29 @@ final class ExtractorFacade {
         value.put("avatarUrl", avatarUrl);
         value.put("subscriberCount", subscriberCount);
         return value;
+    }
+
+    Map<String, Object> channel(final int serviceId, final String url) throws Exception {
+        final ChannelInfo info = channelInfo(serviceId, url);
+        final Map<String, Object> value = new LinkedHashMap<>();
+        value.put("serviceId", info.getServiceId());
+        value.put("url", info.getUrl());
+        value.put("name", info.getName());
+        value.put("avatarUrl", blankToNull(info.getAvatarUrl()));
+        value.put("bannerUrl", blankToNull(info.getBannerUrl()));
+        value.put("subscriberCount", info.getSubscriberCount() < 0 ? null : info.getSubscriberCount());
+        value.put("description", blankToNull(info.getDescription()));
+        value.put("streams", info.getRelatedItems().stream().limit(60)
+                .map(this::searchItem).toList());
+        return value;
+    }
+
+    private ChannelInfo channelInfo(final int serviceId, final String url) throws Exception {
+        if (serviceId < 0 || url == null || url.length() > 4_096
+                || !(url.startsWith("https://") || url.startsWith("http://"))) {
+            throw new IllegalArgumentException("Invalid channel URL");
+        }
+        return ChannelInfo.getInfo(NewPipe.getService(serviceId), url);
     }
 
     private Map<String, Object> searchItem(final InfoItem item) {

--- a/desktop/scripts/verify-build.mjs
+++ b/desktop/scripts/verify-build.mjs
@@ -18,6 +18,7 @@ assert.match(preloadSource, /require\(["']electron["']\)/, 'sandboxed preload mu
 assert.doesNotMatch(preloadSource, /^\s*import\s/m, 'sandboxed preload must not contain ESM imports');
 assert.match(mainSource, /preload[\\/]index\.cjs/, 'main process must load the CommonJS preload');
 assert.match(mainSource, /library\.history\.record/, 'main process must allow Phase 3 library RPC');
+assert.match(mainSource, /channel\.resolve/, 'main process must allow internal channel navigation');
 assert.match(mainSource, /downloads:start/, 'main process must expose Phase 4 downloads');
 assert.match(mainSource, /embeddedMpvAvailable/, 'main process must gate the embedded native renderer');
 
@@ -104,6 +105,8 @@ assert.match(rendererJavaScript, /History and cache/, 'renderer must include app
 assert.match(rendererJavaScript, /Device synchronization/, 'renderer must link settings to Devices');
 assert.match(rendererJavaScript, /Refresh channel details/, 'renderer must offer subscription metadata refresh');
 assert.match(rendererJavaScript, /subscription-grid/, 'renderer must display subscriptions in a grid');
+assert.match(rendererJavaScript, /Back to subscriptions/, 'renderer must include the internal channel view');
+assert.match(rendererJavaScript, /Recent videos/, 'renderer must show channel videos');
 assert.match(rendererJavaScript, /Backup and restore/, 'renderer must include Desktop backup tools');
 assert.match(rendererJavaScript, /Android JSON subscription export/, 'renderer must explain Android subscription compatibility');
 

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -26,7 +26,7 @@ let settings: SettingsManager | undefined;
 let embeddedAddonPath = '';
 let shutdownStarted = false;
 const backendMethods = new Set<BackendMethod>([
-  'health', 'services.list', 'search', 'stream.resolve', 'library.summary',
+  'health', 'services.list', 'search', 'stream.resolve', 'channel.resolve', 'library.summary',
   'library.subscriptions.list', 'library.subscriptions.save',
   'library.subscriptions.refresh-metadata', 'library.subscriptions.delete',
   'library.playlists.list', 'library.playlists.create', 'library.playlists.rename',

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import {
 import { useColorScheme } from '@mui/material/styles';
 import { defineMpvVideoElement, type MpvVideoElement } from 'electron-mpv-video/renderer';
 import AddRounded from '@mui/icons-material/AddRounded';
+import ArrowBackRounded from '@mui/icons-material/ArrowBackRounded';
 import DeleteOutlineRounded from '@mui/icons-material/DeleteOutlineRounded';
 import DevicesRounded from '@mui/icons-material/DevicesRounded';
 import DownloadRounded from '@mui/icons-material/DownloadRounded';
@@ -30,7 +31,7 @@ import SubscriptionsRounded from '@mui/icons-material/SubscriptionsRounded';
 import SystemUpdateAltRounded from '@mui/icons-material/SystemUpdateAltRounded';
 import { defaultDesktopSettings } from '../shared/contracts';
 import type {
-  DesktopSettings, DownloadJob, DownloadSource, EmbeddedPlayerRequest,
+  ChannelDetails, DesktopSettings, DownloadJob, DownloadSource, EmbeddedPlayerRequest,
   HistoryItem, LearningNote, LibraryStream, PlayerStatus, PlaylistItem, PlaylistSummary,
   SearchHistoryItem, SearchItem, ServiceSummary, StreamDetails, StreamVariant, SubtitleVariant,
   AutomaticSyncPolicy, SubscriptionItem, SyncRunLog, SyncRunResult, SyncStatus,
@@ -296,7 +297,7 @@ export function App() {
               </CardContent>
             </Box></Card>}
             {!loading && !selected && results.length > 0 && <Box className="result-grid" sx={{ mt: 4 }}>{results.map((item) => <Card key={`${item.type}:${item.url}`} variant="outlined"><CardActionArea onClick={() => void openResult(item)} disabled={item.type !== 'STREAM'} sx={{ height: '100%' }}>{item.thumbnailUrl && <Box component="img" src={item.thumbnailUrl} alt="" className="result-thumbnail" />}<CardContent><Chip label={item.type.toLowerCase()} size="small" /><Typography variant="h6" sx={{ mt: 1 }} className="two-lines">{item.name}</Typography><Typography color="text.secondary" variant="body2" sx={{ mt: 1 }}>{item.uploaderName}</Typography></CardContent></CardActionArea></Card>)}</Box>}
-          </> : section === 'subscriptions' ? <SubscriptionsPanel services={services} />
+          </> : section === 'subscriptions' ? <SubscriptionsPanel services={services} onOpen={resolveStream} />
             : section === 'playlists' ? <PlaylistsPanel currentStream={selectedLibraryStream} onOpen={resolveStream} />
               : section === 'history' ? <HistoryPanel onOpen={resolveStream} />
                 : section === 'learning' ? <LearningPanel currentStream={selectedLibraryStream} onOpen={resolveStream} />
@@ -405,8 +406,14 @@ function EmbeddedPlayer({ request, externalAvailable, onError }: {
   </Stack></CardContent></Card>;
 }
 
-function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
+function SubscriptionsPanel({ services, onOpen }: {
+  services: ServiceSummary[];
+  onOpen(url: string): Promise<void>;
+}) {
   const [items, setItems] = useState<SubscriptionItem[]>([]);
+  const [selectedChannel, setSelectedChannel] = useState<SubscriptionItem>();
+  const [channelDetails, setChannelDetails] = useState<ChannelDetails>();
+  const [channelLoading, setChannelLoading] = useState(false);
   const [editing, setEditing] = useState<SubscriptionItem>();
   const [open, setOpen] = useState(false);
   const [serviceId, setServiceId] = useState(0);
@@ -473,6 +480,65 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
     try { await window.wizestream.backend.invoke('library.subscriptions.delete', { serviceId: item.serviceId, url: item.url }); await load(); }
     catch (reason) { setError(errorMessage(reason)); }
   }
+
+  async function openChannel(item: SubscriptionItem) {
+    setSelectedChannel(item); setChannelDetails(undefined); setChannelLoading(true); setError(undefined);
+    try {
+      setChannelDetails(await window.wizestream.backend.invoke<ChannelDetails>('channel.resolve', {
+        serviceId: item.serviceId, url: item.url,
+      }));
+    } catch (reason) { setError(errorMessage(reason)); } finally { setChannelLoading(false); }
+  }
+
+  function closeChannel() {
+    setSelectedChannel(undefined); setChannelDetails(undefined); setChannelLoading(false); setError(undefined);
+  }
+
+  if (selectedChannel) return <Stack spacing={3}>
+    <Button startIcon={<ArrowBackRounded />} onClick={closeChannel} sx={{ alignSelf: 'flex-start' }}>
+      Back to subscriptions
+    </Button>
+    {error && <Alert severity="error">{error}</Alert>}
+    {channelLoading && <Stack direction="row" spacing={2} sx={{ alignItems: 'center', py: 6, justifyContent: 'center' }}>
+      <CircularProgress /><Typography color="text.secondary">Loading channel…</Typography>
+    </Stack>}
+    {!channelLoading && channelDetails && <>
+      <Card variant="outlined" sx={{ overflow: 'hidden' }}>
+        {channelDetails.bannerUrl && <Box component="img" src={channelDetails.bannerUrl} alt="" className="channel-banner" />}
+        <CardContent sx={{ p: 3 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} sx={{ alignItems: { xs: 'center', sm: 'flex-start' } }}>
+            <Avatar src={channelDetails.avatarUrl || selectedChannel.avatarUrl} alt=""
+              sx={{ width: 112, height: 112, flexShrink: 0 }}><SubscriptionsRounded sx={{ fontSize: 48 }} /></Avatar>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="h4">{channelDetails.name || selectedChannel.name}</Typography>
+              {subscriberCountLabel(channelDetails.subscriberCount ?? selectedChannel.subscriberCount)
+                && <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+                  {subscriberCountLabel(channelDetails.subscriberCount ?? selectedChannel.subscriberCount)}
+                </Typography>}
+              {channelDetails.description && <Typography sx={{ mt: 2, whiteSpace: 'pre-wrap' }}>
+                {channelDetails.description}
+              </Typography>}
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+      <Typography variant="h5">Recent videos</Typography>
+      {channelDetails.streams.length === 0 ? <LibraryEmpty text="No recent videos are available for this channel." />
+        : <Box className="result-grid">{channelDetails.streams.map((stream) => <Card key={stream.url} variant="outlined">
+          <CardActionArea onClick={() => void onOpen(stream.url)} sx={{ height: '100%' }} aria-label={`Open ${stream.name}`}>
+            {stream.thumbnailUrl && <Box component="img" src={stream.thumbnailUrl} alt="" className="result-thumbnail" />}
+            <CardContent>
+              <Typography variant="h6" className="two-lines">{stream.name}</Typography>
+              <Typography color="text.secondary" variant="body2" sx={{ mt: 1 }}>
+                {[stream.uploaderName, stream.duration && stream.duration > 0 ? formatTimestamp(stream.duration) : undefined]
+                  .filter(Boolean).join(' · ')}
+              </Typography>
+            </CardContent>
+          </CardActionArea>
+        </Card>)}</Box>}
+    </>}
+  </Stack>;
+
   return <Stack spacing={3}><PanelHeader title="Subscriptions" description="Manage channels synchronized with your Android devices." action={<Stack direction="row" spacing={1}>
     <Button startIcon={refreshingDetails ? <CircularProgress size={18} /> : <ReplayRounded />} variant="outlined"
       disabled={refreshingDetails || items.length === 0 || items.every((item) => item.avatarUrl
@@ -481,17 +547,21 @@ function SubscriptionsPanel({ services }: { services: ServiceSummary[] }) {
     <Button startIcon={<AddRounded />} variant="contained" onClick={() => showEditor()}>Add channel</Button>
   </Stack>} />
     {error && <Alert severity="error">{error}</Alert>}
-    {items.length === 0 ? <LibraryEmpty text="No subscriptions yet." /> : <Box className="subscription-grid">{items.map((item) => <Card key={`${item.serviceId}:${item.url}`} variant="outlined">
-      <CardContent sx={{ p: 3, textAlign: 'center', height: '100%', boxSizing: 'border-box' }}>
-        <Avatar src={item.avatarUrl} alt="" sx={{ width: 88, height: 88, mx: 'auto', mb: 2 }}><SubscriptionsRounded sx={{ fontSize: 38 }} /></Avatar>
-        <Typography variant="h6" className="two-lines" sx={{ minHeight: '3em' }}>{item.name}</Typography>
-        {subscriberCountLabel(item.subscriberCount) && <Typography color="text.secondary" sx={{ mt: 0.5 }}>{subscriberCountLabel(item.subscriberCount)}</Typography>}
-        <Typography color="text.secondary" variant="body2" className="two-lines" sx={{ mt: 1, overflowWrap: 'anywhere' }}>{item.url}</Typography>
-        <Stack direction="row" sx={{ justifyContent: 'center', mt: 2 }}>
+    {items.length === 0 ? <LibraryEmpty text="No subscriptions yet." /> : <Box className="subscription-grid">{items.map((item) => <Card key={`${item.serviceId}:${item.url}`} variant="outlined" sx={{ display: 'flex', flexDirection: 'column' }}>
+      <CardActionArea onClick={() => void openChannel(item)} aria-label={`Open ${item.name}`} sx={{ flexGrow: 1 }}>
+        <CardContent sx={{ p: 3, textAlign: 'center', height: '100%', boxSizing: 'border-box' }}>
+          <Avatar src={item.avatarUrl} alt="" sx={{ width: 88, height: 88, mx: 'auto', mb: 2 }}><SubscriptionsRounded sx={{ fontSize: 38 }} /></Avatar>
+          <Typography variant="h6" className="two-lines" sx={{ minHeight: '3em' }}>{item.name}</Typography>
+          {subscriberCountLabel(item.subscriberCount) && <Typography color="text.secondary" sx={{ mt: 0.5 }}>{subscriberCountLabel(item.subscriberCount)}</Typography>}
+          <Typography color="text.secondary" variant="body2" className="two-lines" sx={{ mt: 1, overflowWrap: 'anywhere' }}>{item.url}</Typography>
+        </CardContent>
+      </CardActionArea>
+      <Box sx={{ borderTop: 1, borderColor: 'divider' }}>
+        <Stack direction="row" sx={{ justifyContent: 'center', py: 0.5 }}>
           <Tooltip title="Edit"><IconButton aria-label="Edit subscription" onClick={() => showEditor(item)}><EditRounded /></IconButton></Tooltip>
           <Tooltip title="Remove"><IconButton aria-label="Delete subscription" onClick={() => void remove(item)}><DeleteOutlineRounded /></IconButton></Tooltip>
         </Stack>
-      </CardContent>
+      </Box>
     </Card>)}</Box>}
     <Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="sm"><DialogTitle>{editing ? 'Edit subscription' : 'Add subscription'}</DialogTitle><DialogContent><Stack spacing={2} sx={{ pt: 1 }}><TextField select label="Service" value={serviceId} disabled={Boolean(editing)} onChange={(event) => setServiceId(Number(event.target.value))}>{services.map((service) => <MenuItem key={service.id} value={service.id}>{service.name}</MenuItem>)}</TextField><TextField label="Channel name" value={name} onChange={(event) => setName(event.target.value)} /><TextField label="Channel URL" value={url} disabled={Boolean(editing)} onChange={(event) => setUrl(event.target.value)} /><TextField label="Avatar URL (optional)" value={avatarUrl} onChange={(event) => setAvatarUrl(event.target.value)} />{error && <Alert severity="error">{error}</Alert>}</Stack></DialogContent><DialogActions><Button onClick={() => setOpen(false)}>Cancel</Button><Button variant="contained" disabled={!name.trim() || !url.trim()} onClick={() => void save()}>Save</Button></DialogActions></Dialog>
   </Stack>;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -9,6 +9,7 @@ body { overflow-x: hidden; }
 .search-row { display: flex; gap: 12px; align-items: center; }
 .result-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 20px; }
 .subscription-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 18px; }
+.channel-banner { display: block; width: 100%; max-height: 260px; aspect-ratio: 16 / 4; object-fit: cover; background: #201c24; }
 .result-thumbnail { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; background: #201c24; }
 .details-card { display: grid; grid-template-columns: minmax(360px, 48%) 1fr; }
 .details-thumbnail { width: 100%; height: 100%; min-height: 340px; object-fit: cover; }

--- a/desktop/src/shared/contracts.ts
+++ b/desktop/src/shared/contracts.ts
@@ -3,6 +3,7 @@ export type BackendMethod =
   | 'services.list'
   | 'search'
   | 'stream.resolve'
+  | 'channel.resolve'
   | 'library.summary'
   | 'library.subscriptions.list'
   | 'library.subscriptions.save'
@@ -195,6 +196,17 @@ export interface SubscriptionItem {
   subscriberCount?: number | null;
   description?: string;
   youtubeModeMask?: number;
+}
+
+export interface ChannelDetails {
+  serviceId: number;
+  url: string;
+  name: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+  subscriberCount?: number | null;
+  description?: string;
+  streams: SearchItem[];
 }
 
 export interface PlaylistSummary {


### PR DESCRIPTION
## What changed

- make each Desktop subscription card open an internal channel page
- show the channel banner, avatar, subscriber count, description, and recent videos
- route video clicks through WizeStream’s existing stream resolver and player
- keep edit and remove controls separate from channel navigation
- add a back action and packaged-build assertions for the channel view

## User impact

Desktop users can browse a subscribed channel and open its recent videos without leaving WizeStream.

## Validation

- 21 Vitest tests passed
- renderer production build passed
- Electron main/preload bundle passed
- packaged startup verifier passed
- `git diff --check` passed

Backend compilation and the complete cross-platform matrix will run in GitHub Actions.