### PR TITLE
Fix comment user icons

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractor.java
@@ -159,14 +159,27 @@ class YoutubeCommentsEUVMInfoItemExtractor implements CommentsInfoItemExtractor 
     @Nonnull
     @Override
     public String getUploaderAvatarUrl() throws ParsingException {
-        JsonObject avatar = commentEntityPayload.getObject(AUTHOR).getObject("avatar");
-        if (avatar.isEmpty()) {
-            // Retain compatibility with the older entity payload shape.
-            avatar = commentEntityPayload.getObject("avatar");
+        // Older entity payloads contain a full image object at the root.
+        final JsonObject avatar = commentEntityPayload.getObject("avatar", null);
+        if (avatar != null) {
+            final List<Image> uploaderAvatars = getImagesFromThumbnailsArray(
+                    avatar.getObject("image").getArray("sources"));
+            if (!uploaderAvatars.isEmpty()) {
+                return uploaderAvatars.get(0).getUrl();
+            }
         }
-        final List<Image> uploaderAvatars = getImagesFromThumbnailsArray(
-                avatar.getObject("image").getArray("sources"));
-        return uploaderAvatars.isEmpty() ? "" : uploaderAvatars.get(0).getUrl();
+
+        // Current YouTube entity payloads expose the avatar as a direct URL on the author.
+        final JsonObject author = commentEntityPayload.getObject(AUTHOR);
+        final String avatarThumbnailUrl = author.getString("avatarThumbnailUrl");
+        if (!isNullOrEmpty(avatarThumbnailUrl)) {
+            return avatarThumbnailUrl;
+        }
+
+        // Keep accepting the short-lived nested author shape used by some responses.
+        final List<Image> authorAvatars = getImagesFromThumbnailsArray(
+                author.getObject("avatar").getObject("image").getArray("sources"));
+        return authorAvatars.isEmpty() ? "" : authorAvatars.get(0).getUrl();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractor.java
@@ -159,10 +159,13 @@ class YoutubeCommentsEUVMInfoItemExtractor implements CommentsInfoItemExtractor 
     @Nonnull
     @Override
     public String getUploaderAvatarUrl() throws ParsingException {
+        JsonObject avatar = commentEntityPayload.getObject(AUTHOR).getObject("avatar");
+        if (avatar.isEmpty()) {
+            // Retain compatibility with the older entity payload shape.
+            avatar = commentEntityPayload.getObject("avatar");
+        }
         final List<Image> uploaderAvatars = getImagesFromThumbnailsArray(
-                commentEntityPayload.getObject("avatar")
-                .getObject("image")
-                .getArray("sources"));
+                avatar.getObject("image").getArray("sources"));
         return uploaderAvatars.isEmpty() ? "" : uploaderAvatars.get(0).getUrl();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
@@ -27,7 +27,6 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.image.CoilHelper;
-import org.schabi.newpipe.util.image.ExtractorImageCompat;
 import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.text.LongPressLinkMovementMethod;
 import org.schabi.newpipe.util.text.TextLinkifier;
@@ -86,8 +85,8 @@ public final class CommentRepliesFragment
             final CommentsInfoItem item = commentsInfoItem;
 
             // load the author avatar
-            CoilHelper.INSTANCE.loadAvatar(binding.authorAvatar,
-                    ExtractorImageCompat.uploaderAvatarImages(item));
+            CoilHelper.INSTANCE.loadCommentAvatar(
+                    binding.authorAvatar, item.getUploaderAvatarUrl());
             binding.authorAvatar.setVisibility(ImageStrategy.shouldLoadImages()
                     ? View.VISIBLE : View.GONE);
 

--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -358,6 +358,14 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         }
     }
 
+    @Override
+    public void onViewRecycled(@NonNull final RecyclerView.ViewHolder holder) {
+        if (holder instanceof InfoItemHolder) {
+            ((InfoItemHolder) holder).recycle();
+        }
+        super.onViewRecycled(holder);
+    }
+
     public GridLayoutManager.SpanSizeLookup getSpanSizeLookup(final int spanCount) {
         return new GridLayoutManager.SpanSizeLookup() {
             @Override

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentInfoItemHolder.java
@@ -29,7 +29,6 @@ import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.image.CoilHelper;
-import org.schabi.newpipe.util.image.ExtractorImageCompat;
 import org.schabi.newpipe.util.image.ImageStrategy;
 import org.schabi.newpipe.util.text.TextEllipsizer;
 
@@ -89,8 +88,7 @@ public class CommentInfoItemHolder extends InfoItemHolder {
         }
 
         // load the author avatar
-        CoilHelper.INSTANCE.loadAvatar(itemThumbnailView,
-                ExtractorImageCompat.uploaderAvatarImages(item));
+        CoilHelper.INSTANCE.loadCommentAvatar(itemThumbnailView, item.getUploaderAvatarUrl());
         if (ImageStrategy.shouldLoadImages()) {
             itemThumbnailView.setVisibility(View.VISIBLE);
             itemRoot.setPadding(commentVerticalPadding, commentVerticalPadding,
@@ -174,6 +172,11 @@ public class CommentInfoItemHolder extends InfoItemHolder {
             }
             return true;
         });
+    }
+
+    @Override
+    public void recycle() {
+        CoilHelper.INSTANCE.clearAvatar(itemThumbnailView);
     }
 
     private void openCommentAuthor(@NonNull final CommentsInfoItem item) {

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/InfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/InfoItemHolder.java
@@ -43,4 +43,7 @@ public abstract class InfoItemHolder extends RecyclerView.ViewHolder {
 
     public void updateState(final InfoItem infoItem,
                             final HistoryRecordManager historyRecordManager) { }
+
+    /** Releases resources associated with a recycled item view. */
+    public void recycle() { }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/image/CoilHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/image/CoilHelper.kt
@@ -17,6 +17,7 @@ import coil3.size.Size
 import coil3.target.Target
 import coil3.toBitmap
 import coil3.transform.Transformation
+import coil3.util.CoilUtils
 import kotlin.math.min
 import org.schabi.newpipe.MainActivity
 import org.schabi.newpipe.R
@@ -48,6 +49,20 @@ object CoilHelper {
         url: String?
     ) {
         loadImageDefault(target, url, R.drawable.placeholder_person)
+    }
+
+    /** Loads the direct avatar URL exposed by comment items. */
+    fun loadCommentAvatar(
+        target: ImageView,
+        url: String?
+    ) {
+        clearAvatar(target)
+        loadImageDefault(target, normalizeCommentAvatarUrl(url), R.drawable.placeholder_person)
+    }
+
+    fun clearAvatar(target: ImageView) {
+        CoilUtils.dispose(target)
+        target.setImageResource(R.drawable.placeholder_person)
     }
 
     fun loadThumbnail(
@@ -181,5 +196,15 @@ object CoilHelper {
                     placeholder(placeholderResId)
                 }
             }
+    }
+}
+
+internal fun normalizeCommentAvatarUrl(url: String?): String? {
+    val normalized = url?.trim()?.takeIf(String::isNotEmpty) ?: return null
+    return when {
+        normalized.startsWith("//") -> "https:$normalized"
+        normalized.startsWith("https://", ignoreCase = true) -> normalized
+        normalized.startsWith("http://", ignoreCase = true) -> normalized
+        else -> null
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractorTest.java
@@ -4,6 +4,8 @@ import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 
 import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
+import org.schabi.newpipe.extractor.comments.CommentsInfoItemsCollector;
 import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,25 +13,31 @@ import static org.mockito.Mockito.mock;
 
 class YoutubeCommentsEUVMInfoItemExtractorTest {
     @Test
-    void extractsAvatarFromCurrentAuthorPayload() throws Exception {
+    void extractsAvatarThumbnailUrlFromCurrentAuthorPayload() throws Exception {
         final YoutubeCommentsEUVMInfoItemExtractor extractor = createExtractor("""
                 {
                   "author": {
-                    "avatar": {
-                      "image": {
-                        "sources": [{
-                          "url": "https://yt3.ggpht.com/comment-avatar",
-                          "width": 48,
-                          "height": 48
-                        }]
-                      }
-                    }
+                    "avatarThumbnailUrl": "https://yt3.ggpht.com/comment-avatar"
                   }
                 }
                 """);
 
         assertEquals("https://yt3.ggpht.com/comment-avatar",
                 extractor.getUploaderAvatarUrl());
+    }
+
+    @Test
+    void collectorPreservesCurrentAvatarThumbnailUrl() throws Exception {
+        final YoutubeCommentsEUVMInfoItemExtractor extractor = createExtractor("""
+                {
+                  "author": {
+                    "avatarThumbnailUrl": "https://yt3.ggpht.com/comment-avatar"
+                  }
+                }
+                """);
+        final CommentsInfoItem item = new CommentsInfoItemsCollector(0).extract(extractor);
+
+        assertEquals("https://yt3.ggpht.com/comment-avatar", item.getUploaderAvatarUrl());
     }
 
     @Test
@@ -49,6 +57,28 @@ class YoutubeCommentsEUVMInfoItemExtractorTest {
                 """);
 
         assertEquals("https://yt3.ggpht.com/legacy-comment-avatar",
+                extractor.getUploaderAvatarUrl());
+    }
+
+    @Test
+    void retainsCompatibilityWithNestedAuthorAvatarPayload() throws Exception {
+        final YoutubeCommentsEUVMInfoItemExtractor extractor = createExtractor("""
+                {
+                  "author": {
+                    "avatar": {
+                      "image": {
+                        "sources": [{
+                          "url": "https://yt3.ggpht.com/nested-comment-avatar",
+                          "width": 48,
+                          "height": 48
+                        }]
+                      }
+                    }
+                  }
+                }
+                """);
+
+        assertEquals("https://yt3.ggpht.com/nested-comment-avatar",
                 extractor.getUploaderAvatarUrl());
     }
 

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsEUVMInfoItemExtractorTest.java
@@ -1,0 +1,66 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+
+import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.localization.TimeAgoParser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class YoutubeCommentsEUVMInfoItemExtractorTest {
+    @Test
+    void extractsAvatarFromCurrentAuthorPayload() throws Exception {
+        final YoutubeCommentsEUVMInfoItemExtractor extractor = createExtractor("""
+                {
+                  "author": {
+                    "avatar": {
+                      "image": {
+                        "sources": [{
+                          "url": "https://yt3.ggpht.com/comment-avatar",
+                          "width": 48,
+                          "height": 48
+                        }]
+                      }
+                    }
+                  }
+                }
+                """);
+
+        assertEquals("https://yt3.ggpht.com/comment-avatar",
+                extractor.getUploaderAvatarUrl());
+    }
+
+    @Test
+    void retainsCompatibilityWithLegacyRootAvatarPayload() throws Exception {
+        final YoutubeCommentsEUVMInfoItemExtractor extractor = createExtractor("""
+                {
+                  "avatar": {
+                    "image": {
+                      "sources": [{
+                        "url": "https://yt3.ggpht.com/legacy-comment-avatar",
+                        "width": 48,
+                        "height": 48
+                      }]
+                    }
+                  }
+                }
+                """);
+
+        assertEquals("https://yt3.ggpht.com/legacy-comment-avatar",
+                extractor.getUploaderAvatarUrl());
+    }
+
+    private static YoutubeCommentsEUVMInfoItemExtractor createExtractor(
+            final String commentEntityPayload) throws Exception {
+        final JsonObject payload = JsonParser.object().from(commentEntityPayload);
+        return new YoutubeCommentsEUVMInfoItemExtractor(
+                new JsonObject(),
+                null,
+                payload,
+                new JsonObject(),
+                "https://www.youtube.com/watch?v=abcdefghijk",
+                mock(TimeAgoParser.class));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/image/CommentAvatarUrlTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/util/image/CommentAvatarUrlTest.kt
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.util.image
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CommentAvatarUrlTest {
+    @Test
+    fun `absolute avatar URLs are retained and trimmed`() {
+        assertEquals(
+            "https://yt3.ggpht.com/avatar",
+            normalizeCommentAvatarUrl("  https://yt3.ggpht.com/avatar  ")
+        )
+        assertEquals(
+            "http://example.com/avatar.jpg",
+            normalizeCommentAvatarUrl("http://example.com/avatar.jpg")
+        )
+    }
+
+    @Test
+    fun `scheme-relative avatar URLs use HTTPS`() {
+        assertEquals(
+            "https://yt3.ggpht.com/avatar",
+            normalizeCommentAvatarUrl("//yt3.ggpht.com/avatar")
+        )
+    }
+
+    @Test
+    fun `missing and unsupported avatar URLs use the placeholder`() {
+        assertNull(normalizeCommentAvatarUrl(null))
+        assertNull(normalizeCommentAvatarUrl("  "))
+        assertNull(normalizeCommentAvatarUrl("content://avatar"))
+        assertNull(normalizeCommentAvatarUrl("javascript:alert(1)"))
+    }
+}


### PR DESCRIPTION
- extract commenter avatar URLs from the current YouTube entity payload's `author.avatarThumbnailUrl`
- retain compatibility with legacy root-level `avatar.image.sources` and nested author image payloads
- load comment author avatars from the direct URL exposed by the comment model
- normalize absolute and scheme-relative avatar URLs before sending them to Coil
- apply the same loading path to main comments and comment-reply headers
- cancel stale avatar requests when comment rows are recycled
- retain the circular person placeholder for missing, unsupported, or failed URLs
- continue respecting the global image-quality setting