### PR TITLE
Show local media playback details

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaDescriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaDescriptionFragment.kt
@@ -9,6 +9,9 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
+import java.text.DateFormat
+import java.text.NumberFormat
+import java.util.Date
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -17,9 +20,6 @@ import org.schabi.newpipe.extractor.StreamingService
 import org.schabi.newpipe.extractor.stream.Description
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
 import org.schabi.newpipe.util.Localization
-import java.text.DateFormat
-import java.text.NumberFormat
-import java.util.Date
 
 class LocalMediaDescriptionFragment : BaseDescriptionFragment() {
     private lateinit var item: PlayQueueItem
@@ -49,8 +49,9 @@ class LocalMediaDescriptionFragment : BaseDescriptionFragment() {
 
     override fun displayDescription(): Description = Description.EMPTY_DESCRIPTION
 
-    override fun getService(): StreamingService =
-        error("Local media descriptions do not use a streaming service")
+    override fun getService(): StreamingService = error(
+        "Local media descriptions do not use a streaming service"
+    )
 
     override fun getServiceId(): Int = PlayQueueItem.LOCAL_SERVICE_ID
 
@@ -124,7 +125,9 @@ class LocalMediaDescriptionFragment : BaseDescriptionFragment() {
             }
             when (metadata.audioChannelCount) {
                 1 -> add(getString(R.string.local_media_audio_mono))
+
                 2 -> add(getString(R.string.local_media_audio_stereo))
+
                 in 3..Int.MAX_VALUE -> add(
                     getString(
                         R.string.local_media_audio_channels,

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaDescriptionFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaDescriptionFragment.kt
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.fragments.detail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import androidx.core.os.BundleCompat
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.schabi.newpipe.R
+import org.schabi.newpipe.extractor.StreamingService
+import org.schabi.newpipe.extractor.stream.Description
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+import org.schabi.newpipe.util.Localization
+import java.text.DateFormat
+import java.text.NumberFormat
+import java.util.Date
+
+class LocalMediaDescriptionFragment : BaseDescriptionFragment() {
+    private lateinit var item: PlayQueueItem
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        item = requireNotNull(
+            BundleCompat.getSerializable(
+                requireArguments(),
+                ARG_ITEM,
+                PlayQueueItem::class.java
+            )
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val inflater = LayoutInflater.from(requireContext())
+        val appContext = requireContext().applicationContext
+        viewLifecycleOwner.lifecycleScope.launch {
+            val metadata = withContext(Dispatchers.IO) {
+                LocalMediaMetadataReader.read(appContext, item)
+            }
+            populateMetadata(inflater, metadata)
+        }
+    }
+
+    override fun displayDescription(): Description = Description.EMPTY_DESCRIPTION
+
+    override fun getService(): StreamingService =
+        error("Local media descriptions do not use a streaming service")
+
+    override fun getServiceId(): Int = PlayQueueItem.LOCAL_SERVICE_ID
+
+    override fun getStreamUrl(): String = item.url
+
+    override fun getTags(): List<String> = emptyList()
+
+    override fun setupMetadata(inflater: LayoutInflater, layout: LinearLayout) {
+        binding.detailUploadDateView.visibility = View.GONE
+    }
+
+    private fun populateMetadata(
+        inflater: LayoutInflater,
+        metadata: LocalMediaTechnicalMetadata
+    ) {
+        val layout = binding.detailMetadataLayout
+        layout.removeAllViews()
+
+        addMetadataItem(
+            inflater,
+            layout,
+            false,
+            R.string.local_media_metadata_format,
+            LocalMediaMetadataFormatter.format(item.mimeType)
+        )
+        addMetadataItem(
+            inflater,
+            layout,
+            false,
+            R.string.local_media_metadata_resolution,
+            LocalMediaMetadataFormatter.resolution(metadata)
+        )
+        if (item.duration > 0) {
+            addMetadataItem(
+                inflater,
+                layout,
+                false,
+                R.string.local_media_metadata_length,
+                Localization.getDurationString(item.duration)
+            )
+        }
+        if (metadata.capturedAtMillis > 0) {
+            addMetadataItem(
+                inflater,
+                layout,
+                false,
+                R.string.local_media_metadata_captured_on,
+                DateFormat.getDateInstance(DateFormat.MEDIUM).format(
+                    Date(metadata.capturedAtMillis)
+                )
+            )
+        }
+
+        val audioQuality = formatAudioQuality(metadata)
+        addMetadataItem(
+            inflater,
+            layout,
+            false,
+            R.string.local_media_metadata_audio_quality,
+            audioQuality
+        )
+    }
+
+    private fun formatAudioQuality(metadata: LocalMediaTechnicalMetadata): String {
+        val values = buildList {
+            if (metadata.audioSampleRate > 0) {
+                val sampleRate = NumberFormat.getNumberInstance().apply {
+                    maximumFractionDigits = 1
+                }.format(metadata.audioSampleRate / 1_000.0)
+                add(getString(R.string.local_media_sample_rate, sampleRate))
+            }
+            when (metadata.audioChannelCount) {
+                1 -> add(getString(R.string.local_media_audio_mono))
+                2 -> add(getString(R.string.local_media_audio_stereo))
+                in 3..Int.MAX_VALUE -> add(
+                    getString(
+                        R.string.local_media_audio_channels,
+                        metadata.audioChannelCount
+                    )
+                )
+            }
+            if (metadata.audioBitrate > 0) {
+                add(
+                    getString(
+                        R.string.local_media_audio_bitrate,
+                        metadata.audioBitrate / 1_000
+                    )
+                )
+            }
+        }
+        return values.joinToString(" • ")
+    }
+
+    companion object {
+        private const val ARG_ITEM = "local_media_item"
+
+        @JvmStatic
+        fun newInstance(item: PlayQueueItem) = LocalMediaDescriptionFragment().apply {
+            arguments = Bundle().apply { putSerializable(ARG_ITEM, item) }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaMetadataReader.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaMetadataReader.kt
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.fragments.detail
+
+import android.content.Context
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+internal data class LocalMediaTechnicalMetadata(
+    val width: Int = 0,
+    val height: Int = 0,
+    val rotation: Int = 0,
+    val capturedAtMillis: Long = 0,
+    val audioSampleRate: Int = 0,
+    val audioChannelCount: Int = 0,
+    val audioBitrate: Int = 0
+)
+
+internal object LocalMediaMetadataReader {
+    fun read(context: Context, item: PlayQueueItem): LocalMediaTechnicalMetadata {
+        val uri = Uri.parse(item.url)
+        val retrieverMetadata = readRetrieverMetadata(context, uri)
+        val audioMetadata = readAudioMetadata(context, uri)
+        return retrieverMetadata.copy(
+            capturedAtMillis = readCapturedAtMillis(context, uri)
+                .takeIf { it > 0 } ?: retrieverMetadata.capturedAtMillis,
+            audioSampleRate = audioMetadata.audioSampleRate,
+            audioChannelCount = audioMetadata.audioChannelCount,
+            audioBitrate = audioMetadata.audioBitrate
+        )
+    }
+
+    private fun readRetrieverMetadata(
+        context: Context,
+        uri: Uri
+    ): LocalMediaTechnicalMetadata {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(context, uri)
+            LocalMediaTechnicalMetadata(
+                width = retriever.intMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH),
+                height = retriever.intMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT),
+                rotation = retriever.intMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION
+                ),
+                capturedAtMillis = parseMetadataDate(
+                    retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE)
+                )
+            )
+        } catch (_: Exception) {
+            LocalMediaTechnicalMetadata()
+        } finally {
+            retriever.release()
+        }
+    }
+
+    private fun readAudioMetadata(context: Context, uri: Uri): LocalMediaTechnicalMetadata {
+        val extractor = MediaExtractor()
+        return try {
+            extractor.setDataSource(context, uri, null)
+            (0 until extractor.trackCount)
+                .asSequence()
+                .map(extractor::getTrackFormat)
+                .firstOrNull { format ->
+                    format.getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
+                }
+                ?.let { format ->
+                    LocalMediaTechnicalMetadata(
+                        audioSampleRate = format.intValue(MediaFormat.KEY_SAMPLE_RATE),
+                        audioChannelCount = format.intValue(MediaFormat.KEY_CHANNEL_COUNT),
+                        audioBitrate = format.intValue(MediaFormat.KEY_BIT_RATE)
+                    )
+                } ?: LocalMediaTechnicalMetadata()
+        } catch (_: Exception) {
+            LocalMediaTechnicalMetadata()
+        } finally {
+            extractor.release()
+        }
+    }
+
+    private fun readCapturedAtMillis(context: Context, uri: Uri): Long = try {
+        context.contentResolver.query(
+            uri,
+            arrayOf(DATE_TAKEN_COLUMN),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) cursor.getLong(0) else 0L
+        } ?: 0L
+    } catch (_: Exception) {
+        0L
+    }
+
+    private fun MediaMetadataRetriever.intMetadata(key: Int): Int =
+        extractMetadata(key)?.toIntOrNull() ?: 0
+
+    private fun MediaFormat.intValue(key: String): Int =
+        if (containsKey(key)) getInteger(key) else 0
+
+    private fun parseMetadataDate(value: String?): Long {
+        val compactDate = value?.take(8)?.takeIf { date -> date.all(Char::isDigit) }
+            ?: return 0L
+        return try {
+            LocalDate.parse(compactDate, DateTimeFormatter.BASIC_ISO_DATE)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
+        } catch (_: Exception) {
+            0L
+        }
+    }
+
+    private const val DATE_TAKEN_COLUMN = "datetaken"
+}
+
+internal object LocalMediaMetadataFormatter {
+    fun format(mimeType: String?): String = when (mimeType?.lowercase(Locale.ROOT)) {
+        "video/mp4" -> "MP4"
+        "video/x-matroska" -> "MKV"
+        "video/webm" -> "WebM"
+        "audio/mpeg" -> "MP3"
+        "audio/mp4", "audio/x-m4a" -> "M4A"
+        "audio/flac" -> "FLAC"
+        "audio/ogg", "application/ogg" -> "OGG"
+        "audio/wav", "audio/x-wav" -> "WAV"
+        else -> mimeType?.substringAfter('/')?.uppercase().orEmpty()
+    }
+
+    fun resolution(metadata: LocalMediaTechnicalMetadata): String {
+        if (metadata.width <= 0 || metadata.height <= 0) return ""
+        val rotated = metadata.rotation == 90 || metadata.rotation == 270
+        val width = if (rotated) metadata.height else metadata.width
+        val height = if (rotated) metadata.width else metadata.height
+        return "$width × $height"
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaMetadataReader.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/LocalMediaMetadataReader.kt
@@ -8,11 +8,11 @@ import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
 import android.net.Uri
-import org.schabi.newpipe.player.playqueue.PlayQueueItem
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
 
 internal data class LocalMediaTechnicalMetadata(
     val width: Int = 0,
@@ -100,11 +100,14 @@ internal object LocalMediaMetadataReader {
         0L
     }
 
-    private fun MediaMetadataRetriever.intMetadata(key: Int): Int =
-        extractMetadata(key)?.toIntOrNull() ?: 0
+    private fun MediaMetadataRetriever.intMetadata(key: Int): Int = extractMetadata(key)
+        ?.toIntOrNull() ?: 0
 
-    private fun MediaFormat.intValue(key: String): Int =
-        if (containsKey(key)) getInteger(key) else 0
+    private fun MediaFormat.intValue(key: String): Int = if (containsKey(key)) {
+        getInteger(key)
+    } else {
+        0
+    }
 
     private fun parseMetadataDate(value: String?): Long {
         val compactDate = value?.take(8)?.takeIf { date -> date.all(Char::isDigit) }

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -926,9 +926,14 @@ public final class VideoDetailFragment
             scrollToTop();
         }
         pageAdapter.clearAllItems();
+        pageAdapter.addFragment(LocalMediaDescriptionFragment.newInstance(item),
+                DESCRIPTION_TAB_TAG);
         pageAdapter.notifyDataSetUpdate();
-        binding.viewPager.setVisibility(View.GONE);
-        binding.detailNavigation.setVisibility(View.GONE);
+        binding.viewPager.setVisibility(View.VISIBLE);
+        binding.viewPager.setCurrentItem(0, false);
+        updateDetailNavigationItems();
+        updateDetailNavigationSelection(0);
+        updateDetailNavigationVisibility();
         if (binding.relatedItemsLayout != null) {
             binding.relatedItemsLayout.setVisibility(View.GONE);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1331,4 +1331,14 @@
     <string name="local_media_sort_recent">Recently added</string>
     <string name="local_media_play_background">Play in background</string>
     <string name="local_media_enqueue_next">Enqueue next</string>
+    <string name="local_media_metadata_format">Format</string>
+    <string name="local_media_metadata_resolution">Resolution</string>
+    <string name="local_media_metadata_length">Length</string>
+    <string name="local_media_metadata_captured_on">Captured on</string>
+    <string name="local_media_metadata_audio_quality">Audio quality</string>
+    <string name="local_media_sample_rate">%1$s kHz</string>
+    <string name="local_media_audio_mono">Mono</string>
+    <string name="local_media_audio_stereo">Stereo</string>
+    <string name="local_media_audio_channels">%1$d channels</string>
+    <string name="local_media_audio_bitrate">%1$d kbps</string>
 </resources>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/LocalMediaMetadataFormatterTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/LocalMediaMetadataFormatterTest.kt
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.fragments.detail
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalMediaMetadataFormatterTest {
+    @Test
+    fun `formats common local media mime types`() {
+        assertEquals("MP4", LocalMediaMetadataFormatter.format("video/mp4"))
+        assertEquals("MP3", LocalMediaMetadataFormatter.format("audio/mpeg"))
+        assertEquals("MKV", LocalMediaMetadataFormatter.format("video/x-matroska"))
+    }
+
+    @Test
+    fun `formats landscape resolution`() {
+        val metadata = LocalMediaTechnicalMetadata(width = 1920, height = 1080)
+
+        assertEquals("1920 × 1080", LocalMediaMetadataFormatter.resolution(metadata))
+    }
+
+    @Test
+    fun `applies video rotation to resolution`() {
+        val metadata = LocalMediaTechnicalMetadata(
+            width = 1920,
+            height = 1080,
+            rotation = 90
+        )
+
+        assertEquals("1080 × 1920", LocalMediaMetadataFormatter.resolution(metadata))
+    }
+}


### PR DESCRIPTION
- replace the empty local-media detail area with the shared description metadata presentation
- show Format, Resolution, Length, Captured on, and Audio quality when the file exposes each value
- resolve technical metadata only for the selected file and off the main thread
- read audio sample rate, channel count, and audio-track bitrate from the actual audio track
- account for video rotation when presenting resolution
- add focused tests for common format labels and rotated resolutions