### PR TITLE
Fix Android 8 app-data export crash

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/util/FilePickerCompatibilityTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/util/FilePickerCompatibilityTest.kt
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.util
+
+import android.content.Context
+import android.content.Intent
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nononsenseapps.filepicker.R as FilePickerR
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.R
+import org.schabi.newpipe.streams.io.StoredFileHelper
+
+@RunWith(AndroidJUnit4::class)
+class FilePickerCompatibilityTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun legacyFilePickerLayoutInflatesWithBothAppThemes() {
+        listOf(R.style.FilePickerThemeLight, R.style.FilePickerThemeDark).forEach { theme ->
+            val themedContext = ContextThemeWrapper(context, theme)
+            val layout = LayoutInflater.from(themedContext)
+                .inflate(FilePickerR.layout.nnf_fragment_filepicker, null, false)
+
+            assertNotNull(layout.findViewById(FilePickerR.id.nnf_current_dir))
+        }
+    }
+
+    @Test
+    fun systemExportPickerIgnoresLegacyStoragePreference() {
+        val intent = StoredFileHelper.getNewSystemPicker(
+            context,
+            "WizeStreamData.zip",
+            "application/zip",
+            null
+        )
+
+        assertEquals(Intent.ACTION_CREATE_DOCUMENT, intent.action)
+        assertEquals("application/zip", intent.type)
+        assertEquals("WizeStreamData.zip", intent.getStringExtra(Intent.EXTRA_TITLE))
+        assertNull(intent.component)
+    }
+
+    @Test
+    fun systemImportPickerIgnoresLegacyStoragePreference() {
+        val intent = StoredFileHelper.getSystemPicker(context, "application/zip", null)
+
+        assertEquals(Intent.ACTION_OPEN_DOCUMENT, intent.action)
+        assertEquals("application/zip", intent.type)
+        assertNull(intent.component)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionsImportExportHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionsImportExportHelper.kt
@@ -60,7 +60,7 @@ class SubscriptionsImportExportHelper(
 
         NoFileManagerSafeGuard.launchSafe(
             requestExportLauncher,
-            StoredFileHelper.getNewPicker(
+            StoredFileHelper.getNewSystemPicker(
                 context,
                 exportName,
                 JSON_MIME_TYPE,
@@ -74,7 +74,7 @@ class SubscriptionsImportExportHelper(
     fun onImportPreviousSelected() {
         NoFileManagerSafeGuard.launchSafe(
             requestImportLauncher,
-            StoredFileHelper.getPicker(context, JSON_MIME_TYPE),
+            StoredFileHelper.getSystemPicker(context, JSON_MIME_TYPE, null),
             TAG,
             context
         )

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -77,7 +77,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         importDataPreference.setOnPreferenceClickListener((Preference p) -> {
             NoFileManagerSafeGuard.launchSafe(
                     requestImportPathLauncher,
-                    StoredFileHelper.getPicker(requireContext(),
+                    StoredFileHelper.getSystemPicker(requireContext(),
                             ZIP_MIME_TYPE, getImportExportDataUri()),
                     TAG,
                     getContext()
@@ -90,7 +90,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         exportDataPreference.setOnPreferenceClickListener((final Preference p) -> {
             NoFileManagerSafeGuard.launchSafe(
                     requestExportPathLauncher,
-                    StoredFileHelper.getNewPicker(requireContext(),
+                    StoredFileHelper.getNewSystemPicker(requireContext(),
                             "WizeStreamData-" + exportDateFormat.format(new Date()) + ".zip",
                             ZIP_MIME_TYPE, getImportExportDataUri()),
                     TAG,

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -484,12 +484,7 @@ public class StoredFileHelper implements Serializable {
     public static Intent getPicker(@NonNull final Context ctx,
                                    @NonNull final String mimeType) {
         if (NewPipeSettings.useStorageAccessFramework(ctx)) {
-            return new Intent(Intent.ACTION_OPEN_DOCUMENT)
-                    .putExtra("android.content.extra.SHOW_ADVANCED", true)
-                    .setType(mimeType)
-                    .addCategory(Intent.CATEGORY_OPENABLE)
-                    .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                            | StoredDirectoryHelper.PERMISSION_FLAGS);
+            return getSystemPicker(ctx, mimeType, null);
         } else {
             return new Intent(ctx, FilePickerActivityHelper.class)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_MULTIPLE, false)
@@ -506,21 +501,31 @@ public class StoredFileHelper implements Serializable {
         return applyInitialPathToPickerIntent(ctx, getPicker(ctx, mimeType), initialPath, null);
     }
 
+    /**
+     * Creates a system document picker intent regardless of the download-storage preference.
+     *
+     * <p>Import and export operations must use this picker because their destination is chosen by
+     * the user and is not part of WizeStream's configured download storage.</p>
+     */
+    public static Intent getSystemPicker(@NonNull final Context ctx,
+                                         @NonNull final String mimeType,
+                                         @Nullable final Uri initialPath) {
+        final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                .putExtra("android.content.extra.SHOW_ADVANCED", true)
+                .setType(mimeType)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                        | StoredDirectoryHelper.PERMISSION_FLAGS);
+        return applyInitialPathToPickerIntent(ctx, intent, initialPath, null, true);
+    }
+
     public static Intent getNewPicker(@NonNull final Context ctx,
                                       @Nullable final String filename,
                                       @NonNull final String mimeType,
                                       @Nullable final Uri initialPath) {
         final Intent i;
         if (NewPipeSettings.useStorageAccessFramework(ctx)) {
-            i = new Intent(Intent.ACTION_CREATE_DOCUMENT)
-                    .putExtra("android.content.extra.SHOW_ADVANCED", true)
-                    .setType(mimeType)
-                    .addCategory(Intent.CATEGORY_OPENABLE)
-                    .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                            | StoredDirectoryHelper.PERMISSION_FLAGS);
-            if (filename != null) {
-                i.putExtra(Intent.EXTRA_TITLE, filename);
-            }
+            return getNewSystemPicker(ctx, filename, mimeType, initialPath);
         } else {
             i = new Intent(ctx, FilePickerActivityHelper.class)
                     .putExtra(FilePickerActivityHelper.EXTRA_ALLOW_MULTIPLE, false)
@@ -532,12 +537,38 @@ public class StoredFileHelper implements Serializable {
         return applyInitialPathToPickerIntent(ctx, i, initialPath, filename);
     }
 
+    /** Creates a system create-document intent independently of the download-storage preference. */
+    public static Intent getNewSystemPicker(@NonNull final Context ctx,
+                                            @Nullable final String filename,
+                                            @NonNull final String mimeType,
+                                            @Nullable final Uri initialPath) {
+        final Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                .putExtra("android.content.extra.SHOW_ADVANCED", true)
+                .setType(mimeType)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                        | StoredDirectoryHelper.PERMISSION_FLAGS);
+        if (filename != null) {
+            intent.putExtra(Intent.EXTRA_TITLE, filename);
+        }
+        return applyInitialPathToPickerIntent(ctx, intent, initialPath, filename, true);
+    }
+
     private static Intent applyInitialPathToPickerIntent(@NonNull final Context ctx,
                                                          @NonNull final Intent intent,
                                                          @Nullable final Uri initialPath,
                                                          @Nullable final String filename) {
+        return applyInitialPathToPickerIntent(ctx, intent, initialPath, filename,
+                NewPipeSettings.useStorageAccessFramework(ctx));
+    }
 
-        if (NewPipeSettings.useStorageAccessFramework(ctx)) {
+    private static Intent applyInitialPathToPickerIntent(@NonNull final Context ctx,
+                                                         @NonNull final Intent intent,
+                                                         @Nullable final Uri initialPath,
+                                                         @Nullable final String filename,
+                                                         final boolean useStorageAccessFramework) {
+
+        if (useStorageAccessFramework) {
             if (initialPath == null) {
                 return intent; // nothing to do, no initial path provided
             }

--- a/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/io/StoredFileHelper.java
@@ -506,6 +506,11 @@ public class StoredFileHelper implements Serializable {
      *
      * <p>Import and export operations must use this picker because their destination is chosen by
      * the user and is not part of WizeStream's configured download storage.</p>
+     *
+     * @param ctx context used to apply an initial document location
+     * @param mimeType MIME type accepted by the picker
+     * @param initialPath optional initial document location
+     * @return an implicit Android system document-picker intent
      */
     public static Intent getSystemPicker(@NonNull final Context ctx,
                                          @NonNull final String mimeType,
@@ -537,7 +542,15 @@ public class StoredFileHelper implements Serializable {
         return applyInitialPathToPickerIntent(ctx, i, initialPath, filename);
     }
 
-    /** Creates a system create-document intent independently of the download-storage preference. */
+    /**
+     * Creates a system create-document intent independently of the download-storage preference.
+     *
+     * @param ctx context used to apply an initial document location
+     * @param filename optional suggested file name
+     * @param mimeType MIME type assigned to the new document
+     * @param initialPath optional initial document location
+     * @return an implicit Android system create-document intent
+     */
     public static Intent getNewSystemPicker(@NonNull final Context ctx,
                                             @Nullable final String filename,
                                             @NonNull final String mimeType,

--- a/app/src/main/res/values/styles_misc.xml
+++ b/app/src/main/res/values/styles_misc.xml
@@ -71,7 +71,7 @@
         <item name="colorAccent">@color/light_settings_accent_color</item>
 
         <item name="actionColor">@color/white</item>
-        <item name="nnf_toolbarTheme">@style/ToolbarTheme</item>
+        <item name="nnf_toolbarTheme">@style/FilePickerToolbarTheme</item>
 
         <item name="android:windowBackground">@color/light_background_color</item>
         <item name="nnf_separator_color">@color/light_separator_color</item>
@@ -85,7 +85,7 @@
         <item name="colorAccent">@color/dark_settings_accent_color</item>
 
         <item name="actionColor">@color/white</item>
-        <item name="nnf_toolbarTheme">@style/ToolbarTheme</item>
+        <item name="nnf_toolbarTheme">@style/FilePickerToolbarTheme</item>
 
         <item name="android:windowBackground">@color/dark_background_color</item>
         <item name="nnf_separator_color">@color/black_separator_color</item>
@@ -103,6 +103,19 @@
         <item name="colorPrimary">@color/dark_youtube_primary_color</item>
         <item name="colorPrimaryDark">@color/dark_youtube_primary_color</item>
         <item name="colorAccent">@color/dark_settings_accent_color</item>
+    </style>
+
+    <!--
+        NoNonsense-FilePicker inflates an AppCompat action-bar title inside this overlay. Keep the
+        overlay AppCompat-based and define the framework text colors explicitly so Android 8 can
+        resolve TextView's textColor attributes during inflation.
+    -->
+    <style name="FilePickerToolbarTheme" parent="ThemeOverlay.AppCompat.ActionBar">
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:textColorSecondary">@color/white_secondary</item>
+        <item name="actionMenuTextColor">@color/white</item>
+        <item name="android:colorControlNormal">@color/white</item>
+        <item name="colorControlNormal">@color/white</item>
     </style>
 
     <style name="PlayQueueItemTextTheme">

--- a/app/src/test/java/org/schabi/newpipe/util/FilePickerExportIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/FilePickerExportIntegrationTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class FilePickerExportIntegrationTest {
+    private final Path projectDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of(".") : Path.of("app");
+
+    @Test
+    public void appDataImportAndExportAlwaysUseSystemDocumentPicker() throws Exception {
+        final String subscriptions = read(
+                "src/main/java/org/schabi/newpipe/local/subscription/"
+                        + "SubscriptionsImportExportHelper.kt");
+        final String backupRestore = read(
+                "src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java");
+
+        for (final String source : new String[] {subscriptions, backupRestore}) {
+            assertTrue(source.contains("StoredFileHelper.getSystemPicker("));
+            assertTrue(source.contains("StoredFileHelper.getNewSystemPicker("));
+            assertFalse(source.contains("StoredFileHelper.getPicker("));
+            assertFalse(source.contains("StoredFileHelper.getNewPicker("));
+        }
+    }
+
+    @Test
+    public void legacyPickerUsesAppCompatToolbarOverlayWithExplicitTextColors()
+            throws Exception {
+        final String styles = read("src/main/res/values/styles_misc.xml");
+
+        assertTrue(styles.contains(
+                "name=\"FilePickerToolbarTheme\" parent=\"ThemeOverlay.AppCompat.ActionBar\""));
+        assertTrue(styles.contains("name=\"android:textColorPrimary\">@color/white"));
+        assertTrue(styles.contains("name=\"android:textColorSecondary\">@color/white_secondary"));
+        assertFalse(styles.contains("name=\"nnf_toolbarTheme\">@style/ToolbarTheme"));
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(projectDirectory.resolve(relativePath));
+    }
+}


### PR DESCRIPTION
- always use Android's system document picker for subscription and database import/export
- keep download-storage selection independent from app-data transfer destinations
- replace the Material 3 toolbar overlay used by the legacy embedded picker with an AppCompat-safe overlay
- define framework text colors explicitly so the legacy picker can still inflate on Android 8
- add instrumentation coverage for system-picker intents and both legacy picker themes
- add integration coverage ensuring app-data import/export cannot regress to the embedded picker