### PR TITLE
Fix bookmark removal before playlist loading

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/playlist/RemotePlaylistManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/playlist/RemotePlaylistManagerTest.kt
@@ -1,0 +1,71 @@
+package org.schabi.newpipe.local.playlist
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.playlist.model.PlaylistRemoteEntity
+import org.schabi.newpipe.testUtil.TestDatabase
+import org.schabi.newpipe.testUtil.TrampolineSchedulerRule
+
+class RemotePlaylistManagerTest {
+
+    private lateinit var manager: RemotePlaylistManager
+    private lateinit var database: AppDatabase
+
+    @get:Rule
+    val trampolineScheduler = TrampolineSchedulerRule()
+
+    @Before
+    fun setup() {
+        database = TestDatabase.createReplacingNewPipeDatabase()
+        manager = RemotePlaylistManager(database)
+    }
+
+    @After
+    fun cleanUp() {
+        database.close()
+    }
+
+    @Test
+    fun lookupByServiceAndUrlDoesNotRequireLoadedPlaylistInfo() {
+        val url = "https://www.youtube.com/playlist?list=large"
+        val uid = database.playlistRemoteDAO().upsert(remotePlaylist(url, streamCount = 50_000))
+
+        manager.getPlaylist(SERVICE_ID, url)
+            .test()
+            .awaitCount(1)
+            .assertValue { playlists ->
+                playlists.size == 1 && playlists.single().uid == uid &&
+                    playlists.single().streamCount == 50_000L
+            }
+    }
+
+    @Test
+    fun deleteByStoredUidRefreshesLookupAndIsIdempotent() {
+        val url = "https://www.youtube.com/playlist?list=remove"
+        val uid = database.playlistRemoteDAO().upsert(remotePlaylist(url))
+        val lookup = manager.getPlaylist(SERVICE_ID, url).test().awaitCount(1)
+
+        manager.deletePlaylist(uid).test().await().assertValue(1)
+        lookup.awaitCount(2).assertValueAt(1) { it.isEmpty() }
+        manager.deletePlaylist(uid).test().await().assertValue(0)
+    }
+
+    private fun remotePlaylist(
+        url: String,
+        streamCount: Long = 1
+    ) = PlaylistRemoteEntity(
+        serviceId = SERVICE_ID,
+        orderingName = "Large playlist",
+        url = url,
+        thumbnailUrl = null,
+        uploader = "Uploader",
+        streamCount = streamCount
+    )
+
+    companion object {
+        private const val SERVICE_ID = 0
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/BookmarkButtonState.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/BookmarkButtonState.java
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.fragments.list.playlist;
+
+final class BookmarkButtonState {
+    private BookmarkButtonState() {
+    }
+
+    static boolean isEnabled(final boolean lookupReady,
+                             final boolean hasStoredBookmark,
+                             final boolean hasLoadedPlaylistInfo,
+                             final boolean actionRunning) {
+        return lookupReady
+                && (hasStoredBookmark || hasLoadedPlaylistInfo)
+                && !actionRunning;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -73,7 +73,6 @@ import java.util.stream.Collectors;
 
 import coil3.util.CoilUtils;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
-import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -86,6 +85,7 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
     private AtomicBoolean isBookmarkButtonReady;
     private final BookmarkActionGuard bookmarkActionGuard = new BookmarkActionGuard();
     private Disposable streamStateWorker;
+    private Disposable bookmarkMetadataUpdater;
 
     private RemotePlaylistManager remotePlaylistManager;
     private PlaylistRemoteEntity playlistEntity;
@@ -175,6 +175,8 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
         // Is mini variant still relevant?
         // Only the remote playlist screen uses it now
         infoListAdapter.setUseMiniVariant(true);
+
+        observeBookmark();
     }
 
     private PlayQueue getPlayQueueStartingAt(final StreamInfoItem infoItem) {
@@ -238,6 +240,7 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
 
         bookmarkReactor = null;
         streamStateWorker = null;
+        bookmarkMetadataUpdater = null;
         bookmarkActionGuard.finish();
     }
 
@@ -420,11 +423,8 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                     result.getUrl(), result));
         }
 
-        remotePlaylistManager.getPlaylist(result)
-                .flatMap(lists -> getUpdateProcessor(lists, result), (lists, id) -> lists)
-                .onBackpressureLatest()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(getPlaylistBookmarkSubscriber());
+        updateBookmarkMetadataIfNeeded();
+        updateBookmarkButtons();
 
         PlayButtonHelper.initPlaylistControlClickListener(activity, playlistControlBinding, this);
         refreshStreamStatesAfterPageLoad();
@@ -570,20 +570,34 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
     // Utils
     //////////////////////////////////////////////////////////////////////////*/
 
-    private Flowable<Integer> getUpdateProcessor(
-            @NonNull final List<PlaylistRemoteEntity> playlists,
-            @NonNull final PlaylistInfo result) {
-        final Flowable<Integer> noItemToUpdate = Flowable.just(/*noItemToUpdate=*/-1);
-        if (playlists.isEmpty()) {
-            return noItemToUpdate;
+    private void observeBookmark() {
+        if (remotePlaylistManager == null || url == null || isBookmarkButtonReady == null) {
+            return;
         }
 
-        final PlaylistRemoteEntity playlistRemoteEntity = playlists.get(0);
-        if (playlistRemoteEntity.isIdenticalTo(result)) {
-            return noItemToUpdate;
+        isBookmarkButtonReady.set(false);
+        updateBookmarkButtons();
+        remotePlaylistManager.getPlaylist(serviceId, url)
+                .onBackpressureLatest()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(getPlaylistBookmarkSubscriber());
+    }
+
+    private void updateBookmarkMetadataIfNeeded() {
+        if (remotePlaylistManager == null || currentInfo == null || playlistEntity == null
+                || playlistEntity.isIdenticalTo(currentInfo)
+                || bookmarkMetadataUpdater != null && !bookmarkMetadataUpdater.isDisposed()) {
+            return;
         }
 
-        return remotePlaylistManager.onUpdate(playlists.get(0).getUid(), result).toFlowable();
+        final long playlistUid = playlistEntity.getUid();
+        bookmarkMetadataUpdater = remotePlaylistManager.onUpdate(playlistUid, currentInfo)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(ignored -> { /* The database observer refreshes the entity. */ },
+                        throwable -> showError(new ErrorInfo(throwable,
+                                UserAction.REQUESTED_BOOKMARK,
+                                "Updating playlist bookmark")));
+        disposables.add(bookmarkMetadataUpdater);
     }
 
     private Subscriber<List<PlaylistRemoteEntity>> getPlaylistBookmarkSubscriber() {
@@ -601,8 +615,9 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
             public void onNext(final List<PlaylistRemoteEntity> playlist) {
                 playlistEntity = playlist.isEmpty() ? null : playlist.get(0);
 
-                updateBookmarkButtons();
                 isBookmarkButtonReady.set(true);
+                updateBookmarkMetadataIfNeeded();
+                updateBookmarkButtons();
 
                 if (bookmarkReactor != null) {
                     bookmarkReactor.request(1);
@@ -611,6 +626,8 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
 
             @Override
             public void onError(final Throwable throwable) {
+                isBookmarkButtonReady.set(false);
+                updateBookmarkButtons();
                 showError(new ErrorInfo(throwable, UserAction.REQUESTED_BOOKMARK,
                         "Get playlist bookmarks"));
             }
@@ -630,7 +647,9 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
 
     private void onBookmarkClicked() {
         if (isBookmarkButtonReady == null || !isBookmarkButtonReady.get()
-                || remotePlaylistManager == null || !bookmarkActionGuard.tryStart()) {
+                || remotePlaylistManager == null
+                || (playlistEntity == null && currentInfo == null)
+                || !bookmarkActionGuard.tryStart()) {
             return;
         }
 
@@ -645,12 +664,16 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                             showError(new ErrorInfo(throwable, UserAction.REQUESTED_BOOKMARK,
                                     "Adding playlist bookmark")));
         } else if (playlistEntity != null) {
+            final boolean returnToBookmarks = cancelPlaylistLoadingForRemoval();
             action = remotePlaylistManager.deletePlaylist(playlistEntity.getUid())
                     .observeOn(AndroidSchedulers.mainThread())
                     .doFinally(this::finishBookmarkAction)
                     .subscribe(ignored -> {
                         playlistEntity = null;
                         updateBookmarkButtons();
+                        if (returnToBookmarks && isAdded()) {
+                            getFM().popBackStack();
+                        }
                     }, throwable ->
                             showError(new ErrorInfo(throwable, UserAction.REQUESTED_BOOKMARK,
                                     "Deleting playlist bookmark")));
@@ -660,6 +683,28 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
         }
 
         disposables.add(action);
+    }
+
+    /**
+     * Stops an expensive playlist extraction before deleting its small database bookmark row.
+     * This makes removal available even when the remote playlist itself cannot be opened within
+     * the process heap limit.
+     *
+     * @return whether the initial playlist load was cancelled and the fragment should return to
+     *         the bookmarks screen after a successful deletion
+     */
+    private boolean cancelPlaylistLoadingForRemoval() {
+        final boolean initialLoadWasRunning = currentInfo == null && currentWorker != null;
+        if (currentWorker != null) {
+            currentWorker.dispose();
+            currentWorker = null;
+        }
+        if (streamStateWorker != null) {
+            streamStateWorker.dispose();
+            streamStateWorker = null;
+        }
+        isLoading.set(false);
+        return initialLoadWasRunning;
     }
 
     private void finishBookmarkAction() {
@@ -680,8 +725,11 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
 
         playlistBookmarkButton.setIcon(drawable);
         playlistBookmarkButton.setTitle(titleRes);
-        playlistBookmarkButton.setEnabled(isBookmarkButtonReady != null
-                && isBookmarkButtonReady.get() && !bookmarkActionGuard.isRunning());
+        playlistBookmarkButton.setEnabled(BookmarkButtonState.isEnabled(
+                isBookmarkButtonReady != null && isBookmarkButtonReady.get(),
+                playlistEntity != null,
+                currentInfo != null,
+                bookmarkActionGuard.isRunning()));
     }
 
     private void setStreamCountAndOverallDuration(final List<StreamInfoItem> list,

--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
@@ -391,20 +391,45 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
         if (itemListAdapter == null) {
             return;
         }
+
+        if (item instanceof PlaylistRemoteEntity) {
+            deleteRemoteBookmark((PlaylistRemoteEntity) item);
+            return;
+        }
+
         itemListAdapter.removeItem(item);
 
         if (item instanceof PlaylistMetadataEntry) {
             deletedItems.add(new Pair<>(item.getUid(),
                     LocalItem.LocalItemType.PLAYLIST_LOCAL_ITEM));
-        } else if (item instanceof PlaylistRemoteEntity) {
-            deletedItems.add(new Pair<>(item.getUid(),
-                    LocalItem.LocalItemType.PLAYLIST_REMOTE_ITEM));
         }
 
         if (debounceSaver != null) {
             debounceSaver.setHasChangesToSave();
             saveImmediate();
         }
+    }
+
+    private void deleteRemoteBookmark(final PlaylistRemoteEntity item) {
+        if (remotePlaylistManager == null || disposables == null) {
+            return;
+        }
+
+        disposables.add(remotePlaylistManager.deletePlaylist(item.getUid())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(ignored -> {
+                    // The database Flowable refreshes the list. Removing here also gives immediate
+                    // feedback if that refresh is queued behind another emission.
+                    if (itemListAdapter != null) {
+                        itemListAdapter.removeItem(item);
+                    }
+                    completePlaylists = completePlaylists.stream()
+                            .filter(playlist -> playlist.getUid() != item.getUid()
+                                    || playlist.getLocalItemType()
+                                    != LocalItem.LocalItemType.PLAYLIST_REMOTE_ITEM)
+                            .collect(java.util.stream.Collectors.toList());
+                }, throwable -> showError(new ErrorInfo(throwable,
+                        UserAction.REQUESTED_BOOKMARK, "Deleting playlist bookmark"))));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/RemotePlaylistManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/RemotePlaylistManager.kt
@@ -24,7 +24,11 @@ class RemotePlaylistManager(private val database: AppDatabase) {
     }
 
     fun getPlaylist(info: PlaylistInfo): Flowable<MutableList<PlaylistRemoteEntity>> {
-        return playlistRemoteTable.getPlaylist(info.serviceId.toLong(), info.url)
+        return getPlaylist(info.serviceId, info.url)
+    }
+
+    fun getPlaylist(serviceId: Int, url: String?): Flowable<MutableList<PlaylistRemoteEntity>> {
+        return playlistRemoteTable.getPlaylist(serviceId.toLong(), url)
             .subscribeOn(Schedulers.io())
     }
 

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/playlist/BookmarkButtonStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/playlist/BookmarkButtonStateTest.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.fragments.list.playlist;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class BookmarkButtonStateTest {
+    @Test
+    public void storedBookmarkCanBeRemovedBeforePlaylistInfoLoads() {
+        assertTrue(BookmarkButtonState.isEnabled(true, true, false, false));
+    }
+
+    @Test
+    public void addingBookmarkWaitsForPlaylistInfo() {
+        assertFalse(BookmarkButtonState.isEnabled(true, false, false, false));
+        assertTrue(BookmarkButtonState.isEnabled(true, false, true, false));
+    }
+
+    @Test
+    public void lookupAndRunningActionDisableButton() {
+        assertFalse(BookmarkButtonState.isEnabled(false, true, true, false));
+        assertFalse(BookmarkButtonState.isEnabled(true, true, true, true));
+    }
+}


### PR DESCRIPTION
- observe stored remote bookmarks by service ID and URL before playlist extraction completes
- allow an existing bookmark to be removed while its large remote playlist is still loading
- cancel in-flight playlist and stream-state work before the database deletion
- delete remote entries directly from Bookmarked Playlists by their stored UID
- preserve the existing metadata refresh after a playlist loads
- add button-state unit coverage and Room-backed manager regression tests, including a 50,000-item metadata case and idempotent deletion