### PR TITLE
Improve YouTube media URL recovery

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -228,6 +228,10 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final PlayerHttpErrorRecovery.RecoveryGuard mediaUrlRecoveryGuard =
         new PlayerHttpErrorRecovery.RecoveryGuard();
+    @NonNull
+    private final Handler mediaUrlRecoveryHandler = new Handler(Looper.getMainLooper());
+    @Nullable
+    private Runnable pendingMediaUrlRecovery;
 
     @NonNull
     private List<SponsorBlockSegment> sponsorBlockSegments = Collections.emptyList();
@@ -733,6 +737,8 @@ public final class Player implements PlaybackListener, Listener {
         if (DEBUG) {
             Log.d(TAG, "destroyPlayer() called");
         }
+        cancelPendingMediaUrlRecovery();
+        mediaUrlRecoveryGuard.reset();
         learningSessionTracker.stop();
         UIs.call(PlayerUi::destroyPlayer);
         equalizerController.releaseAudioSession();
@@ -2218,6 +2224,10 @@ public final class Player implements PlaybackListener, Listener {
 
         // Refresh the playback if there is a transition to the next video
         final int newIndex = newPosition.mediaItemIndex;
+        if (newIndex != oldPosition.mediaItemIndex) {
+            cancelPendingMediaUrlRecovery();
+            mediaUrlRecoveryGuard.reset();
+        }
         if (discontinuityReason == DISCONTINUITY_REASON_AUTO_TRANSITION) {
             maybeFinishSleepTimerAtEndOfItem(playQueue.getItem(oldPosition.mediaItemIndex), true);
         }
@@ -2391,19 +2401,62 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         final String recoveryKey = item.getServiceId() + ":" + item.getUrl();
-        if (!mediaUrlRecoveryGuard.canRetry(recoveryKey)) {
-            return false;
-        }
-        if (DEBUG) {
-            Log.w(TAG, "Refreshing YouTube StreamInfo after a recoverable media URL failure");
+        final PlayerHttpErrorRecovery.RecoveryAttempt attempt =
+                mediaUrlRecoveryGuard.acquireAttempt(recoveryKey);
+        if (attempt == null) {
+            Log.w(TAG, "YouTube media URL recovery exhausted after "
+                    + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + " attempts");
+            cancelPendingMediaUrlRecovery();
+            InfoCache.getInstance()
+                    .removeInfo(item.getServiceId(), item.getUrl(), InfoCache.Type.STREAM);
+            mediaUrlRecoveryGuard.reset();
+            if (!exoPlayerIsNull()) {
+                simpleExoPlayer.pause();
+            }
+            changeState(STATE_PAUSED);
+            createErrorNotification(error);
+            if (fragmentListener != null) {
+                fragmentListener.onPlayerError(error, true);
+            }
+            return true;
         }
 
         setRecovery();
-        InfoCache.getInstance()
-                .removeInfo(item.getServiceId(), item.getUrl(), InfoCache.Type.STREAM);
-        reloadPlayQueueManager();
         onBuffering();
+        cancelPendingMediaUrlRecovery();
+
+        final Runnable recovery = () -> {
+            pendingMediaUrlRecovery = null;
+            if (playQueue == null) {
+                return;
+            }
+            final PlayQueueItem currentQueueItem = playQueue.getItem();
+            if (currentQueueItem == null
+                    || currentQueueItem.getServiceId() != item.getServiceId()
+                    || !currentQueueItem.getUrl().equals(item.getUrl())) {
+                return;
+            }
+
+            final Integer responseCode = PlayerHttpErrorRecovery.findInvalidResponseCode(error);
+            Log.w(TAG, "Refreshing YouTube StreamInfo after recoverable media URL failure"
+                    + " (status=" + (responseCode == null ? "network" : responseCode)
+                    + ", attempt=" + attempt.getNumber() + "/"
+                    + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + ")");
+            InfoCache.getInstance().removeInfo(item.getServiceId(), item.getUrl(),
+                    InfoCache.Type.STREAM);
+            reloadPlayQueueManager();
+        };
+        pendingMediaUrlRecovery = recovery;
+        mediaUrlRecoveryHandler.postDelayed(recovery, attempt.getDelayMillis());
         return true;
+    }
+
+    private void cancelPendingMediaUrlRecovery() {
+        if (pendingMediaUrlRecovery == null) {
+            return;
+        }
+        mediaUrlRecoveryHandler.removeCallbacks(pendingMediaUrlRecovery);
+        pendingMediaUrlRecovery = null;
     }
 
     private void createErrorNotification(@NonNull final PlaybackException error) {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.player;
 
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 
+import android.os.SystemClock;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -11,6 +13,7 @@ import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 /** Utility methods for deciding whether a player media URL failure can be retried safely. */
 final class PlayerHttpErrorRecovery {
@@ -18,36 +21,70 @@ final class PlayerHttpErrorRecovery {
     }
 
     static final class RecoveryGuard {
-        private static final long RESET_AFTER_MILLIS = TimeUnit.MINUTES.toMillis(10);
+        static final int MAX_ATTEMPTS = 3;
+        static final long RESET_AFTER_MILLIS = TimeUnit.MINUTES.toMillis(10);
+        private static final long[] RETRY_DELAYS_MILLIS = {0, 1_000, 3_000};
 
+        @NonNull
+        private final LongSupplier elapsedRealtimeSupplier;
         @Nullable
         private String currentRecoveryKey;
-        @Nullable
-        private String lastRetriedRecoveryKey;
-        private long lastRetryAtMillis;
+        private int attemptCount;
+        private long lastAttemptAtMillis;
+
+        RecoveryGuard() {
+            this(SystemClock::elapsedRealtime);
+        }
+
+        RecoveryGuard(@NonNull final LongSupplier elapsedRealtimeSupplier) {
+            this.elapsedRealtimeSupplier = elapsedRealtimeSupplier;
+        }
 
         void reset() {
             currentRecoveryKey = null;
-            lastRetriedRecoveryKey = null;
-            lastRetryAtMillis = 0;
+            attemptCount = 0;
+            lastAttemptAtMillis = 0;
         }
 
-        boolean canRetry(@NonNull final String recoveryKey) {
-            final long now = System.currentTimeMillis();
-            if (now - lastRetryAtMillis > RESET_AFTER_MILLIS) {
+        @Nullable
+        RecoveryAttempt acquireAttempt(@NonNull final String recoveryKey) {
+            final long now = elapsedRealtimeSupplier.getAsLong();
+            if (attemptCount > 0
+                    && now - lastAttemptAtMillis >= RESET_AFTER_MILLIS) {
                 reset();
             }
 
             if (!recoveryKey.equals(currentRecoveryKey)) {
                 currentRecoveryKey = recoveryKey;
-                lastRetriedRecoveryKey = null;
+                attemptCount = 0;
             }
-            if (recoveryKey.equals(lastRetriedRecoveryKey)) {
-                return false;
+            if (attemptCount >= MAX_ATTEMPTS) {
+                return null;
             }
-            lastRetriedRecoveryKey = recoveryKey;
-            lastRetryAtMillis = now;
-            return true;
+
+            final RecoveryAttempt attempt = new RecoveryAttempt(attemptCount + 1,
+                    RETRY_DELAYS_MILLIS[attemptCount]);
+            attemptCount++;
+            lastAttemptAtMillis = now;
+            return attempt;
+        }
+    }
+
+    static final class RecoveryAttempt {
+        private final int number;
+        private final long delayMillis;
+
+        RecoveryAttempt(final int number, final long delayMillis) {
+            this.number = number;
+            this.delayMillis = delayMillis;
+        }
+
+        int getNumber() {
+            return number;
+        }
+
+        long getDelayMillis() {
+            return delayMillis;
         }
     }
 

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.player;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.android.exoplayer2.upstream.HttpDataSource;
@@ -11,7 +13,10 @@ import org.schabi.newpipe.extractor.ServiceList;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class PlayerHttpErrorRecoveryTest {
     @Test
@@ -47,15 +52,67 @@ public class PlayerHttpErrorRecoveryTest {
     }
 
     @Test
-    public void retryGuardAllowsOneRetryPerCurrentKey() {
+    public void retryGuardBoundsAttemptsAndAppliesBackoff() {
+        final AtomicLong elapsedRealtime = new AtomicLong(1);
         final PlayerHttpErrorRecovery.RecoveryGuard guard =
-                new PlayerHttpErrorRecovery.RecoveryGuard();
+                new PlayerHttpErrorRecovery.RecoveryGuard(elapsedRealtime::get);
 
-        assertTrue(guard.canRetry("youtube:https://example.com/watch?v=one"));
-        assertFalse(guard.canRetry("youtube:https://example.com/watch?v=one"));
-        assertTrue(guard.canRetry("youtube:https://example.com/watch?v=two"));
-        assertFalse(guard.canRetry("youtube:https://example.com/watch?v=two"));
-        assertTrue(guard.canRetry("youtube:https://example.com/watch?v=one"));
+        assertAttempt(guard.acquireAttempt("youtube:https://example.com/watch?v=one"), 1, 0);
+        assertAttempt(guard.acquireAttempt("youtube:https://example.com/watch?v=one"),
+                2, 1_000);
+        assertAttempt(guard.acquireAttempt("youtube:https://example.com/watch?v=one"),
+                3, 3_000);
+        assertNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+    }
+
+    @Test
+    public void retryGuardResetsWhenCurrentItemChanges() {
+        final PlayerHttpErrorRecovery.RecoveryGuard guard =
+                new PlayerHttpErrorRecovery.RecoveryGuard(() -> 1);
+
+        assertNotNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+        assertNotNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+        assertNotNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+        assertNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+
+        assertAttempt(guard.acquireAttempt("youtube:https://example.com/watch?v=two"), 1, 0);
+    }
+
+    @Test
+    public void retryGuardResetsAfterQuietWindow() {
+        final AtomicLong elapsedRealtime = new AtomicLong(1);
+        final PlayerHttpErrorRecovery.RecoveryGuard guard =
+                new PlayerHttpErrorRecovery.RecoveryGuard(elapsedRealtime::get);
+
+        assertNotNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+        assertNotNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+        assertNotNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+        assertNull(guard.acquireAttempt("youtube:https://example.com/watch?v=one"));
+
+        elapsedRealtime.addAndGet(PlayerHttpErrorRecovery.RecoveryGuard.RESET_AFTER_MILLIS);
+        assertAttempt(guard.acquireAttempt("youtube:https://example.com/watch?v=one"), 1, 0);
+    }
+
+    @Test
+    public void playerRecoveryPreservesPositionAndDoesNotSkipCurrentItem() throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/Player.java"));
+        final int methodStart = source.indexOf(
+                "private boolean tryRecoverFromYouTubeMediaUrlFailure");
+        final int methodEnd = source.indexOf(
+                "private void cancelPendingMediaUrlRecovery", methodStart);
+        assertTrue(methodStart >= 0);
+        assertTrue(methodEnd > methodStart);
+        final String recoveryMethod = source.substring(methodStart, methodEnd);
+
+        assertTrue(recoveryMethod.contains("setRecovery();"));
+        assertTrue(recoveryMethod.indexOf("setRecovery();")
+                < recoveryMethod.indexOf("postDelayed"));
+        assertTrue(recoveryMethod.contains("InfoCache.getInstance()"));
+        assertTrue(recoveryMethod.contains("changeState(STATE_PAUSED);"));
+        assertFalse(recoveryMethod.contains("playQueue.error()"));
     }
 
     @Test
@@ -69,5 +126,14 @@ public class PlayerHttpErrorRecoveryTest {
             final int responseCode) {
         return new HttpDataSource.InvalidResponseCodeException(responseCode, "HTTP error",
                 new IOException("HTTP error"), Collections.emptyMap(), null, new byte[0]);
+    }
+
+    private static void assertAttempt(
+            final PlayerHttpErrorRecovery.RecoveryAttempt attempt,
+            final int expectedNumber,
+            final long expectedDelayMillis) {
+        assertNotNull(attempt);
+        assertEquals(expectedNumber, attempt.getNumber());
+        assertEquals(expectedDelayMillis, attempt.getDelayMillis());
     }
 }


### PR DESCRIPTION
- replace the one-shot YouTube media URL retry with a bounded three-attempt recovery budget
- apply 0, 1, and 3-second backoff delays while preserving the exact playback position
- evict cached `StreamInfo` and rebuild the media source for every recovery attempt
- cancel stale delayed recoveries and reset the budget when the queue item changes or the ten-minute quiet window expires
- keep the current playlist item selected after exhaustion instead of calling `playQueue.error()` and prematurely advancing the queue
- add unit and player-integration coverage for retry limits, backoff, resets, position preservation, and no-skip behavior