### PR TITLE
Fix Safari YouTube stream user agent

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -259,6 +259,8 @@ YoutubeParsingHelper {
             "https://www.youtube.com/feeds/videos.xml?channel_id=";
     private static final String FEED_BASE_USER = "https://www.youtube.com/feeds/videos.xml?user=";
     private static final Pattern C_WEB_PATTERN = Pattern.compile("&c=WEB");
+    private static final Pattern C_SAFARI_VERSION_PATTERN = Pattern.compile(
+            "[?&]cver=" + Pattern.quote(SAFARI_CLIENT_VERSION) + "(?:[&#]|$)");
     private static final Pattern C_TVHTML5_SIMPLY_EMBEDDED_PLAYER_PATTERN =
             Pattern.compile("&c=TVHTML5_SIMPLY_EMBEDDED_PLAYER");
     private static final Pattern C_ANDROID_PATTERN = Pattern.compile("&c=(?:ANDROID|ANDROID_VR)");
@@ -2362,6 +2364,31 @@ YoutubeParsingHelper {
      */
     public static boolean isWebStreamingUrl(@Nonnull final String url) {
         return Parser.isMatch(C_WEB_PATTERN, url);
+    }
+
+    /**
+     * Check if the streaming URL was issued to the Safari-flavoured {@code WEB} client.
+     *
+     * <p>The Safari fallback identifies itself as {@code WEB}, so the client version is required
+     * to distinguish its URLs from regular desktop WEB URLs. Googlevideo can bind stream URLs to
+     * the user agent used to request them, and replaying a Safari URL with the app's default
+     * Firefox user agent can result in HTTP 403 responses.</p>
+     *
+     * @param url the streaming URL to be checked
+     * @return true if this is a Safari WEB-client streaming URL, false otherwise
+     */
+    public static boolean isSafariStreamingUrl(@Nonnull final String url) {
+        return isWebStreamingUrl(url) && Parser.isMatch(C_SAFARI_VERSION_PATTERN, url);
+    }
+
+    /**
+     * Return the user agent used when requesting Safari player responses.
+     *
+     * @return the Safari player user agent
+     */
+    @Nonnull
+    public static String getSafariUserAgent() {
+        return SAFARI_USER_AGENT;
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSource.java
@@ -14,8 +14,10 @@ import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
 import static com.google.android.exoplayer2.util.Util.castNonNull;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getAndroidUserAgent;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getIosUserAgent;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getSafariUserAgent;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isAndroidStreamingUrl;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isIosStreamingUrl;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isSafariStreamingUrl;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isWebStreamingUrl;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isTvHtml5SimplyEmbeddedPlayerStreamingUrl;
 import static java.lang.Math.min;
@@ -670,20 +672,8 @@ public final class YoutubeHttpDataSource extends BaseDataSource implements HttpD
 
         httpURLConnection.setRequestProperty(HttpHeaders.TE, "trailers");
 
-        final boolean isAndroidStreamingUrl = isAndroidStreamingUrl(requestUrl);
-        final boolean isIosStreamingUrl = isIosStreamingUrl(requestUrl);
-        if (isAndroidStreamingUrl) {
-            // Improvement which may be done: find the content country used to request YouTube
-            // contents to add it in the user agent instead of using the default
-            httpURLConnection.setRequestProperty(HttpHeaders.USER_AGENT,
-                    getAndroidUserAgent(null));
-        } else if (isIosStreamingUrl) {
-            httpURLConnection.setRequestProperty(HttpHeaders.USER_AGENT,
-                    getIosUserAgent(null));
-        } else {
-            // non-mobile user agent
-            httpURLConnection.setRequestProperty(HttpHeaders.USER_AGENT, DownloaderImpl.USER_AGENT);
-        }
+        httpURLConnection.setRequestProperty(HttpHeaders.USER_AGENT,
+                resolveUserAgent(requestUrl));
 
         httpURLConnection.setRequestProperty(HttpHeaders.ACCEPT_ENCODING,
                 allowGzip ? "gzip" : "identity");
@@ -699,6 +689,24 @@ public final class YoutubeHttpDataSource extends BaseDataSource implements HttpD
         os.close();
 
         return httpURLConnection;
+    }
+
+    @NonNull
+    static String resolveUserAgent(@NonNull final String requestUrl) {
+        // Safari fallback URLs still identify as c=WEB. Check their client version first so they
+        // are not replayed with WizeStream's default Firefox user agent, which YouTube may reject.
+        if (isSafariStreamingUrl(requestUrl)) {
+            return getSafariUserAgent();
+        }
+        if (isAndroidStreamingUrl(requestUrl)) {
+            // Improvement which may be done: find the content country used to request YouTube
+            // contents to add it in the user agent instead of using the default
+            return getAndroidUserAgent(null);
+        }
+        if (isIosStreamingUrl(requestUrl)) {
+            return getIosUserAgent(null);
+        }
+        return DownloaderImpl.USER_AGENT;
     }
 
     /**
@@ -1006,4 +1014,3 @@ public final class YoutubeHttpDataSource extends BaseDataSource implements HttpD
         }
     }
 }
-

--- a/app/src/test/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSourceTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSourceTest.java
@@ -1,0 +1,56 @@
+package org.schabi.newpipe.player.datasource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getAndroidUserAgent;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getIosUserAgent;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getSafariUserAgent;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.isSafariStreamingUrl;
+
+import org.junit.Test;
+import org.schabi.newpipe.DownloaderImpl;
+
+public class YoutubeHttpDataSourceTest {
+    private static final String STREAM_URL =
+            "https://rr1---sn.example.googlevideo.com/videoplayback?itag=18";
+
+    @Test
+    public void safariWebStreamUsesSafariUserAgent() {
+        final String url = STREAM_URL + "&c=WEB&cver=2.20260114.08.00";
+
+        assertTrue(isSafariStreamingUrl(url));
+        assertEquals(getSafariUserAgent(), YoutubeHttpDataSource.resolveUserAgent(url));
+    }
+
+    @Test
+    public void regularWebStreamUsesDefaultUserAgent() {
+        final String url = STREAM_URL + "&c=WEB&cver=2.20241126.01.00";
+
+        assertFalse(isSafariStreamingUrl(url));
+        assertEquals(DownloaderImpl.USER_AGENT, YoutubeHttpDataSource.resolveUserAgent(url));
+    }
+
+    @Test
+    public void safariVersionWithoutWebClientUsesDefaultUserAgent() {
+        final String url = STREAM_URL + "&c=TVHTML5_SIMPLY_EMBEDDED_PLAYER"
+                + "&cver=2.20260114.08.00";
+
+        assertFalse(isSafariStreamingUrl(url));
+        assertEquals(DownloaderImpl.USER_AGENT, YoutubeHttpDataSource.resolveUserAgent(url));
+    }
+
+    @Test
+    public void androidStreamKeepsAndroidUserAgent() {
+        final String url = STREAM_URL + "&c=ANDROID&cver=21.03.36";
+
+        assertEquals(getAndroidUserAgent(null), YoutubeHttpDataSource.resolveUserAgent(url));
+    }
+
+    @Test
+    public void iosStreamKeepsIosUserAgent() {
+        final String url = STREAM_URL + "&c=IOS&cver=19.45.4";
+
+        assertEquals(getIosUserAgent(null), YoutubeHttpDataSource.resolveUserAgent(url));
+    }
+}


### PR DESCRIPTION
- detect Safari-generated YouTube media URLs using the `WEB` client and Safari client version
- replay those URLs with the same Safari user agent used during extraction
- preserve the existing user-agent behavior for regular WEB, Android, iOS, and TVHTML5 streams
- add focused tests for Safari and the unaffected client types