### PR TITLE
Show channel avatars in channel video lists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelHelper.java
@@ -1,7 +1,9 @@
 package org.schabi.newpipe.extractor.services.youtube;
 
+import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonWriter;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
@@ -12,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.defaultAlertsCheck;
@@ -335,6 +338,51 @@ public final class YoutubeChannelHelper {
         } else {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Get a channel's avatars from any supported YouTube channel header.
+     *
+     * @param channelHeader the parsed channel header
+     * @return the channel avatar images
+     * @throws ParsingException if the channel header does not contain avatars
+     */
+    @Nonnull
+    public static List<Image> getChannelAvatars(
+            @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+            @Nonnull final Optional<ChannelHeader> channelHeader) throws ParsingException {
+        return channelHeader.map(header -> {
+                    switch (header.headerType) {
+                        case PAGE:
+                            final JsonObject image = header.json.getObject(CONTENT)
+                                    .getObject(PAGE_HEADER_VIEW_MODEL)
+                                    .getObject("image");
+
+                            if (image.has("contentPreviewImageViewModel")) {
+                                return image.getObject("contentPreviewImageViewModel")
+                                        .getObject("image")
+                                        .getArray("sources");
+                            }
+
+                            if (image.has("decoratedAvatarViewModel")) {
+                                return image.getObject("decoratedAvatarViewModel")
+                                        .getObject("avatar")
+                                        .getObject("avatarViewModel")
+                                        .getObject("image")
+                                        .getArray("sources");
+                            }
+
+                            return new JsonArray();
+                        case INTERACTIVE_TABBED:
+                            return header.json.getObject("boxArt").getArray("thumbnails");
+                        case C4_TABBED:
+                        case CAROUSEL:
+                        default:
+                            return header.json.getObject("avatar").getArray("thumbnails");
+                    }
+                })
+                .map(YoutubeParsingHelper::getImagesFromThumbnailsArray)
+                .orElseThrow(() -> new ParsingException("Could not get avatars"));
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -172,42 +172,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                     .orElseThrow(() -> new ParsingException("Could not get avatars"));
         }
 
-        return channelHeader.map(header -> {
-                    switch (header.headerType) {
-                        case PAGE:
-                            final JsonObject imageObj = header.json.getObject(CONTENT)
-                                    .getObject(PAGE_HEADER_VIEW_MODEL)
-                                    .getObject(IMAGE);
-
-                            if (imageObj.has(CONTENT_PREVIEW_IMAGE_VIEW_MODEL)) {
-                                return imageObj.getObject(CONTENT_PREVIEW_IMAGE_VIEW_MODEL)
-                                        .getObject(IMAGE)
-                                        .getArray(SOURCES);
-                            }
-
-                            if (imageObj.has("decoratedAvatarViewModel")) {
-                                return imageObj.getObject("decoratedAvatarViewModel")
-                                        .getObject(AVATAR)
-                                        .getObject("avatarViewModel")
-                                        .getObject(IMAGE)
-                                        .getArray(SOURCES);
-                            }
-
-                            // Return an empty avatar array as a fallback
-                            return new JsonArray();
-                        case INTERACTIVE_TABBED:
-                            return header.json.getObject("boxArt")
-                                    .getArray(THUMBNAILS);
-
-                        case C4_TABBED:
-                        case CAROUSEL:
-                        default:
-                            return header.json.getObject(AVATAR)
-                                    .getArray(THUMBNAILS);
-                    }
-                })
-                .map(YoutubeParsingHelper::getImagesFromThumbnailsArray)
-                .orElseThrow(() -> new ParsingException("Could not get avatars"));
+        return YoutubeChannelHelper.getChannelAvatars(channelHeader);
     }
 
     @Nonnull

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -143,6 +143,7 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
             channelIds.add(getChannelName());
             channelIds.add(YoutubeChannelLinkHandlerFactory.getInstance()
                     .getUrl("channel/" + getId()));
+            channelIds.add(getChannelAvatarUrl());
             final JsonObject continuation = collectItemsFrom(collector, items, channelIds);
 
             nextPage = getNextPageFrom(continuation, channelIds);
@@ -423,6 +424,11 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                     public String getUploaderUrl() {
                         return channelIds.get(1);
                     }
+
+                    @Override
+                    public String getUploaderAvatarUrl() throws ParsingException {
+                        return resolveUploaderAvatarUrl(super.getUploaderAvatarUrl(), channelIds);
+                    }
                 });
 
         if (item.has("gridVideoRenderer")) {
@@ -444,6 +450,11 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                     @Override
                     public String getUploaderName() {
                         return channelIds.get(0);
+                    }
+
+                    @Override
+                    public String getUploaderAvatarUrl() throws ParsingException {
+                        return resolveUploaderAvatarUrl(super.getUploaderAvatarUrl(), channelIds);
                     }
                 });
             } else if (richItem.has("lockupViewModel")) {
@@ -554,8 +565,38 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                 public String getUploaderUrl() {
                     return channelIds.get(1);
                 }
+
+                @Override
+                public String getUploaderAvatarUrl() throws ParsingException {
+                    return resolveUploaderAvatarUrl(super.getUploaderAvatarUrl(), channelIds);
+                }
             });
         }
+    }
+
+    @Nonnull
+    private String getChannelAvatarUrl() {
+        try {
+            return YoutubeChannelHelper.getChannelAvatars(channelHeader).stream()
+                    .findFirst()
+                    .map(Image::getUrl)
+                    .orElse("");
+        } catch (final Exception ignored) {
+            return "";
+        }
+    }
+
+    @Nullable
+    static String resolveUploaderAvatarUrl(@Nullable final String itemAvatarUrl,
+                                           @Nullable final List<String> channelIds) {
+        if (!isNullOrEmpty(itemAvatarUrl)) {
+            return itemAvatarUrl;
+        }
+        if (channelIds == null || channelIds.size() < 3) {
+            return itemAvatarUrl;
+        }
+        final String channelAvatarUrl = channelIds.get(2);
+        return isNullOrEmpty(channelAvatarUrl) ? itemAvatarUrl : channelAvatarUrl;
     }
 
     @Nonnull

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelAvatarTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeChannelAvatarTest.java
@@ -1,0 +1,36 @@
+package org.schabi.newpipe.extractor.services.youtube;
+
+import static org.junit.Assert.assertEquals;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+
+import org.junit.Test;
+
+public class YoutubeChannelAvatarTest {
+    @Test
+    public void extractsAvatarFromClassicChannelHeader() throws Exception {
+        final JsonObject response = JsonParser.object().from("{\"header\":{"
+                + "\"c4TabbedHeaderRenderer\":{\"avatar\":{\"thumbnails\":[{"
+                + "\"url\":\"https://example.com/classic.jpg\","
+                + "\"width\":88,\"height\":88}]}}}}");
+
+        assertEquals("https://example.com/classic.jpg",
+                YoutubeChannelHelper.getChannelAvatars(
+                        YoutubeChannelHelper.getChannelHeader(response)).get(0).getUrl());
+    }
+
+    @Test
+    public void extractsAvatarFromPageChannelHeader() throws Exception {
+        final JsonObject response = JsonParser.object().from("{\"header\":{"
+                + "\"pageHeaderRenderer\":{\"content\":{\"pageHeaderViewModel\":{"
+                + "\"image\":{\"decoratedAvatarViewModel\":{\"avatar\":{"
+                + "\"avatarViewModel\":{\"image\":{\"sources\":[{"
+                + "\"url\":\"https://example.com/page.jpg\","
+                + "\"width\":176,\"height\":176}]}}}}}}}}}}");
+
+        assertEquals("https://example.com/page.jpg",
+                YoutubeChannelHelper.getChannelAvatars(
+                        YoutubeChannelHelper.getChannelHeader(response)).get(0).getUrl());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabAvatarFallbackTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabAvatarFallbackTest.java
@@ -1,0 +1,34 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class YoutubeChannelTabAvatarFallbackTest {
+    @Test
+    public void usesChannelAvatarWhenItemAvatarIsMissing() {
+        assertEquals("https://example.com/channel.jpg",
+                YoutubeChannelTabExtractor.resolveUploaderAvatarUrl(null,
+                        Arrays.asList("Channel", "https://example.com/channel",
+                                "https://example.com/channel.jpg")));
+    }
+
+    @Test
+    public void preservesAvatarProvidedByVideoItem() {
+        assertEquals("https://example.com/item.jpg",
+                YoutubeChannelTabExtractor.resolveUploaderAvatarUrl(
+                        "https://example.com/item.jpg",
+                        Arrays.asList("Channel", "https://example.com/channel",
+                                "https://example.com/channel.jpg")));
+    }
+
+    @Test
+    public void toleratesContinuationMetadataWithoutAvatar() {
+        assertNull(YoutubeChannelTabExtractor.resolveUploaderAvatarUrl(null,
+                Collections.singletonList("Channel")));
+    }
+}


### PR DESCRIPTION
- extract the channel avatar once from the YouTube channel-tab header
- use it as a fallback when video entries omit their uploader avatar
- preserve avatars supplied directly by individual video entries
- carry the channel avatar through continuation metadata for paginated results
- cover regular videos, Shorts, and lockup-style video entries
- share channel-header avatar parsing between the channel and channel-tab extractors