### PR TITLE
Fix YouTube media 403 recovery and client selection

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -258,14 +258,21 @@ YoutubeParsingHelper {
     private static final String FEED_BASE_CHANNEL_ID =
             "https://www.youtube.com/feeds/videos.xml?channel_id=";
     private static final String FEED_BASE_USER = "https://www.youtube.com/feeds/videos.xml?user=";
-    private static final Pattern C_WEB_PATTERN = Pattern.compile("&c=WEB");
+    private static final Pattern C_WEB_PATTERN = Pattern.compile(
+            "(?:[?&]c=WEB(?:[&#]|$)|/c/WEB(?:/|[?#]|$))");
     private static final Pattern C_SAFARI_VERSION_PATTERN = Pattern.compile(
-            "[?&]cver=" + Pattern.quote(SAFARI_CLIENT_VERSION) + "(?:[&#]|$)");
+            "(?:[?&]cver=" + Pattern.quote(SAFARI_CLIENT_VERSION) + "(?:[&#]|$)"
+                    + "|/cver/" + Pattern.quote(SAFARI_CLIENT_VERSION) + "(?:/|[?#]|$))");
     private static final Pattern C_TVHTML5_SIMPLY_EMBEDDED_PLAYER_PATTERN =
-            Pattern.compile("&c=TVHTML5_SIMPLY_EMBEDDED_PLAYER");
-    private static final Pattern C_ANDROID_PATTERN = Pattern.compile("&c=(?:ANDROID|ANDROID_VR)");
-    private static final Pattern C_IOS_PATTERN = Pattern.compile("&c=IOS");
-    private static final Pattern C_VISIONOS_PATTERN = Pattern.compile("&c=VISIONOS");
+            Pattern.compile("(?:[?&]c=TVHTML5_SIMPLY_EMBEDDED_PLAYER(?:[&#]|$)"
+                    + "|/c/TVHTML5_SIMPLY_EMBEDDED_PLAYER(?:/|[?#]|$))");
+    private static final Pattern C_ANDROID_PATTERN = Pattern.compile(
+            "(?:[?&]c=(?:ANDROID|ANDROID_VR)(?:[&#]|$)"
+                    + "|/c/(?:ANDROID|ANDROID_VR)(?:/|[?#]|$))");
+    private static final Pattern C_IOS_PATTERN = Pattern.compile(
+            "(?:[?&]c=IOS(?:[&#]|$)|/c/IOS(?:/|[?#]|$))");
+    private static final Pattern C_VISIONOS_PATTERN = Pattern.compile(
+            "(?:[?&]c=VISIONOS(?:[&#]|$)|/c/VISIONOS(?:/|[?#]|$))");
 
     private static final Set<String> GOOGLE_URLS = Set.of("google.", "m.google.", "www.google.");
     private static final Set<String> INVIDIOUS_URLS = Set.of("invidio.us", "dev.invidio.us",

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -821,6 +821,24 @@ public class YoutubeStreamExtractor extends StreamExtractor {
      * This method collects all audio, video, and video-only streams,
      * then performs batch deobfuscation in one request.
      */
+    /**
+     * Returns direct stream responses in reliability order.
+     *
+     * <p>VISIONOS is preferred because YouTube can expose ANDROID_VR adaptive URLs that start
+     * successfully but return HTTP 403 on a later byte-range request. Android remains the final
+     * fallback for content unavailable through the other clients.</p>
+     */
+    @Nonnull
+    private java.util.stream.Stream<Pair<JsonObject, String>>
+            getPreferredStreamingData() {
+        return java.util.stream.Stream.of(
+                new Pair<>(visionOsStreamingData, visionOsCpn),
+                new Pair<>(safariStreamingData, safariCpn),
+                new Pair<>(iosStreamingData, iosCpn),
+                new Pair<>(tvHtml5SimplyEmbedStreamingData, tvHtml5SimplyEmbedCpn),
+                new Pair<>(androidStreamingData, androidCpn));
+    }
+
     private void ensureStreamsAreCached() throws ExtractionException {
         if (streamsCached) {
             return;
@@ -837,13 +855,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         try {
             // Collect audio streams
-            java.util.stream.Stream.of(
-                    new Pair<>(safariStreamingData, safariCpn),
-                    new Pair<>(androidStreamingData, androidCpn),
-                    new Pair<>(visionOsStreamingData, visionOsCpn),
-                    new Pair<>(iosStreamingData, iosCpn),
-                    new Pair<>(tvHtml5SimplyEmbedStreamingData, tvHtml5SimplyEmbedCpn)
-            )
+            getPreferredStreamingData()
                     .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
                             ADAPTIVE_FORMATS, ItagItem.ItagType.AUDIO, pair.getSecond()))
                     .forEachOrdered(allItagInfos::add);
@@ -851,13 +863,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             videoStartIndex = allItagInfos.size();
 
             // Collect video streams
-            java.util.stream.Stream.of(
-                    new Pair<>(safariStreamingData, safariCpn),
-                    new Pair<>(androidStreamingData, androidCpn),
-                    new Pair<>(visionOsStreamingData, visionOsCpn),
-                    new Pair<>(iosStreamingData, iosCpn),
-                    new Pair<>(tvHtml5SimplyEmbedStreamingData, tvHtml5SimplyEmbedCpn)
-            )
+            getPreferredStreamingData()
                     .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
                             FORMATS, ItagItem.ItagType.VIDEO, pair.getSecond()))
                     .forEachOrdered(allItagInfos::add);
@@ -865,13 +871,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             videoOnlyStartIndex = allItagInfos.size();
 
             // Collect video-only streams
-            java.util.stream.Stream.of(
-                    new Pair<>(safariStreamingData, safariCpn),
-                    new Pair<>(androidStreamingData, androidCpn),
-                    new Pair<>(visionOsStreamingData, visionOsCpn),
-                    new Pair<>(iosStreamingData, iosCpn),
-                    new Pair<>(tvHtml5SimplyEmbedStreamingData, tvHtml5SimplyEmbedCpn)
-            )
+            getPreferredStreamingData()
                     .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
                             ADAPTIVE_FORMATS, ItagItem.ItagType.VIDEO_ONLY, pair.getSecond()))
                     .forEachOrdered(allItagInfos::add);
@@ -2069,23 +2069,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             // First pass: collect all ItagInfo objects without deobfuscating URLs
             final List<ItagInfo> itagInfoList = new ArrayList<>();
 
-            java.util.stream.Stream.of(
-                     /*
-                    Use the iosStreamingData object first because there is no n param and no
-                    signatureCiphers in streaming URLs of the iOS client
-                    The androidStreamingData is used as second way as it isn't used on livestreams,
-                    it doesn't return all available streams, and the Android client extraction is
-                    more likely to break
-                    As age-restricted videos are not common, use tvHtml5SimplyEmbedStreamingData
-                    last, which will be the only one not empty for age-restricted content
-                     */
-                    new Pair<>(safariStreamingData, safariCpn),
-                    new Pair<>(androidStreamingData, androidCpn),
-                    new Pair<>(visionOsStreamingData, visionOsCpn),
-                    new Pair<>(iosStreamingData, iosCpn),
-                    new Pair<>(tvHtml5SimplyEmbedStreamingData, tvHtml5SimplyEmbedCpn)
-
-            )
+            getPreferredStreamingData()
                     .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
                             streamingDataKey, itagTypeWanted, pair.getSecond()))
                     .forEachOrdered(itagInfoList::add);

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -817,11 +817,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private boolean streamsCached = false;
 
     /**
-     * Pre-fetch and batch-process all streams in a single API call.
-     * This method collects all audio, video, and video-only streams,
-     * then performs batch deobfuscation in one request.
-     */
-    /**
      * Returns direct stream responses in reliability order.
      *
      * <p>VISIONOS is preferred because YouTube can expose ANDROID_VR adaptive URLs that start
@@ -839,6 +834,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 new Pair<>(androidStreamingData, androidCpn));
     }
 
+    /**
+     * Pre-fetch and batch-process all streams in a single API call.
+     * This method collects all audio, video, and video-only streams,
+     * then performs batch deobfuscation in one request.
+     */
     private void ensureStreamsAreCached() throws ExtractionException {
         if (streamsCached) {
             return;

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2407,14 +2407,15 @@ public final class Player implements PlaybackListener, Listener {
             Log.w(TAG, "YouTube media URL recovery exhausted after "
                     + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + " attempts");
             cancelPendingMediaUrlRecovery();
-            InfoCache.getInstance()
-                    .removeInfo(item.getServiceId(), item.getUrl(), InfoCache.Type.STREAM);
+            invalidateYouTubeMediaCaches(item);
             mediaUrlRecoveryGuard.reset();
             if (!exoPlayerIsNull()) {
                 simpleExoPlayer.pause();
             }
             changeState(STATE_PAUSED);
-            createErrorNotification(error);
+            createErrorNotification(error, "recovery=exhausted, attempts="
+                    + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + "/"
+                    + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS);
             if (fragmentListener != null) {
                 fragmentListener.onPlayerError(error, true);
             }
@@ -2442,8 +2443,7 @@ public final class Player implements PlaybackListener, Listener {
                     + " (status=" + (responseCode == null ? "network" : responseCode)
                     + ", attempt=" + attempt.getNumber() + "/"
                     + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + ")");
-            InfoCache.getInstance().removeInfo(item.getServiceId(), item.getUrl(),
-                    InfoCache.Type.STREAM);
+            invalidateYouTubeMediaCaches(item);
             reloadPlayQueueManager();
         };
         pendingMediaUrlRecovery = recovery;
@@ -2459,16 +2459,37 @@ public final class Player implements PlaybackListener, Listener {
         pendingMediaUrlRecovery = null;
     }
 
+    private static void invalidateYouTubeMediaCaches(@NonNull final PlayQueueItem item) {
+        PlayerDataSource.invalidateYoutubeManifestCaches();
+        InfoCache.getInstance().removeInfo(item.getServiceId(), item.getUrl(),
+                InfoCache.Type.STREAM);
+    }
+
     private void createErrorNotification(@NonNull final PlaybackException error) {
+        createErrorNotification(error, null);
+    }
+
+    private void createErrorNotification(@NonNull final PlaybackException error,
+                                         @Nullable final String recoveryDiagnostic) {
+        final String safeErrorContext = PlayerHttpErrorRecovery.buildSafeErrorContext(error);
+        final StringBuilder diagnosticSuffix = new StringBuilder();
+        if (safeErrorContext != null) {
+            diagnosticSuffix.append(" [").append(safeErrorContext).append(']');
+        }
+        if (recoveryDiagnostic != null) {
+            diagnosticSuffix.append(" [").append(recoveryDiagnostic).append(']');
+        }
+
         final ErrorInfo errorInfo;
         if (currentMetadata == null) {
             errorInfo = new ErrorInfo(error, UserAction.PLAY_STREAM,
                     "Player error[type=" + error.getErrorCodeName()
-                            + "] occurred, currentMetadata is null");
+                            + "] occurred, currentMetadata is null" + diagnosticSuffix);
         } else {
             errorInfo = new ErrorInfo(error, UserAction.PLAY_STREAM,
                     "Player error[type=" + error.getErrorCodeName()
-                            + "] occurred while playing " + currentMetadata.getStreamUrl(),
+                            + "] occurred while playing " + currentMetadata.getStreamUrl()
+                            + diagnosticSuffix,
                     currentMetadata.getServiceId(), currentMetadata.getStreamUrl());
         }
         ErrorUtil.createNotification(context, errorInfo);

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
@@ -17,6 +17,9 @@ import java.util.function.LongSupplier;
 
 /** Utility methods for deciding whether a player media URL failure can be retried safely. */
 final class PlayerHttpErrorRecovery {
+    private static final String REQUEST_DIAGNOSTIC_PREFIX =
+            "YouTube media request diagnostic: ";
+
     private PlayerHttpErrorRecovery() {
     }
 
@@ -132,5 +135,39 @@ final class PlayerHttpErrorRecovery {
             current = current.getCause();
         }
         return false;
+    }
+
+    @Nullable
+    static String findSafeRequestDiagnostic(@NonNull final Throwable error) {
+        Throwable current = error;
+        while (current != null) {
+            final String message = current.getMessage();
+            if (message != null && message.startsWith(REQUEST_DIAGNOSTIC_PREFIX)) {
+                return message.substring(REQUEST_DIAGNOSTIC_PREFIX.length());
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    @Nullable
+    static String buildSafeErrorContext(@NonNull final Throwable error) {
+        final Integer responseCode = findInvalidResponseCode(error);
+        final String requestDiagnostic = findSafeRequestDiagnostic(error);
+        if (responseCode == null && requestDiagnostic == null) {
+            return null;
+        }
+
+        final StringBuilder context = new StringBuilder();
+        if (responseCode != null) {
+            context.append("status=").append(responseCode);
+        }
+        if (requestDiagnostic != null) {
+            if (context.length() > 0) {
+                context.append(", ");
+            }
+            context.append(requestDiagnostic);
+        }
+        return context.toString();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSource.java
@@ -719,26 +719,33 @@ public final class YoutubeHttpDataSource extends BaseDataSource implements HttpD
 
     @NonNull
     static String buildSafeRequestDiagnostic(@NonNull final String requestUrl) {
-        return "client=" + safeDiagnosticValue(getQueryParameter(requestUrl, "c"))
-                + ", cver=" + safeDiagnosticValue(getQueryParameter(requestUrl, "cver"))
-                + ", itag=" + safeDiagnosticValue(getQueryParameter(requestUrl, "itag"))
+        return "client=" + safeDiagnosticValue(getUrlParameter(requestUrl, "c"))
+                + ", cver=" + safeDiagnosticValue(getUrlParameter(requestUrl, "cver"))
+                + ", itag=" + safeDiagnosticValue(getUrlParameter(requestUrl, "itag"))
                 + ", userAgent=" + resolveUserAgentFamily(requestUrl);
     }
 
     @Nullable
-    private static String getQueryParameter(@NonNull final String requestUrl,
-                                            @NonNull final String name) {
+    private static String getUrlParameter(@NonNull final String requestUrl,
+                                          @NonNull final String name) {
         try {
-            final String query = new URL(requestUrl).getQuery();
-            if (query == null) {
-                return null;
+            final URL url = new URL(requestUrl);
+            final String query = url.getQuery();
+            if (query != null) {
+                for (final String parameter : query.split("&")) {
+                    final int separator = parameter.indexOf('=');
+                    final String parameterName = separator < 0
+                            ? parameter : parameter.substring(0, separator);
+                    if (name.equals(parameterName)) {
+                        return separator < 0 ? "" : parameter.substring(separator + 1);
+                    }
+                }
             }
-            for (final String parameter : query.split("&")) {
-                final int separator = parameter.indexOf('=');
-                final String parameterName = separator < 0
-                        ? parameter : parameter.substring(0, separator);
-                if (name.equals(parameterName)) {
-                    return separator < 0 ? "" : parameter.substring(separator + 1);
+
+            final String[] pathSegments = url.getPath().split("/");
+            for (int i = 0; i + 1 < pathSegments.length; i++) {
+                if (name.equals(pathSegments[i])) {
+                    return pathSegments[i + 1];
                 }
             }
         } catch (final MalformedURLException ignored) {

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -200,6 +200,20 @@ public class PlayerDataSource {
         return new DefaultDashChunkSource.Factory(dataSourceFactory);
     }
 
+    /**
+     * Invalidates generated YouTube manifests after a media URL is rejected.
+     *
+     * <p>Refreshing {@code StreamInfo} alone is not sufficient for generated progressive, OTF,
+     * or post-live DASH manifests: their cached XML can still reference the rejected redirected
+     * CDN URL. Clearing these small in-memory caches ensures that the next recovery rebuilds the
+     * manifest from the refreshed extractor response.</p>
+     */
+    public static void invalidateYoutubeManifestCaches() {
+        YoutubeProgressiveDashManifestCreator.getCache().clear();
+        YoutubeOtfDashManifestCreator.getCache().clear();
+        YoutubePostLiveStreamDvrDashManifestCreator.getCache().clear();
+    }
+
     private static YoutubeHttpDataSource.Factory getYoutubeHttpDataSourceFactory(
             final boolean rangeParameterEnabled,
             final boolean rnParameterEnabled) {

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractorTest.java
@@ -1,0 +1,58 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class YoutubeStreamExtractorTest {
+    @Test
+    public void directStreamsPreferVisionOsAndKeepAndroidAsLastFallback()
+            throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/extractor/services/youtube/extractors/"
+                        + "YoutubeStreamExtractor.java"));
+        final int helperStart = source.indexOf(
+                "getPreferredStreamingData() {");
+        final int helperEnd = source.indexOf(
+                "private void ensureStreamsAreCached", helperStart);
+
+        assertTrue(helperStart >= 0);
+        assertTrue(helperEnd > helperStart);
+
+        final String priority = source.substring(helperStart, helperEnd);
+        final int visionOs = priority.indexOf(
+                "new Pair<>(visionOsStreamingData, visionOsCpn)");
+        final int safari = priority.indexOf(
+                "new Pair<>(safariStreamingData, safariCpn)");
+        final int ios = priority.indexOf(
+                "new Pair<>(iosStreamingData, iosCpn)");
+        final int tv = priority.indexOf(
+                "new Pair<>(tvHtml5SimplyEmbedStreamingData, tvHtml5SimplyEmbedCpn)");
+        final int android = priority.indexOf(
+                "new Pair<>(androidStreamingData, androidCpn)");
+
+        assertTrue(visionOs >= 0);
+        assertTrue(visionOs < safari);
+        assertTrue(safari < ios);
+        assertTrue(ios < tv);
+        assertTrue(tv < android);
+        assertEquals(5, countOccurrences(source, "getPreferredStreamingData()"));
+    }
+
+    private static int countOccurrences(final String source, final String value) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = source.indexOf(value, offset)) >= 0) {
+            count++;
+            offset += value.length();
+        }
+        return count;
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
@@ -52,6 +52,17 @@ public class PlayerHttpErrorRecoveryTest {
     }
 
     @Test
+    public void buildsSafeErrorContextFromNestedRequestDiagnostic() {
+        final IOException diagnostic = new IOException("YouTube media request diagnostic: "
+                + "client=VISIONOS, cver=1.02, itag=18, userAgent=VISIONOS");
+        final Throwable error = new RuntimeException("source",
+                invalidResponseCodeException(403, diagnostic));
+
+        assertEquals("status=403, client=VISIONOS, cver=1.02, itag=18, userAgent=VISIONOS",
+                PlayerHttpErrorRecovery.buildSafeErrorContext(error));
+    }
+
+    @Test
     public void retryGuardBoundsAttemptsAndAppliesBackoff() {
         final AtomicLong elapsedRealtime = new AtomicLong(1);
         final PlayerHttpErrorRecovery.RecoveryGuard guard =
@@ -110,7 +121,7 @@ public class PlayerHttpErrorRecoveryTest {
         assertTrue(recoveryMethod.contains("setRecovery();"));
         assertTrue(recoveryMethod.indexOf("setRecovery();")
                 < recoveryMethod.indexOf("postDelayed"));
-        assertTrue(recoveryMethod.contains("InfoCache.getInstance()"));
+        assertTrue(recoveryMethod.contains("invalidateYouTubeMediaCaches(item)"));
         assertTrue(recoveryMethod.contains("changeState(STATE_PAUSED);"));
         assertFalse(recoveryMethod.contains("playQueue.error()"));
     }
@@ -124,8 +135,14 @@ public class PlayerHttpErrorRecoveryTest {
 
     private static HttpDataSource.InvalidResponseCodeException invalidResponseCodeException(
             final int responseCode) {
+        return invalidResponseCodeException(responseCode, new IOException("HTTP error"));
+    }
+
+    private static HttpDataSource.InvalidResponseCodeException invalidResponseCodeException(
+            final int responseCode,
+            final IOException cause) {
         return new HttpDataSource.InvalidResponseCodeException(responseCode, "HTTP error",
-                new IOException("HTTP error"), Collections.emptyMap(), null, new byte[0]);
+                cause, Collections.emptyMap(), null, new byte[0]);
     }
 
     private static void assertAttempt(

--- a/app/src/test/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSourceTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSourceTest.java
@@ -63,6 +63,21 @@ public class YoutubeHttpDataSourceTest {
     }
 
     @Test
+    public void pathEncodedClientMarkersUseMatchingUserAgents() {
+        final String pathStreamUrl =
+                "https://rr1---sn.example.googlevideo.com/videoplayback/itag/18";
+
+        assertEquals(getSafariUserAgent(), YoutubeHttpDataSource.resolveUserAgent(
+                pathStreamUrl + "/c/WEB/cver/2.20260114.08.00"));
+        assertEquals(getAndroidUserAgent(null), YoutubeHttpDataSource.resolveUserAgent(
+                pathStreamUrl + "/c/ANDROID/cver/21.03.36"));
+        assertEquals(getIosUserAgent(null), YoutubeHttpDataSource.resolveUserAgent(
+                pathStreamUrl + "/c/IOS/cver/19.45.4"));
+        assertEquals(getVisionOsUserAgent(null), YoutubeHttpDataSource.resolveUserAgent(
+                pathStreamUrl + "/c/VISIONOS/cver/1.02"));
+    }
+
+    @Test
     public void rejectedRequestDiagnosticExcludesSignedUrlData() {
         final String url = STREAM_URL + "&c=VISIONOS&cver=1.02"
                 + "&sig=secret-signature";
@@ -71,6 +86,18 @@ public class YoutubeHttpDataSourceTest {
 
         assertEquals("client=VISIONOS, cver=1.02, itag=18, userAgent=VISIONOS",
                 diagnostic);
+        assertFalse(diagnostic.contains("secret-signature"));
+        assertFalse(diagnostic.contains("googlevideo.com"));
+    }
+
+    @Test
+    public void rejectedRequestDiagnosticReadsPathEncodedParameters() {
+        final String url = "https://rr1---sn.example.googlevideo.com/videoplayback"
+                + "/itag/18/c/VISIONOS/cver/1.02/sig/secret-signature";
+
+        final String diagnostic = YoutubeHttpDataSource.buildSafeRequestDiagnostic(url);
+
+        assertEquals("client=VISIONOS, cver=1.02, itag=18, userAgent=VISIONOS", diagnostic);
         assertFalse(diagnostic.contains("secret-signature"));
         assertFalse(diagnostic.contains("googlevideo.com"));
     }

--- a/app/src/test/java/org/schabi/newpipe/player/helper/PlayerDataSourceTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/PlayerDataSourceTest.java
@@ -1,0 +1,23 @@
+package org.schabi.newpipe.player.helper;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeOtfDashManifestCreator;
+import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubePostLiveStreamDvrDashManifestCreator;
+import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeProgressiveDashManifestCreator;
+
+public class PlayerDataSourceTest {
+    @Test
+    public void invalidatesEveryGeneratedYoutubeManifestCache() {
+        YoutubeProgressiveDashManifestCreator.getCache().put("progressive", "manifest");
+        YoutubeOtfDashManifestCreator.getCache().put("otf", "manifest");
+        YoutubePostLiveStreamDvrDashManifestCreator.getCache().put("post-live", "manifest");
+
+        PlayerDataSource.invalidateYoutubeManifestCaches();
+
+        assertEquals(0, YoutubeProgressiveDashManifestCreator.getCache().size());
+        assertEquals(0, YoutubeOtfDashManifestCreator.getCache().size());
+        assertEquals(0, YoutubePostLiveStreamDvrDashManifestCreator.getCache().size());
+    }
+}


### PR DESCRIPTION
- prefer VisionOS direct streams over Android VR for audio, combined video, and video-only playback
- keep Android VR as the final fallback when other clients do not provide the requested format
- invalidate generated YouTube progressive, OTF, and post-live manifests before retrying rejected media URLs
- recognize both query-form and path-form YouTube client markers when choosing the playback user agent
- include safe HTTP status, client, version, itag, user-agent family, and exhausted-attempt context in future error reports
- add regression coverage for client priority, manifest invalidation, path-form detection, and diagnostic propagation