### PR TITLE
Fix media.ccc.de live stream lookup

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/media_ccc/extractors/MediaCCCLiveStreamExtractor.java
@@ -57,7 +57,7 @@ public class MediaCCCLiveStreamExtractor extends StreamExtractor {
                 final JsonArray rooms = groups.getObject(g).getArray("rooms");
                 for (int r = 0; r < rooms.size(); r++) {
                     final JsonObject roomObject = rooms.getObject(r);
-                    if (getId().equals(conferenceObject.getString("slug") + "/"
+                    if (getId().equals(conferenceObject.getString("mandator") + "/"
                             + roomObject.getString("slug"))) {
                         conference = conferenceObject;
                         group = groupObject;

--- a/fastlane/metadata/android/en-US/changelogs/1007001.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1007001.txt
@@ -2,3 +2,4 @@ WizeStream 1.7.1
 
 - Fixed YouTube playback stopping with HTTP 403, including streams failing around the one-minute mark.
 - Improved recovery and client fallback for expiring or rejected YouTube media URLs.
+- Fixed media.ccc.de live streams failing to open.


### PR DESCRIPTION
## Summary

- use the media.ccc.de conference `mandator` when matching live room identifiers
- port the functional fix included in NewPipeExtractor v0.26.5
- document the fix in the WizeStream 1.7.1 release notes

## Root cause

media.ccc.de live room identifiers are formed as `mandator/room-slug`. WizeStream was comparing them against `conference-slug/room-slug`, so valid live rooms could not be found and extraction ended with `Could not find room matching id`.

## User impact

media.ccc.de live streams can be resolved and opened again.

## Validation

- exact one-line port of TeamNewPipe/NewPipeExtractor commit [be9c03f](https://github.com/TeamNewPipe/NewPipeExtractor/commit/be9c03fd10721bdce1dae82139bd249cf18e8ade)
- functional code diff is limited to `MediaCCCLiveStreamExtractor.java`
- the only additional change is the `1007001.txt` release-note entry
- no YouTube playback or application dependency behavior is changed
