### PR TITLE
Add bulk playlist and queue downloads

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/BulkDownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/BulkDownloadDialog.java
@@ -1,0 +1,292 @@
+package org.schabi.newpipe.download;
+
+import android.app.Dialog;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.preference.PreferenceManager;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.databinding.BulkDownloadDialogBinding;
+import org.schabi.newpipe.error.ErrorInfo;
+import org.schabi.newpipe.error.ErrorUtil;
+import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.settings.NewPipeSettings;
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
+import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.util.PermissionHelper;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import us.shandian.giga.service.DownloadManagerService;
+import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder;
+
+/** Queues a list of streams using the user's default video or audio quality. */
+public final class BulkDownloadDialog extends DialogFragment {
+    private static final String ARG_ITEMS = "bulk_download_items";
+
+    private final CompositeDisposable disposables = new CompositeDisposable();
+    private ArrayList<BulkDownloadItem> items = new ArrayList<>();
+    private BulkDownloadDialogBinding binding;
+    private AlertDialog dialog;
+    private StoredDirectoryHelper videoDirectory;
+    private StoredDirectoryHelper audioDirectory;
+    private boolean askForSavePath;
+    private boolean serviceReady;
+    private boolean running;
+
+    @NonNull
+    public static BulkDownloadDialog newInstance(@NonNull final List<BulkDownloadItem> items) {
+        final BulkDownloadDialog dialog = new BulkDownloadDialog();
+        final Bundle arguments = new Bundle();
+        arguments.putSerializable(ARG_ITEMS, new ArrayList<>(items));
+        dialog.setArguments(arguments);
+        return dialog;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final Serializable value = requireArguments().getSerializable(ARG_ITEMS);
+        if (value instanceof ArrayList<?>) {
+            items = (ArrayList<BulkDownloadItem>) value;
+        }
+        if (!PermissionHelper.checkStoragePermissions(getActivity(),
+                PermissionHelper.DOWNLOAD_DIALOG_REQUEST_CODE)) {
+            dismiss();
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
+        binding = BulkDownloadDialogBinding.inflate(LayoutInflater.from(requireContext()));
+        binding.bulkDownloadSummary.setText(getResources().getQuantityString(
+                R.plurals.bulk_download_summary, items.size(), items.size()));
+        binding.bulkDownloadNumberFiles.setVisibility(items.size() > 1 ? View.VISIBLE : View.GONE);
+
+        final String lastType = PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getString(getString(R.string.last_used_download_type),
+                        getString(R.string.last_download_type_video_key));
+        binding.bulkDownloadMediaType.check(lastType.equals(
+                getString(R.string.last_download_type_audio_key))
+                ? R.id.bulk_download_audio : R.id.bulk_download_video);
+
+        dialog = new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.bulk_download_title)
+                .setView(binding.getRoot())
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.download, null)
+                .create();
+        dialog.setOnShowListener(ignored -> {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(serviceReady);
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+                    .setOnClickListener(view -> startBulkDownload());
+        });
+        return dialog;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        bindDownloadService();
+    }
+
+    private void bindDownloadService() {
+        final Context context = requireContext();
+        final Intent intent = new Intent(context, DownloadManagerService.class);
+        context.startService(intent);
+        context.bindService(intent, new ServiceConnection() {
+            @Override
+            public void onServiceConnected(final ComponentName name, final IBinder service) {
+                final DownloadManagerBinder binder = (DownloadManagerBinder) service;
+                videoDirectory = binder.getMainStorageVideo();
+                audioDirectory = binder.getMainStorageAudio();
+                askForSavePath = binder.askForSavePath();
+                serviceReady = true;
+                if (dialog != null) {
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                }
+                context.unbindService(this);
+            }
+
+            @Override
+            public void onServiceDisconnected(final ComponentName name) {
+                serviceReady = false;
+            }
+        }, Context.BIND_AUTO_CREATE);
+    }
+
+    private void startBulkDownload() {
+        if (running || !serviceReady || items.isEmpty()) {
+            return;
+        }
+        final BulkDownloadMissionFactory.MediaType mediaType =
+                binding.bulkDownloadMediaType.getCheckedRadioButtonId()
+                        == R.id.bulk_download_audio
+                        ? BulkDownloadMissionFactory.MediaType.AUDIO
+                        : BulkDownloadMissionFactory.MediaType.VIDEO;
+        final StoredDirectoryHelper directory = mediaType
+                == BulkDownloadMissionFactory.MediaType.AUDIO ? audioDirectory : videoDirectory;
+
+        if (askForSavePath) {
+            showInlineError(R.string.bulk_download_ask_path_error);
+            return;
+        }
+        if (directory == null
+                || directory.isDirect() == NewPipeSettings.useStorageAccessFramework(
+                        requireContext())
+                || directory.isInvalidSafStorage()) {
+            showInlineError(R.string.bulk_download_folder_error);
+            return;
+        }
+
+        final String selectedMediaType = mediaType == BulkDownloadMissionFactory.MediaType.AUDIO
+                ? getString(R.string.last_download_type_audio_key)
+                : getString(R.string.last_download_type_video_key);
+        PreferenceManager.getDefaultSharedPreferences(requireContext()).edit()
+                .putString(getString(R.string.last_used_download_type), selectedMediaType)
+                .apply();
+
+        running = true;
+        setCancelable(false);
+        dialog.setCanceledOnTouchOutside(false);
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setEnabled(false);
+        binding.bulkDownloadMediaType.setEnabled(false);
+        binding.bulkDownloadVideo.setEnabled(false);
+        binding.bulkDownloadAudio.setEnabled(false);
+        binding.bulkDownloadNumberFiles.setEnabled(false);
+        binding.bulkDownloadError.setVisibility(View.GONE);
+        binding.bulkDownloadProgressGroup.setVisibility(View.VISIBLE);
+        binding.bulkDownloadProgress.setMax(items.size());
+        updateProgress(0);
+
+        final int threads = PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getInt(getString(R.string.default_download_threads), 3);
+        final boolean numberFiles = binding.bulkDownloadNumberFiles.isChecked();
+        final int total = items.size();
+        final Context appContext = requireContext().getApplicationContext();
+        final int[] successes = {0};
+        final List<String> failures = new ArrayList<>();
+
+        disposables.add(Observable.range(0, total)
+                .concatMapSingle(index -> {
+                    final BulkDownloadItem item = items.get(index);
+                    return ExtractorHelper.getStreamInfo(item.getServiceId(), item.getUrl(), false)
+                            .subscribeOn(Schedulers.io())
+                            .map(info -> {
+                                BulkDownloadMissionFactory.enqueue(appContext, directory,
+                                        info, mediaType, threads, index + 1, total, numberFiles);
+                                return BatchResult.success(item);
+                            })
+                            .onErrorReturn(error -> BatchResult.failure(item, error));
+                })
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(result -> {
+                    if (result.error == null) {
+                        successes[0]++;
+                    } else {
+                        failures.add(result.item.getTitle());
+                    }
+                    updateProgress(successes[0] + failures.size());
+                }, error -> finishWithUnexpectedError(error),
+                        () -> finishBatch(successes[0], failures)));
+    }
+
+    private void updateProgress(final int completed) {
+        if (binding == null) {
+            return;
+        }
+        binding.bulkDownloadProgress.setProgress(completed);
+        binding.bulkDownloadProgressText.setText(getString(
+                R.string.bulk_download_progress, completed, items.size()));
+    }
+
+    private void finishBatch(final int successes, @NonNull final List<String> failures) {
+        if (!isAdded()) {
+            return;
+        }
+        if (failures.isEmpty()) {
+            Toast.makeText(requireContext(), getResources().getQuantityString(
+                    R.plurals.bulk_download_queued, successes, successes),
+                    Toast.LENGTH_LONG).show();
+        } else {
+            Toast.makeText(requireContext(), getString(R.string.bulk_download_partial_result,
+                    successes, failures.size()), Toast.LENGTH_LONG).show();
+            ErrorUtil.createNotification(requireContext(), new ErrorInfo(
+                    new IllegalStateException("Failed items: " + String.join(", ", failures)),
+                    UserAction.DOWNLOAD_FAILED, "Bulk download"));
+        }
+        dismissAllowingStateLoss();
+    }
+
+    private void finishWithUnexpectedError(@NonNull final Throwable error) {
+        if (!isAdded()) {
+            return;
+        }
+        ErrorUtil.showSnackbar(requireActivity(), new ErrorInfo(
+                error, UserAction.DOWNLOAD_FAILED, "Bulk download"));
+        dismissAllowingStateLoss();
+    }
+
+    private void showInlineError(final int message) {
+        binding.bulkDownloadError.setText(message);
+        binding.bulkDownloadError.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void onDestroyView() {
+        binding = null;
+        dialog = null;
+        super.onDestroyView();
+    }
+
+    @Override
+    public void onDestroy() {
+        disposables.dispose();
+        super.onDestroy();
+    }
+
+    private static final class BatchResult {
+        @NonNull
+        private final BulkDownloadItem item;
+        private final Throwable error;
+
+        private BatchResult(@NonNull final BulkDownloadItem item, final Throwable error) {
+            this.item = item;
+            this.error = error;
+        }
+
+        @NonNull
+        private static BatchResult success(@NonNull final BulkDownloadItem item) {
+            return new BatchResult(item, null);
+        }
+
+        @NonNull
+        private static BatchResult failure(@NonNull final BulkDownloadItem item,
+                                           @NonNull final Throwable error) {
+            return new BatchResult(item, error);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/download/BulkDownloadItem.java
+++ b/app/src/main/java/org/schabi/newpipe/download/BulkDownloadItem.java
@@ -1,0 +1,51 @@
+package org.schabi.newpipe.download;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+
+import java.io.Serializable;
+
+/** Lightweight, serializable reference to a stream that can be queued for download. */
+public final class BulkDownloadItem implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int serviceId;
+    @NonNull
+    private final String url;
+    @NonNull
+    private final String title;
+
+    public BulkDownloadItem(final int serviceId,
+                            @NonNull final String url,
+                            @NonNull final String title) {
+        this.serviceId = serviceId;
+        this.url = url;
+        this.title = title;
+    }
+
+    @NonNull
+    public static BulkDownloadItem from(@NonNull final StreamInfoItem item) {
+        return new BulkDownloadItem(item.getServiceId(), item.getUrl(), item.getName());
+    }
+
+    @NonNull
+    public static BulkDownloadItem from(@NonNull final PlayQueueItem item) {
+        return new BulkDownloadItem(item.getServiceId(), item.getUrl(), item.getTitle());
+    }
+
+    public int getServiceId() {
+        return serviceId;
+    }
+
+    @NonNull
+    public String getUrl() {
+        return url;
+    }
+
+    @NonNull
+    public String getTitle() {
+        return title;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/download/BulkDownloadMissionFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/download/BulkDownloadMissionFactory.java
@@ -1,0 +1,204 @@
+package org.schabi.newpipe.download;
+
+import static org.schabi.newpipe.extractor.stream.DeliveryMethod.PROGRESSIVE_HTTP;
+import static org.schabi.newpipe.util.ListHelper.getStreamsOfSpecifiedDelivery;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.Stream;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
+import org.schabi.newpipe.streams.io.StoredFileHelper;
+import org.schabi.newpipe.util.FilenameUtils;
+import org.schabi.newpipe.util.ListHelper;
+import org.schabi.newpipe.util.SecondaryStreamHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import us.shandian.giga.get.MissionRecoveryInfo;
+import us.shandian.giga.postprocessing.Postprocessing;
+import us.shandian.giga.service.DownloadManagerService;
+
+final class BulkDownloadMissionFactory {
+    enum MediaType {
+        VIDEO,
+        AUDIO
+    }
+
+    private BulkDownloadMissionFactory() {
+    }
+
+    static void enqueue(@NonNull final Context context,
+                        @NonNull final StoredDirectoryHelper directory,
+                        @NonNull final StreamInfo info,
+                        @NonNull final MediaType mediaType,
+                        final int threads,
+                        final int position,
+                        final int total,
+                        final boolean addNumberPrefix) {
+        final MissionSelection selection = mediaType == MediaType.AUDIO
+                ? selectAudio(context, info) : selectVideo(context, info);
+
+        if (!directory.mkdirs()) {
+            throw new IllegalStateException("Unable to create the download directory");
+        }
+
+        final String title = numberedTitle(info.getName(), position, total, addNumberPrefix);
+        final String filename = FilenameUtils.createFilename(context, title)
+                + "." + selection.suffix;
+        final StoredFileHelper storage = directory.createUniqueFile(filename, selection.mimeType);
+        if (storage == null || !storage.canWrite()) {
+            throw new IllegalStateException("Unable to create " + filename);
+        }
+
+        final String[] urls;
+        final ArrayList<MissionRecoveryInfo> recoveryInfo = new ArrayList<>();
+        urls = selection.secondaryStream == null
+                ? new String[]{selection.primaryStream.getContent()}
+                : new String[]{selection.primaryStream.getContent(),
+                        selection.secondaryStream.getContent()};
+        recoveryInfo.add(new MissionRecoveryInfo(selection.primaryStream));
+        if (selection.secondaryStream != null) {
+            recoveryInfo.add(new MissionRecoveryInfo(selection.secondaryStream));
+        }
+
+        DownloadManagerService.startMission(context, urls, storage, selection.kind, threads,
+                info, selection.postprocessingName, selection.postprocessingArguments,
+                0, recoveryInfo);
+    }
+
+    @NonNull
+    static String numberedTitle(@NonNull final String title,
+                                final int position,
+                                final int total,
+                                final boolean addNumberPrefix) {
+        if (!addNumberPrefix) {
+            return title;
+        }
+        final int width = Math.max(2, String.valueOf(Math.max(total, 1)).length());
+        return String.format(Locale.ROOT, "%0" + width + "d - %s", position, title);
+    }
+
+    @NonNull
+    private static MissionSelection selectAudio(@NonNull final Context context,
+                                                @NonNull final StreamInfo info) {
+        final List<AudioStream> streams = defaultAudioTrack(context, info);
+        if (streams.isEmpty()) {
+            throw new IllegalStateException("No downloadable audio stream is available");
+        }
+        final int selectedIndex = ListHelper.getDefaultAudioFormat(context, streams);
+        if (selectedIndex < 0 || selectedIndex >= streams.size()) {
+            throw new IllegalStateException("No default audio format is available");
+        }
+
+        final AudioStream selected = streams.get(selectedIndex);
+        final MediaFormat format = selected.getFormat();
+        if (format == null) {
+            throw new IllegalStateException("The selected audio format is unknown");
+        }
+
+        if (format == MediaFormat.WEBMA_OPUS) {
+            return new MissionSelection(selected, null, 'a', "audio/ogg", "opus",
+                    Postprocessing.ALGORITHM_OGG_FROM_WEBM_DEMUXER, null);
+        }
+        return new MissionSelection(selected, null, 'a', format.mimeType, format.getSuffix(),
+                format == MediaFormat.M4A ? Postprocessing.ALGORITHM_M4A_NO_DASH : null,
+                null);
+    }
+
+    @NonNull
+    private static MissionSelection selectVideo(@NonNull final Context context,
+                                                @NonNull final StreamInfo info) {
+        final List<List<AudioStream>> groupedAudioStreams = ListHelper.getGroupedAudioStreams(
+                context, getStreamsOfSpecifiedDelivery(info.getAudioStreams(), PROGRESSIVE_HTTP));
+        final List<AudioStream> audioStreams = selectedAudioTrack(context, groupedAudioStreams);
+        final List<VideoStream> videoStreams = ListHelper.getSortedStreamVideosList(
+                context,
+                getStreamsOfSpecifiedDelivery(info.getVideoStreams(), PROGRESSIVE_HTTP),
+                getStreamsOfSpecifiedDelivery(info.getVideoOnlyStreams(), PROGRESSIVE_HTTP),
+                false,
+                groupedAudioStreams.size() > 1);
+        if (videoStreams.isEmpty()) {
+            throw new IllegalStateException("No downloadable video stream is available");
+        }
+
+        final int selectedIndex = ListHelper.getDefaultResolutionIndex(context, videoStreams);
+        if (selectedIndex < 0 || selectedIndex >= videoStreams.size()) {
+            throw new IllegalStateException("No default video resolution is available");
+        }
+
+        final VideoStream selected = videoStreams.get(selectedIndex);
+        final MediaFormat format = selected.getFormat();
+        if (format == null) {
+            throw new IllegalStateException("The selected video format is unknown");
+        }
+
+        Stream secondary = null;
+        String postprocessing = null;
+        if (selected.isVideoOnly()) {
+            secondary = SecondaryStreamHelper.getAudioStreamFor(context, audioStreams, selected);
+            if (secondary != null) {
+                postprocessing = format == MediaFormat.MPEG_4
+                        ? Postprocessing.ALGORITHM_MP4_FROM_DASH_MUXER
+                        : Postprocessing.ALGORITHM_WEBM_MUXER;
+            }
+        }
+
+        return new MissionSelection(selected, secondary, 'v', format.mimeType,
+                format.getSuffix(), postprocessing, null);
+    }
+
+    @NonNull
+    private static List<AudioStream> defaultAudioTrack(@NonNull final Context context,
+                                                       @NonNull final StreamInfo info) {
+        return selectedAudioTrack(context, ListHelper.getGroupedAudioStreams(context,
+                getStreamsOfSpecifiedDelivery(info.getAudioStreams(), PROGRESSIVE_HTTP)));
+    }
+
+    @NonNull
+    private static List<AudioStream> selectedAudioTrack(
+            @NonNull final Context context,
+            @NonNull final List<List<AudioStream>> groupedAudioStreams) {
+        final int trackIndex = ListHelper.getDefaultAudioTrackGroup(context, groupedAudioStreams);
+        if (trackIndex < 0 || trackIndex >= groupedAudioStreams.size()) {
+            return List.of();
+        }
+        return groupedAudioStreams.get(trackIndex);
+    }
+
+    private static final class MissionSelection {
+        @NonNull
+        private final Stream primaryStream;
+        private final Stream secondaryStream;
+        private final char kind;
+        @NonNull
+        private final String mimeType;
+        @NonNull
+        private final String suffix;
+        private final String postprocessingName;
+        private final String[] postprocessingArguments;
+
+        private MissionSelection(@NonNull final Stream primaryStream,
+                                 final Stream secondaryStream,
+                                 final char kind,
+                                 @NonNull final String mimeType,
+                                 @NonNull final String suffix,
+                                 final String postprocessingName,
+                                 final String[] postprocessingArguments) {
+            this.primaryStream = primaryStream;
+            this.secondaryStream = secondaryStream;
+            this.kind = kind;
+            this.mimeType = mimeType;
+            this.suffix = suffix;
+            this.postprocessingName = postprocessingName;
+            this.postprocessingArguments = postprocessingArguments;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -36,6 +36,8 @@ import org.schabi.newpipe.database.stream.model.StreamStateEntity;
 import org.schabi.newpipe.databinding.FragmentPlaylistBinding;
 import org.schabi.newpipe.databinding.PlaylistControlBinding;
 import org.schabi.newpipe.databinding.PlaylistHeaderBinding;
+import org.schabi.newpipe.download.BulkDownloadDialog;
+import org.schabi.newpipe.download.BulkDownloadItem;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
@@ -112,6 +114,8 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
     protected StreamListFilter selectedStreamFilter = StreamListFilter.NONE;
     @State
     protected PlaylistSortOrder selectedPlaylistSort = PlaylistSortOrder.PLAYLIST_ORDER;
+    @State
+    protected boolean bulkDownloadPending;
     private final List<StreamInfoItem> unfilteredItems = new ArrayList<>();
     private final Map<String, StreamStateEntity> streamStates = new HashMap<>();
     private HistoryRecordManager historyRecordManager;
@@ -329,6 +333,8 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                         dialog -> dialog.show(getFM(), TAG)
                 ));
             }
+        } else if (itemId == R.id.menu_item_download_playlist) {
+            beginBulkDownload();
         } else if (itemId == R.id.menu_item_learning_content) {
             toggleLearningPlaylist();
         } else {
@@ -390,6 +396,7 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
         refreshStreamStatesAfterPageLoad();
         setStreamCountAndOverallDuration(result.getItems(), !result.hasNextPage());
         continueLoadingPlaylistForSorting();
+        continueBulkDownloadAfterPageLoad();
     }
 
     @Override
@@ -486,6 +493,51 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
         PlayButtonHelper.initPlaylistControlClickListener(activity, playlistControlBinding, this);
         refreshStreamStatesAfterPageLoad();
         continueLoadingPlaylistForSorting();
+    }
+
+    private void beginBulkDownload() {
+        if (currentInfo == null || unfilteredItems.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.bulk_download_empty,
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (hasMoreItems()) {
+            bulkDownloadPending = true;
+            Toast.makeText(requireContext(), R.string.bulk_download_loading_playlist,
+                    Toast.LENGTH_SHORT).show();
+            if (!isLoading.get()) {
+                loadMoreItems();
+            }
+            return;
+        }
+        showBulkDownloadDialog();
+    }
+
+    private void continueBulkDownloadAfterPageLoad() {
+        if (!bulkDownloadPending) {
+            return;
+        }
+        if (hasMoreItems()) {
+            if (!isLoading.get()) {
+                loadMoreItems();
+            }
+            return;
+        }
+        bulkDownloadPending = false;
+        showBulkDownloadDialog();
+    }
+
+    private void showBulkDownloadDialog() {
+        final List<BulkDownloadItem> downloadItems = unfilteredItems.stream()
+                .map(BulkDownloadItem::from)
+                .collect(Collectors.toList());
+        if (downloadItems.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.bulk_download_empty,
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+        BulkDownloadDialog.newInstance(downloadItems)
+                .show(getChildFragmentManager(), "bulkDownloadDialog");
     }
 
     private void indexLearningPlaylistItems(final List<StreamInfoItem> items) {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -28,6 +29,8 @@ import com.google.android.exoplayer2.PlaybackParameters;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.ActivityPlayerQueueControlBinding;
+import org.schabi.newpipe.download.BulkDownloadDialog;
+import org.schabi.newpipe.download.BulkDownloadItem;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
@@ -51,6 +54,7 @@ import org.schabi.newpipe.util.ThemeHelper;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class PlayQueueActivity extends AppCompatActivity
         implements PlayerEventListener, SeekBar.OnSeekBarChangeListener,
@@ -155,6 +159,9 @@ public final class PlayQueueActivity extends AppCompatActivity
         } else if (itemId == R.id.action_system_audio) {
             startActivity(new Intent(Settings.ACTION_SOUND_SETTINGS));
             return true;
+        } else if (itemId == R.id.action_download_queue) {
+            showBulkDownloadDialog();
+            return true;
         } else if (itemId == R.id.action_switch_main) {
             this.player.setRecovery();
             NavigationHelper.playOnMainPlayer(this, player.getPlayQueue(), true);
@@ -177,6 +184,22 @@ public final class PlayQueueActivity extends AppCompatActivity
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private void showBulkDownloadDialog() {
+        if (player == null || player.getPlayQueue() == null) {
+            return;
+        }
+        final List<BulkDownloadItem> items = player.getPlayQueue().getStreams().stream()
+                .filter(item -> !item.isLocalMedia())
+                .map(BulkDownloadItem::from)
+                .collect(Collectors.toList());
+        if (items.isEmpty()) {
+            Toast.makeText(this, R.string.bulk_download_empty, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        BulkDownloadDialog.newInstance(items)
+                .show(getSupportFragmentManager(), "bulkDownloadDialog");
     }
 
     @Override

--- a/app/src/main/res/layout/bulk_download_dialog.xml
+++ b/app/src/main/res/layout/bulk_download_dialog.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/bulk_download_summary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp"
+        android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+    <RadioGroup
+        android:id="@+id/bulk_download_media_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/bulk_download_video"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/video" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/bulk_download_audio"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/audio" />
+    </RadioGroup>
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/bulk_download_number_files"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/bulk_download_number_files" />
+
+    <LinearLayout
+        android:id="@+id/bulk_download_progress_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <ProgressBar
+            android:id="@+id/bulk_download_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:indeterminate="false" />
+
+        <TextView
+            android:id="@+id/bulk_download_progress_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="?attr/textAppearanceLabelMedium" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/bulk_download_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textColor="?attr/colorError"
+        android:textAppearance="?attr/textAppearanceBodySmall"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_play_queue.xml
+++ b/app/src/main/res/menu/menu_play_queue.xml
@@ -53,8 +53,15 @@
         app:showAsAction="never" />
 
     <item
-        android:id="@+id/action_switch_main"
+        android:id="@+id/action_download_queue"
+        android:icon="@drawable/ic_file_download"
         android:orderInCategory="3"
+        android:title="@string/download_queue"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_switch_main"
+        android:orderInCategory="4"
         android:title="@string/switch_to_main"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/menu_playlist.xml
+++ b/app/src/main/res/menu/menu_playlist.xml
@@ -36,8 +36,15 @@
         app:showAsAction="never" />
 
     <item
-        android:id="@+id/menu_item_learning_content"
+        android:id="@+id/menu_item_download_playlist"
+        android:icon="@drawable/ic_file_download"
         android:orderInCategory="4"
+        android:title="@string/download_playlist"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/menu_item_learning_content"
+        android:orderInCategory="5"
         android:title="@string/learning_mark_content"
         android:visible="false"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,24 @@
     <string name="open_with">Open with</string>
     <string name="share">Share</string>
     <string name="download">Download</string>
+    <string name="bulk_download_title">Bulk download</string>
+    <string name="download_playlist">Download playlist</string>
+    <string name="download_queue">Download loaded queue</string>
+    <string name="bulk_download_number_files">Add track numbers to filenames</string>
+    <plurals name="bulk_download_summary">
+        <item quantity="one">Queue %d item using the default quality for each stream.</item>
+        <item quantity="other">Queue %d items using the default quality for each stream.</item>
+    </plurals>
+    <string name="bulk_download_progress">%1$d/%2$d</string>
+    <plurals name="bulk_download_queued">
+        <item quantity="one">Queued %d download</item>
+        <item quantity="other">Queued %d downloads</item>
+    </plurals>
+    <string name="bulk_download_partial_result">Queued %1$d downloads; %2$d failed</string>
+    <string name="bulk_download_loading_playlist">Loading the complete playlist before downloading…</string>
+    <string name="bulk_download_empty">There are no downloadable streams in this list</string>
+    <string name="bulk_download_ask_path_error">Bulk download needs a default download folder. Turn off “Ask where to download” in Download settings.</string>
+    <string name="bulk_download_folder_error">Choose a valid default download folder in Download settings first.</string>
     <string name="controls_download_desc">Download stream file</string>
     <string name="search">Search</string>
     <string name="search_filters">Search filters</string>

--- a/app/src/test/java/org/schabi/newpipe/download/BulkDownloadMissionFactoryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/download/BulkDownloadMissionFactoryTest.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.download;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BulkDownloadMissionFactoryTest {
+    @Test
+    void numberedTitlePadsToAtLeastTwoDigits() {
+        assertEquals("01 - First", BulkDownloadMissionFactory.numberedTitle(
+                "First", 1, 8, true));
+    }
+
+    @Test
+    void numberedTitleUsesEnoughDigitsForLargeLists() {
+        assertEquals("007 - Seventh", BulkDownloadMissionFactory.numberedTitle(
+                "Seventh", 7, 120, true));
+    }
+
+    @Test
+    void numberedTitleCanBeDisabled() {
+        assertEquals("Original", BulkDownloadMissionFactory.numberedTitle(
+                "Original", 4, 20, false));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -2,6 +2,12 @@
 
 Release history is listed newest first. The number beside each release is its Android version code.
 
+## Unreleased
+
+### New features
+
+- Added bulk video and audio downloads for complete playlists and loaded play queues, with default-quality selection, collision-safe filenames, and optional track-number prefixes.
+
 ## WizeStream 1.7.0 (`1007000`)
 
 ### New features


### PR DESCRIPTION
- adds **Download playlist** and **Download loaded queue** actions
- loads every remaining playlist page before opening the batch dialog
- lets the user choose video or audio once for the whole batch
- applies the configured default quality and preferred audio track to each item
- optionally prefixes filenames with zero-padded track numbers
- creates collision-safe files and queues stream extraction sequentially
- reports partial failures without cancelling successful missions
- documents the feature in the changelog