### PR TITLE
Add content blocking controls

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -15,6 +15,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
 import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -23,6 +24,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.BaseStateFragment;
 import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
@@ -30,6 +32,7 @@ import org.schabi.newpipe.info_list.InfoListAdapter;
 import org.schabi.newpipe.info_list.ItemViewMode;
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.ServiceHelper;
@@ -268,13 +271,32 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             }
         });
 
-        infoListAdapter.setOnChannelSelectedListener(selectedItem -> {
-            try {
-                onItemSelected(selectedItem);
-                NavigationHelper.openChannelFragment(getFM(), selectedItem.getServiceId(),
-                        selectedItem.getUrl(), selectedItem.getName());
-            } catch (final Exception e) {
-                ErrorUtil.showUiErrorSnackbar(this, "Opening channel fragment", e);
+        infoListAdapter.setOnChannelSelectedListener(new OnClickGesture<>() {
+            @Override
+            public void selected(final ChannelInfoItem selectedItem) {
+                try {
+                    onItemSelected(selectedItem);
+                    NavigationHelper.openChannelFragment(getFM(), selectedItem.getServiceId(),
+                            selectedItem.getUrl(), selectedItem.getName());
+                } catch (final Exception e) {
+                    ErrorUtil.showUiErrorSnackbar(BaseListFragment.this,
+                            "Opening channel fragment", e);
+                }
+            }
+
+            @Override
+            public void held(final ChannelInfoItem selectedItem) {
+                new AlertDialog.Builder(requireContext())
+                        .setTitle(selectedItem.getName())
+                        .setItems(new String[]{getString(R.string.block_channel)},
+                                (dialog, which) -> {
+                                    ContentBlockingHelper.blockChannel(requireContext(),
+                                            selectedItem.getUrl(), selectedItem.getName());
+                                    android.widget.Toast.makeText(requireContext(),
+                                            R.string.channel_blocked,
+                                            android.widget.Toast.LENGTH_SHORT).show();
+                                })
+                        .show();
             }
         });
 
@@ -489,6 +511,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
                                           final String key) {
         if (getString(R.string.list_view_mode_key).equals(key)) {
             updateFlags |= LIST_MODE_UPDATE_FLAG;
+        } else if (ContentBlockingHelper.isPreferenceKey(requireContext(), key)) {
+            reloadContent();
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -33,6 +33,7 @@ import org.schabi.newpipe.info_list.holder.StreamGridInfoItemHolder;
 import org.schabi.newpipe.info_list.holder.StreamInfoItemHolder;
 import org.schabi.newpipe.info_list.holder.StreamMiniInfoItemHolder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.FallbackViewHolder;
 import org.schabi.newpipe.util.MembersOnlyContentHelper;
 import org.schabi.newpipe.util.OnClickGesture;
@@ -139,9 +140,14 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         final List<InfoItem> visibleData = new ArrayList<>(data.size());
         final boolean hideMembersOnly = MembersOnlyContentHelper.shouldHide(
                 infoItemBuilder.getContext());
+        final ContentBlockingHelper.Rules blockingRules = ContentBlockingHelper.getRules(
+                infoItemBuilder.getContext());
         for (final InfoItem item : data) {
             if (!hideMembersOnly || !(item instanceof StreamInfoItem)
                     || !((StreamInfoItem) item).requiresMembership()) {
+                if (blockingRules.isBlocked(item)) {
+                    continue;
+                }
                 visibleData.add(item);
             }
         }

--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
@@ -342,7 +342,9 @@ public final class InfoItemDialog {
                     StreamDialogDefaultEntry.DOWNLOAD,
                     StreamDialogDefaultEntry.APPEND_PLAYLIST,
                     StreamDialogDefaultEntry.SHARE,
-                    StreamDialogDefaultEntry.OPEN_IN_BROWSER
+                    StreamDialogDefaultEntry.OPEN_IN_BROWSER,
+                    StreamDialogDefaultEntry.BLOCK_VIDEO,
+                    StreamDialogDefaultEntry.BLOCK_CHANNEL
             );
             addPlayWithKodiEntryIfNeeded();
             addLearningContentEntryIfNeeded();

--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
@@ -22,6 +22,7 @@ import org.schabi.newpipe.local.dialog.PlaylistAppendDialog;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.learning.LearningContentManager;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.external_communication.KoreUtils;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
@@ -136,6 +137,21 @@ public enum StreamDialogDefaultEntry {
                         }
                     })
     ),
+
+    BLOCK_VIDEO(R.string.block_video, (fragment, item) -> {
+        ContentBlockingHelper.blockVideo(fragment.requireContext(), item);
+        Toast.makeText(fragment.requireContext(), R.string.video_blocked,
+                Toast.LENGTH_SHORT).show();
+    }),
+
+    BLOCK_CHANNEL(R.string.block_channel, (fragment, item) ->
+            fetchUploaderUrlIfSparse(fragment.requireContext(), item.getServiceId(), item.getUrl(),
+                    item.getUploaderUrl(), url -> {
+                        ContentBlockingHelper.blockChannel(fragment.requireContext(), url,
+                                item.getUploaderName());
+                        Toast.makeText(fragment.requireContext(), R.string.channel_blocked,
+                                Toast.LENGTH_SHORT).show();
+                    })),
 
     OPEN_IN_BROWSER(R.string.open_in_browser, (fragment, item) ->
             ShareUtils.openUrlInBrowser(fragment.requireContext(), item.getUrl())),

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -82,6 +82,7 @@ import org.schabi.newpipe.local.search.ContextualSearchHelper
 import org.schabi.newpipe.local.search.ContextualSearchable
 import org.schabi.newpipe.local.subscription.SubscriptionManager
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue
+import org.schabi.newpipe.util.ContentBlockingHelper
 import org.schabi.newpipe.util.DeviceUtils
 import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.MembersOnlyContentHelper
@@ -145,6 +146,8 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         onSettingsChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (getString(R.string.list_view_mode_key).equals(key)) {
                 updateListViewModeOnResume = true
+            } else if (ContentBlockingHelper.isPreferenceKey(requireContext(), key)) {
+                latestLoadedState?.let { showFilteredFeedItems(it, false) }
             }
         }
         PreferenceManager.getDefaultSharedPreferences(activity)
@@ -520,12 +523,16 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         }
 
         val hideMembersOnly = MembersOnlyContentHelper.shouldHide(requireContext())
+        val blockingRules = ContentBlockingHelper.getRules(requireContext())
         val streamFilteredItems = loadedState.items.filter { item ->
             val streamWithState = item.streamWithState
             if (hideMembersOnly && streamWithState.stream.requiresMembership) {
                 return@filter false
             }
             val stream = streamWithState.stream.toStreamInfoItem()
+            if (blockingRules.isBlocked(stream)) {
+                return@filter false
+            }
             val state = streamWithState.stateProgressMillis?.let {
                 StreamStateEntity(streamWithState.stream.uid, it)
             }

--- a/app/src/main/java/org/schabi/newpipe/settings/ContentBlockingSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentBlockingSettingsFragment.java
@@ -1,0 +1,151 @@
+package org.schabi.newpipe.settings;
+
+import android.os.Bundle;
+import android.text.InputType;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.EditTextPreference;
+import androidx.preference.Preference;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.ContentBlockingHelper;
+import org.schabi.newpipe.util.ContentBlockingHelper.Entry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ContentBlockingSettingsFragment extends BasePreferenceFragment {
+    private Preference blockedChannelsPreference;
+    private Preference blockedVideosPreference;
+    private EditTextPreference blockedKeywordsPreference;
+
+    @Override
+    public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
+        addPreferencesFromResourceRegistry();
+
+        blockedKeywordsPreference = requirePreference(R.string.blocked_keywords_key);
+        blockedChannelsPreference = requirePreference(R.string.manage_blocked_channels_key);
+        blockedVideosPreference = requirePreference(R.string.manage_blocked_videos_key);
+
+        blockedKeywordsPreference.setOnBindEditTextListener(editText -> {
+            editText.setInputType(InputType.TYPE_CLASS_TEXT
+                    | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+            editText.setMinLines(4);
+        });
+        blockedKeywordsPreference.setOnPreferenceChangeListener((preference, value) -> {
+            preference.setSummary(keywordSummary(value == null ? "" : value.toString()));
+            return true;
+        });
+        blockedChannelsPreference.setOnPreferenceClickListener(preference -> {
+            showEntries(false);
+            return true;
+        });
+        blockedVideosPreference.setOnPreferenceClickListener(preference -> {
+            showEntries(true);
+            return true;
+        });
+        requirePreference(R.string.clear_blocked_content_key)
+                .setOnPreferenceClickListener(preference -> {
+                    confirmClearAll();
+                    return true;
+                });
+        updateSummaries();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateSummaries();
+    }
+
+    private void showEntries(final boolean videos) {
+        final List<Entry> entries = videos
+                ? ContentBlockingHelper.getBlockedVideos(requireContext())
+                : ContentBlockingHelper.getBlockedChannels(requireContext());
+        if (entries.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.blocked_content_empty,
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        final String[] labels = entries.stream().map(Entry::getLabel).toArray(String[]::new);
+        final boolean[] checked = new boolean[entries.size()];
+        java.util.Arrays.fill(checked, true);
+
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(videos ? R.string.manage_blocked_videos_title
+                        : R.string.manage_blocked_channels_title)
+                .setMultiChoiceItems(labels, checked,
+                        (ignored, which, isChecked) -> checked[which] = isChecked)
+                .setNegativeButton(R.string.cancel, null)
+                .setNeutralButton(R.string.clear, null)
+                .setPositiveButton(R.string.ok, (ignored, which) -> {
+                    final List<Entry> kept = new ArrayList<>();
+                    for (int index = 0; index < entries.size(); index++) {
+                        if (checked[index]) {
+                            kept.add(entries.get(index));
+                        }
+                    }
+                    saveEntries(videos, kept);
+                })
+                .create();
+        dialog.setOnShowListener(ignored -> dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
+                .setOnClickListener(view -> {
+                    saveEntries(videos, List.of());
+                    dialog.dismiss();
+                }));
+        dialog.show();
+    }
+
+    private void saveEntries(final boolean videos, @NonNull final List<Entry> entries) {
+        if (videos) {
+            ContentBlockingHelper.saveBlockedVideos(requireContext(), entries);
+        } else {
+            ContentBlockingHelper.saveBlockedChannels(requireContext(), entries);
+        }
+        updateSummaries();
+    }
+
+    private void confirmClearAll() {
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.clear_blocked_content_title)
+                .setMessage(R.string.clear_blocked_content_confirmation)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.clear, (dialog, which) -> {
+                    ContentBlockingHelper.clearAll(requireContext());
+                    blockedKeywordsPreference.setText("");
+                    updateSummaries();
+                })
+                .show();
+    }
+
+    private void updateSummaries() {
+        if (blockedChannelsPreference == null) {
+            return;
+        }
+        final int channelCount = ContentBlockingHelper.getBlockedChannels(requireContext()).size();
+        final int videoCount = ContentBlockingHelper.getBlockedVideos(requireContext()).size();
+        blockedChannelsPreference.setSummary(getResources().getQuantityString(
+                R.plurals.blocked_channels_count, channelCount, channelCount));
+        blockedVideosPreference.setSummary(getResources().getQuantityString(
+                R.plurals.blocked_videos_count, videoCount, videoCount));
+        blockedKeywordsPreference.setSummary(keywordSummary(
+                blockedKeywordsPreference.getText()));
+    }
+
+    @NonNull
+    private String keywordSummary(@Nullable final String value) {
+        int count = 0;
+        for (final String keyword : (value == null ? "" : value).split("[,\\n]")) {
+            if (!keyword.trim().isEmpty()) {
+                count++;
+            }
+        }
+        return getResources().getQuantityString(R.plurals.blocked_keywords_count, count, count);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
@@ -33,6 +33,7 @@ public final class SettingsResourceRegistry {
 
         add(AppearanceSettingsFragment.class, R.xml.appearance_settings);
         add(ContentSettingsFragment.class, R.xml.content_settings);
+        add(ContentBlockingSettingsFragment.class, R.xml.content_blocking_settings);
         add(DebugSettingsFragment.class, R.xml.debug_settings).setSearchable(false);
         add(DownloadSettingsFragment.class, R.xml.download_settings);
         add(DeviceSyncSettingsFragment.class, R.xml.device_sync_settings);

--- a/app/src/main/java/org/schabi/newpipe/util/ContentBlockingHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ContentBlockingHelper.java
@@ -1,0 +1,291 @@
+package org.schabi.newpipe.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
+import org.schabi.newpipe.extractor.post.PostInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/** Stores and applies user-defined video, channel, and keyword blocking rules. */
+public final class ContentBlockingHelper {
+    private static final String ENTRY_SEPARATOR = "\t";
+
+    private ContentBlockingHelper() {
+    }
+
+    @NonNull
+    public static Rules getRules(@NonNull final Context context) {
+        final SharedPreferences preferences = preferences(context);
+        return Rules.create(
+                preferences.getBoolean(context.getString(
+                        R.string.content_blocking_enabled_key), true),
+                copySet(preferences, context.getString(R.string.blocked_videos_key)),
+                copySet(preferences, context.getString(R.string.blocked_channels_key)),
+                preferences.getString(context.getString(
+                        R.string.blocked_keywords_key), ""));
+    }
+
+    public static void blockVideo(@NonNull final Context context,
+                                  @NonNull final StreamInfoItem item) {
+        addEntry(context, R.string.blocked_videos_key, item.getUrl(), item.getName());
+        enable(context);
+    }
+
+    public static void blockChannel(@NonNull final Context context,
+                                    @Nullable final String channelUrl,
+                                    @Nullable final String channelName) {
+        final String key = !isBlank(channelUrl) ? channelUrl : channelName;
+        if (isBlank(key)) {
+            return;
+        }
+        addEntry(context, R.string.blocked_channels_key, key,
+                isBlank(channelName) ? key : channelName);
+        enable(context);
+    }
+
+    @NonNull
+    public static List<Entry> getBlockedVideos(@NonNull final Context context) {
+        return decodeEntries(copySet(preferences(context),
+                context.getString(R.string.blocked_videos_key)));
+    }
+
+    @NonNull
+    public static List<Entry> getBlockedChannels(@NonNull final Context context) {
+        return decodeEntries(copySet(preferences(context),
+                context.getString(R.string.blocked_channels_key)));
+    }
+
+    public static void saveBlockedVideos(@NonNull final Context context,
+                                         @NonNull final List<Entry> entries) {
+        saveEntries(context, R.string.blocked_videos_key, entries);
+    }
+
+    public static void saveBlockedChannels(@NonNull final Context context,
+                                           @NonNull final List<Entry> entries) {
+        saveEntries(context, R.string.blocked_channels_key, entries);
+    }
+
+    public static void clearAll(@NonNull final Context context) {
+        preferences(context).edit()
+                .remove(context.getString(R.string.blocked_videos_key))
+                .remove(context.getString(R.string.blocked_channels_key))
+                .remove(context.getString(R.string.blocked_keywords_key))
+                .apply();
+    }
+
+    public static boolean isPreferenceKey(@NonNull final Context context,
+                                          @Nullable final String key) {
+        return context.getString(R.string.content_blocking_enabled_key).equals(key)
+                || context.getString(R.string.blocked_videos_key).equals(key)
+                || context.getString(R.string.blocked_channels_key).equals(key)
+                || context.getString(R.string.blocked_keywords_key).equals(key);
+    }
+
+    private static void enable(@NonNull final Context context) {
+        preferences(context).edit()
+                .putBoolean(context.getString(R.string.content_blocking_enabled_key), true)
+                .apply();
+    }
+
+    private static void addEntry(@NonNull final Context context,
+                                 final int preferenceKey,
+                                 @NonNull final String key,
+                                 @Nullable final String label) {
+        final SharedPreferences preferences = preferences(context);
+        final String resolvedKey = context.getString(preferenceKey);
+        final Set<String> entries = copySet(preferences, resolvedKey);
+        entries.removeIf(value -> decodeEntry(value).key.equals(normalize(key)));
+        entries.add(encodeEntry(key, label));
+        preferences.edit().putStringSet(resolvedKey, entries).apply();
+    }
+
+    private static void saveEntries(@NonNull final Context context,
+                                    final int preferenceKey,
+                                    @NonNull final List<Entry> entries) {
+        final Set<String> encoded = new HashSet<>();
+        for (final Entry entry : entries) {
+            encoded.add(encodeEntry(entry.key, entry.label));
+        }
+        preferences(context).edit()
+                .putStringSet(context.getString(preferenceKey), encoded)
+                .apply();
+    }
+
+    @NonNull
+    private static SharedPreferences preferences(@NonNull final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    @NonNull
+    private static Set<String> copySet(@NonNull final SharedPreferences preferences,
+                                       @NonNull final String key) {
+        return new HashSet<>(preferences.getStringSet(key, Collections.emptySet()));
+    }
+
+    @NonNull
+    private static String encodeEntry(@NonNull final String key, @Nullable final String label) {
+        final String safeLabel = isBlank(label) ? key : label.replace('\t', ' ');
+        return normalize(key) + ENTRY_SEPARATOR + safeLabel.trim();
+    }
+
+    @NonNull
+    private static List<Entry> decodeEntries(@NonNull final Set<String> values) {
+        final List<Entry> entries = new ArrayList<>();
+        for (final String value : values) {
+            entries.add(decodeEntry(value));
+        }
+        entries.sort((first, second) -> first.label.compareToIgnoreCase(second.label));
+        return entries;
+    }
+
+    @NonNull
+    private static Entry decodeEntry(@NonNull final String value) {
+        final int separator = value.indexOf(ENTRY_SEPARATOR);
+        if (separator < 0) {
+            return new Entry(normalize(value), value);
+        }
+        return new Entry(normalize(value.substring(0, separator)),
+                value.substring(separator + ENTRY_SEPARATOR.length()));
+    }
+
+    private static boolean isBlank(@Nullable final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    @NonNull
+    private static String normalize(@Nullable final String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    public static final class Entry {
+        @NonNull
+        private final String key;
+        @NonNull
+        private final String label;
+
+        private Entry(@NonNull final String key, @NonNull final String label) {
+            this.key = key;
+            this.label = label;
+        }
+
+        @NonNull
+        public String getLabel() {
+            return label;
+        }
+    }
+
+    public static final class Rules {
+        private final boolean enabled;
+        @NonNull
+        private final Set<String> blockedVideoUrls;
+        @NonNull
+        private final Set<String> blockedChannelKeys;
+        @NonNull
+        private final Set<String> blockedChannelNames;
+        @NonNull
+        private final List<String> blockedKeywords;
+
+        private Rules(final boolean enabled,
+                      @NonNull final Set<String> blockedVideoUrls,
+                      @NonNull final Set<String> blockedChannelKeys,
+                      @NonNull final Set<String> blockedChannelNames,
+                      @NonNull final List<String> blockedKeywords) {
+            this.enabled = enabled;
+            this.blockedVideoUrls = blockedVideoUrls;
+            this.blockedChannelKeys = blockedChannelKeys;
+            this.blockedChannelNames = blockedChannelNames;
+            this.blockedKeywords = blockedKeywords;
+        }
+
+        @NonNull
+        static Rules create(final boolean enabled,
+                            @NonNull final Set<String> videoEntries,
+                            @NonNull final Set<String> channelEntries,
+                            @Nullable final String keywords) {
+            final Set<String> videos = new HashSet<>();
+            for (final String value : videoEntries) {
+                videos.add(decodeEntry(value).key);
+            }
+
+            final Set<String> channels = new HashSet<>();
+            final Set<String> channelNames = new HashSet<>();
+            for (final String value : channelEntries) {
+                final Entry entry = decodeEntry(value);
+                channels.add(entry.key);
+                channelNames.add(normalize(entry.label));
+            }
+
+            final List<String> keywordList = new ArrayList<>();
+            if (keywords != null) {
+                for (final String value : keywords.split("[,\\n]")) {
+                    final String keyword = normalize(value);
+                    if (!keyword.isEmpty() && !keywordList.contains(keyword)) {
+                        keywordList.add(keyword);
+                    }
+                }
+            }
+            return new Rules(enabled, videos, channels, channelNames, keywordList);
+        }
+
+        public boolean isBlocked(@Nullable final InfoItem item) {
+            if (!enabled || item == null) {
+                return false;
+            }
+            if (item instanceof StreamInfoItem) {
+                final StreamInfoItem stream = (StreamInfoItem) item;
+                return blockedVideoUrls.contains(normalize(stream.getUrl()))
+                        || isBlockedChannel(stream.getUploaderUrl(), stream.getUploaderName())
+                        || containsKeyword(stream.getName(), stream.getUploaderName());
+            }
+            if (item instanceof ChannelInfoItem) {
+                return isBlockedChannel(item.getUrl(), item.getName())
+                        || containsKeyword(item.getName());
+            }
+            if (item instanceof PlaylistInfoItem) {
+                final PlaylistInfoItem playlist = (PlaylistInfoItem) item;
+                return isBlockedChannel(null, playlist.getUploaderName())
+                        || containsKeyword(playlist.getName(), playlist.getUploaderName());
+            }
+            if (item instanceof PostInfoItem) {
+                final PostInfoItem post = (PostInfoItem) item;
+                return isBlockedChannel(post.getUploaderUrl(), post.getUploaderName())
+                        || containsKeyword(post.getName(), post.getContent(),
+                                post.getUploaderName());
+            }
+            return containsKeyword(item.getName());
+        }
+
+        private boolean isBlockedChannel(@Nullable final String url,
+                                         @Nullable final String name) {
+            return blockedChannelKeys.contains(normalize(url))
+                    || blockedChannelNames.contains(normalize(name));
+        }
+
+        private boolean containsKeyword(@Nullable final String... values) {
+            for (final String value : values) {
+                final String normalized = normalize(value);
+                for (final String keyword : blockedKeywords) {
+                    if (normalized.contains(keyword)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,6 +381,41 @@
     <string name="background_player_playing_toast">Playing in background</string>
     <string name="popup_playing_toast">Playing in popup mode</string>
     <string name="content">Content</string>
+    <string name="content_blocking_settings_key" translatable="false">content_blocking_settings</string>
+    <string name="content_blocking_enabled_key" translatable="false">content_blocking_enabled</string>
+    <string name="blocked_videos_key" translatable="false">blocked_videos</string>
+    <string name="blocked_channels_key" translatable="false">blocked_channels</string>
+    <string name="blocked_keywords_key" translatable="false">blocked_keywords</string>
+    <string name="manage_blocked_channels_key" translatable="false">manage_blocked_channels</string>
+    <string name="manage_blocked_videos_key" translatable="false">manage_blocked_videos</string>
+    <string name="clear_blocked_content_key" translatable="false">clear_blocked_content</string>
+    <string name="content_blocking_title">Blocked content</string>
+    <string name="content_blocking_summary">Hide videos, channels, and posts using your blocking rules</string>
+    <string name="content_blocking_enabled_title">Enable content blocking</string>
+    <string name="content_blocking_enabled_summary">Apply blocked videos, channels, and keywords to remote content lists</string>
+    <string name="blocked_keywords_title">Blocked keywords</string>
+    <string name="manage_blocked_channels_title">Blocked channels</string>
+    <string name="manage_blocked_videos_title">Blocked videos</string>
+    <string name="clear_blocked_content_title">Clear all blocking rules</string>
+    <string name="clear_blocked_content_summary">Remove every blocked video, channel, and keyword</string>
+    <string name="clear_blocked_content_confirmation">Remove all content-blocking rules?</string>
+    <string name="block_video">Block this video</string>
+    <string name="block_channel">Block this channel</string>
+    <string name="video_blocked">Video blocked</string>
+    <string name="channel_blocked">Channel blocked</string>
+    <string name="blocked_content_empty">Nothing is blocked in this list</string>
+    <plurals name="blocked_channels_count">
+        <item quantity="one">%d blocked channel</item>
+        <item quantity="other">%d blocked channels</item>
+    </plurals>
+    <plurals name="blocked_videos_count">
+        <item quantity="one">%d blocked video</item>
+        <item quantity="other">%d blocked videos</item>
+    </plurals>
+    <plurals name="blocked_keywords_count">
+        <item quantity="one">%d blocked keyword</item>
+        <item quantity="other">%d blocked keywords</item>
+    </plurals>
     <string name="show_age_restricted_content_title">Show age restricted content</string>
     <string name="show_age_restricted_content_summary">Show content possibly unsuitable for children because it has an age limit (like 18+)</string>
     <string name="youtube_restricted_mode_enabled_title">Turn on YouTube\'s \"Restricted Mode\"</string>

--- a/app/src/main/res/xml/content_blocking_settings.xml
+++ b/app/src/main/res/xml/content_blocking_settings.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/content_blocking_title">
+
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:key="@string/content_blocking_enabled_key"
+        android:summary="@string/content_blocking_enabled_summary"
+        android:title="@string/content_blocking_enabled_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <EditTextPreference
+        android:dialogTitle="@string/blocked_keywords_title"
+        android:key="@string/blocked_keywords_key"
+        android:title="@string/blocked_keywords_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/manage_blocked_channels_key"
+        android:title="@string/manage_blocked_channels_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/manage_blocked_videos_key"
+        android:title="@string/manage_blocked_videos_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+    <Preference
+        android:key="@string/clear_blocked_content_key"
+        android:summary="@string/clear_blocked_content_summary"
+        android:title="@string/clear_blocked_content_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -90,6 +90,14 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <PreferenceScreen
+        android:fragment="org.schabi.newpipe.settings.ContentBlockingSettingsFragment"
+        android:key="@string/content_blocking_settings_key"
+        android:summary="@string/content_blocking_summary"
+        android:title="@string/content_blocking_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
     <MultiSelectListPreference
         android:key="@string/show_search_suggestions_key"
         android:summary="@string/show_search_suggestions_summary"

--- a/app/src/test/java/org/schabi/newpipe/util/ContentBlockingHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ContentBlockingHelperTest.java
@@ -1,0 +1,61 @@
+package org.schabi.newpipe.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
+
+import java.util.Set;
+
+class ContentBlockingHelperTest {
+    @Test
+    void blocksExactVideoUrl() {
+        final ContentBlockingHelper.Rules rules = ContentBlockingHelper.Rules.create(
+                true, Set.of("https://example.com/watch/1\tVideo"), Set.of(), "");
+
+        assertTrue(rules.isBlocked(stream("https://example.com/watch/1", "Allowed title",
+                "Channel", "https://example.com/channel")));
+        assertFalse(rules.isBlocked(stream("https://example.com/watch/2", "Allowed title",
+                "Channel", "https://example.com/channel")));
+    }
+
+    @Test
+    void blocksChannelByUrlOrStoredDisplayName() {
+        final ContentBlockingHelper.Rules rules = ContentBlockingHelper.Rules.create(
+                true, Set.of(), Set.of("https://example.com/channel\tBlocked Channel"), "");
+
+        assertTrue(rules.isBlocked(stream("video-1", "Title", "Different name",
+                "https://example.com/channel")));
+        assertTrue(rules.isBlocked(stream("video-2", "Title", "blocked channel", null)));
+    }
+
+    @Test
+    void keywordMatchingIsCaseInsensitiveAndSupportsCommaOrLineBreaks() {
+        final ContentBlockingHelper.Rules rules = ContentBlockingHelper.Rules.create(
+                true, Set.of(), Set.of(), "Spoiler, clickbait\nRumor");
+
+        assertTrue(rules.isBlocked(stream("video-1", "Major SPOILER", "Channel", null)));
+        assertTrue(rules.isBlocked(stream("video-2", "Normal", "Rumor Network", null)));
+        assertFalse(rules.isBlocked(stream("video-3", "Documentary", "Science", null)));
+    }
+
+    @Test
+    void disabledRulesDoNotHideAnything() {
+        final ContentBlockingHelper.Rules rules = ContentBlockingHelper.Rules.create(
+                false, Set.of("video-1\tVideo"), Set.of(), "video");
+
+        assertFalse(rules.isBlocked(stream("video-1", "Video", "Channel", null)));
+    }
+
+    private static StreamInfoItem stream(final String url,
+                                         final String title,
+                                         final String uploader,
+                                         final String uploaderUrl) {
+        final StreamInfoItem item = new StreamInfoItem(0, url, title, StreamType.VIDEO_STREAM);
+        item.setUploaderName(uploader);
+        item.setUploaderUrl(uploaderUrl);
+        return item;
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -7,6 +7,7 @@ Release history is listed newest first. The number beside each release is its An
 ### New features
 
 - Added bulk video and audio downloads for complete playlists and loaded play queues, with default-quality selection, collision-safe filenames, and optional track-number prefixes.
+- Added local content blocking for individual videos, channels, and title/uploader keywords, with long-press actions and a dedicated management screen.
 
 ## WizeStream 1.7.0 (`1007000`)
 


### PR DESCRIPTION
- add local blocking rules for individual videos and channels
- add case-insensitive title and uploader keyword filters
- expose block actions from stream menus and channel long-press menus
- apply rules to remote info lists and the subscription feed
- add a dedicated settings screen to review, remove, disable, or clear rules
- document the feature and add focused rule-matching unit tests