### PR TITLE
Add optional DeArrow titles and thumbnails

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/dearrow/DeArrowService.java
+++ b/app/src/main/java/org/schabi/newpipe/dearrow/DeArrowService.java
@@ -1,0 +1,271 @@
+package org.schabi.newpipe.dearrow;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.LruCache;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+
+import org.schabi.newpipe.DownloaderImpl;
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.Image;
+import org.schabi.newpipe.extractor.Info;
+import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.util.image.ExtractorImageCompat;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+/** Fetches and applies community-contributed DeArrow titles and thumbnails. */
+public final class DeArrowService {
+    static final String BRANDING_ENDPOINT = "https://sponsor.ajay.app/api/branding";
+    static final String THUMBNAIL_ENDPOINT =
+            "https://dearrow-thumb.ajay.app/api/v1/getThumbnail";
+    private static final int CACHE_SIZE = 500;
+    private static final Pattern YOUTUBE_VIDEO_ID_PATTERN = Pattern.compile(
+            "(?:[?&]v=|youtu\\.be/|/(?:embed|shorts|live)/)([A-Za-z0-9_-]{11})");
+    private static final Object CACHE_LOCK = new Object();
+    private static final LruCache<String, Branding> CACHE = new LruCache<>(CACHE_SIZE);
+    private static final Map<String, Single<Branding>> IN_FLIGHT = new HashMap<>();
+
+    private DeArrowService() {
+    }
+
+    /**
+     * Returns branding for a YouTube video. Errors and missing submissions deliberately resolve to
+     * {@link Branding#EMPTY}, allowing callers to keep the original metadata without error UI.
+     *
+     * @param context context used to read the DeArrow preferences
+     * @param info    video metadata containing the service and video identifier
+     * @return a single that emits accepted branding or {@link Branding#EMPTY}
+     */
+    @NonNull
+    public static Single<Branding> getBranding(@NonNull final Context context,
+                                                @NonNull final Info info) {
+        return getBranding(context, info.getServiceId(), info.getId());
+    }
+
+    /**
+     * Returns branding for a YouTube list item.
+     *
+     * @param context context used to read the DeArrow preferences
+     * @param item    list item containing the service and video URL
+     * @return a single that emits accepted branding or {@link Branding#EMPTY}
+     */
+    @NonNull
+    public static Single<Branding> getBranding(@NonNull final Context context,
+                                                @NonNull final InfoItem item) {
+        return getBranding(context, item.getServiceId(), youtubeVideoId(item.getUrl()));
+    }
+
+    @NonNull
+    private static Single<Branding> getBranding(@NonNull final Context context,
+                                                 final int serviceId,
+                                                 final String videoId) {
+        if (!isEnabled(context) || serviceId != ServiceList.YouTube.getServiceId()
+                || !isYoutubeVideoId(videoId)) {
+            return Single.just(Branding.EMPTY);
+        }
+
+        synchronized (CACHE_LOCK) {
+            final Branding cached = CACHE.get(videoId);
+            if (cached != null) {
+                return Single.just(cached);
+            }
+            final Single<Branding> pending = IN_FLIGHT.get(videoId);
+            if (pending != null) {
+                return pending;
+            }
+
+            final Single<Branding> request = Single.fromCallable(() -> fetch(videoId))
+                    .subscribeOn(Schedulers.io())
+                    .onErrorReturnItem(Branding.EMPTY)
+                    .doOnSuccess(branding -> {
+                        synchronized (CACHE_LOCK) {
+                            CACHE.put(videoId, branding);
+                        }
+                    })
+                    .doFinally(() -> {
+                        synchronized (CACHE_LOCK) {
+                            IN_FLIGHT.remove(videoId);
+                        }
+                    })
+                    .cache();
+            IN_FLIGHT.put(videoId, request);
+            return request;
+        }
+    }
+
+    /**
+     * Applies the enabled parts of a branding response.
+     *
+     * @param context  context used to read the DeArrow preferences
+     * @param info     metadata object to update
+     * @param branding accepted branding returned by {@link #getBranding(Context, Info)}
+     * @return whether a title or thumbnail was changed
+     */
+    public static boolean applyBranding(@NonNull final Context context,
+                                        @NonNull final Info info,
+                                        @NonNull final Branding branding) {
+        if (!isEnabled(context)) {
+            return false;
+        }
+        boolean changed = false;
+        final SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        if (preferences.getBoolean(context.getString(R.string.dearrow_titles_key), true)
+                && branding.title != null && !branding.title.equals(info.getName())) {
+            info.setName(branding.title);
+            changed = true;
+        }
+        if (preferences.getBoolean(context.getString(R.string.dearrow_thumbnails_key), true)
+                && branding.thumbnailUrl != null) {
+            final Image image = new Image(branding.thumbnailUrl, Image.HEIGHT_UNKNOWN,
+                    Image.WIDTH_UNKNOWN, Image.ResolutionLevel.UNKNOWN);
+            if (info instanceof StreamInfo) {
+                ((StreamInfo) info).setThumbnails(Collections.singletonList(image));
+            }
+            changed = true;
+        }
+        return changed;
+    }
+
+    /**
+     * Applies the enabled parts of a branding response to a list item.
+     *
+     * @param context  context used to read the DeArrow preferences
+     * @param item     list item to update
+     * @param branding accepted branding returned by {@link #getBranding(Context, InfoItem)}
+     * @return whether a title or thumbnail was changed
+     */
+    public static boolean applyBranding(@NonNull final Context context,
+                                        @NonNull final InfoItem item,
+                                        @NonNull final Branding branding) {
+        if (!isEnabled(context)) {
+            return false;
+        }
+        boolean changed = false;
+        final SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        if (preferences.getBoolean(context.getString(R.string.dearrow_titles_key), true)
+                && branding.title != null && !branding.title.equals(item.getName())) {
+            item.setName(branding.title);
+            changed = true;
+        }
+        if (preferences.getBoolean(context.getString(R.string.dearrow_thumbnails_key), true)
+                && branding.thumbnailUrl != null) {
+            final Image image = new Image(branding.thumbnailUrl, Image.HEIGHT_UNKNOWN,
+                    Image.WIDTH_UNKNOWN, Image.ResolutionLevel.UNKNOWN);
+            ExtractorImageCompat.setThumbnailImages(item, Collections.singletonList(image));
+            changed = true;
+        }
+        return changed;
+    }
+
+    private static boolean isEnabled(@NonNull final Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.dearrow_enable_key), false);
+    }
+
+    private static boolean isYoutubeVideoId(final String id) {
+        return id != null && id.matches("[A-Za-z0-9_-]{11}");
+    }
+
+    private static String youtubeVideoId(final String url) {
+        if (url == null) {
+            return null;
+        }
+        final Matcher matcher = YOUTUBE_VIDEO_ID_PATTERN.matcher(url);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    @NonNull
+    private static Branding fetch(@NonNull final String videoId) throws Exception {
+        final String encodedId = URLEncoder.encode(videoId, StandardCharsets.UTF_8.name());
+        final Response response = DownloaderImpl.getInstance().get(
+                BRANDING_ENDPOINT + "?videoID=" + encodedId + "&fetchAll=true");
+        if (response.responseCode() != 200) {
+            return Branding.EMPTY;
+        }
+        return parseBranding(videoId, response.responseBody());
+    }
+
+    @NonNull
+    static Branding parseBranding(@NonNull final String videoId, @NonNull final String body)
+            throws JsonParserException, IOException {
+        final JsonObject root = JsonParser.object().from(body);
+        String title = null;
+        String thumbnailUrl = null;
+
+        final JsonArray titles = root.getArray("titles");
+        if (titles != null && !titles.isEmpty()) {
+            final JsonObject candidate = titles.getObject(0);
+            if (isAccepted(candidate) && !candidate.getBoolean("original", false)) {
+                final String candidateTitle = candidate.getString("title");
+                title = candidateTitle == null ? null : candidateTitle.trim();
+                if (title != null && title.isEmpty()) {
+                    title = null;
+                }
+            }
+        }
+
+        final JsonArray thumbnails = root.getArray("thumbnails");
+        if (thumbnails != null && !thumbnails.isEmpty()) {
+            final JsonObject candidate = thumbnails.getObject(0);
+            if (isAccepted(candidate) && !candidate.getBoolean("original", false)
+                    && candidate.containsKey("timestamp")) {
+                final double timestamp = candidate.getDouble("timestamp");
+                if (Double.isFinite(timestamp) && timestamp >= 0) {
+                    thumbnailUrl = THUMBNAIL_ENDPOINT + "?videoID="
+                            + URLEncoder.encode(videoId, StandardCharsets.UTF_8.name())
+                            + "&time=" + timestamp;
+                }
+            }
+        }
+        return title == null && thumbnailUrl == null
+                ? Branding.EMPTY : new Branding(title, thumbnailUrl);
+    }
+
+    private static boolean isAccepted(final JsonObject candidate) {
+        return candidate != null
+                && (candidate.getBoolean("locked", false) || candidate.getInt("votes", -1) >= 0);
+    }
+
+    public static final class Branding {
+        public static final Branding EMPTY = new Branding(null, null);
+
+        private final String title;
+        private final String thumbnailUrl;
+
+        Branding(final String title, final String thumbnailUrl) {
+            this.title = title;
+            this.thumbnailUrl = thumbnailUrl;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getThumbnailUrl() {
+            return thumbnailUrl;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/extractor/InfoItem.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/InfoItem.java
@@ -26,7 +26,7 @@ public abstract class InfoItem implements Serializable {
     private final InfoType infoType;
     private final int serviceId;
     private final String url;
-    private final String name;
+    private String name;
     private String thumbnailUrl;
 
     public InfoItem(final InfoType infoType,
@@ -53,6 +53,10 @@ public abstract class InfoItem implements Serializable {
 
     public String getName() {
         return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
     }
 
     public void setThumbnailUrl(final String thumbnailUrl) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -66,6 +66,7 @@ import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.stream.model.StreamEntity;
 import org.schabi.newpipe.databinding.FragmentVideoDetailBinding;
+import org.schabi.newpipe.dearrow.DeArrowService;
 import org.schabi.newpipe.download.DownloadDialog;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
@@ -1924,6 +1925,23 @@ public final class VideoDetailFragment
         LocalMediaThumbnailLoader.INSTANCE.clear(binding.detailThumbnailImageView);
         CoilHelper.INSTANCE.loadDetailsThumbnail(binding.detailThumbnailImageView,
                 ExtractorImageCompat.thumbnailImages(info));
+        disposables.add(DeArrowService.getBranding(requireContext(), info)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(branding -> {
+                    if (currentInfo != info
+                            || !DeArrowService.applyBranding(requireContext(), info, branding)) {
+                        return;
+                    }
+                    title = info.getName();
+                    binding.detailVideoTitleView.setText(title);
+                    LocalMediaThumbnailLoader.INSTANCE.clear(binding.detailThumbnailImageView);
+                    CoilHelper.INSTANCE.loadDetailsThumbnail(binding.detailThumbnailImageView,
+                            ExtractorImageCompat.thumbnailImages(info));
+                    if (!isPlayerAvailable() || player.isStopped()) {
+                        updateOverlayData(info.getName(), info.getUploaderName(),
+                                ExtractorImageCompat.thumbnailImages(info));
+                    }
+                }, throwable -> Log.w(TAG, "Unable to load DeArrow branding", throwable)));
         showMetaInfoInTextView(info.getMetaInfo(), binding.detailMetaInfoTextView,
                 binding.detailMetaInfoSeparator, disposables);
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -24,6 +24,7 @@ import androidx.core.graphics.ColorUtils;
 import androidx.core.view.MenuProvider;
 import androidx.lifecycle.Lifecycle;
 import androidx.preference.PreferenceManager;
+import androidx.viewpager.widget.ViewPager;
 
 import com.evernote.android.state.State;
 import com.google.android.material.snackbar.Snackbar;
@@ -44,11 +45,14 @@ import org.schabi.newpipe.fragments.BaseStateFragment;
 import org.schabi.newpipe.fragments.detail.TabAdapter;
 import org.schabi.newpipe.ktx.AnimationType;
 import org.schabi.newpipe.local.feed.notifications.NotificationHelper;
+import org.schabi.newpipe.local.search.ContextualSearchHelper;
+import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.local.subscription.SubscriptionManager;
 import org.schabi.newpipe.util.ChannelTabHelper;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.ExtractorApiCompat;
 import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.util.ExpandableSearchViewHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.StateSaver;
@@ -85,6 +89,10 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
     protected String url;
     @State
     protected String selectedChannelVideoSort;
+    @State
+    protected String channelSearchQuery = "";
+    @State
+    protected boolean channelSearchExpanded;
 
     private ChannelInfo currentInfo;
     private Disposable currentWorker;
@@ -145,6 +153,18 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
             public void onCreateMenu(@NonNull final Menu menu,
                                      @NonNull final MenuInflater inflater) {
                 inflater.inflate(R.menu.menu_channel, menu);
+
+                final MenuItem searchItem = menu.findItem(R.id.menu_item_search_content);
+                ExpandableSearchViewHelper.configure(
+                        searchItem,
+                        getString(R.string.contextual_search_hint, name),
+                        channelSearchQuery,
+                        channelSearchExpanded,
+                        query -> {
+                            channelSearchQuery = ContextualSearchHelper.normalizeQuery(query);
+                            applySearchToCurrentTab();
+                        },
+                        expanded -> channelSearchExpanded = expanded);
 
                 if (DEBUG) {
                     Log.d(TAG, "onCreateOptionsMenu() called with: "
@@ -228,6 +248,12 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         };
         binding.subChannelAvatarView.setOnClickListener(openSubChannel);
         binding.subChannelTitleView.setOnClickListener(openSubChannel);
+        binding.viewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
+            @Override
+            public void onPageSelected(final int position) {
+                applySearchToTab(position);
+            }
+        });
     }
 
     @Override
@@ -484,6 +510,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                                     name,
                                     selectedChannelVideoSort);
                     channelTabFragment.useAsFrontPage(useAsFrontPage);
+                    channelTabFragment.setContextualSearchQuery(channelSearchQuery);
                     tabAdapter.addFragment(channelTabFragment,
                             context.getString(ChannelTabHelper.getTranslationKey(tab)));
                 }
@@ -507,6 +534,23 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         final TabLayout.Tab ltab = binding.tabLayout.getTabAt(lastTab);
         if (ltab != null) {
             binding.tabLayout.selectTab(ltab);
+        }
+        applySearchToCurrentTab();
+    }
+
+    private void applySearchToCurrentTab() {
+        if (binding != null) {
+            applySearchToTab(binding.viewPager.getCurrentItem());
+        }
+    }
+
+    private void applySearchToTab(final int position) {
+        if (tabAdapter == null || position < 0 || position >= tabAdapter.getCount()) {
+            return;
+        }
+        final androidx.fragment.app.Fragment fragment = tabAdapter.getItem(position);
+        if (fragment instanceof ContextualSearchable) {
+            ((ContextualSearchable) fragment).setContextualSearchQuery(channelSearchQuery);
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
@@ -32,6 +32,8 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.fragments.list.playlist.PlaylistControlViewHolder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.local.search.ContextualSearchHelper;
+import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.player.playqueue.ChannelTabPlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.util.ChannelTabHelper;
@@ -53,7 +55,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
 
 public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTabInfo>
-        implements PlaylistControlViewHolder {
+        implements PlaylistControlViewHolder, ContextualSearchable {
 
     // states must be protected and not private for State being able to access them
     @State
@@ -64,6 +66,8 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
     protected StreamListFilter selectedStreamFilter = StreamListFilter.NONE;
     @State
     protected String selectedChannelVideoSort;
+    @State
+    protected String contextualSearchQuery = "";
 
     private FragmentChannelTabBinding binding;
     private PlaylistControlBinding playlistControlBinding;
@@ -317,6 +321,7 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
 
     private void refreshStreamStates() {
         if (!ChannelTabHelper.isStreamsTab(tabHandler)) {
+            applyStreamFilter();
             return;
         }
         final List<InfoItem> snapshot = new ArrayList<>(unfilteredItems);
@@ -347,13 +352,18 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
                         || item instanceof StreamInfoItem
                         && StreamListFilter.matches(selectedStreamFilter,
                                 (StreamInfoItem) item, streamStates.get(item.getUrl())))
+                .filter(item -> ContextualSearchHelper.matchesInfoItem(
+                        contextualSearchQuery, item))
                 .collect(Collectors.toList());
         infoListAdapter.clearStreamItemList();
         infoListAdapter.addInfoItemList(displayedItems);
         showListFooter(hasMoreItems());
         final boolean isEmpty = infoListAdapter.getItemsList().isEmpty();
-        if (isEmpty) {
+        if (isEmpty && !hasMoreItems()) {
             showEmptyState();
+            if (ContextualSearchHelper.isActive(contextualSearchQuery)) {
+                setEmptyStateMessage(R.string.search_no_results);
+            }
         } else {
             hideLoading();
         }
@@ -364,6 +374,12 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
     }
 
     @Override
+    public void setContextualSearchQuery(@NonNull final String query) {
+        contextualSearchQuery = ContextualSearchHelper.normalizeQuery(query);
+        applyStreamFilter();
+    }
+
+    @Override
     public PlayQueue getPlayQueue() {
         final List<StreamInfoItem> streamItems = infoListAdapter.getItemsList().stream()
                 .filter(StreamInfoItem.class::isInstance)
@@ -371,6 +387,8 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
                 .collect(Collectors.toList());
 
         return new ChannelTabPlayQueue(currentInfo.getServiceId(), tabHandler,
-                currentInfo.getNextPage(), streamItems, 0);
+                ContextualSearchHelper.isActive(contextualSearchQuery)
+                        ? null : currentInfo.getNextPage(),
+                streamItems, 0);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -57,9 +57,12 @@ import org.schabi.newpipe.learning.LearningMode;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.local.playlist.RemotePlaylistManager;
+import org.schabi.newpipe.local.search.ContextualSearchHelper;
+import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlaylistPlayQueue;
 import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.util.ExpandableSearchViewHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PlayButtonHelper;
@@ -85,7 +88,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, PlaylistInfo>
-        implements PlaylistControlViewHolder {
+        implements PlaylistControlViewHolder, ContextualSearchable {
 
     private CompositeDisposable disposables;
     private Subscription bookmarkReactor;
@@ -116,6 +119,10 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
     protected PlaylistSortOrder selectedPlaylistSort = PlaylistSortOrder.PLAYLIST_ORDER;
     @State
     protected boolean bulkDownloadPending;
+    @State
+    protected String contextualSearchQuery = "";
+    @State
+    protected boolean standaloneSearchExpanded;
     private final List<StreamInfoItem> unfilteredItems = new ArrayList<>();
     private final Map<String, StreamStateEntity> streamStates = new HashMap<>();
     private HistoryRecordManager historyRecordManager;
@@ -222,6 +229,18 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
         }
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.menu_playlist, menu);
+
+        final MenuItem searchItem = menu.findItem(R.id.menu_item_search_content);
+        searchItem.setVisible(!useAsFrontPage);
+        if (!useAsFrontPage) {
+            ExpandableSearchViewHelper.configure(
+                    searchItem,
+                    getString(R.string.contextual_search_hint, name),
+                    contextualSearchQuery,
+                    standaloneSearchExpanded,
+                    this::setContextualSearchQuery,
+                    expanded -> standaloneSearchExpanded = expanded);
+        }
 
         playlistBookmarkButton = menu.findItem(R.id.menu_item_bookmark);
         updateBookmarkButtons();
@@ -579,6 +598,9 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
     private void refreshStreamStatesAfterPageLoad() {
         if (selectedStreamFilter == StreamListFilter.NONE
                 && selectedPlaylistSort == PlaylistSortOrder.PLAYLIST_ORDER) {
+            if (ContextualSearchHelper.isActive(contextualSearchQuery)) {
+                applyStreamFilter();
+            }
             return;
         }
         refreshStreamStates();
@@ -622,19 +644,31 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
         if (infoListAdapter == null) {
             return;
         }
-        final List<StreamInfoItem> displayedItems = PlaylistSortHelper.itemsForDisplay(
+        final List<StreamInfoItem> sortedItems = PlaylistSortHelper.itemsForDisplay(
                 unfilteredItems, selectedStreamFilter, streamStates, selectedPlaylistSort);
+        final List<StreamInfoItem> displayedItems = ContextualSearchHelper.filter(
+                sortedItems, contextualSearchQuery,
+                item -> new String[]{item.getName(), item.getUploaderName()});
         infoListAdapter.clearStreamItemList();
         infoListAdapter.addInfoItemList(displayedItems);
         showListFooter(hasMoreItems());
         final boolean isEmpty = infoListAdapter.getItemsList().isEmpty();
         playlistControlBinding.getRoot().setVisibility(
                 isEmpty ? View.GONE : View.VISIBLE);
-        if (isEmpty) {
+        if (isEmpty && !hasMoreItems()) {
             showEmptyState();
+            if (ContextualSearchHelper.isActive(contextualSearchQuery)) {
+                setEmptyStateMessage(R.string.search_no_results);
+            }
         } else {
             hideLoading();
         }
+    }
+
+    @Override
+    public void setContextualSearchQuery(@NonNull final String query) {
+        contextualSearchQuery = ContextualSearchHelper.normalizeQuery(query);
+        applyStreamFilter();
     }
 
     private void showPlaylistSortDialog() {
@@ -705,6 +739,7 @@ public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, Playl
                 currentInfo.getServiceId(),
                 currentInfo.getUrl(),
                 selectedPlaylistSort == PlaylistSortOrder.PLAYLIST_ORDER
+                        && !ContextualSearchHelper.isActive(contextualSearchQuery)
                         ? currentInfo.getNextPage() : null,
                 infoItems,
                 index

--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.schabi.newpipe.databinding.PignateFooterBinding;
+import org.schabi.newpipe.dearrow.DeArrowService;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
@@ -41,6 +42,8 @@ import org.schabi.newpipe.util.OnClickGesture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 
 /*
  * Created by Christian Schabesberger on 01.08.16.
@@ -153,6 +156,12 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         }
         infoItemList.addAll(visibleData);
 
+        for (final InfoItem item : visibleData) {
+            if (item instanceof StreamInfoItem) {
+                loadDeArrowBranding((StreamInfoItem) item);
+            }
+        }
+
         if (DEBUG) {
             Log.d(TAG, "addInfoItemList() after > offsetStart = " + offsetStart + ", "
                     + "infoItemList.size() = " + infoItemList.size() + ", "
@@ -172,6 +181,21 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         + " to " + footerNow);
             }
         }
+    }
+
+    private void loadDeArrowBranding(@NonNull final StreamInfoItem item) {
+        DeArrowService.getBranding(infoItemBuilder.getContext(), item)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(branding -> {
+                    if (!DeArrowService.applyBranding(infoItemBuilder.getContext(), item,
+                            branding)) {
+                        return;
+                    }
+                    final int index = infoItemList.indexOf(item);
+                    if (index >= 0) {
+                        notifyItemChanged(index + (hasHeader() ? 1 : 0));
+                    }
+                }, throwable -> Log.w(TAG, "Unable to load DeArrow branding", throwable));
     }
 
     public void clearStreamItemList() {

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -57,6 +57,8 @@ import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.info_list.dialog.StreamDialogDefaultEntry;
 import org.schabi.newpipe.local.BaseLocalListFragment;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.local.search.ContextualSearchHelper;
+import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.learning.LearningContentManager;
 import org.schabi.newpipe.learning.LearningMode;
 import org.schabi.newpipe.learning.LearningPlaylistProgress;
@@ -65,6 +67,7 @@ import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
 import org.schabi.newpipe.util.DeviceUtils;
+import org.schabi.newpipe.util.ExpandableSearchViewHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
@@ -88,7 +91,7 @@ import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistStreamEntry>, Void>
-        implements PlaylistControlViewHolder, DebounceSavable {
+        implements PlaylistControlViewHolder, DebounceSavable, ContextualSearchable {
 
     private static final int MINIMUM_INITIAL_DRAG_VELOCITY = 12;
     @State
@@ -97,6 +100,10 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     protected String name;
     @State
     Parcelable itemsListState;
+    @State
+    protected String contextualSearchQuery = "";
+    @State
+    protected boolean standaloneSearchExpanded;
 
     private LocalPlaylistHeaderBinding headerBinding;
     private PlaylistControlBinding playlistControlBinding;
@@ -116,6 +123,7 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     private DebounceSaver debounceSaver;
     /** Flag to prevent simultaneous rewrites of the playlist. */
     private boolean isRewritingPlaylist = false;
+    private final List<PlaylistStreamEntry> unfilteredItems = new ArrayList<>();
 
     /**
      * The pager adapter that the fragment is created from when it is used as frontpage, i.e.
@@ -289,6 +297,18 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         }
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.menu_local_playlist, menu);
+
+        final MenuItem searchItem = menu.findItem(R.id.menu_item_search_content);
+        searchItem.setVisible(!useAsFrontPage);
+        if (!useAsFrontPage) {
+            ExpandableSearchViewHelper.configure(
+                    searchItem,
+                    getString(R.string.contextual_search_hint, name),
+                    contextualSearchQuery,
+                    standaloneSearchExpanded,
+                    this::setContextualSearchQuery,
+                    expanded -> standaloneSearchExpanded = expanded);
+        }
     }
 
     @Override
@@ -535,8 +555,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                     final List<PlaylistStreamEntry> itemsToKeep = flow.first;
                     final boolean thumbnailVideoRemoved = flow.second;
 
-                    itemListAdapter.clearStreamItemList();
-                    itemListAdapter.addItems(itemsToKeep);
+                    replaceUnfilteredItems(itemsToKeep);
+                    applyPlaylistSearch();
                     debounceSaver.setHasChangesToSave();
                     saveImmediate();
 
@@ -544,13 +564,12 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
                         updateThumbnailUrl();
                     }
 
-                    final long videoCount = itemListAdapter.getItemsList().size();
-                    setStreamCountAndOverallDuration(itemListAdapter.getItemsList());
+                    final long videoCount = unfilteredItems.size();
+                    setStreamCountAndOverallDuration(unfilteredItems);
                     if (videoCount == 0) {
                         showEmptyState();
                     }
 
-                    hideLoading();
                     isRewritingPlaylist = false;
                 }, throwable -> showError(new ErrorInfo(throwable, UserAction.REQUESTED_BOOKMARK,
                         "Removing watched videos, partially watched=" + removePartiallyWatched))));
@@ -565,22 +584,77 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
         itemListAdapter.clearStreamItemList();
         updateLearningProgress(result);
+        unfilteredItems.clear();
+        unfilteredItems.addAll(result);
 
         if (result.isEmpty()) {
             showEmptyState();
             return;
         }
 
-        itemListAdapter.addItems(result);
+        applyPlaylistSearch();
         if (itemsListState != null) {
             itemsList.getLayoutManager().onRestoreInstanceState(itemsListState);
             itemsListState = null;
         }
-        setStreamCountAndOverallDuration(itemListAdapter.getItemsList());
+        setStreamCountAndOverallDuration(result);
 
         PlayButtonHelper.initPlaylistControlClickListener(activity, playlistControlBinding, this);
+    }
 
-        hideLoading();
+    @Override
+    public void setContextualSearchQuery(@NonNull final String query) {
+        final String normalizedQuery = ContextualSearchHelper.normalizeQuery(query);
+        if (!ContextualSearchHelper.isActive(contextualSearchQuery)
+                && ContextualSearchHelper.isActive(normalizedQuery)) {
+            captureUnfilteredItemsFromAdapter();
+        }
+        contextualSearchQuery = normalizedQuery;
+        applyPlaylistSearch();
+    }
+
+    private void captureUnfilteredItemsFromAdapter() {
+        if (itemListAdapter == null) {
+            return;
+        }
+        unfilteredItems.clear();
+        itemListAdapter.getItemsList().stream()
+                .filter(PlaylistStreamEntry.class::isInstance)
+                .map(PlaylistStreamEntry.class::cast)
+                .forEach(unfilteredItems::add);
+    }
+
+    private void replaceUnfilteredItems(
+            @NonNull final List<PlaylistStreamEntry> items) {
+        unfilteredItems.clear();
+        unfilteredItems.addAll(items);
+    }
+
+    private void applyPlaylistSearch() {
+        if (itemListAdapter == null) {
+            return;
+        }
+        final List<PlaylistStreamEntry> displayedItems = ContextualSearchHelper.filter(
+                unfilteredItems, contextualSearchQuery,
+                item -> new String[]{item.getStreamEntity().getTitle(),
+                        item.getStreamEntity().getUploader(),
+                        item.getStreamEntity().getLocalAlbum(),
+                        item.getStreamEntity().getLocalFolder()});
+        itemListAdapter.clearStreamItemList();
+        itemListAdapter.addItems(displayedItems);
+
+        final boolean searchActive = ContextualSearchHelper.isActive(contextualSearchQuery);
+        if (itemTouchHelper != null) {
+            itemTouchHelper.attachToRecyclerView(searchActive ? null : itemsList);
+        }
+        if (displayedItems.isEmpty()) {
+            showEmptyState();
+            if (searchActive) {
+                setEmptyStateMessage(R.string.search_no_results);
+            }
+        } else {
+            hideLoading();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -672,8 +746,10 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
         final long thumbnailStreamId;
 
-        if (!itemListAdapter.getItemsList().isEmpty()) {
-            thumbnailStreamId = ((PlaylistStreamEntry) itemListAdapter.getItemsList().get(0))
+        final List<? extends LocalItem> items = ContextualSearchHelper.isActive(
+                contextualSearchQuery) ? unfilteredItems : itemListAdapter.getItemsList();
+        if (!items.isEmpty()) {
+            thumbnailStreamId = ((PlaylistStreamEntry) items.get(0))
                     .getStreamEntity().getUid();
         } else {
             thumbnailStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID;
@@ -706,13 +782,12 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         disposables.add(streamsMaybe.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(itemsToKeep -> {
-                    itemListAdapter.clearStreamItemList();
-                    itemListAdapter.addItems(itemsToKeep);
-                    setStreamCountAndOverallDuration(itemListAdapter.getItemsList());
+                    replaceUnfilteredItems(itemsToKeep);
+                    applyPlaylistSearch();
+                    setStreamCountAndOverallDuration(unfilteredItems);
                     debounceSaver.setHasChangesToSave();
                     saveImmediate();
 
-                    hideLoading();
                     isRewritingPlaylist = false;
                 }, throwable -> showError(new ErrorInfo(throwable, UserAction.REQUESTED_BOOKMARK,
                         "Removing duplicated streams"))));
@@ -723,12 +798,20 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             return;
         }
 
+        final boolean searchActive = ContextualSearchHelper.isActive(contextualSearchQuery);
+        if (searchActive) {
+            unfilteredItems.remove(item);
+        }
         itemListAdapter.removeItem(item);
         if (playlistManager.getPlaylistThumbnailStreamId(playlistId) == item.getStreamId()) {
             updateThumbnailUrl();
         }
+        if (searchActive) {
+            applyPlaylistSearch();
+        }
 
-        setStreamCountAndOverallDuration(itemListAdapter.getItemsList());
+        setStreamCountAndOverallDuration(
+                searchActive ? unfilteredItems : itemListAdapter.getItemsList());
         debounceSaver.setHasChangesToSave();
         saveImmediate();
     }
@@ -750,7 +833,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             return;
         }
 
-        final List<LocalItem> items = itemListAdapter.getItemsList();
+        final List<? extends LocalItem> items = ContextualSearchHelper.isActive(
+                contextualSearchQuery) ? unfilteredItems : itemListAdapter.getItemsList();
         final List<Long> streamIds = new ArrayList<>(items.size());
         for (final LocalItem item : items) {
             if (item instanceof PlaylistStreamEntry entry) {
@@ -1009,7 +1093,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
         this.name = !TextUtils.isEmpty(title) ? title : "";
     }
 
-    private void setStreamCountAndOverallDuration(final ArrayList<LocalItem> itemsList) {
+    private void setStreamCountAndOverallDuration(
+            final List<? extends LocalItem> itemsList) {
         if (activity != null && headerBinding != null) {
             final long streamCount = itemsList.size();
             final long playlistOverallDurationSeconds = itemsList.stream()

--- a/app/src/main/java/org/schabi/newpipe/local/search/ContextualSearchHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/local/search/ContextualSearchHelper.java
@@ -3,6 +3,11 @@ package org.schabi.newpipe.local.search;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
+import org.schabi.newpipe.extractor.post.PostInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -41,6 +46,26 @@ public final class ContextualSearchHelper {
             }
         }
         return false;
+    }
+
+    public static boolean matchesInfoItem(@Nullable final CharSequence query,
+                                          @Nullable final InfoItem item) {
+        if (item == null) {
+            return false;
+        }
+        if (item instanceof StreamInfoItem) {
+            final StreamInfoItem stream = (StreamInfoItem) item;
+            return matches(query, stream.getName(), stream.getUploaderName());
+        }
+        if (item instanceof PlaylistInfoItem) {
+            final PlaylistInfoItem playlist = (PlaylistInfoItem) item;
+            return matches(query, playlist.getName(), playlist.getUploaderName());
+        }
+        if (item instanceof PostInfoItem) {
+            final PostInfoItem post = (PostInfoItem) item;
+            return matches(query, post.getName(), post.getContent(), post.getUploaderName());
+        }
+        return matches(query, item.getName());
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/streams/MediaTagMetadata.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/MediaTagMetadata.java
@@ -1,0 +1,43 @@
+package org.schabi.newpipe.streams;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+
+import java.time.format.DateTimeFormatter;
+
+/** Immutable metadata fields embedded into supported downloaded media containers. */
+public final class MediaTagMetadata {
+    @Nullable
+    final String title;
+    @Nullable
+    final String artist;
+    @Nullable
+    final String genre;
+    @Nullable
+    final String date;
+    @Nullable
+    final String comment;
+
+    public MediaTagMetadata(@Nullable final String title,
+                            @Nullable final String artist,
+                            @Nullable final String genre,
+                            @Nullable final String date,
+                            @Nullable final String comment) {
+        this.title = title;
+        this.artist = artist;
+        this.genre = genre;
+        this.date = date;
+        this.comment = comment;
+    }
+
+    @NonNull
+    public static MediaTagMetadata from(@NonNull final StreamInfo streamInfo) {
+        final String uploadDate = streamInfo.getUploadDate() == null
+                ? null
+                : streamInfo.getUploadDate().offsetDateTime().format(DateTimeFormatter.ISO_DATE);
+        return new MediaTagMetadata(streamInfo.getName(), streamInfo.getUploaderName(),
+                streamInfo.getCategory(), uploadDate, streamInfo.getUrl());
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -47,6 +47,7 @@ public class Mp4FromDashWriter {
     private Mp4DashChunk[] readersChunks;
 
     private int overrideMainBrand = 0x00;
+    private MediaTagMetadata metadata;
 
     private final ArrayList<Integer> compatibleBrands = new ArrayList<>(5);
 
@@ -114,6 +115,10 @@ public class Mp4FromDashWriter {
 
     public void setMainBrand(final int brand) {
         overrideMainBrand = brand;
+    }
+
+    public void setMetadata(final MediaTagMetadata mediaMetadata) {
+        metadata = mediaMetadata;
     }
 
     public boolean isDone() {
@@ -718,6 +723,10 @@ public class Mp4FromDashWriter {
                     new RuntimeException("bad track matrix length (expected 36) in track n°" + i);
             }
             makeTrak(i, durations[i], defaultMediaTime[i], tablesInfo[i], is64);
+        }
+
+        if (metadata != null) {
+            auxWrite(Mp4MetadataWriter.makeUdta(metadata));
         }
 
         return lengthFor(start);

--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4MetadataWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4MetadataWriter.java
@@ -1,0 +1,78 @@
+package org.schabi.newpipe.streams;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Creates the iTunes-style metadata atoms stored below an MP4 {@code moov/udta} box. */
+final class Mp4MetadataWriter {
+    private static final int ATOM_UDTA = 0x75647461;
+    private static final int ATOM_META = 0x6D657461;
+    private static final int ATOM_HDLR = 0x68646C72;
+    private static final int ATOM_ILST = 0x696C7374;
+    private static final int ATOM_DATA = 0x64617461;
+
+    private static final int TAG_TITLE = 0xA96E616D;
+    private static final int TAG_ARTIST = 0xA9415254;
+    private static final int TAG_GENRE = 0xA967656E;
+    private static final int TAG_DATE = 0xA9646179;
+    private static final int TAG_COMMENT = 0xA9636D74;
+
+    private Mp4MetadataWriter() {
+    }
+
+    @NonNull
+    static byte[] makeUdta(@NonNull final MediaTagMetadata metadata) {
+        final List<byte[]> items = new ArrayList<>();
+        addTextItem(items, TAG_TITLE, metadata.title);
+        addTextItem(items, TAG_ARTIST, metadata.artist);
+        addTextItem(items, TAG_GENRE, metadata.genre);
+        addTextItem(items, TAG_DATE, metadata.date);
+        addTextItem(items, TAG_COMMENT, metadata.comment);
+
+        final byte[] handler = makeHandler();
+        final byte[] itemList = box(ATOM_ILST, items.toArray(new byte[0][]));
+        final byte[] meta = box(ATOM_META, ByteBuffer.allocate(4).putInt(0).array(),
+                handler, itemList);
+        return box(ATOM_UDTA, meta);
+    }
+
+    private static void addTextItem(@NonNull final List<byte[]> items,
+                                    final int type,
+                                    final String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return;
+        }
+        final byte[] text = value.trim().getBytes(StandardCharsets.UTF_8);
+        final byte[] data = box(ATOM_DATA,
+                ByteBuffer.allocate(8).putInt(1).putInt(0).array(), text);
+        items.add(box(type, data));
+    }
+
+    @NonNull
+    private static byte[] makeHandler() {
+        return box(ATOM_HDLR, ByteBuffer.allocate(25)
+                .putInt(0)
+                .putInt(0)
+                .putInt(0x6D646972)
+                .put(new byte[12])
+                .put((byte) 0)
+                .array());
+    }
+
+    @NonNull
+    private static byte[] box(final int type, @NonNull final byte[]... payloads) {
+        int size = 8;
+        for (final byte[] payload : payloads) {
+            size += payload.length;
+        }
+        final ByteBuffer buffer = ByteBuffer.allocate(size).putInt(size).putInt(type);
+        for (final byte[] payload : payloads) {
+            buffer.put(payload);
+        }
+        return buffer.array();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/streams/OggFromWebMWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/OggFromWebMWriter.java
@@ -291,14 +291,16 @@ public class OggFromWebMWriter implements Closeable {
         if ("A_OPUS".equals(webmTrack.codecId)) {
             final var metadata = new ArrayList<Pair<String, String>>();
             if (streamInfo != null) {
-                metadata.add(Pair.create("COMMENT", streamInfo.getUrl()));
-                metadata.add(Pair.create("GENRE", streamInfo.getCategory()));
-                metadata.add(Pair.create("ARTIST", streamInfo.getUploaderName()));
-                metadata.add(Pair.create("TITLE", streamInfo.getName()));
-                metadata.add(Pair.create("DATE", streamInfo
-                        .getUploadDate()
-                        .offsetDateTime()
-                        .format(DateTimeFormatter.ISO_DATE)));
+                addMetadata(metadata, "COMMENT", streamInfo.getUrl());
+                addMetadata(metadata, "GENRE", streamInfo.getCategory());
+                addMetadata(metadata, "ARTIST", streamInfo.getUploaderName());
+                addMetadata(metadata, "TITLE", streamInfo.getName());
+                if (streamInfo.getUploadDate() != null) {
+                    addMetadata(metadata, "DATE", streamInfo
+                            .getUploadDate()
+                            .offsetDateTime()
+                            .format(DateTimeFormatter.ISO_DATE));
+                }
             }
 
             if (DEBUG) {
@@ -320,6 +322,14 @@ public class OggFromWebMWriter implements Closeable {
 
         // not implemented for the desired codec
         return null;
+    }
+
+    private static void addMetadata(@NonNull final List<Pair<String, String>> metadata,
+                                    @NonNull final String key,
+                                    @Nullable final String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            metadata.add(Pair.create(key, value.trim()));
+        }
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/util/ExpandableSearchViewHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExpandableSearchViewHelper.java
@@ -1,0 +1,58 @@
+package org.schabi.newpipe.util;
+
+import android.view.MenuItem;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.SearchView;
+
+import java.util.function.Consumer;
+
+/** Configures a toolbar SearchView with consistent query and expansion behavior. */
+public final class ExpandableSearchViewHelper {
+    private ExpandableSearchViewHelper() {
+    }
+
+    public static void configure(@NonNull final MenuItem searchItem,
+                                 @NonNull final String hint,
+                                 @NonNull final String restoredQuery,
+                                 final boolean restoredExpanded,
+                                 @NonNull final Consumer<String> queryConsumer,
+                                 @NonNull final Consumer<Boolean> expansionConsumer) {
+        final SearchView searchView = (SearchView) searchItem.getActionView();
+        searchView.setMaxWidth(Integer.MAX_VALUE);
+        searchView.setQueryHint(hint);
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(final String query) {
+                queryConsumer.accept(query);
+                searchView.clearFocus();
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(final String newText) {
+                queryConsumer.accept(newText);
+                return true;
+            }
+        });
+        searchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+            @Override
+            public boolean onMenuItemActionExpand(@NonNull final MenuItem item) {
+                expansionConsumer.accept(true);
+                return true;
+            }
+
+            @Override
+            public boolean onMenuItemActionCollapse(@NonNull final MenuItem item) {
+                expansionConsumer.accept(false);
+                queryConsumer.accept("");
+                return true;
+            }
+        });
+
+        if (restoredExpanded) {
+            searchItem.expandActionView();
+            searchView.setQuery(restoredQuery, false);
+        }
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/M4aNoDash.java
@@ -2,6 +2,7 @@ package us.shandian.giga.postprocessing;
 
 import org.schabi.newpipe.streams.Mp4DashReader;
 import org.schabi.newpipe.streams.Mp4FromDashWriter;
+import org.schabi.newpipe.streams.MediaTagMetadata;
 import org.schabi.newpipe.streams.io.SharpStream;
 
 import java.io.IOException;
@@ -32,6 +33,9 @@ class M4aNoDash extends Postprocessing {
     int process(SharpStream out, SharpStream... sources) throws IOException {
         Mp4FromDashWriter muxer = new Mp4FromDashWriter(sources[0]);
         muxer.setMainBrand(0x4D344120);// binary string "M4A "
+        if (streamInfo != null) {
+            muxer.setMetadata(MediaTagMetadata.from(streamInfo));
+        }
         muxer.parseSources();
         muxer.selectTracks(0);
         muxer.build(out);

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp4FromDashMuxer.java
@@ -1,5 +1,6 @@
 package us.shandian.giga.postprocessing;
 
+import org.schabi.newpipe.streams.MediaTagMetadata;
 import org.schabi.newpipe.streams.Mp4FromDashWriter;
 import org.schabi.newpipe.streams.io.SharpStream;
 
@@ -17,6 +18,9 @@ class Mp4FromDashMuxer extends Postprocessing {
     @Override
     int process(SharpStream out, SharpStream... sources) throws IOException {
         Mp4FromDashWriter muxer = new Mp4FromDashWriter(sources);
+        if (streamInfo != null) {
+            muxer.setMetadata(MediaTagMetadata.from(streamInfo));
+        }
         muxer.parseSources();
         muxer.selectTracks(0, 0);
         muxer.build(out);

--- a/app/src/main/res/menu/menu_channel.xml
+++ b/app/src/main/res/menu/menu_channel.xml
@@ -18,6 +18,14 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/menu_item_search_content"
+        android:icon="@drawable/ic_search"
+        android:title="@string/search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="always|collapseActionView"
+        tools:ignore="AlwaysShowAction" />
+
+    <item
         android:id="@+id/menu_item_notify"
         android:checkable="true"
         android:orderInCategory="1"

--- a/app/src/main/res/menu/menu_local_playlist.xml
+++ b/app/src/main/res/menu/menu_local_playlist.xml
@@ -1,12 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <item
         android:id="@+id/menu_item_share_playlist"
         android:icon="@drawable/ic_share"
         android:title="@string/share"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/menu_item_search_content"
+        android:icon="@drawable/ic_search"
+        android:title="@string/search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="always|collapseActionView"
+        tools:ignore="AlwaysShowAction" />
 
     <item
         android:id="@+id/menu_item_rename_playlist"

--- a/app/src/main/res/menu/menu_playlist.xml
+++ b/app/src/main/res/menu/menu_playlist.xml
@@ -10,6 +10,14 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/menu_item_search_content"
+        android:icon="@drawable/ic_search"
+        android:title="@string/search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="always|collapseActionView"
+        tools:ignore="AlwaysShowAction" />
+
+    <item
         android:id="@+id/menu_item_bookmark"
         android:icon="@drawable/ic_playlist_add"
         android:title="@string/bookmark_playlist"

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1622,6 +1622,9 @@
     <string name="sponsor_block_graced_rewind_key">sponsor_block_graced_rewind</string>
     <string name="sponsor_block_show_manual_skip_key">sponsor_block_show_manual_skip</string>
     <string name="sponsor_block_user_id_key">sponsor_block_user_id</string>
+    <string name="dearrow_enable_key">dearrow_enable</string>
+    <string name="dearrow_titles_key">dearrow_titles</string>
+    <string name="dearrow_thumbnails_key">dearrow_thumbnails</string>
     <string name="sponsor_block_category_sponsor_key">sponsor_block_category_sponsor</string>
     <string name="sponsor_block_category_intro_key">sponsor_block_category_intro</string>
     <string name="sponsor_block_category_outro_key">sponsor_block_category_outro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1322,6 +1322,15 @@
     <string name="sponsor_block_category_highlight_title">Highlight</string>
     <string name="sponsor_block_category_highlight_summary">Point-of-interest markers; not skipped automatically</string>
 
+    <!-- DeArrow -->
+    <string name="dearrow_settings_category_title">DeArrow</string>
+    <string name="dearrow_enable_title">Enable DeArrow</string>
+    <string name="dearrow_enable_summary">Use community-contributed titles and thumbnails for YouTube videos</string>
+    <string name="dearrow_titles_title">Replace titles</string>
+    <string name="dearrow_titles_summary">Show approved descriptive titles instead of sensational titles</string>
+    <string name="dearrow_thumbnails_title">Replace thumbnails</string>
+    <string name="dearrow_thumbnails_summary">Show approved thumbnail frames instead of original thumbnails</string>
+
     <string name="sponsor_block_category_presets_title">Category presets</string>
     <string name="sponsor_block_categories_group_title">Categories</string>
     <string name="sponsor_block_activate_all_title">Activate all</string>

--- a/app/src/main/res/xml/sponsor_block_settings.xml
+++ b/app/src/main/res/xml/sponsor_block_settings.xml
@@ -57,4 +57,33 @@
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/dearrow_settings_category_title"
+        app:iconSpaceReserved="false">
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/dearrow_enable_key"
+            android:summary="@string/dearrow_enable_summary"
+            android:title="@string/dearrow_enable_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:dependency="@string/dearrow_enable_key"
+            android:key="@string/dearrow_titles_key"
+            android:summary="@string/dearrow_titles_summary"
+            android:title="@string/dearrow_titles_title"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:dependency="@string/dearrow_enable_key"
+            android:key="@string/dearrow_thumbnails_key"
+            android:summary="@string/dearrow_thumbnails_summary"
+            android:title="@string/dearrow_thumbnails_title"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/test/java/org/schabi/newpipe/dearrow/DeArrowServiceTest.java
+++ b/app/src/test/java/org/schabi/newpipe/dearrow/DeArrowServiceTest.java
@@ -1,0 +1,60 @@
+package org.schabi.newpipe.dearrow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class DeArrowServiceTest {
+    private static final String VIDEO_ID = "dQw4w9WgXcQ";
+
+    @Test
+    public void parseBrandingAcceptsNonNegativeVotes() throws Exception {
+        final String json = "{\"titles\":[{\"title\":\"A descriptive title\","
+                + "\"original\":false,\"votes\":0,\"locked\":false}],"
+                + "\"thumbnails\":[{\"timestamp\":12.5,\"original\":false,"
+                + "\"votes\":3,\"locked\":false}]}";
+
+        final DeArrowService.Branding branding =
+                DeArrowService.parseBranding(VIDEO_ID, json);
+
+        assertEquals("A descriptive title", branding.getTitle());
+        assertEquals(DeArrowService.THUMBNAIL_ENDPOINT + "?videoID=" + VIDEO_ID + "&time=12.5",
+                branding.getThumbnailUrl());
+    }
+
+    @Test
+    public void parseBrandingRejectsNegativeVotes() throws Exception {
+        final String json = "{\"titles\":[{\"title\":\"Rejected\",\"original\":false,"
+                + "\"votes\":-1,\"locked\":false}],\"thumbnails\":[{\"timestamp\":2,"
+                + "\"original\":false,\"votes\":-2,\"locked\":false}]}";
+
+        final DeArrowService.Branding branding =
+                DeArrowService.parseBranding(VIDEO_ID, json);
+
+        assertNull(branding.getTitle());
+        assertNull(branding.getThumbnailUrl());
+    }
+
+    @Test
+    public void parseBrandingAcceptsLockedSubmission() throws Exception {
+        final String json = "{\"titles\":[{\"title\":\"Locked title\",\"original\":false,"
+                + "\"votes\":-4,\"locked\":true}],\"thumbnails\":[]}";
+
+        assertEquals("Locked title",
+                DeArrowService.parseBranding(VIDEO_ID, json).getTitle());
+    }
+
+    @Test
+    public void parseBrandingKeepsOriginalSubmissionsUnchanged() throws Exception {
+        final String json = "{\"titles\":[{\"title\":\"Original\",\"original\":true,"
+                + "\"votes\":10,\"locked\":true}],\"thumbnails\":[{\"original\":true,"
+                + "\"votes\":10,\"locked\":true}]}";
+
+        final DeArrowService.Branding branding =
+                DeArrowService.parseBranding(VIDEO_ID, json);
+
+        assertNull(branding.getTitle());
+        assertNull(branding.getThumbnailUrl());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchHelperTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +45,17 @@ public class ContextualSearchHelperTest {
 
         assertEquals(Arrays.asList(first, third), filtered);
         assertEquals(Arrays.asList(first, second, third), items);
+    }
+
+    @Test
+    public void matchesRemoteInfoItemsByTitleOrUploader() {
+        final StreamInfoItem item = new StreamInfoItem(
+                0, "https://example.com/watch", "Quiet documentary", StreamType.VIDEO_STREAM);
+        item.setUploaderName("Science Channel");
+
+        assertTrue(ContextualSearchHelper.matchesInfoItem("documentary", item));
+        assertTrue(ContextualSearchHelper.matchesInfoItem("SCIENCE", item));
+        assertFalse(ContextualSearchHelper.matchesInfoItem("cooking", item));
     }
 
     private static final class SearchItem {

--- a/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
@@ -138,6 +138,30 @@ public class ContextualSearchIntegrationTest {
         assertTrue(menu.contains("app:showAsAction=\"always|collapseActionView\""));
     }
 
+    @Test
+    public void channelsAndPlaylistsExposeInPageSearch() throws Exception {
+        assertSourceContains("org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java",
+                "implements PlaylistControlViewHolder, ContextualSearchable");
+        assertSourceContains("org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java",
+                "implements PlaylistControlViewHolder, ContextualSearchable");
+        assertSourceContains("org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java",
+                "DebounceSavable, ContextualSearchable");
+        assertSourceContains("org/schabi/newpipe/fragments/list/channel/ChannelFragment.java",
+                "applySearchToCurrentTab()");
+
+        assertSearchMenu("menu/menu_channel.xml");
+        assertSearchMenu("menu/menu_playlist.xml");
+        assertSearchMenu("menu/menu_local_playlist.xml");
+    }
+
+    private void assertSearchMenu(final String relativePath) throws Exception {
+        final String menu = readResource(relativePath);
+        assertTrue(menu.contains("android:id=\"@+id/menu_item_search_content\""));
+        assertTrue(menu.contains(
+                "app:actionViewClass=\"androidx.appcompat.widget.SearchView\""));
+        assertTrue(menu.contains("app:showAsAction=\"always|collapseActionView\""));
+    }
+
     private void assertSourceContains(final String relativePath, final String expected)
             throws Exception {
         assertTrue(relativePath, read(relativePath).contains(expected));

--- a/app/src/test/java/org/schabi/newpipe/streams/Mp4MetadataWriterTest.java
+++ b/app/src/test/java/org/schabi/newpipe/streams/Mp4MetadataWriterTest.java
@@ -1,0 +1,56 @@
+package org.schabi.newpipe.streams;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+public class Mp4MetadataWriterTest {
+    @Test
+    public void createsSizedUdtaAndMetaAtomsWithUtf8Values() {
+        final MediaTagMetadata metadata = new MediaTagMetadata(
+                "Café session", "Channel Artist", "Music", "2026-08-20",
+                "https://example.com/watch/1");
+
+        final byte[] result = Mp4MetadataWriter.makeUdta(metadata);
+
+        assertEquals(result.length, readInt(result, 0));
+        assertEquals(0x75647461, readInt(result, 4));
+        assertEquals(result.length - 8, readInt(result, 8));
+        assertEquals(0x6D657461, readInt(result, 12));
+
+        final String binaryText = new String(result, StandardCharsets.ISO_8859_1);
+        assertTrue(binaryText.contains("CafÃ© session"));
+        assertTrue(binaryText.contains("Channel Artist"));
+        assertTrue(binaryText.contains("2026-08-20"));
+        assertTrue(binaryText.contains("https://example.com/watch/1"));
+    }
+
+    @Test
+    public void skipsBlankMetadataValues() {
+        final byte[] result = Mp4MetadataWriter.makeUdta(
+                new MediaTagMetadata("Title", "Artist", "  ", null, null));
+        final String binaryText = new String(result, StandardCharsets.ISO_8859_1);
+
+        assertTrue(binaryText.contains("Title"));
+        assertTrue(binaryText.contains("Artist"));
+        assertFalse(containsInt(result, 0xA967656E));
+    }
+
+    private static int readInt(final byte[] source, final int offset) {
+        return ByteBuffer.wrap(source, offset, Integer.BYTES).getInt();
+    }
+
+    private static boolean containsInt(final byte[] source, final int value) {
+        for (int offset = 0; offset <= source.length - Integer.BYTES; offset++) {
+            if (readInt(source, offset) == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -10,6 +10,10 @@ Release history is listed newest first. The number beside each release is its An
 - Added local content blocking for individual videos, channels, and title/uploader keywords, with long-press actions and a dedicated management screen.
 - Added in-page search for channel tabs, remote playlists, and local playlists.
 
+### Improvements
+
+- Embedded title, uploader, genre, upload date, and source URL metadata in generated M4A, MP4, and Opus downloads.
+
 ## WizeStream 1.7.0 (`1007000`)
 
 ### New features

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -1,5 +1,11 @@
 # WizeStream changelogs
 
+## Unreleased
+
+### New features
+
+- Added optional DeArrow titles and thumbnails for YouTube lists and video details, with request deduplication, in-memory caching, and automatic fallback to original metadata.
+
 Release history is listed newest first. The number beside each release is its Android version code.
 
 ## Unreleased

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -8,6 +8,7 @@ Release history is listed newest first. The number beside each release is its An
 
 - Added bulk video and audio downloads for complete playlists and loaded play queues, with default-quality selection, collision-safe filenames, and optional track-number prefixes.
 - Added local content blocking for individual videos, channels, and title/uploader keywords, with long-press actions and a dedicated management screen.
+- Added in-page search for channel tabs, remote playlists, and local playlists.
 
 ## WizeStream 1.7.0 (`1007000`)
 


### PR DESCRIPTION
- add opt-in DeArrow branding controls under SponsorBlock settings
- apply accepted community titles and thumbnails to YouTube stream lists and video details
- deduplicate concurrent requests, cache results in memory, and fall back silently to original metadata
- add parser coverage for accepted, rejected, locked, and original submissions
- update the changelog