### PR TITLE
Add bulk downloads to local playlists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistBulkDownloadMapper.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistBulkDownloadMapper.java
@@ -1,0 +1,24 @@
+package org.schabi.newpipe.local.playlist;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.database.playlist.PlaylistStreamEntry;
+import org.schabi.newpipe.download.BulkDownloadItem;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Converts downloadable entries from a local playlist into batch download items. */
+final class LocalPlaylistBulkDownloadMapper {
+    private LocalPlaylistBulkDownloadMapper() {
+    }
+
+    @NonNull
+    static List<BulkDownloadItem> from(@NonNull final List<PlaylistStreamEntry> entries) {
+        return entries.stream()
+                .filter(entry -> !entry.getStreamEntity().isLocalMedia())
+                .map(PlaylistStreamEntry::toStreamInfoItem)
+                .map(BulkDownloadItem::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -48,6 +48,8 @@ import org.schabi.newpipe.database.stream.model.StreamEntity;
 import org.schabi.newpipe.databinding.DialogEditTextBinding;
 import org.schabi.newpipe.databinding.LocalPlaylistHeaderBinding;
 import org.schabi.newpipe.databinding.PlaylistControlBinding;
+import org.schabi.newpipe.download.BulkDownloadDialog;
+import org.schabi.newpipe.download.BulkDownloadItem;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -419,6 +421,8 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == R.id.menu_item_share_playlist) {
             createShareConfirmationDialog();
+        } else if (item.getItemId() == R.id.menu_item_download_playlist) {
+            showBulkDownloadDialog();
         } else if (item.getItemId() == R.id.menu_item_rename_playlist) {
             createRenameDialog();
         } else if (item.getItemId() == R.id.menu_item_remove_watched) {
@@ -439,6 +443,18 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             return super.onOptionsItemSelected(item);
         }
         return true;
+    }
+
+    private void showBulkDownloadDialog() {
+        final List<BulkDownloadItem> downloadItems =
+                LocalPlaylistBulkDownloadMapper.from(unfilteredItems);
+        if (downloadItems.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.bulk_download_empty,
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+        BulkDownloadDialog.newInstance(downloadItems)
+                .show(getChildFragmentManager(), "bulkDownloadDialog");
     }
 
     private void toggleLearningPlaylist() {

--- a/app/src/main/res/menu/menu_local_playlist.xml
+++ b/app/src/main/res/menu/menu_local_playlist.xml
@@ -18,6 +18,12 @@
         tools:ignore="AlwaysShowAction" />
 
     <item
+        android:id="@+id/menu_item_download_playlist"
+        android:icon="@drawable/ic_file_download"
+        android:title="@string/download_playlist"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_item_rename_playlist"
         android:title="@string/rename_playlist"
         app:showAsAction="never" />

--- a/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistBulkDownloadMapperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistBulkDownloadMapperTest.java
@@ -1,0 +1,46 @@
+package org.schabi.newpipe.local.playlist;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.schabi.newpipe.database.playlist.PlaylistStreamEntry;
+import org.schabi.newpipe.database.stream.model.StreamEntity;
+import org.schabi.newpipe.download.BulkDownloadItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
+
+import java.util.List;
+
+public class LocalPlaylistBulkDownloadMapperTest {
+    @Test
+    public void localMediaIsSkippedAndRemoteOrderIsPreserved() {
+        final PlaylistStreamEntry first = remoteEntry(0, "https://example.test/first", "First");
+        final PlaylistStreamEntry local = mock(PlaylistStreamEntry.class);
+        final StreamEntity localEntity = mock(StreamEntity.class);
+        when(local.getStreamEntity()).thenReturn(localEntity);
+        when(localEntity.isLocalMedia()).thenReturn(true);
+        final PlaylistStreamEntry second = remoteEntry(1, "https://example.test/second", "Second");
+
+        final List<BulkDownloadItem> result =
+                LocalPlaylistBulkDownloadMapper.from(List.of(first, local, second));
+
+        assertEquals(2, result.size());
+        assertEquals("First", result.get(0).getTitle());
+        assertEquals("https://example.test/first", result.get(0).getUrl());
+        assertEquals("Second", result.get(1).getTitle());
+    }
+
+    private static PlaylistStreamEntry remoteEntry(final int serviceId,
+                                                   final String url,
+                                                   final String title) {
+        final PlaylistStreamEntry entry = mock(PlaylistStreamEntry.class);
+        final StreamEntity entity = mock(StreamEntity.class);
+        when(entry.getStreamEntity()).thenReturn(entity);
+        when(entity.isLocalMedia()).thenReturn(false);
+        when(entry.toStreamInfoItem()).thenReturn(
+                new StreamInfoItem(serviceId, url, title, StreamType.VIDEO_STREAM));
+        return entry;
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Improvements
+
+- Added bulk video and audio downloads directly from local playlists; entries that already point to
+  local media files are skipped.
+
 ## WizeStream 1.8.0 (`1008000`)
 
 ### New features

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,14 +53,14 @@ main [README](../README.md#supported-services) for the current list.
 
 ## How do bulk downloads work?
 
-Open a remote playlist's menu and choose **Download playlist**, or open the play queue and choose
-its download action. WizeStream loads the complete remote playlist, then lets you choose video or
-audio once for the batch. Each item uses its default available quality and audio track. Track-number
-prefixes are optional, and duplicate filenames are made unique automatically.
+Open a remote or local playlist's menu and choose **Download playlist**, or open the play queue and
+choose its download action. WizeStream loads the complete remote playlist when needed, then lets you
+choose video or audio once for the batch. Each item uses its default available quality and audio
+track. Track-number prefixes are optional, duplicate filenames are made unique automatically, and
+entries that already point to local media files are skipped.
 
 Bulk downloading requires valid default video and audio folders. Disable **Ask where to download**
-and choose the folders under **Settings > Download** before starting a batch. Local files in a play
-queue are skipped.
+and choose the folders under **Settings > Download** before starting a batch.
 
 ## How does content blocking work?
 


### PR DESCRIPTION
- expose Download playlist from local playlists
- reuse the existing batch video/audio download workflow
- skip entries that already point to local media files
- add mapper regression coverage and update the FAQ/changelog