### PR TITLE
Add pinch-to-zoom and video panning

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -58,9 +58,13 @@ class MainPlayerGestureListener(
     private var twoFingerStartSpeed = 1f
     private var twoFingerSpeedStep = PlaybackParameterPreferences.DEFAULT_ADJUSTMENT_STEP
     private var lastGestureSpeed = 1f
+    private var twoFingerStartZoom = 1f
+    private var lastGestureZoom = 1f
+    private var twoFingerStartTranslationX = 0f
+    private var twoFingerStartTranslationY = 0f
 
     override fun onTouch(v: View, event: MotionEvent): Boolean {
-        if (handleTwoFingerSpeedGesture(v, event)) {
+        if (handleTwoFingerGesture(v, event)) {
             return true
         }
 
@@ -130,12 +134,12 @@ class MainPlayerGestureListener(
         }
     }
 
-    private fun handleTwoFingerSpeedGesture(v: View, event: MotionEvent): Boolean {
+    private fun handleTwoFingerGesture(v: View, event: MotionEvent): Boolean {
         if (event.actionMasked == MotionEvent.ACTION_POINTER_DOWN &&
             event.pointerCount == 2 &&
-            PlayerHelper.isTwoFingerSpeedGestureEnabled(player.context) &&
             !player.exoPlayerIsNull() &&
-            player.currentState != Player.STATE_COMPLETED
+            player.currentState != Player.STATE_COMPLETED &&
+            binding.surfaceView.isVisible
         ) {
             cancelSingleFingerGesture(event)
             restoreHoldToSpeed()
@@ -154,6 +158,10 @@ class MainPlayerGestureListener(
             twoFingerStartSpeed = player.playbackSpeed
             twoFingerSpeedStep = PlaybackParameterPreferences.getAdjustmentStep(player.context)
             lastGestureSpeed = twoFingerStartSpeed
+            twoFingerStartZoom = binding.surfaceView.userZoomScale
+            lastGestureZoom = twoFingerStartZoom
+            twoFingerStartTranslationX = binding.surfaceView.userTranslationX
+            twoFingerStartTranslationY = binding.surfaceView.userTranslationY
             twoFingerGestureState = TwoFingerGestureState.PENDING
             suppressSingleTouchUntilUp = true
             v.parent?.requestDisallowInterceptTouchEvent(true)
@@ -167,14 +175,14 @@ class MainPlayerGestureListener(
         when (event.actionMasked) {
             MotionEvent.ACTION_MOVE -> {
                 if (event.pointerCount >= 2) {
-                    updateTwoFingerSpeedGesture(v, event)
+                    updateTwoFingerGesture(v, event)
                 }
             }
 
-            MotionEvent.ACTION_POINTER_UP -> finishTwoFingerSpeedGesture()
+            MotionEvent.ACTION_POINTER_UP -> finishTwoFingerGesture()
 
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                finishTwoFingerSpeedGesture()
+                finishTwoFingerGesture()
                 suppressSingleTouchUntilUp = false
                 v.parent?.requestDisallowInterceptTouchEvent(false)
             }
@@ -189,7 +197,7 @@ class MainPlayerGestureListener(
         cancelEvent.recycle()
     }
 
-    private fun updateTwoFingerSpeedGesture(v: View, event: MotionEvent) {
+    private fun updateTwoFingerGesture(v: View, event: MotionEvent) {
         val verticalMovement = twoFingerInitialCenterY - centerY(event)
         val horizontalMovement = centerX(event) - twoFingerInitialCenterX
         val spanChange = abs(pointerSpan(event) - twoFingerInitialSpan)
@@ -201,8 +209,14 @@ class MainPlayerGestureListener(
                 verticalMovement,
                 horizontalMovement,
                 spanChange,
-                lockThreshold
+                lockThreshold,
+                twoFingerStartZoom > 1f
             )
+            if (twoFingerGestureState == TwoFingerGestureState.SPEED &&
+                !PlayerHelper.isTwoFingerSpeedGestureEnabled(player.context)
+            ) {
+                twoFingerGestureState = TwoFingerGestureState.IGNORED
+            }
             if (twoFingerGestureState == TwoFingerGestureState.SPEED) {
                 binding.speedGestureDisplay.text =
                     PlayerHelper.formatSpeed(twoFingerStartSpeed.toDouble())
@@ -211,13 +225,24 @@ class MainPlayerGestureListener(
                     150,
                     AnimationType.SCALE_AND_ALPHA
                 )
+            } else if (twoFingerGestureState == TwoFingerGestureState.ZOOM) {
+                binding.speedGestureDisplay.text = formatZoom(twoFingerStartZoom)
+                binding.speedGestureDisplay.animate(
+                    true,
+                    150,
+                    AnimationType.SCALE_AND_ALPHA
+                )
             }
         }
 
-        if (twoFingerGestureState != TwoFingerGestureState.SPEED) {
-            return
+        when (twoFingerGestureState) {
+            TwoFingerGestureState.SPEED -> updateTwoFingerSpeed(v, verticalMovement)
+            TwoFingerGestureState.ZOOM -> updateTwoFingerZoom(v, event)
+            else -> Unit
         }
+    }
 
+    private fun updateTwoFingerSpeed(v: View, verticalMovement: Float) {
         val pixelsPerStep = TWO_FINGER_SPEED_STEP_DP *
             player.context.resources.displayMetrics.density
         val newSpeed = calculatePlaybackSpeed(
@@ -238,10 +263,28 @@ class MainPlayerGestureListener(
         lastGestureSpeed = newSpeed
     }
 
-    private fun finishTwoFingerSpeedGesture() {
-        if (twoFingerGestureState == TwoFingerGestureState.SPEED &&
-            binding.speedGestureDisplay.isVisible
-        ) {
+    private fun updateTwoFingerZoom(v: View, event: MotionEvent) {
+        val newZoom = calculateZoomScale(
+            twoFingerStartZoom,
+            pointerSpan(event),
+            twoFingerInitialSpan
+        )
+        binding.surfaceView.setUserTransform(
+            newZoom,
+            twoFingerStartTranslationX + centerX(event) - twoFingerInitialCenterX,
+            twoFingerStartTranslationY + centerY(event) - twoFingerInitialCenterY
+        )
+        binding.speedGestureDisplay.text = formatZoom(binding.surfaceView.userZoomScale)
+        if (binding.surfaceView.userZoomScale == 1f && lastGestureZoom != 1f) {
+            v.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+        }
+        lastGestureZoom = binding.surfaceView.userZoomScale
+    }
+
+    private fun finishTwoFingerGesture() {
+        val wasActive = twoFingerGestureState == TwoFingerGestureState.SPEED ||
+            twoFingerGestureState == TwoFingerGestureState.ZOOM
+        if (wasActive && binding.speedGestureDisplay.isVisible) {
             binding.speedGestureDisplay.animate(
                 false,
                 200,
@@ -251,6 +294,8 @@ class MainPlayerGestureListener(
         }
         twoFingerGestureState = TwoFingerGestureState.IDLE
     }
+
+    private fun formatZoom(zoomScale: Float): String = "${round(zoomScale * 100).toInt()}%"
 
     private fun centerX(event: MotionEvent): Float = (event.getX(0) + event.getX(1)) / 2f
 
@@ -556,18 +601,38 @@ class MainPlayerGestureListener(
             verticalMovement: Float,
             horizontalMovement: Float,
             spanChange: Float,
-            threshold: Float
+            threshold: Float,
+            alreadyZoomed: Boolean
         ): TwoFingerGestureState {
             val vertical = abs(verticalMovement)
             val horizontal = abs(horizontalMovement)
             if (vertical < threshold && horizontal < threshold && spanChange < threshold) {
                 return TwoFingerGestureState.PENDING
             }
-            return if (vertical > horizontal * 1.25f && vertical > spanChange * 1.25f) {
-                TwoFingerGestureState.SPEED
-            } else {
-                TwoFingerGestureState.IGNORED
+            return when {
+                spanChange > vertical * 1.25f && spanChange > horizontal * 1.25f ->
+                    TwoFingerGestureState.ZOOM
+
+                alreadyZoomed && (vertical >= threshold || horizontal >= threshold) ->
+                    TwoFingerGestureState.ZOOM
+
+                vertical > horizontal * 1.25f && vertical > spanChange * 1.25f ->
+                    TwoFingerGestureState.SPEED
+
+                else -> TwoFingerGestureState.IGNORED
             }
+        }
+
+        @JvmStatic
+        fun calculateZoomScale(
+            startZoom: Float,
+            currentSpan: Float,
+            initialSpan: Float
+        ): Float {
+            if (initialSpan <= 0f || !initialSpan.isFinite() || !currentSpan.isFinite()) {
+                return startZoom.coerceIn(1f, 4f)
+            }
+            return (startZoom * currentSpan / initialSpan).coerceIn(1f, 4f)
         }
 
         @JvmStatic
@@ -606,6 +671,7 @@ class MainPlayerGestureListener(
         IDLE,
         PENDING,
         SPEED,
+        ZOOM,
         IGNORED
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -1043,6 +1043,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @Override
     public void onMetadataChanged(@NonNull final StreamInfo info) {
         super.onMetadataChanged(info);
+        binding.surfaceView.resetUserTransform();
 
         updateStreamRelatedViews();
 
@@ -1055,6 +1056,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @Override
     public void onMetadataChanged(@NonNull final MediaItemTag tag) {
         super.onMetadataChanged(tag);
+        binding.surfaceView.resetUserTransform();
         binding.qualityTextView.setVisibility(View.GONE);
         binding.audioTrackTextView.setVisibility(View.GONE);
         binding.playbackLiveSync.setVisibility(View.GONE);
@@ -1570,6 +1572,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     }
 
     void onResizeClicked() {
+        binding.surfaceView.resetUserTransform();
         setResizeMode(nextResizeModeAndSaveToPrefs(player, binding.surfaceView.getResizeMode()));
     }
 

--- a/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
@@ -10,12 +10,18 @@ import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MOD
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_ZOOM;
 
 public class ExpandableSurfaceView extends SurfaceView {
+    public static final float MIN_USER_ZOOM = 1.0f;
+    public static final float MAX_USER_ZOOM = 4.0f;
+
     private int resizeMode = RESIZE_MODE_FIT;
     private int baseHeight = 0;
     private int maxHeight = 0;
     private float videoAspectRatio = 0.0f;
     private float scaleX = 1.0f;
     private float scaleY = 1.0f;
+    private float userZoomScale = MIN_USER_ZOOM;
+    private float userTranslationX;
+    private float userTranslationY;
 
     public ExpandableSurfaceView(final Context context, final AttributeSet attrs) {
         super(context, attrs);
@@ -68,8 +74,27 @@ public class ExpandableSurfaceView extends SurfaceView {
     @Override
     protected void onLayout(final boolean changed,
                             final int left, final int top, final int right, final int bottom) {
-        setScaleX(scaleX);
-        setScaleY(scaleY);
+        applyUserTransform();
+    }
+
+    private void applyUserTransform() {
+        final float effectiveScaleX = scaleX * userZoomScale;
+        final float effectiveScaleY = scaleY * userZoomScale;
+        setPivotX(getWidth() / 2.0f);
+        setPivotY(getHeight() / 2.0f);
+        setScaleX(effectiveScaleX);
+        setScaleY(effectiveScaleY);
+
+        final float maxTranslationX = Math.max(0.0f,
+                getWidth() * (effectiveScaleX - 1.0f) / 2.0f);
+        final float maxTranslationY = Math.max(0.0f,
+                getHeight() * (effectiveScaleY - 1.0f) / 2.0f);
+        userTranslationX = Math.max(-maxTranslationX,
+                Math.min(userTranslationX, maxTranslationX));
+        userTranslationY = Math.max(-maxTranslationY,
+                Math.min(userTranslationY, maxTranslationY));
+        setTranslationX(userTranslationX);
+        setTranslationY(userTranslationY);
     }
 
     /**
@@ -97,6 +122,31 @@ public class ExpandableSurfaceView extends SurfaceView {
     @AspectRatioFrameLayout.ResizeMode
     public int getResizeMode() {
         return resizeMode;
+    }
+
+    public void setUserTransform(final float zoomScale,
+                                 final float translationX,
+                                 final float translationY) {
+        userZoomScale = Math.max(MIN_USER_ZOOM, Math.min(zoomScale, MAX_USER_ZOOM));
+        userTranslationX = userZoomScale == MIN_USER_ZOOM ? 0.0f : translationX;
+        userTranslationY = userZoomScale == MIN_USER_ZOOM ? 0.0f : translationY;
+        applyUserTransform();
+    }
+
+    public void resetUserTransform() {
+        setUserTransform(MIN_USER_ZOOM, 0.0f, 0.0f);
+    }
+
+    public float getUserZoomScale() {
+        return userZoomScale;
+    }
+
+    public float getUserTranslationX() {
+        return userTranslationX;
+    }
+
+    public float getUserTranslationY() {
+        return userTranslationY;
     }
 
     public void setAspectRatio(final float aspectRatio) {

--- a/app/src/test/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListenerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListenerTest.java
@@ -49,19 +49,39 @@ public class MainPlayerGestureListenerTest {
     @Test
     public void verticalTwoFingerMovementLocksSpeedGesture() {
         assertEquals(MainPlayerGestureListener.TwoFingerGestureState.SPEED,
-                MainPlayerGestureListener.classifyTwoFingerGesture(60f, 5f, 8f, 12f));
+                MainPlayerGestureListener.classifyTwoFingerGesture(
+                        60f, 5f, 8f, 12f, false));
     }
 
     @Test
     public void spanDominantMovementIsTreatedAsPinch() {
-        assertEquals(MainPlayerGestureListener.TwoFingerGestureState.IGNORED,
-                MainPlayerGestureListener.classifyTwoFingerGesture(20f, 2f, 50f, 12f));
+        assertEquals(MainPlayerGestureListener.TwoFingerGestureState.ZOOM,
+                MainPlayerGestureListener.classifyTwoFingerGesture(
+                        20f, 2f, 50f, 12f, false));
     }
 
     @Test
     public void twoFingerGestureWaitsForClearIntent() {
         assertEquals(MainPlayerGestureListener.TwoFingerGestureState.PENDING,
-                MainPlayerGestureListener.classifyTwoFingerGesture(8f, 4f, 3f, 12f));
+                MainPlayerGestureListener.classifyTwoFingerGesture(
+                        8f, 4f, 3f, 12f, false));
+    }
+
+    @Test
+    public void twoFingerMovementPansWhileAlreadyZoomed() {
+        assertEquals(MainPlayerGestureListener.TwoFingerGestureState.ZOOM,
+                MainPlayerGestureListener.classifyTwoFingerGesture(
+                        60f, 4f, 2f, 12f, true));
+    }
+
+    @Test
+    public void pinchZoomIsScaledAndClamped() {
+        assertEquals(2f, MainPlayerGestureListener.calculateZoomScale(1f, 200f, 100f),
+                FLOAT_TOLERANCE);
+        assertEquals(4f, MainPlayerGestureListener.calculateZoomScale(3f, 200f, 100f),
+                FLOAT_TOLERANCE);
+        assertEquals(1f, MainPlayerGestureListener.calculateZoomScale(2f, 20f, 100f),
+                FLOAT_TOLERANCE);
     }
 
     @Test

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### New features
+
+- Added continuous pinch-to-zoom from 100% to 400% and two-finger panning in the main player while
+  preserving the existing vertical two-finger playback-speed gesture.
+
 ### Improvements
 
 - Added bulk video and audio downloads directly from local playlists; entries that already point to

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -77,6 +77,13 @@ thumbnail frames. It is disabled by default. Enable it under **Settings > Sponso
 where title and thumbnail replacement can be controlled separately. If no accepted contribution is
 available or the request fails, WizeStream keeps the original title and thumbnail.
 
+## How do I zoom a video?
+
+Pinch with two fingers over the main player to zoom continuously from 100% to 400%. Once enlarged,
+drag with two fingers to move around the video. Pinch back to 100% or tap the Fit/Fill/Zoom control
+to reset the custom zoom. A vertical two-finger swipe still changes playback speed when that gesture
+is enabled and the video has not already been enlarged.
+
 ## How do I cast to a TV?
 
 On Android 8 or newer, open a compatible video's details and select **Cast to TV**. WizeStream


### PR DESCRIPTION
- add continuous 100%–400% pinch zoom to the main video player
- allow two-finger panning while enlarged and clamp movement to the scaled video
- preserve the existing vertical two-finger playback-speed gesture
- reset custom zoom on stream changes and Fit/Fill/Zoom mode changes
- add gesture classification and zoom-clamping regression tests
- document the gesture and update the changelog