### PR TITLE
Add authenticated HTTP and SOCKS proxy support

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/network/ProxyCredentialStoreTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/network/ProxyCredentialStoreTest.kt
@@ -1,0 +1,31 @@
+package org.schabi.newpipe.network
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ProxyCredentialStoreTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun passwordRoundTripsThroughKeystoreAndCanBeCleared() {
+        val store = ProxyCredentialStore(context)
+        store.clearPassword()
+        try {
+            assertTrue(store.savePassword("pāssword-123"))
+            assertTrue(store.hasPassword())
+            assertEquals("pāssword-123", store.readPassword())
+            assertTrue(store.clearPassword())
+            assertFalse(store.hasPassword())
+            assertNull(store.readPassword())
+        } finally {
+            store.clearPassword()
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/App.kt
+++ b/app/src/main/java/org/schabi/newpipe/App.kt
@@ -27,6 +27,7 @@ import java.io.IOException
 import java.io.InterruptedIOException
 import java.net.SocketException
 import java.util.concurrent.Executors
+import okhttp3.OkHttpClient
 import org.acra.ACRA.init
 import org.acra.ACRA.isACRASenderServiceProcess
 import org.acra.config.CoreConfigurationBuilder
@@ -34,6 +35,7 @@ import org.schabi.newpipe.error.ReCaptchaActivity
 import org.schabi.newpipe.extractor.NewPipe
 import org.schabi.newpipe.extractor.downloader.Downloader
 import org.schabi.newpipe.ktx.hasAssignableCause
+import org.schabi.newpipe.network.AppProxySelector
 import org.schabi.newpipe.settings.NewPipeSettings
 import org.schabi.newpipe.sync.DeviceSyncBackgroundScheduler
 import org.schabi.newpipe.sync.DeviceSyncManager
@@ -172,7 +174,12 @@ open class App :
         }.build()
 
     protected open fun getDownloader(): Downloader {
-        val downloader = DownloaderImpl.init(null)
+        val proxySelector = AppProxySelector.install(this)
+        val downloader = DownloaderImpl.init(
+            OkHttpClient.Builder()
+                .proxySelector(proxySelector)
+                .proxyAuthenticator(proxySelector.okHttpAuthenticator)
+        )
         setCookiesToDownloader(downloader)
         return downloader
     }

--- a/app/src/main/java/org/schabi/newpipe/network/AppProxySelector.java
+++ b/app/src/main/java/org/schabi/newpipe/network/AppProxySelector.java
@@ -1,0 +1,368 @@
+package org.schabi.newpipe.network;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.DownloaderImpl;
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.helper.PlayerDataSource;
+import org.schabi.newpipe.util.InfoCache;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/** Application-wide HTTP/SOCKS proxy selector with local-network bypass rules. */
+public final class AppProxySelector extends ProxySelector {
+    private static AppProxySelector instance;
+
+    @NonNull
+    private final Context context;
+    @NonNull
+    private final SharedPreferences preferences;
+    @NonNull
+    private final SharedPreferences.OnSharedPreferenceChangeListener preferenceListener;
+    @Nullable
+    private final ProxySelector fallbackSelector;
+    @NonNull
+    private final Authenticator scopedAuthenticator;
+    @NonNull
+    private final okhttp3.Authenticator okHttpAuthenticator;
+    @NonNull
+    private final ProxyCredentialStore credentialStore;
+    @NonNull
+    private volatile ProxyConfiguration configuration;
+
+    private AppProxySelector(@NonNull final Context context,
+                             @Nullable final ProxySelector fallbackSelector) {
+        this.context = context.getApplicationContext();
+        this.fallbackSelector = fallbackSelector;
+        credentialStore = new ProxyCredentialStore(this.context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(this.context);
+        configuration = readConfiguration();
+        scopedAuthenticator = new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                final ProxyConfiguration current = configuration;
+                if (!shouldAuthenticateProxy(getRequestorType(), getRequestingHost(),
+                        getRequestingPort(), current.host, current.port,
+                        current.username, current.password)) {
+                    return null;
+                }
+                return new PasswordAuthentication(current.username,
+                        current.password.toCharArray());
+            }
+        };
+        okHttpAuthenticator = this::authenticateOkHttp;
+        preferenceListener = (sharedPreferences, key) -> {
+            if (isProxyPreference(key)) {
+                refresh();
+            }
+        };
+        preferences.registerOnSharedPreferenceChangeListener(preferenceListener);
+        updateDefaultAuthenticator();
+    }
+
+    @NonNull
+    public static synchronized AppProxySelector install(@NonNull final Context context) {
+        if (instance == null) {
+            instance = new AppProxySelector(context, ProxySelector.getDefault());
+        }
+        if (ProxySelector.getDefault() != instance) {
+            ProxySelector.setDefault(instance);
+        }
+        instance.updateDefaultAuthenticator();
+        return instance;
+    }
+
+    public static synchronized void refreshInstalled() {
+        if (instance != null) {
+            instance.refresh();
+        }
+    }
+
+    @NonNull
+    public okhttp3.Authenticator getOkHttpAuthenticator() {
+        return okHttpAuthenticator;
+    }
+
+    public void refresh() {
+        configuration = readConfiguration();
+        updateDefaultAuthenticator();
+        InfoCache.getInstance().clearCache();
+        PlayerDataSource.invalidateYoutubeManifestCaches();
+        final DownloaderImpl downloader = DownloaderImpl.getInstance();
+        if (downloader != null) {
+            downloader.getClient().connectionPool().evictAll();
+        }
+    }
+
+    @NonNull
+    @Override
+    public List<Proxy> select(@NonNull final URI uri) {
+        final ProxyConfiguration current = configuration;
+        if (!current.isEnabled()) {
+            return selectFallback(uri);
+        }
+        if (shouldBypass(uri)) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
+        return Collections.singletonList(current.toProxy());
+    }
+
+    @Override
+    public void connectFailed(@NonNull final URI uri,
+                              @NonNull final SocketAddress socketAddress,
+                              @NonNull final IOException exception) {
+        if (!configuration.isEnabled() && fallbackSelector != null
+                && fallbackSelector != this) {
+            fallbackSelector.connectFailed(uri, socketAddress, exception);
+        }
+    }
+
+    @NonNull
+    public static HttpURLConnection openConnection(@NonNull final URL url) throws IOException {
+        final AppProxySelector current = instance;
+        if (current == null) {
+            return (HttpURLConnection) url.openConnection();
+        }
+        try {
+            final List<Proxy> proxies = current.select(url.toURI());
+            final Proxy proxy = proxies.isEmpty() ? Proxy.NO_PROXY : proxies.get(0);
+            return (HttpURLConnection) url.openConnection(proxy);
+        } catch (final URISyntaxException e) {
+            throw new IOException("Invalid URL for proxy selection", e);
+        }
+    }
+
+    private boolean isProxyPreference(@Nullable final String key) {
+        return key != null && (key.equals(context.getString(R.string.proxy_mode_key))
+                || key.equals(context.getString(R.string.proxy_host_key))
+                || key.equals(context.getString(R.string.proxy_port_key))
+                || key.equals(context.getString(R.string.proxy_username_key)));
+    }
+
+    @NonNull
+    private ProxyConfiguration readConfiguration() {
+        final String mode = preferences.getString(context.getString(R.string.proxy_mode_key),
+                context.getString(R.string.proxy_mode_disabled_value));
+        final String host = preferences.getString(context.getString(R.string.proxy_host_key), "");
+        final String portValue = preferences.getString(
+                context.getString(R.string.proxy_port_key), "8080");
+        final String username = preferences.getString(
+                context.getString(R.string.proxy_username_key), "");
+        final String password = credentialStore.readPassword();
+        final int port;
+        try {
+            port = Integer.parseInt(portValue == null ? "" : portValue);
+        } catch (final NumberFormatException ignored) {
+            return ProxyConfiguration.create(mode, host, 0, username, password,
+                    context.getString(R.string.proxy_mode_http_value),
+                    context.getString(R.string.proxy_mode_socks_value));
+        }
+        return ProxyConfiguration.create(mode, host, port, username, password,
+                context.getString(R.string.proxy_mode_http_value),
+                context.getString(R.string.proxy_mode_socks_value));
+    }
+
+    private void updateDefaultAuthenticator() {
+        Authenticator.setDefault(scopedAuthenticator);
+    }
+
+    @Nullable
+    private okhttp3.Request authenticateOkHttp(@Nullable final okhttp3.Route route,
+                                               @NonNull final okhttp3.Response response) {
+        final ProxyConfiguration current = configuration;
+        if (!current.hasAuthentication() || route == null
+                || !isConfiguredProxy(route.proxy(), current.host, current.port)
+                || response.request().header("Proxy-Authorization") != null) {
+            return null;
+        }
+        return response.request().newBuilder()
+                .header("Proxy-Authorization", okhttp3.Credentials.basic(
+                        current.username, current.password))
+                .build();
+    }
+
+    static boolean shouldAuthenticateProxy(@Nullable final Authenticator.RequestorType requestType,
+                                           @Nullable final String requestHost,
+                                           final int requestPort,
+                                           @NonNull final String configuredHost,
+                                           final int configuredPort,
+                                           @NonNull final String username,
+                                           @Nullable final String password) {
+        return requestType == Authenticator.RequestorType.PROXY
+                && requestHost != null && requestHost.equalsIgnoreCase(configuredHost)
+                && requestPort == configuredPort
+                && !username.isBlank() && password != null;
+    }
+
+    static boolean isConfiguredProxy(@Nullable final Proxy proxy,
+                                     @NonNull final String configuredHost,
+                                     final int configuredPort) {
+        if (proxy == null || !(proxy.address() instanceof InetSocketAddress)) {
+            return false;
+        }
+        final InetSocketAddress address = (InetSocketAddress) proxy.address();
+        return address.getHostString().equalsIgnoreCase(configuredHost)
+                && address.getPort() == configuredPort;
+    }
+
+    @NonNull
+    private List<Proxy> selectFallback(@NonNull final URI uri) {
+        if (fallbackSelector == null || fallbackSelector == this) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
+        try {
+            final List<Proxy> selected = fallbackSelector.select(uri);
+            return selected == null || selected.isEmpty()
+                    ? Collections.singletonList(Proxy.NO_PROXY) : selected;
+        } catch (final RuntimeException ignored) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
+    }
+
+    static boolean shouldBypass(@NonNull final URI uri) {
+        final String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http")
+                || scheme.equalsIgnoreCase("https"))) {
+            return true;
+        }
+        final String rawHost = uri.getHost();
+        if (rawHost == null || rawHost.isBlank()) {
+            return true;
+        }
+        final String host = rawHost.toLowerCase(Locale.ROOT);
+        if (host.equals("localhost") || host.endsWith(".localhost")
+                || host.endsWith(".local") || host.endsWith(".lan")
+                || host.endsWith(".home") || host.endsWith(".internal")
+                || !host.contains(".")) {
+            return true;
+        }
+        if (host.contains(":")) {
+            return isPrivateIpv6(host);
+        }
+        return isPrivateIpv4(host);
+    }
+
+    private static boolean isPrivateIpv4(@NonNull final String host) {
+        final String[] parts = host.split("\\.", -1);
+        if (parts.length != 4) {
+            return false;
+        }
+        final int[] octets = new int[4];
+        try {
+            for (int i = 0; i < parts.length; i++) {
+                octets[i] = Integer.parseInt(parts[i]);
+                if (octets[i] < 0 || octets[i] > 255) {
+                    return false;
+                }
+            }
+        } catch (final NumberFormatException ignored) {
+            return false;
+        }
+        return octets[0] == 0 || octets[0] == 10 || octets[0] == 127
+                || octets[0] == 169 && octets[1] == 254
+                || octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31
+                || octets[0] == 192 && octets[1] == 168
+                || octets[0] == 100 && octets[1] >= 64 && octets[1] <= 127
+                || octets[0] >= 224;
+    }
+
+    private static boolean isPrivateIpv6(@NonNull final String host) {
+        final String normalized = host.startsWith("[") && host.endsWith("]")
+                ? host.substring(1, host.length() - 1) : host;
+        return normalized.equals("::1") || normalized.equals("::")
+                || normalized.startsWith("fc") || normalized.startsWith("fd")
+                || normalized.matches("^fe[89ab].*")
+                || normalized.startsWith("::ffff:127.")
+                || normalized.startsWith("::ffff:10.")
+                || normalized.startsWith("::ffff:192.168.")
+                || normalized.matches("^::ffff:172\\.(1[6-9]|2[0-9]|3[01])\\..*")
+                || normalized.matches("^::ffff:100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\..*");
+    }
+
+    private static final class ProxyConfiguration {
+        @Nullable
+        private final Proxy.Type type;
+        @NonNull
+        private final String host;
+        private final int port;
+        @NonNull
+        private final String username;
+        @Nullable
+        private final String password;
+
+        private ProxyConfiguration(@Nullable final Proxy.Type type,
+                                   @NonNull final String host,
+                                   final int port,
+                                   @NonNull final String username,
+                                   @Nullable final String password) {
+            this.type = type;
+            this.host = host;
+            this.port = port;
+            this.username = username;
+            this.password = password;
+        }
+
+        @NonNull
+        static ProxyConfiguration create(@Nullable final String mode,
+                                         @Nullable final String host,
+                                         final int port,
+                                         @Nullable final String username,
+                                         @Nullable final String password,
+                                         @NonNull final String httpValue,
+                                         @NonNull final String socksValue) {
+            final Proxy.Type type;
+            if (httpValue.equals(mode)) {
+                type = Proxy.Type.HTTP;
+            } else if (socksValue.equals(mode)) {
+                type = Proxy.Type.SOCKS;
+            } else {
+                return disabled();
+            }
+            final String normalizedHost = host == null ? "" : host.trim();
+            final String normalizedUsername = username == null ? "" : username;
+            if (normalizedHost.isEmpty() || port < 1 || port > 65_535) {
+                // Fail closed if malformed settings arrive through a restored backup.
+                return new ProxyConfiguration(type, "127.0.0.1", 1,
+                        normalizedUsername, password);
+            }
+            return new ProxyConfiguration(type, normalizedHost, port,
+                    normalizedUsername, password);
+        }
+
+        @NonNull
+        static ProxyConfiguration disabled() {
+            return new ProxyConfiguration(null, "", 0, "", null);
+        }
+
+        boolean isEnabled() {
+            return type != null;
+        }
+
+        boolean hasAuthentication() {
+            return isEnabled() && !username.isBlank() && password != null;
+        }
+
+        @NonNull
+        Proxy toProxy() {
+            return new Proxy(type, InetSocketAddress.createUnresolved(host, port));
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/network/ProxyCredentialStore.java
+++ b/app/src/main/java/org/schabi/newpipe/network/ProxyCredentialStore.java
@@ -1,0 +1,143 @@
+package org.schabi.newpipe.network;
+
+import android.content.Context;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.AtomicFile;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+/** Stores the proxy password encrypted with a key held by Android Keystore. */
+public final class ProxyCredentialStore {
+    private static final String TAG = ProxyCredentialStore.class.getSimpleName();
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    private static final String KEY_ALIAS = "wizestream_proxy_password_v1";
+    private static final String FILE_NAME = "proxy_password_v1";
+    private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int FILE_VERSION = 1;
+    private static final int MIN_IV_BYTES = 12;
+    private static final int MAX_IV_BYTES = 16;
+    private static final int MAX_FILE_BYTES = 16 * 1024;
+
+    @NonNull
+    private final AtomicFile passwordFile;
+
+    public ProxyCredentialStore(@NonNull final Context context) {
+        passwordFile = new AtomicFile(new File(context.getNoBackupFilesDir(), FILE_NAME));
+    }
+
+    public synchronized boolean savePassword(@NonNull final String password) {
+        if (password.isEmpty()) {
+            return clearPassword();
+        }
+        FileOutputStream output = null;
+        try {
+            final Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateEncryptionKey());
+            final byte[] ciphertext = cipher.doFinal(
+                    password.getBytes(StandardCharsets.UTF_8));
+
+            final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (DataOutputStream data = new DataOutputStream(bytes)) {
+                data.writeByte(FILE_VERSION);
+                data.writeByte(cipher.getIV().length);
+                data.write(cipher.getIV());
+                data.write(ciphertext);
+            }
+
+            output = passwordFile.startWrite();
+            output.write(bytes.toByteArray());
+            passwordFile.finishWrite(output);
+            return true;
+        } catch (final Exception e) {
+            if (output != null) {
+                passwordFile.failWrite(output);
+            }
+            Log.e(TAG, "Could not securely store the proxy password", e);
+            return false;
+        }
+    }
+
+    @Nullable
+    public synchronized String readPassword() {
+        if (!passwordFile.getBaseFile().exists()) {
+            return null;
+        }
+        try {
+            final byte[] encrypted = passwordFile.readFully();
+            if (encrypted.length == 0 || encrypted.length > MAX_FILE_BYTES) {
+                return null;
+            }
+            try (DataInputStream input = new DataInputStream(
+                    new ByteArrayInputStream(encrypted))) {
+                if (input.readUnsignedByte() != FILE_VERSION) {
+                    return null;
+                }
+                final int ivLength = input.readUnsignedByte();
+                if (ivLength < MIN_IV_BYTES || ivLength > MAX_IV_BYTES) {
+                    return null;
+                }
+                final byte[] iv = new byte[ivLength];
+                input.readFully(iv);
+                final byte[] ciphertext = new byte[input.available()];
+                input.readFully(ciphertext);
+                if (ciphertext.length == 0) {
+                    return null;
+                }
+
+                final Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+                cipher.init(Cipher.DECRYPT_MODE, getOrCreateEncryptionKey(),
+                        new GCMParameterSpec(128, iv));
+                return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+            }
+        } catch (final Exception e) {
+            Log.e(TAG, "Could not decrypt the proxy password", e);
+            return null;
+        }
+    }
+
+    public synchronized boolean hasPassword() {
+        return readPassword() != null;
+    }
+
+    public synchronized boolean clearPassword() {
+        passwordFile.delete();
+        return !passwordFile.getBaseFile().exists();
+    }
+
+    @NonNull
+    private SecretKey getOrCreateEncryptionKey() throws Exception {
+        final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+        keyStore.load(null);
+        final SecretKey existingKey = (SecretKey) keyStore.getKey(KEY_ALIAS, null);
+        if (existingKey != null) {
+            return existingKey;
+        }
+
+        final KeyGenerator keyGenerator = KeyGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+        keyGenerator.init(new KeyGenParameterSpec.Builder(
+                KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build());
+        return keyGenerator.generateKey();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/YoutubeHttpDataSource.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Sets;
 import com.google.common.net.HttpHeaders;
 
 import org.schabi.newpipe.DownloaderImpl;
+import org.schabi.newpipe.network.AppProxySelector;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -787,7 +788,7 @@ public final class YoutubeHttpDataSource extends BaseDataSource implements HttpD
      * @return an {@link HttpURLConnection} created with the {@code url}
      */
     private HttpURLConnection openConnection(@NonNull final URL url) throws IOException {
-        return (HttpURLConnection) url.openConnection();
+        return AppProxySelector.openConnection(url);
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/NewPipeSettings.java
@@ -60,6 +60,7 @@ public final class NewPipeSettings {
         PreferenceManager.setDefaultValues(context, R.xml.history_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.learning_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.content_settings, true);
+        PreferenceManager.setDefaultValues(context, R.xml.proxy_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.player_notification_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.update_settings, true);
         PreferenceManager.setDefaultValues(context, R.xml.debug_settings, true);

--- a/app/src/main/java/org/schabi/newpipe/settings/ProxySettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ProxySettingsFragment.java
@@ -1,0 +1,120 @@
+package org.schabi.newpipe.settings;
+
+import android.os.Bundle;
+import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
+import android.widget.Toast;
+
+import androidx.preference.EditTextPreference;
+import androidx.preference.ListPreference;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.network.AppProxySelector;
+import org.schabi.newpipe.network.ProxyCredentialStore;
+
+public final class ProxySettingsFragment extends BasePreferenceFragment {
+    private EditTextPreference hostPreference;
+    private EditTextPreference portPreference;
+    private EditTextPreference passwordPreference;
+    private ProxyCredentialStore credentialStore;
+
+    @Override
+    public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
+        addPreferencesFromResourceRegistry();
+
+        final ListPreference modePreference = requirePreference(R.string.proxy_mode_key);
+        hostPreference = requirePreference(R.string.proxy_host_key);
+        portPreference = requirePreference(R.string.proxy_port_key);
+        passwordPreference = requirePreference(R.string.proxy_password_key);
+        credentialStore = new ProxyCredentialStore(requireContext());
+
+        hostPreference.setOnBindEditTextListener(editText -> {
+            editText.setInputType(InputType.TYPE_CLASS_TEXT
+                    | InputType.TYPE_TEXT_VARIATION_URI);
+            editText.setSingleLine(true);
+        });
+        portPreference.setOnBindEditTextListener(editText -> {
+            editText.setInputType(InputType.TYPE_CLASS_NUMBER);
+            editText.setSingleLine(true);
+        });
+        passwordPreference.setPersistent(false);
+        passwordPreference.setOnBindEditTextListener(editText -> {
+            editText.setInputType(InputType.TYPE_CLASS_TEXT
+                    | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+            editText.setTransformationMethod(PasswordTransformationMethod.getInstance());
+            editText.setSingleLine(true);
+        });
+        passwordPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            final String password = String.valueOf(newValue);
+            final boolean saved = password.isEmpty()
+                    ? credentialStore.clearPassword()
+                    : credentialStore.savePassword(password);
+            if (!saved) {
+                Toast.makeText(requireContext(), R.string.proxy_password_save_error,
+                        Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            passwordPreference.setText(null);
+            updatePasswordSummary();
+            AppProxySelector.refreshInstalled();
+            return false;
+        });
+        updatePasswordSummary();
+
+        hostPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!isValidHost(String.valueOf(newValue))) {
+                Toast.makeText(requireContext(), R.string.proxy_invalid_host,
+                        Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            return true;
+        });
+        portPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!isValidPort(String.valueOf(newValue))) {
+                Toast.makeText(requireContext(), R.string.proxy_invalid_port,
+                        Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            return true;
+        });
+        modePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!getString(R.string.proxy_mode_disabled_value).equals(newValue)
+                    && !isValidHost(hostPreference.getText())) {
+                Toast.makeText(requireContext(), R.string.proxy_invalid_host,
+                        Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            if (!getString(R.string.proxy_mode_disabled_value).equals(newValue)
+                    && !isValidPort(portPreference.getText())) {
+                Toast.makeText(requireContext(), R.string.proxy_invalid_port,
+                        Toast.LENGTH_SHORT).show();
+                return false;
+            }
+            return true;
+        });
+    }
+
+    private void updatePasswordSummary() {
+        passwordPreference.setSummary(credentialStore.hasPassword()
+                ? R.string.proxy_password_configured
+                : R.string.proxy_password_not_configured);
+    }
+
+    static boolean isValidHost(final String host) {
+        if (host == null) {
+            return false;
+        }
+        final String value = host.trim();
+        return !value.isEmpty() && !value.contains("://") && !value.contains("/")
+                && value.chars().noneMatch(Character::isWhitespace);
+    }
+
+    static boolean isValidPort(final String port) {
+        try {
+            final int value = Integer.parseInt(port);
+            return value >= 1 && value <= 65_535;
+        } catch (final NumberFormatException ignored) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsResourceRegistry.java
@@ -41,6 +41,7 @@ public final class SettingsResourceRegistry {
         add(LearningSettingsFragment.class, R.xml.learning_settings);
         add(NotificationSettingsFragment.class, R.xml.notifications_settings);
         add(PlayerNotificationSettingsFragment.class, R.xml.player_notification_settings);
+        add(ProxySettingsFragment.class, R.xml.proxy_settings);
         add(UpdateSettingsFragment.class, R.xml.update_settings);
         add(SponsorBlockSettingsFragment.class, R.xml.sponsor_block_settings);
         add(SponsorBlockCategoriesSettingsFragment.class, R.xml.sponsor_block_categories_settings);

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.schabi.newpipe.DownloaderImpl;
+import org.schabi.newpipe.network.AppProxySelector;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -219,7 +220,7 @@ public class DownloadMission extends Mission {
     }
 
     HttpURLConnection openConnection(String url, boolean headRequest, long rangeStart, long rangeEnd) throws IOException {
-        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        HttpURLConnection conn = AppProxySelector.openConnection(new URL(url));
         conn.setInstanceFollowRedirects(true);
         conn.setRequestProperty("User-Agent", DownloaderImpl.USER_AGENT);
         conn.setRequestProperty("Accept", "*/*");

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1626,6 +1626,21 @@
     <string name="dearrow_enable_key">dearrow_enable</string>
     <string name="dearrow_titles_key">dearrow_titles</string>
     <string name="dearrow_thumbnails_key">dearrow_thumbnails</string>
+
+    <!-- Proxy -->
+    <string name="proxy_mode_key">proxy_mode</string>
+    <string name="proxy_host_key">proxy_host</string>
+    <string name="proxy_port_key">proxy_port</string>
+    <string name="proxy_username_key">proxy_username</string>
+    <string name="proxy_password_key">proxy_password</string>
+    <string name="proxy_mode_disabled_value">disabled</string>
+    <string name="proxy_mode_http_value">http</string>
+    <string name="proxy_mode_socks_value">socks5</string>
+    <string-array name="proxy_mode_values">
+        <item>@string/proxy_mode_disabled_value</item>
+        <item>@string/proxy_mode_http_value</item>
+        <item>@string/proxy_mode_socks_value</item>
+    </string-array>
     <string name="sponsor_block_category_sponsor_key">sponsor_block_category_sponsor</string>
     <string name="sponsor_block_category_intro_key">sponsor_block_category_intro</string>
     <string name="sponsor_block_category_outro_key">sponsor_block_category_outro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1433,4 +1433,28 @@
     <string name="local_media_audio_stereo">Stereo</string>
     <string name="local_media_audio_channels">%1$d channels</string>
     <string name="local_media_audio_bitrate">%1$d kbps</string>
+
+    <!-- Proxy -->
+    <string name="proxy_settings_title">Proxy</string>
+    <string name="proxy_settings_summary">Route remote network requests through an HTTP or SOCKS5 proxy</string>
+    <string name="proxy_mode_title">Proxy type</string>
+    <string name="proxy_disabled">Disabled</string>
+    <string name="proxy_http">HTTP</string>
+    <string name="proxy_socks">SOCKS5</string>
+    <string-array name="proxy_mode_entries">
+        <item>@string/proxy_disabled</item>
+        <item>@string/proxy_http</item>
+        <item>@string/proxy_socks</item>
+    </string-array>
+    <string name="proxy_host_title">Proxy host</string>
+    <string name="proxy_port_title">Proxy port</string>
+    <string name="proxy_username_title">Proxy username (optional)</string>
+    <string name="proxy_password_title">Proxy password (optional)</string>
+    <string name="proxy_password_dialog_message">Enter a new password, or leave it blank to clear the saved password.</string>
+    <string name="proxy_password_configured">Password saved securely</string>
+    <string name="proxy_password_not_configured">No password saved</string>
+    <string name="proxy_password_save_error">Could not securely save the proxy password</string>
+    <string name="proxy_invalid_host">Enter a host name or IP address without a URL scheme</string>
+    <string name="proxy_invalid_port">Enter a port from 1 to 65535</string>
+    <string name="proxy_privacy_notice">Changes apply to new connections. Local and LAN addresses bypass the proxy. Passwords are encrypted with Android Keystore and excluded from backup. HTTP Basic and SOCKS5 username/password authentication are supported.</string>
 </resources>

--- a/app/src/main/res/xml/main_settings.xml
+++ b/app/src/main/res/xml/main_settings.xml
@@ -40,6 +40,13 @@
         app:iconSpaceReserved="false" />
 
     <PreferenceScreen
+        android:fragment="org.schabi.newpipe.settings.ProxySettingsFragment"
+        android:icon="@drawable/ic_public"
+        android:summary="@string/proxy_settings_summary"
+        android:title="@string/proxy_settings_title"
+        app:iconSpaceReserved="false" />
+
+    <PreferenceScreen
         android:fragment="org.schabi.newpipe.settings.NotificationsSettingsFragment"
         android:icon="@drawable/ic_notifications"
         android:title="@string/notifications"

--- a/app/src/main/res/xml/proxy_settings.xml
+++ b/app/src/main/res/xml/proxy_settings.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:title="@string/proxy_settings_title">
+
+    <PreferenceCategory
+        android:layout="@layout/settings_category_header_layout"
+        android:title="@string/proxy_settings_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false">
+
+        <ListPreference
+            android:defaultValue="@string/proxy_mode_disabled_value"
+            android:entries="@array/proxy_mode_entries"
+            android:entryValues="@array/proxy_mode_values"
+            android:key="@string/proxy_mode_key"
+            android:title="@string/proxy_mode_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
+            android:key="@string/proxy_host_key"
+            android:title="@string/proxy_host_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
+            android:defaultValue="8080"
+            android:inputType="number"
+            android:key="@string/proxy_port_key"
+            android:title="@string/proxy_port_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
+            android:key="@string/proxy_username_key"
+            android:title="@string/proxy_username_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+
+        <EditTextPreference
+            android:dialogMessage="@string/proxy_password_dialog_message"
+            android:key="@string/proxy_password_key"
+            android:persistent="false"
+            android:title="@string/proxy_password_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+
+        <Preference
+            android:selectable="false"
+            android:summary="@string/proxy_privacy_notice"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/test/java/org/schabi/newpipe/network/AppProxySelectorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/network/AppProxySelectorTest.java
@@ -1,0 +1,76 @@
+package org.schabi.newpipe.network;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+
+public class AppProxySelectorTest {
+    @Test
+    public void localAndPrivateDestinationsBypassProxy() {
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://localhost")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("https://receiver.local/play")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://device")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://127.0.0.1")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://10.1.2.3")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://172.31.1.2")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://192.168.0.10")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://169.254.1.2")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://100.64.1.2")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://[::1]")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://[fd00::1]")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("http://[fe80::1]")));
+    }
+
+    @Test
+    public void publicDestinationsUseConfiguredProxy() {
+        assertFalse(AppProxySelector.shouldBypass(URI.create("https://www.youtube.com/watch?v=x")));
+        assertFalse(AppProxySelector.shouldBypass(URI.create("https://googlevideo.com/video")));
+        assertFalse(AppProxySelector.shouldBypass(URI.create("https://8.8.8.8/query")));
+    }
+
+    @Test
+    public void nonHttpSchemesBypassProxy() {
+        assertTrue(AppProxySelector.shouldBypass(URI.create("file:///storage/video.mp4")));
+        assertTrue(AppProxySelector.shouldBypass(URI.create("content://media/video/1")));
+    }
+
+    @Test
+    public void proxyAuthenticationIsScopedToConfiguredEndpoint() {
+        assertTrue(AppProxySelector.shouldAuthenticateProxy(
+                Authenticator.RequestorType.PROXY, "proxy.example.com", 1080,
+                "proxy.example.com", 1080, "user", "password"));
+        assertFalse(AppProxySelector.shouldAuthenticateProxy(
+                Authenticator.RequestorType.SERVER, "proxy.example.com", 1080,
+                "proxy.example.com", 1080, "user", "password"));
+        assertFalse(AppProxySelector.shouldAuthenticateProxy(
+                Authenticator.RequestorType.PROXY, "other.example.com", 1080,
+                "proxy.example.com", 1080, "user", "password"));
+        assertFalse(AppProxySelector.shouldAuthenticateProxy(
+                Authenticator.RequestorType.PROXY, "proxy.example.com", 8080,
+                "proxy.example.com", 1080, "user", "password"));
+        assertFalse(AppProxySelector.shouldAuthenticateProxy(
+                Authenticator.RequestorType.PROXY, "proxy.example.com", 1080,
+                "proxy.example.com", 1080, "", "password"));
+        assertFalse(AppProxySelector.shouldAuthenticateProxy(
+                Authenticator.RequestorType.PROXY, "proxy.example.com", 1080,
+                "proxy.example.com", 1080, "user", null));
+    }
+
+    @Test
+    public void okHttpProxyEndpointMatchingUsesHostAndPort() {
+        final Proxy proxy = new Proxy(Proxy.Type.HTTP,
+                InetSocketAddress.createUnresolved("proxy.example.com", 8080));
+        assertTrue(AppProxySelector.isConfiguredProxy(proxy, "proxy.example.com", 8080));
+        assertTrue(AppProxySelector.isConfiguredProxy(proxy, "PROXY.EXAMPLE.COM", 8080));
+        assertFalse(AppProxySelector.isConfiguredProxy(proxy, "other.example.com", 8080));
+        assertFalse(AppProxySelector.isConfiguredProxy(proxy, "proxy.example.com", 1080));
+        assertFalse(AppProxySelector.isConfiguredProxy(Proxy.NO_PROXY,
+                "proxy.example.com", 8080));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/settings/ProxySettingsFragmentTest.java
+++ b/app/src/test/java/org/schabi/newpipe/settings/ProxySettingsFragmentTest.java
@@ -1,0 +1,29 @@
+package org.schabi.newpipe.settings;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ProxySettingsFragmentTest {
+    @Test
+    public void validatesProxyHosts() {
+        assertTrue(ProxySettingsFragment.isValidHost("proxy.example.com"));
+        assertTrue(ProxySettingsFragment.isValidHost("127.0.0.1"));
+        assertTrue(ProxySettingsFragment.isValidHost("::1"));
+        assertFalse(ProxySettingsFragment.isValidHost(""));
+        assertFalse(ProxySettingsFragment.isValidHost("https://proxy.example.com"));
+        assertFalse(ProxySettingsFragment.isValidHost("proxy.example.com/path"));
+        assertFalse(ProxySettingsFragment.isValidHost("proxy example.com"));
+    }
+
+    @Test
+    public void validatesProxyPorts() {
+        assertTrue(ProxySettingsFragment.isValidPort("1"));
+        assertTrue(ProxySettingsFragment.isValidPort("8080"));
+        assertTrue(ProxySettingsFragment.isValidPort("65535"));
+        assertFalse(ProxySettingsFragment.isValidPort("0"));
+        assertFalse(ProxySettingsFragment.isValidPort("65536"));
+        assertFalse(ProxySettingsFragment.isValidPort("proxy"));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -11,6 +11,9 @@ Release history is listed newest first. The number beside each release is its An
 - Added opt-in native Android picture-in-picture for visible video playback on Android 8 and newer,
   with automatic Android 12+ entry, media-session controls, and popup-player fallback on older
   devices.
+- Added app-wide HTTP and SOCKS5 proxy configuration for remote browsing, playback, images, and
+  downloads, including securely stored proxy authentication and automatic local-network bypass
+  for casting and device synchronization.
 
 ### Improvements
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,6 +70,20 @@ videos and channels, remove individual rules, or clear everything. Matching remo
 channels, posts, playlists, feeds, search results, and related content are hidden locally. Blocking
 does not unsubscribe from channels, delete history, or report anything to a service.
 
+## How do proxy settings work?
+
+Open **Settings > Proxy** and select **HTTP** or **SOCKS5**, then enter the proxy host and port.
+The setting applies to new remote browsing, image, playback, download, update, and community-service
+connections. Existing connections are closed when the configuration changes.
+
+Localhost, private IP addresses, and local host names bypass the proxy so TV casting and device
+synchronization remain reachable on the LAN. HTTPS content stays encrypted in transit, but the proxy
+operator can still see destination hosts. Optional HTTP Basic and SOCKS5 username/password
+authentication is supported. The password is encrypted with Android Keystore in app-private,
+non-backed-up storage and is never included in WizeStream exports. HTTP Basic credentials are not
+encrypted between the device and a plain HTTP proxy, so use only a proxy and network you trust. A
+failed configured proxy does not silently expose the request through a direct connection.
+
 ## What is DeArrow support?
 
 DeArrow is an optional community service that provides descriptive YouTube titles and alternative


### PR DESCRIPTION
- add app-wide HTTP and SOCKS5 proxy settings for remote requests
- support optional HTTP Basic and SOCKS5 username/password authentication
- encrypt proxy passwords with Android Keystore in app-private, non-backed-up storage
- scope credentials to the configured proxy host and port so they are never sent to destination servers
- cover extractor/API traffic, images, playback media, and downloads
- bypass localhost and private/LAN destinations for casting and device sync
- reload the live selector and clear affected connections/caches when settings change
- fail closed instead of silently falling back to a direct connection