### PR TITLE
Add first-class audio listening mode

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlaybackPresentationMode.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlaybackPresentationMode.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player;
+
+/** Describes how active playback is presented without creating a second playback engine. */
+public enum PlaybackPresentationMode {
+    VIDEO(true, false),
+    LISTEN_VISUALIZER(false, true),
+    AUDIO_BACKGROUND(false, false),
+    CAR_AUDIO(false, false);
+
+    private final boolean rendersVideo;
+    private final boolean allowsVisualizer;
+
+    PlaybackPresentationMode(final boolean rendersVideo, final boolean allowsVisualizer) {
+        this.rendersVideo = rendersVideo;
+        this.allowsVisualizer = allowsVisualizer;
+    }
+
+    public boolean rendersVideo() {
+        return rendersVideo;
+    }
+
+    public boolean allowsVisualizer() {
+        return allowsVisualizer;
+    }
+
+    public boolean isAudioOnly() {
+        return !rendersVideo;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -293,6 +293,8 @@ public final class Player implements PlaybackListener, Listener {
     // audio only mode does not mean that player type is background, but that the player was
     // minimized to background but will resume automatically to the original player type
     private boolean isAudioOnly = false;
+    @NonNull
+    private PlaybackPresentationMode playbackPresentationMode = PlaybackPresentationMode.VIDEO;
     private boolean isPrepared = false;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -439,6 +441,11 @@ public final class Player implements PlaybackListener, Listener {
         }
         initUIsForCurrentPlayerType();
         isAudioOnly = audioPlayerSelected();
+        if (playerIntentType != PlayerIntentType.TimestampChange) {
+            playbackPresentationMode = audioPlayerSelected()
+                    ? PlaybackPresentationMode.AUDIO_BACKGROUND
+                    : PlaybackPresentationMode.VIDEO;
+        }
 
         if (intent.hasExtra(PLAYBACK_QUALITY)) {
             videoResolver.setPlaybackQuality(intent.getStringExtra(PLAYBACK_QUALITY));
@@ -3318,6 +3325,16 @@ public final class Player implements PlaybackListener, Listener {
                 .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, !videoAndSubtitlesEnabled));
     }
 
+    public void setPlaybackPresentationMode(
+            @NonNull final PlaybackPresentationMode newMode) {
+        if (playbackPresentationMode == newMode) {
+            return;
+        }
+        playbackPresentationMode = newMode;
+        useVideoAndSubtitles(newMode.rendersVideo());
+        UIs.call(playerUi -> playerUi.onPlaybackPresentationModeChanged(newMode));
+    }
+
     /**
      * Return whether the play queue manager needs to be reloaded when switching player type.
      *
@@ -3503,6 +3520,11 @@ public final class Player implements PlaybackListener, Listener {
 
     public boolean isAudioOnly() {
         return isAudioOnly;
+    }
+
+    @NonNull
+    public PlaybackPresentationMode getPlaybackPresentationMode() {
+        return playbackPresentationMode;
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -62,6 +62,7 @@ import org.schabi.newpipe.learning.LearningNoteDialog;
 import org.schabi.newpipe.learning.LearningNoteManager;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.PlaybackPresentationMode;
 import org.schabi.newpipe.player.equalizer.EqualizerDialog;
 import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.event.PlayerServiceEventListener;
@@ -180,6 +181,13 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.equalizerButton.setOnClickListener(v ->
                 getParentActivity().ifPresent(activity -> EqualizerDialog.show(
                         activity, EqualizerDialog.forPlayer(player))));
+        binding.listenModeButton.setOnClickListener(v -> {
+            final boolean listening = player.getPlaybackPresentationMode()
+                    == PlaybackPresentationMode.LISTEN_VISUALIZER;
+            player.setPlaybackPresentationMode(listening
+                    ? PlaybackPresentationMode.VIDEO
+                    : PlaybackPresentationMode.LISTEN_VISUALIZER);
+        });
         binding.learningNoteButton.setOnClickListener(v -> showLearningNoteDialog());
 
         binding.addToPlaylistButton.setOnClickListener(v ->
@@ -256,6 +264,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.segmentsButton.setOnClickListener(null);
         binding.sleepTimerButton.setOnClickListener(null);
         binding.equalizerButton.setOnClickListener(null);
+        binding.listenModeButton.setOnClickListener(null);
         binding.addToPlaylistButton.setOnClickListener(null);
         hideSponsorBlockSkipButton();
         clearSponsorBlockSeekBarMarkers();
@@ -350,6 +359,8 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.sleepTimerButton.setVisibility(View.VISIBLE);
         binding.equalizerButton.setVisibility(View.VISIBLE);
         binding.equalizerButton.setActivated(player.getEqualizerState().isEnabled());
+        binding.listenModeButton.setVisibility(View.VISIBLE);
+        updateListenModeUi(player.getPlaybackPresentationMode());
         updateLearningNoteButtonVisibility(player.getCurrentStreamInfo().orElse(null));
         binding.switchMute.setVisibility(View.VISIBLE);
         binding.playerCloseButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
@@ -364,6 +375,23 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.audioTrackTextView.setMaxWidth(Integer.MAX_VALUE);
         updateSleepTimerButton(player.getSleepTimerMode(),
                 player.getSleepTimerRemainingMillis());
+    }
+
+    @Override
+    public void onPlaybackPresentationModeChanged(
+            @NonNull final PlaybackPresentationMode mode) {
+        updateListenModeUi(mode);
+        updateStreamRelatedViews();
+        if (mode.rendersVideo()) {
+            setupVideoSurfaceIfNeeded();
+        }
+    }
+
+    private void updateListenModeUi(@NonNull final PlaybackPresentationMode mode) {
+        final boolean listening = mode == PlaybackPresentationMode.LISTEN_VISUALIZER;
+        binding.listenModeButton.setActivated(listening);
+        binding.listenModeButton.setContentDescription(context.getString(listening
+                ? R.string.exit_listen_mode : R.string.enter_listen_mode));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -16,6 +16,7 @@ import com.google.android.exoplayer2.video.VideoSize;
 import org.schabi.newpipe.extractor.sponsorblock.SponsorBlockSegment;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.PlaybackPresentationMode;
 import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.helper.SleepTimer;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
@@ -71,6 +72,13 @@ public abstract class PlayerUi {
      * will therefore always be not null.
      */
     public void initPlayback() {
+    }
+
+    /**
+     * @param mode the new video, listening, background, or car presentation mode
+     */
+    public void onPlaybackPresentationModeChanged(
+            @NonNull final PlaybackPresentationMode mode) {
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -1072,7 +1072,18 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         seekbarPreviewThumbnailHolder.resetFrom(player.getContext(), Collections.emptyList());
     }
 
-    private void updateStreamRelatedViews() {
+    protected void updateStreamRelatedViews() {
+        if (!player.getPlaybackPresentationMode().rendersVideo()) {
+            binding.qualityTextView.setVisibility(View.GONE);
+            binding.audioTrackTextView.setVisibility(View.GONE);
+            binding.surfaceView.setVisibility(View.GONE);
+            binding.endScreen.setVisibility(View.VISIBLE);
+            binding.playbackLiveSync.setVisibility(View.GONE);
+            binding.playbackEndTime.setVisibility(View.VISIBLE);
+            buildPlaybackSpeedMenu();
+            binding.playbackSpeed.setVisibility(View.VISIBLE);
+            return;
+        }
         player.getCurrentStreamInfo().ifPresent(info -> {
             binding.qualityTextView.setVisibility(View.GONE);
             binding.audioTrackTextView.setVisibility(View.GONE);

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -410,6 +410,20 @@
                         app:tint="@color/white" />
 
                     <androidx.appcompat.widget.AppCompatImageButton
+                        android:id="@+id/listenModeButton"
+                        android:layout_width="35dp"
+                        android:layout_height="35dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:clickable="true"
+                        android:contentDescription="@string/enter_listen_mode"
+                        android:focusable="true"
+                        android:padding="@dimen/player_main_buttons_padding"
+                        android:scaleType="fitCenter"
+                        android:src="@drawable/ic_headset"
+                        app:tint="@color/white" />
+
+                    <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/switchMute"
                         android:layout_width="wrap_content"
                         android:layout_height="37dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1388,6 +1388,8 @@
     <string name="sponsor_block_skip_button_content_description">Skip SponsorBlock segment</string>
     <!-- Equalizer -->
     <string name="equalizer">Equalizer</string>
+    <string name="enter_listen_mode">Listen without video</string>
+    <string name="exit_listen_mode">Return to video</string>
     <string name="equalizer_settings_key" translatable="false">equalizer_settings</string>
     <string name="equalizer_enable">Enable equalizer</string>
     <string name="equalizer_preset">Preset</string>

--- a/app/src/test/java/org/schabi/newpipe/player/PlaybackPresentationModeTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlaybackPresentationModeTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlaybackPresentationModeTest {
+    @Test
+    public void onlyVideoModeRendersVideo() {
+        assertThat(PlaybackPresentationMode.VIDEO.rendersVideo()).isTrue();
+        assertThat(PlaybackPresentationMode.LISTEN_VISUALIZER.rendersVideo()).isFalse();
+        assertThat(PlaybackPresentationMode.AUDIO_BACKGROUND.rendersVideo()).isFalse();
+        assertThat(PlaybackPresentationMode.CAR_AUDIO.rendersVideo()).isFalse();
+    }
+
+    @Test
+    public void visualizerIsLimitedToVisibleListenMode() {
+        assertThat(PlaybackPresentationMode.LISTEN_VISUALIZER.allowsVisualizer()).isTrue();
+        assertThat(PlaybackPresentationMode.VIDEO.allowsVisualizer()).isFalse();
+        assertThat(PlaybackPresentationMode.AUDIO_BACKGROUND.allowsVisualizer()).isFalse();
+        assertThat(PlaybackPresentationMode.CAR_AUDIO.allowsVisualizer()).isFalse();
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/PlaybackPresentationModeTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlaybackPresentationModeTest.java
@@ -5,24 +5,25 @@
 
 package org.schabi.newpipe.player;
 
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 public class PlaybackPresentationModeTest {
     @Test
     public void onlyVideoModeRendersVideo() {
-        assertThat(PlaybackPresentationMode.VIDEO.rendersVideo()).isTrue();
-        assertThat(PlaybackPresentationMode.LISTEN_VISUALIZER.rendersVideo()).isFalse();
-        assertThat(PlaybackPresentationMode.AUDIO_BACKGROUND.rendersVideo()).isFalse();
-        assertThat(PlaybackPresentationMode.CAR_AUDIO.rendersVideo()).isFalse();
+        assertTrue(PlaybackPresentationMode.VIDEO.rendersVideo());
+        assertFalse(PlaybackPresentationMode.LISTEN_VISUALIZER.rendersVideo());
+        assertFalse(PlaybackPresentationMode.AUDIO_BACKGROUND.rendersVideo());
+        assertFalse(PlaybackPresentationMode.CAR_AUDIO.rendersVideo());
     }
 
     @Test
     public void visualizerIsLimitedToVisibleListenMode() {
-        assertThat(PlaybackPresentationMode.LISTEN_VISUALIZER.allowsVisualizer()).isTrue();
-        assertThat(PlaybackPresentationMode.VIDEO.allowsVisualizer()).isFalse();
-        assertThat(PlaybackPresentationMode.AUDIO_BACKGROUND.allowsVisualizer()).isFalse();
-        assertThat(PlaybackPresentationMode.CAR_AUDIO.allowsVisualizer()).isFalse();
+        assertTrue(PlaybackPresentationMode.LISTEN_VISUALIZER.allowsVisualizer());
+        assertFalse(PlaybackPresentationMode.VIDEO.allowsVisualizer());
+        assertFalse(PlaybackPresentationMode.AUDIO_BACKGROUND.allowsVisualizer());
+        assertFalse(PlaybackPresentationMode.CAR_AUDIO.allowsVisualizer());
     }
 }

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### New features
 
+- Added a first-class Listen mode that switches videos to audio-only playback without losing the
+  queue or playback position and keeps the normal player controls available.
 - Added continuous pinch-to-zoom from 100% to 400% and two-finger panning in the main player while
   preserving the existing vertical two-finger playback-speed gesture.
 - Added opt-in native Android picture-in-picture for visible video playback on Android 8 and newer,


### PR DESCRIPTION
- add a first-class Listen mode to the main player
- preserve the active queue and recovery position when switching modes
- prefer audio-only sources and disable video/subtitle renderers
- expose one shared presentation-mode contract for phone, background, visualizer, and car playback
- add player controls, accessibility labels, changelog entry, and regression tests