### PR TITLE
Add permission-free audio visualizer

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -134,6 +134,7 @@ import org.schabi.newpipe.player.ui.PlayerUi;
 import org.schabi.newpipe.player.ui.PlayerUiList;
 import org.schabi.newpipe.player.ui.PopupPlayerUi;
 import org.schabi.newpipe.player.ui.VideoPlayerUi;
+import org.schabi.newpipe.player.visualizer.VisualizerAudioProcessor;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.InfoCache;
@@ -259,6 +260,8 @@ public final class Player implements PlaybackListener, Listener {
     private final LoadController loadController;
     @NonNull
     private final DefaultRenderersFactory renderFactory;
+    @NonNull
+    private final VisualizerAudioProcessor visualizerAudioProcessor;
 
     @NonNull
     private final VideoPlaybackResolver videoResolver;
@@ -364,10 +367,12 @@ public final class Player implements PlaybackListener, Listener {
                 new DefaultBandwidthMeter.Builder(context).build());
         loadController = new LoadController();
 
-        renderFactory = prefs.getBoolean(
+        visualizerAudioProcessor = new VisualizerAudioProcessor();
+        final boolean useCustomVideoRenderer = prefs.getBoolean(
                 context.getString(
-                        R.string.always_use_exoplayer_set_output_surface_workaround_key), false)
-                ? new CustomRenderersFactory(context) : new DefaultRenderersFactory(context);
+                        R.string.always_use_exoplayer_set_output_surface_workaround_key), false);
+        renderFactory = new CustomRenderersFactory(context, useCustomVideoRenderer,
+                visualizerAudioProcessor);
 
         renderFactory.setEnableDecoderFallback(
                 prefs.getBoolean(
@@ -1794,7 +1799,8 @@ public final class Player implements PlaybackListener, Listener {
     private void updateAudioTunneling() {
         final boolean tunnelingEnabled = !prefs.getBoolean(
                 context.getString(R.string.disable_media_tunneling_key), false)
-                && !equalizerController.getState().isEnabled();
+                && !equalizerController.getState().isEnabled()
+                && !playbackPresentationMode.allowsVisualizer();
         trackSelector.setParameters(trackSelector.buildUponParameters()
                 .setTunnelingEnabled(tunnelingEnabled));
     }
@@ -3331,7 +3337,9 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
         playbackPresentationMode = newMode;
+        visualizerAudioProcessor.setEnabled(newMode.allowsVisualizer());
         useVideoAndSubtitles(newMode.rendersVideo());
+        updateAudioTunneling();
         UIs.call(playerUi -> playerUi.onPlaybackPresentationModeChanged(newMode));
     }
 
@@ -3525,6 +3533,11 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     public PlaybackPresentationMode getPlaybackPresentationMode() {
         return playbackPresentationMode;
+    }
+
+    @NonNull
+    public VisualizerAudioProcessor getVisualizerAudioProcessor() {
+        return visualizerAudioProcessor;
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
@@ -3,10 +3,17 @@ package org.schabi.newpipe.player.helper;
 import android.content.Context;
 import android.os.Handler;
 
+import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.Renderer;
+import com.google.android.exoplayer2.audio.AudioProcessor;
+import com.google.android.exoplayer2.audio.AudioSink;
+import com.google.android.exoplayer2.audio.DefaultAudioSink;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
+
+import org.schabi.newpipe.player.visualizer.VisualizerAudioProcessor;
 
 import java.util.ArrayList;
 
@@ -21,9 +28,26 @@ import java.util.ArrayList;
  * </p>
  */
 public final class CustomRenderersFactory extends DefaultRenderersFactory {
+    private final boolean useCustomVideoRenderer;
+    private final VisualizerAudioProcessor visualizerAudioProcessor;
 
     public CustomRenderersFactory(final Context context) {
+        this(context, true, new VisualizerAudioProcessor());
+    }
+
+    /**
+     * Create a renderer factory with decoded-audio visualization support.
+     *
+     * @param context application context
+     * @param useCustomVideoRenderer whether the surface workaround renderer should be used
+     * @param visualizerAudioProcessor processor that receives decoded PCM samples
+     */
+    public CustomRenderersFactory(final Context context,
+                                  final boolean useCustomVideoRenderer,
+                                  final VisualizerAudioProcessor visualizerAudioProcessor) {
         super(context);
+        this.useCustomVideoRenderer = useCustomVideoRenderer;
+        this.visualizerAudioProcessor = visualizerAudioProcessor;
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -36,8 +60,30 @@ public final class CustomRenderersFactory extends DefaultRenderersFactory {
                                        final VideoRendererEventListener eventListener,
                                        final long allowedVideoJoiningTimeMs,
                                        final ArrayList<Renderer> out) {
+        if (!useCustomVideoRenderer) {
+            super.buildVideoRenderers(context, extensionRendererMode, mediaCodecSelector,
+                    enableDecoderFallback, eventHandler, eventListener,
+                    allowedVideoJoiningTimeMs, out);
+            return;
+        }
         out.add(new CustomMediaCodecVideoRenderer(context, getCodecAdapterFactory(),
                 mediaCodecSelector, allowedVideoJoiningTimeMs, enableDecoderFallback, eventHandler,
                 eventListener, MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY));
+    }
+
+    @Nullable
+    @Override
+    protected AudioSink buildAudioSink(final Context context,
+                                       final boolean enableFloatOutput,
+                                       final boolean enableAudioTrackPlaybackParams,
+                                       final boolean enableOffload) {
+        return new DefaultAudioSink.Builder(context)
+                .setEnableFloatOutput(enableFloatOutput)
+                .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                .setOffloadMode(enableOffload
+                        ? DefaultAudioSink.OFFLOAD_MODE_ENABLED_GAPLESS_REQUIRED
+                        : DefaultAudioSink.OFFLOAD_MODE_DISABLED)
+                .setAudioProcessors(new AudioProcessor[] {visualizerAudioProcessor})
+                .build();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -360,6 +360,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.equalizerButton.setVisibility(View.VISIBLE);
         binding.equalizerButton.setActivated(player.getEqualizerState().isEnabled());
         binding.listenModeButton.setVisibility(View.VISIBLE);
+        binding.audioVisualizer.setAudioProcessor(player.getVisualizerAudioProcessor());
         updateListenModeUi(player.getPlaybackPresentationMode());
         updateLearningNoteButtonVisibility(player.getCurrentStreamInfo().orElse(null));
         binding.switchMute.setVisibility(View.VISIBLE);
@@ -390,6 +391,10 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     private void updateListenModeUi(@NonNull final PlaybackPresentationMode mode) {
         final boolean listening = mode == PlaybackPresentationMode.LISTEN_VISUALIZER;
         binding.listenModeButton.setActivated(listening);
+        binding.audioVisualizer.setVisibility(listening ? View.VISIBLE : View.GONE);
+        if (listening) {
+            binding.endScreen.setVisibility(View.GONE);
+        }
         binding.listenModeButton.setContentDescription(context.getString(listening
                 ? R.string.exit_listen_mode : R.string.enter_listen_mode));
     }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -1077,7 +1077,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
             binding.qualityTextView.setVisibility(View.GONE);
             binding.audioTrackTextView.setVisibility(View.GONE);
             binding.surfaceView.setVisibility(View.GONE);
-            binding.endScreen.setVisibility(View.VISIBLE);
+            binding.endScreen.setVisibility(player.getPlaybackPresentationMode().allowsVisualizer()
+                    ? View.GONE : View.VISIBLE);
             binding.playbackLiveSync.setVisibility(View.GONE);
             binding.playbackEndTime.setVisibility(View.VISIBLE);
             buildPlaybackSpeedMenu();

--- a/app/src/main/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessor.java
@@ -1,0 +1,87 @@
+package org.schabi.newpipe.player.visualizer;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.audio.AudioProcessor;
+import com.google.android.exoplayer2.audio.BaseAudioProcessor;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+/**
+ * Pass-through PCM processor that exposes a small, normalized waveform for the player visualizer.
+ * It operates on decoded audio and therefore does not require microphone access.
+ */
+public final class VisualizerAudioProcessor extends BaseAudioProcessor {
+    public static final int SAMPLE_COUNT = 128;
+
+    private final float[] workingSamples = new float[SAMPLE_COUNT];
+    private volatile float[] latestSamples = new float[SAMPLE_COUNT];
+    private volatile boolean enabled;
+
+    /**
+     * Enable or disable waveform capture. Audio remains pass-through in both states.
+     *
+     * @param enabled whether waveform capture should run
+     */
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+        if (!enabled) {
+            latestSamples = new float[SAMPLE_COUNT];
+        }
+    }
+
+    /**
+     * Copy the latest waveform into a caller-owned array.
+     *
+     * @param target destination array
+     * @return number of samples copied
+     */
+    public int copyLatestSamples(final float[] target) {
+        final float[] snapshot = latestSamples;
+        final int count = Math.min(target.length, snapshot.length);
+        System.arraycopy(snapshot, 0, target, 0, count);
+        return count;
+    }
+
+    @Override
+    protected AudioFormat onConfigure(final AudioFormat inputAudioFormat)
+            throws AudioProcessor.UnhandledAudioFormatException {
+        return inputAudioFormat.encoding == C.ENCODING_PCM_16BIT
+                ? inputAudioFormat : AudioFormat.NOT_SET;
+    }
+
+    @Override
+    public void queueInput(final ByteBuffer inputBuffer) {
+        final int size = inputBuffer.remaining();
+        if (enabled && size >= 2) {
+            captureWaveform(inputBuffer);
+        }
+        final ByteBuffer outputBuffer = replaceOutputBuffer(size);
+        outputBuffer.put(inputBuffer);
+        outputBuffer.flip();
+    }
+
+    private void captureWaveform(final ByteBuffer inputBuffer) {
+        final ByteBuffer samples = inputBuffer.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        final int channelCount = Math.max(1, inputAudioFormat.channelCount);
+        final int frameSize = channelCount * 2;
+        final int frameCount = samples.remaining() / frameSize;
+        if (frameCount == 0) {
+            return;
+        }
+
+        Arrays.fill(workingSamples, 0.0f);
+        for (int outputIndex = 0; outputIndex < SAMPLE_COUNT; outputIndex++) {
+            final int frame = Math.min(frameCount - 1,
+                    outputIndex * frameCount / SAMPLE_COUNT);
+            final int frameOffset = samples.position() + frame * frameSize;
+            float mixed = 0.0f;
+            for (int channel = 0; channel < channelCount; channel++) {
+                mixed += samples.getShort(frameOffset + channel * 2) / 32768.0f;
+            }
+            workingSamples[outputIndex] = mixed / channelCount;
+        }
+        latestSamples = workingSamples.clone();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/AudioVisualizerView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/AudioVisualizerView.java
@@ -1,0 +1,93 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.LinearGradient;
+import android.graphics.Paint;
+import android.graphics.Shader;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.player.visualizer.VisualizerAudioProcessor;
+
+/** A lightweight spectrum view backed by decoded player audio. */
+public final class AudioVisualizerView extends View {
+    private static final int BAR_COUNT = 24;
+    private static final float MIN_BAR_HEIGHT = 0.03f;
+    private static final float SMOOTHING = 0.72f;
+
+    private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final float[] samples = new float[VisualizerAudioProcessor.SAMPLE_COUNT];
+    private final float[] levels = new float[BAR_COUNT];
+    @Nullable
+    private VisualizerAudioProcessor audioProcessor;
+
+    public AudioVisualizerView(final Context context, @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+        paint.setStyle(Paint.Style.FILL);
+    }
+
+    /**
+     * Set the decoded-audio source used by this view.
+     *
+     * @param processor visualizer processor, or {@code null} to detach
+     */
+    public void setAudioProcessor(@Nullable final VisualizerAudioProcessor processor) {
+        audioProcessor = processor;
+        invalidate();
+    }
+
+    @Override
+    protected void onDraw(final Canvas canvas) {
+        super.onDraw(canvas);
+        final VisualizerAudioProcessor processor = audioProcessor;
+        if (processor == null || getWidth() == 0 || getHeight() == 0) {
+            return;
+        }
+        processor.copyLatestSamples(samples);
+        updateLevels();
+        drawBars(canvas);
+        if (getVisibility() == VISIBLE && isShown()) {
+            postInvalidateOnAnimation();
+        }
+    }
+
+    private void updateLevels() {
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final int frequencyBin = bar + 1;
+            double real = 0.0;
+            double imaginary = 0.0;
+            for (int sample = 0; sample < samples.length; sample++) {
+                final double window = 0.5 - 0.5
+                        * Math.cos(2.0 * Math.PI * sample / (samples.length - 1));
+                final double angle = 2.0 * Math.PI * frequencyBin * sample / samples.length;
+                real += samples[sample] * window * Math.cos(angle);
+                imaginary -= samples[sample] * window * Math.sin(angle);
+            }
+            final float magnitude = (float) Math.min(1.0,
+                    Math.hypot(real, imaginary) * 4.0 / samples.length);
+            levels[bar] = Math.max(magnitude, levels[bar] * SMOOTHING);
+        }
+    }
+
+    private void drawBars(final Canvas canvas) {
+        paint.setShader(new LinearGradient(0.0f, getHeight(), 0.0f, 0.0f,
+                Color.rgb(84, 110, 255), Color.rgb(84, 255, 218),
+                Shader.TileMode.CLAMP));
+        final float slotWidth = getWidth() / (float) BAR_COUNT;
+        final float barWidth = slotWidth * 0.58f;
+        final float cornerRadius = barWidth / 2.0f;
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final float centerX = slotWidth * (bar + 0.5f);
+            final float height = getHeight()
+                    * Math.max(MIN_BAR_HEIGHT, levels[bar]);
+            final float top = (getHeight() - height) / 2.0f;
+            final float bottom = (getHeight() + height) / 2.0f;
+            canvas.drawRoundRect(centerX - barWidth / 2.0f, top,
+                    centerX + barWidth / 2.0f, bottom, cornerRadius, cornerRadius, paint);
+        }
+    }
+}

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -54,6 +54,16 @@
         tools:ignore="ContentDescription"
         tools:visibility="visible" />
 
+    <org.schabi.newpipe.views.AudioVisualizerView
+        android:id="@+id/audioVisualizer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_centerInParent="true"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginVertical="72dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <View
         android:id="@+id/playbackControlsShadow"
         android:layout_width="match_parent"

--- a/app/src/test/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessorTest.java
@@ -1,0 +1,37 @@
+package org.schabi.newpipe.player.visualizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.audio.AudioProcessor;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class VisualizerAudioProcessorTest {
+    @Test
+    public void processorPassesAudioThroughAndCapturesWaveform() throws Exception {
+        final VisualizerAudioProcessor processor = new VisualizerAudioProcessor();
+        processor.setEnabled(true);
+        processor.configure(new AudioProcessor.AudioFormat(48_000, 2,
+                C.ENCODING_PCM_16BIT));
+        processor.flush();
+
+        final ByteBuffer input = ByteBuffer.allocateDirect(512)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        for (int i = 0; i < 128; i++) {
+            input.putShort((short) 16_384);
+            input.putShort((short) 16_384);
+        }
+        input.flip();
+        processor.queueInput(input);
+
+        assertEquals(512, processor.getOutput().remaining());
+        final float[] waveform = new float[VisualizerAudioProcessor.SAMPLE_COUNT];
+        assertEquals(waveform.length, processor.copyLatestSamples(waveform));
+        assertTrue(waveform[0] > 0.49f);
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -8,6 +8,8 @@ Release history is listed newest first. The number beside each release is its An
 
 - Added a first-class Listen mode that switches videos to audio-only playback without losing the
   queue or playback position and keeps the normal player controls available.
+- Added a permission-free spectrum visualizer for Listen mode, driven directly by decoded player
+  audio without microphone access.
 - Added continuous pinch-to-zoom from 100% to 400% and two-finger panning in the main player while
   preserving the existing vertical two-finger playback-speed gesture.
 - Added opt-in native Android picture-in-picture for visible video playback on Android 8 and newer,


### PR DESCRIPTION
- render a live spectrum in Listen mode from ExoPlayer's decoded PCM audio
- require no microphone or recording permission
- keep audio pass-through intact and disable tunneling only while visualization is active
- add unit coverage for waveform capture and pass-through behavior