### PR TITLE
Add safe Android Auto audio playback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,10 @@
         android:resizeableActivity="true"
         android:theme="@style/OpeningTheme"
         tools:ignore="AllowBackup">
+
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
         <activity
             android:name=".MainActivity"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
@@ -93,7 +97,7 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
             <intent-filter>
-                <action android:name="android.media.browse.MediaBrowserService"/>
+                <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -190,6 +190,7 @@ public final class Player implements PlaybackListener, Listener {
     public static final String RESUME_PLAYBACK = "resume_playback";
     public static final String PLAY_WHEN_READY = "play_when_ready";
     public static final String PLAYER_TYPE = "player_type";
+    public static final String PLAYBACK_PRESENTATION_MODE = "playback_presentation_mode";
     public static final String PLAYER_INTENT_TYPE = "player_intent_type";
     public static final String PLAYER_INTENT_DATA = "player_intent_data";
 
@@ -447,9 +448,14 @@ public final class Player implements PlaybackListener, Listener {
         initUIsForCurrentPlayerType();
         isAudioOnly = audioPlayerSelected();
         if (playerIntentType != PlayerIntentType.TimestampChange) {
-            playbackPresentationMode = audioPlayerSelected()
-                    ? PlaybackPresentationMode.AUDIO_BACKGROUND
-                    : PlaybackPresentationMode.VIDEO;
+            final PlaybackPresentationMode requestedMode = IntentCompat.getSerializableExtra(
+                    intent, PLAYBACK_PRESENTATION_MODE, PlaybackPresentationMode.class);
+            playbackPresentationMode = requestedMode != null
+                    ? requestedMode
+                    : audioPlayerSelected()
+                            ? PlaybackPresentationMode.AUDIO_BACKGROUND
+                            : PlaybackPresentationMode.VIDEO;
+            visualizerAudioProcessor.setEnabled(playbackPresentationMode.allowsVisualizer());
         }
 
         if (intent.hasExtra(PLAYBACK_QUALITY)) {

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/CarAudioSearchResultSelector.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/CarAudioSearchResultSelector.kt
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.mediabrowser
+
+import org.schabi.newpipe.extractor.InfoItem
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+
+internal object CarAudioSearchResultSelector {
+    fun firstPlayable(items: List<InfoItem>): StreamInfoItem? = items
+        .filterIsInstance<StreamInfoItem>()
+        .firstOrNull()
+}

--- a/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserPlaybackPreparer.kt
@@ -32,6 +32,7 @@ import org.schabi.newpipe.player.playqueue.SinglePlayQueue
 import org.schabi.newpipe.util.ChannelTabHelper
 import org.schabi.newpipe.util.ExtractorHelper
 import org.schabi.newpipe.util.NavigationHelper
+import org.schabi.newpipe.util.ServiceHelper
 
 /**
  * This class is used to cleanly separate the Service implementation (in
@@ -62,7 +63,8 @@ class MediaBrowserPlaybackPreparer(
 
     //region Overrides
     override fun getSupportedPrepareActions(): Long {
-        return PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID
+        return PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID or
+            PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH
     }
 
     override fun onPrepare(playWhenReady: Boolean) {
@@ -81,7 +83,7 @@ class MediaBrowserPlaybackPreparer(
             .subscribe(
                 { playQueue ->
                     clearMediaSessionError.run()
-                    NavigationHelper.playOnBackgroundPlayer(context, playQueue, playWhenReady)
+                    NavigationHelper.playOnCarAudioPlayer(context, playQueue, playWhenReady)
                 },
                 { throwable ->
                     Log.e(TAG, "Failed to start playback of media ID [$mediaId]", throwable)
@@ -91,7 +93,34 @@ class MediaBrowserPlaybackPreparer(
     }
 
     override fun onPrepareFromSearch(query: String, playWhenReady: Boolean, extras: Bundle?) {
-        onUnsupportedError()
+        if (query.isBlank()) {
+            onContentNotFoundError()
+            return
+        }
+
+        disposable?.dispose()
+        val serviceId = ServiceHelper.getSelectedServiceId(context)
+        disposable = ExtractorHelper.searchFor(serviceId, query, listOf(), "")
+            .map { searchInfo ->
+                CarAudioSearchResultSelector.firstPlayable(searchInfo.relatedItems)
+                    ?: throw ContentNotAvailableException("No playable result for: $query")
+            }
+            .flatMap { item ->
+                ExtractorHelper.getStreamInfo(item.serviceId, item.url, false)
+            }
+            .map { info -> SinglePlayQueue(info) as PlayQueue }
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { playQueue ->
+                    clearMediaSessionError.run()
+                    NavigationHelper.playOnCarAudioPlayer(context, playQueue, playWhenReady)
+                },
+                { throwable ->
+                    Log.e(TAG, "Failed to start voice search [$query]", throwable)
+                    onPrepareError(throwable)
+                }
+            )
     }
 
     override fun onPrepareFromUri(uri: Uri, playWhenReady: Boolean, extras: Bundle?) {
@@ -113,6 +142,13 @@ class MediaBrowserPlaybackPreparer(
         setMediaSessionError.accept(
             ContextCompat.getString(context, R.string.content_not_supported),
             PlaybackStateCompat.ERROR_CODE_NOT_SUPPORTED
+        )
+    }
+
+    private fun onContentNotFoundError() {
+        setMediaSessionError.accept(
+            ContextCompat.getString(context, R.string.search_no_results),
+            PlaybackStateCompat.ERROR_CODE_APP_ERROR
         )
     }
 

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -63,6 +63,7 @@ import org.schabi.newpipe.player.Player;
 import org.schabi.newpipe.player.PlayerIntentType;
 import org.schabi.newpipe.player.PlayerService;
 import org.schabi.newpipe.player.PlayerType;
+import org.schabi.newpipe.player.PlaybackPresentationMode;
 import org.schabi.newpipe.player.TimestampChangeData;
 import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.helper.PlayerHolder;
@@ -166,6 +167,25 @@ public final class NavigationHelper {
         final Intent intent = getPlayerIntent(context, PlayerService.class, queue,
                 PlayerIntentType.AllOthers)
                 .putExtra(Player.PLAYER_TYPE, PlayerType.AUDIO)
+                .putExtra(Player.RESUME_PLAYBACK, resumePlayback);
+        ContextCompat.startForegroundService(context, intent);
+    }
+
+    /**
+     * Start audio-only playback requested by an automotive media surface.
+     *
+     * @param context application or service context
+     * @param queue queue selected in the car browser
+     * @param resumePlayback whether playback should start immediately
+     */
+    public static void playOnCarAudioPlayer(final Context context,
+                                            final PlayQueue queue,
+                                            final boolean resumePlayback) {
+        final Intent intent = getPlayerIntent(context, PlayerService.class, queue,
+                PlayerIntentType.AllOthers)
+                .putExtra(Player.PLAYER_TYPE, PlayerType.AUDIO)
+                .putExtra(Player.PLAYBACK_PRESENTATION_MODE,
+                        PlaybackPresentationMode.CAR_AUDIO)
                 .putExtra(Player.RESUME_PLAYBACK, resumePlayback);
         ContextCompat.startForegroundService(context, intent);
     }

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <automotiveApp>
     <uses name="media" />
 </automotiveApp>

--- a/app/src/test/java/org/schabi/newpipe/player/mediabrowser/CarAudioSearchResultSelectorTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/player/mediabrowser/CarAudioSearchResultSelectorTest.kt
@@ -1,0 +1,33 @@
+package org.schabi.newpipe.player.mediabrowser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.schabi.newpipe.extractor.InfoItem
+import org.schabi.newpipe.extractor.channel.ChannelInfoItem
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class CarAudioSearchResultSelectorTest {
+    @Test
+    fun `selects the first stream and ignores non-playable search items`() {
+        val channel = ChannelInfoItem(0, "https://example.com/channel", "Channel")
+        val stream = StreamInfoItem(
+            0,
+            "https://example.com/watch?v=test",
+            "Lesson",
+            StreamType.VIDEO_STREAM
+        )
+
+        assertEquals(
+            stream,
+            CarAudioSearchResultSelector.firstPlayable(listOf<InfoItem>(channel, stream))
+        )
+    }
+
+    @Test
+    fun `returns null when search has no stream`() {
+        val channel = ChannelInfoItem(0, "https://example.com/channel", "Channel")
+        assertNull(CarAudioSearchResultSelector.firstPlayable(listOf(channel)))
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -10,6 +10,8 @@ Release history is listed newest first. The number beside each release is its An
   queue or playback position and keeps the normal player controls available.
 - Added a permission-free spectrum visualizer for Listen mode, driven directly by decoded player
   audio without microphone access.
+- Added Android Auto media browsing and voice-search playback for audio-only listening, with video
+  and visualization intentionally excluded from the driving surface.
 - Added continuous pinch-to-zoom from 100% to 400% and two-finger panning in the main player while
   preserving the existing vertical two-finger playback-speed gesture.
 - Added opt-in native Android picture-in-picture for visible video playback on Android 8 and newer,


### PR DESCRIPTION
- advertise WizeStream as an Android Auto media app
- route car selections through a dedicated audio-only presentation mode
- add voice-search playback for the first playable stream result
- keep video and the phone visualizer out of the automotive surface
- cover voice-search result selection with JVM tests