### PR TITLE
Fix History stream filters

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -24,6 +24,7 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.database.stream.StreamStatisticsEntry;
 import org.schabi.newpipe.database.stream.model.StreamEntity;
+import org.schabi.newpipe.databinding.FragmentPlaylistBinding;
 import org.schabi.newpipe.databinding.PlaylistControlBinding;
 import org.schabi.newpipe.databinding.StatisticPlaylistControlBinding;
 import org.schabi.newpipe.error.ErrorInfo;
@@ -43,6 +44,7 @@ import org.schabi.newpipe.settings.HistorySettingsFragment;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.PlayButtonHelper;
+import org.schabi.newpipe.util.StreamListFilter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,6 +66,8 @@ public class StatisticsPlaylistFragment
     private StatisticSortMode sortMode = StatisticSortMode.LAST_PLAYED;
     private List<StreamStatisticsEntry> completeHistory = Collections.emptyList();
     private String contextualSearchQuery = "";
+    @State
+    StreamListFilter selectedStreamFilter = StreamListFilter.NONE;
 
     private StatisticPlaylistControlBinding headerBinding;
     private PlaylistControlBinding playlistControlBinding;
@@ -127,6 +131,17 @@ public class StatisticsPlaylistFragment
     @Override
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
+        final FragmentPlaylistBinding binding = FragmentPlaylistBinding.bind(rootView);
+        if (selectedStreamFilter != StreamListFilter.NONE) {
+            binding.streamFilterChips.streamFilterChipGroup
+                    .check(selectedStreamFilter.getChipId());
+        }
+        binding.streamFilterChips.streamFilterChipGroup
+                .setOnCheckedStateChangeListener((group, checkedIds) -> {
+                    selectedStreamFilter = StreamListFilter.fromChipId(
+                            checkedIds.isEmpty() ? View.NO_ID : checkedIds.get(0));
+                    showFilteredHistory();
+                });
         if (!useAsFrontPage) {
             setTitle(getString(R.string.title_last_played));
         }
@@ -283,8 +298,15 @@ public class StatisticsPlaylistFragment
         setEmptyStateMessage(ContextualSearchHelper.isActive(contextualSearchQuery)
                 ? R.string.search_no_results : R.string.empty_view_no_videos);
 
+        final List<StreamStatisticsEntry> historyMatchingFilter = new ArrayList<>();
+        for (final StreamStatisticsEntry item : completeHistory) {
+            if (StreamListFilter.matches(selectedStreamFilter, item)) {
+                historyMatchingFilter.add(item);
+            }
+        }
+
         final List<StreamStatisticsEntry> filteredHistory = ContextualSearchHelper.filter(
-                completeHistory,
+                historyMatchingFilter,
                 contextualSearchQuery,
                 item -> new String[]{
                         item.getStreamEntity().getTitle(),

--- a/app/src/main/java/org/schabi/newpipe/util/StreamListFilter.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamListFilter.kt
@@ -2,6 +2,7 @@ package org.schabi.newpipe.util
 
 import androidx.annotation.IdRes
 import org.schabi.newpipe.R
+import org.schabi.newpipe.database.stream.StreamStatisticsEntry
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 
@@ -36,6 +37,16 @@ enum class StreamListFilter(@IdRes val chipId: Int) {
             PARTIALLY_WATCHED -> state?.isValid(stream.duration) == true &&
                 !state.isFinished(stream.duration)
         }
+
+        @JvmStatic
+        fun matches(
+            filter: StreamListFilter,
+            historyEntry: StreamStatisticsEntry
+        ): Boolean = matches(
+            filter,
+            historyEntry.toStreamInfoItem(),
+            StreamStateEntity(historyEntry.streamId, historyEntry.progressMillis)
+        )
 
         private fun isShort(stream: StreamInfoItem): Boolean {
             return !StreamTypeUtil.isLiveStream(stream.streamType) &&

--- a/app/src/test/java/org/schabi/newpipe/util/StreamListFilterTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/util/StreamListFilterTest.kt
@@ -1,8 +1,11 @@
 package org.schabi.newpipe.util
 
+import java.time.OffsetDateTime
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.schabi.newpipe.database.stream.StreamStatisticsEntry
+import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.stream.StreamType
@@ -85,6 +88,40 @@ class StreamListFilterTest {
         )
     }
 
+    @Test
+    fun `history entries support every stream filter using saved progress`() {
+        assertTrue(
+            StreamListFilter.matches(
+                StreamListFilter.UNWATCHED,
+                historyEntry(progressMillis = 0)
+            )
+        )
+        assertTrue(
+            StreamListFilter.matches(
+                StreamListFilter.LIVE,
+                historyEntry(type = StreamType.LIVE_STREAM)
+            )
+        )
+        assertTrue(
+            StreamListFilter.matches(
+                StreamListFilter.SHORTS,
+                historyEntry(duration = 120)
+            )
+        )
+        assertTrue(
+            StreamListFilter.matches(
+                StreamListFilter.PARTIALLY_WATCHED,
+                historyEntry(duration = 600, progressMillis = 120_000)
+            )
+        )
+        assertFalse(
+            StreamListFilter.matches(
+                StreamListFilter.PARTIALLY_WATCHED,
+                historyEntry(duration = 600, progressMillis = 590_000)
+            )
+        )
+    }
+
     private fun stream(
         url: String = "https://example.com/watch/video",
         duration: Long = 60,
@@ -92,4 +129,24 @@ class StreamListFilterTest {
     ) = StreamInfoItem(0, url, "Title", type).apply {
         this.duration = duration
     }
+
+    private fun historyEntry(
+        url: String = "https://example.com/watch/video",
+        duration: Long = 600,
+        type: StreamType = StreamType.VIDEO_STREAM,
+        progressMillis: Long = 0
+    ) = StreamStatisticsEntry(
+        streamEntity = StreamEntity(
+            serviceId = 0,
+            url = url,
+            title = "Title",
+            streamType = type,
+            duration = duration,
+            uploader = "Uploader"
+        ),
+        progressMillis = progressMillis,
+        streamId = 1,
+        latestAccessDate = OffsetDateTime.parse("2026-08-21T12:00:00Z"),
+        watchCount = 1
+    )
 }

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -25,6 +25,7 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Improvements
 
+- Fixed History filter chips not updating the displayed watched-video list.
 - Added bulk video and audio downloads directly from local playlists; entries that already point to
   local media files are skipped.
 


### PR DESCRIPTION
- wire the History filter chips to the shared stream-filter contract
- filter History entries using their saved playback progress
- preserve the selected filter across fragment recreation
- keep filtering compatible with contextual search and sorting
- add regression coverage for Unwatched, Live, Shorts, and Partially watched
- update the unreleased changelog