### PR TITLE
Fix large-screen landscape video crash

### DIFF
--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -535,6 +535,22 @@
                                 android:textSize="@dimen/detail_control_text_size" />
 
                             <org.schabi.newpipe.views.NewPipeTextView
+                                android:id="@+id/detail_controls_cast"
+                                android:layout_width="@dimen/detail_control_width"
+                                android:layout_height="@dimen/detail_control_height"
+                                android:layout_gravity="center_vertical"
+                                android:layout_weight="1"
+                                android:background="?attr/selectableItemBackgroundBorderless"
+                                android:clickable="true"
+                                android:contentDescription="@string/cast_to_tv"
+                                android:drawableTop="@drawable/ic_cast"
+                                android:focusable="true"
+                                android:gravity="center"
+                                android:paddingVertical="@dimen/detail_control_padding"
+                                android:text="@string/cast"
+                                android:textSize="@dimen/detail_control_text_size" />
+
+                            <org.schabi.newpipe.views.NewPipeTextView
                                 android:id="@+id/detail_controls_play_with_kodi"
                                 android:layout_width="@dimen/detail_control_width"
                                 android:layout_height="@dimen/detail_control_height"

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
@@ -27,6 +27,13 @@ public class VideoDetailNavigationResourcesTest {
     }
 
     @Test
+    public void phoneAndLargeLandscapeLayoutsExposeCastControl() throws Exception {
+        assertViewIdExists("layout/fragment_video_detail.xml", "@+id/detail_controls_cast");
+        assertViewIdExists("layout-large-land/fragment_video_detail.xml",
+                "@+id/detail_controls_cast");
+    }
+
+    @Test
     public void navigationMenuHasStableLocalizedDestinations() throws Exception {
         final Document document = parse("menu/video_detail_navigation.xml");
         final var items = document.getElementsByTagName("item");
@@ -79,6 +86,19 @@ public class VideoDetailNavigationResourcesTest {
                                 final String title) {
         assertEquals(id, item.getAttribute("android:id"));
         assertEquals(title, item.getAttribute("android:title"));
+    }
+
+    private void assertViewIdExists(final String layoutPath,
+                                    final String id) throws Exception {
+        final Document document = parse(layoutPath);
+        final var elements = document.getElementsByTagName("*");
+        int matches = 0;
+        for (int index = 0; index < elements.getLength(); index++) {
+            if (id.equals(((Element) elements.item(index)).getAttribute("android:id"))) {
+                matches++;
+            }
+        }
+        assertEquals(layoutPath, 1, matches);
     }
 
     private Document parse(final String relativePath) throws Exception {

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -29,6 +29,10 @@ Release history is listed newest first. The number beside each release is its An
 - Added bulk video and audio downloads directly from local playlists; entries that already point to
   local media files are skipped.
 
+### Fixes
+
+- Fixed a crash when opening video details in landscape on large-screen devices.
+
 ## WizeStream 1.8.0 (`1008000`)
 
 ### New features


### PR DESCRIPTION
- Add the missing Cast control to the large-landscape video-detail layout so rotation cannot dereference a missing bound view.
- Add regression coverage requiring the Cast control in both video-detail layout variants.
- Document the large-screen landscape crash fix in the unreleased changelog.