### PR TITLE
Restore bannerless channel headers

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
@@ -38,14 +38,12 @@ class ChannelHeaderLayoutTest {
         val root = LayoutInflater.from(context)
             .inflate(R.layout.fragment_channel, FrameLayout(context), false)
         val banner = root.findViewById<ImageView>(R.id.channel_banner_image)
-        if (!showBanner) {
-            banner.setImageDrawable(null)
-        }
 
-        val width = View.MeasureSpec.makeMeasureSpec(widthPixels, View.MeasureSpec.EXACTLY)
-        val height = View.MeasureSpec.makeMeasureSpec(heightPixels, View.MeasureSpec.EXACTLY)
-        root.measure(width, height)
-        root.layout(0, 0, root.measuredWidth, root.measuredHeight)
+        measureAndLayout(root, widthPixels, heightPixels)
+        if (!showBanner) {
+            banner.visibility = View.GONE
+            measureAndLayout(root, widthPixels, heightPixels)
+        }
 
         val metadata = root.findViewById<View>(R.id.channel_metadata)
         val metadataRow = root.findViewById<View>(R.id.channel_metadata_row)
@@ -54,13 +52,28 @@ class ChannelHeaderLayoutTest {
         val subscriberCount = root.findViewById<View>(R.id.channel_subscriber_view)
         val subscribeButton = root.findViewById<View>(R.id.channel_subscribe_button)
 
-        assertTrue(metadataRow.top >= banner.bottom)
+        if (showBanner) {
+            assertVisibleAndMeasured(banner)
+            assertTrue(metadataRow.top >= banner.bottom)
+        } else {
+            assertEquals(View.GONE, banner.visibility)
+            assertEquals(0, metadataRow.top)
+            assertEquals(metadataRow.height, metadata.height)
+        }
+
         assertTrue(metadataRow.bottom <= metadata.height)
 
         listOf(avatar, title, subscriberCount, subscribeButton).forEach {
             assertVisibleAndMeasured(it)
             assertContainedIn(metadataRow, it)
         }
+    }
+
+    private fun measureAndLayout(root: View, widthPixels: Int, heightPixels: Int) {
+        val width = View.MeasureSpec.makeMeasureSpec(widthPixels, View.MeasureSpec.EXACTLY)
+        val height = View.MeasureSpec.makeMeasureSpec(heightPixels, View.MeasureSpec.EXACTLY)
+        root.measure(width, height)
+        root.layout(0, 0, root.measuredWidth, root.measuredHeight)
     }
 
     private fun assertVisibleAndMeasured(view: View) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -225,7 +225,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         binding.channelTitleView.setText(name);
         if (!ImageStrategy.shouldLoadImages()) {
             // do not waste space for the banner if it is not going to be loaded
-            binding.channelBannerImage.setImageDrawable(null);
+            binding.channelBannerImage.setVisibility(View.GONE);
         }
     }
 
@@ -648,10 +648,13 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         setInitialData(result.getServiceId(), result.getOriginalUrl(), result.getName());
 
         if (ImageStrategy.shouldLoadImages() && !result.getBanners().isEmpty()) {
+            binding.channelBannerImage.setVisibility(View.VISIBLE);
             CoilHelper.INSTANCE.loadBanner(binding.channelBannerImage, result.getBanners());
         } else {
             // do not waste space for the banner, if the user disabled images or there is not one
+            CoilUtils.dispose(binding.channelBannerImage);
             binding.channelBannerImage.setImageDrawable(null);
+            binding.channelBannerImage.setVisibility(View.GONE);
         }
 
         CoilHelper.INSTANCE.loadAvatar(binding.channelAvatarView, result.getAvatars());

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -32,6 +32,7 @@ Release history is listed newest first. The number beside each release is its An
 ### Fixes
 
 - Fixed a crash when opening video details in landscape on large-screen devices.
+- Fixed channel metadata and Subscribe controls disappearing on channels without banners.
 
 ## WizeStream 1.8.0 (`1008000`)
 


### PR DESCRIPTION
- Hide the channel banner view when banner images are unavailable or disabled so the metadata row remains measured and visible.
- Cancel stale banner requests and restore banner visibility before loading a later banner.
- Add portrait and landscape regression coverage for banner-to-no-banner layout transitions.
- Document the channel Subscribe control fix in the unreleased changelog.