### PR TITLE
Fix empty visualizer audio buffers

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessor.java
@@ -53,6 +53,10 @@ public final class VisualizerAudioProcessor extends BaseAudioProcessor {
 
     @Override
     public void queueInput(final ByteBuffer inputBuffer) {
+        if (!inputBuffer.hasRemaining()) {
+            return;
+        }
+
         final int size = inputBuffer.remaining();
         if (enabled && size >= 2) {
             captureWaveform(inputBuffer);

--- a/app/src/test/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/visualizer/VisualizerAudioProcessorTest.java
@@ -13,6 +13,18 @@ import java.nio.ByteOrder;
 
 public class VisualizerAudioProcessorTest {
     @Test
+    public void processorAcceptsSharedEmptyInput() throws Exception {
+        final VisualizerAudioProcessor processor = new VisualizerAudioProcessor();
+        processor.configure(new AudioProcessor.AudioFormat(48_000, 2,
+                C.ENCODING_PCM_16BIT));
+        processor.flush();
+
+        processor.queueInput(AudioProcessor.EMPTY_BUFFER);
+
+        assertEquals(0, processor.getOutput().remaining());
+    }
+
+    @Test
     public void processorPassesAudioThroughAndCapturesWaveform() throws Exception {
         final VisualizerAudioProcessor processor = new VisualizerAudioProcessor();
         processor.setEnabled(true);

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -33,6 +33,7 @@ Release history is listed newest first. The number beside each release is its An
 
 - Fixed a crash when opening video details in landscape on large-screen devices.
 - Fixed channel metadata and Subscribe controls disappearing on channels without banners.
+- Fixed playback failing with an audio visualizer runtime error on newer Android versions.
 
 ## WizeStream 1.8.0 (`1008000`)
 


### PR DESCRIPTION
- Ignore ExoPlayer’s shared empty audio buffer before allocating or copying visualizer output.
- Preserve waveform capture and pass-through behavior for non-empty PCM audio.
- Add regression coverage for the empty-buffer path that caused the runtime playback failure.
- Document the audio visualizer playback fix in the unreleased changelog.