### PR TITLE
Restore automatic landscape fullscreen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.content.res.Configuration;
 import android.database.ContentObserver;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -279,17 +280,7 @@ public final class VideoDetailFragment
             return;
         }
 
-        if (DeviceUtils.isLandscape(requireContext())) {
-            // If the video is playing but orientation changed
-            // let's make the video in fullscreen again
-            checkLandscape();
-        } else if (playerUi.map(ui -> ui.isFullscreen() && !ui.isVerticalVideo()).orElse(false)
-                // Tablet UI has orientation-independent fullscreen
-                && !DeviceUtils.isTablet(activity)) {
-            // Device is in portrait orientation after rotation but UI is in fullscreen.
-            // Return back to non-fullscreen state
-            playerUi.ifPresent(MainPlayerUi::toggleFullscreen);
-        }
+        syncFullscreenWithOrientation(playerUi);
 
         if (playAfterConnect
                 || ((currentInfo != null || currentLocalItem != null)
@@ -415,6 +406,33 @@ public final class VideoDetailFragment
         // Check if it was loading when the fragment was stopped/paused
         if (wasLoading.getAndSet(false) && !wasCleared()) {
             startLoading(false);
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(@NonNull final Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        if (binding == null || player == null) {
+            return;
+        }
+        // MainActivity handles orientation changes for native PiP, so the fragment is no longer
+        // recreated. Wait until the updated layout is applied, then restore the same fullscreen
+        // transition that previously ran when the player reconnected after rotation.
+        binding.getRoot().post(() -> {
+            if (binding != null && player != null && isAdded()) {
+                syncFullscreenWithOrientation(player.UIs().get(MainPlayerUi.class));
+            }
+        });
+    }
+
+    private void syncFullscreenWithOrientation(
+            @NonNull final Optional<MainPlayerUi> playerUi) {
+        if (DeviceUtils.isLandscape(requireContext())) {
+            checkLandscape();
+        } else if (playerUi.map(ui -> ui.isFullscreen() && !ui.isVerticalVideo()).orElse(false)
+                // Tablet UI has orientation-independent fullscreen.
+                && !DeviceUtils.isTablet(activity)) {
+            playerUi.ifPresent(MainPlayerUi::toggleFullscreen);
         }
     }
 

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -1,0 +1,27 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class VideoDetailOrientationHandlingTest {
+    private final Path projectDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main")
+            : Path.of("app/src/main");
+
+    @Test
+    public void handledConfigurationChangesResyncPlayerFullscreen() throws Exception {
+        final String manifest = Files.readString(projectDirectory.resolve("AndroidManifest.xml"));
+        final String fragment = Files.readString(projectDirectory.resolve(
+                "java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));
+
+        assertTrue(manifest.contains("android:configChanges="
+                + "\"screenSize|smallestScreenSize|screenLayout|orientation\""));
+        assertTrue(fragment.contains("public void onConfigurationChanged("));
+        assertTrue(fragment.contains("syncFullscreenWithOrientation("));
+        assertTrue(fragment.contains("binding.getRoot().post("));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -31,6 +31,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
+- Fixed rotating a playing video to landscape no longer entering fullscreen after native
+  picture-in-picture configuration handling was added.
 - Fixed a crash when opening video details in landscape on large-screen devices.
 - Fixed channel metadata and Subscribe controls disappearing on channels without banners.
 - Fixed playback failing with an audio visualizer runtime error on newer Android versions.


### PR DESCRIPTION
- Re-run the player fullscreen orientation policy after handled configuration changes.
- Restore automatic fullscreen when a playing phone video rotates to landscape.
- Return horizontal videos to embedded playback when rotating back to portrait.
- Preserve tablet-specific fullscreen behavior and native picture-in-picture configuration handling.