### PR TITLE
Add selectable Listen mode visualizers

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/visualizer/VisualizerStyle.java
+++ b/app/src/main/java/org/schabi/newpipe/player/visualizer/VisualizerStyle.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.player.visualizer;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/** Stable visualizer style values stored in the player's shared preferences. */
+public enum VisualizerStyle {
+    CENTERED_BARS("centered_bars"),
+    CLASSIC_BARS("classic_bars"),
+    MIRRORED_BARS("mirrored_bars"),
+    WAVEFORM("waveform"),
+    FILLED_WAVEFORM("filled_waveform"),
+    OSCILLOSCOPE("oscilloscope"),
+    SPECTRUM_LINE("spectrum_line"),
+    MOUNTAIN("mountain"),
+    CIRCULAR_SPECTRUM("circular_spectrum"),
+    RADIAL_WAVEFORM("radial_waveform"),
+    EQUALIZER_BLOCKS("equalizer_blocks"),
+    PARTICLES("particles"),
+    PULSE_RINGS("pulse_rings"),
+    VU_METERS("vu_meters"),
+    NEON_DOTS("neon_dots");
+
+    @NonNull
+    private final String preferenceValue;
+
+    VisualizerStyle(@NonNull final String preferenceValue) {
+        this.preferenceValue = preferenceValue;
+    }
+
+    @NonNull
+    public String getPreferenceValue() {
+        return preferenceValue;
+    }
+
+    @NonNull
+    public static VisualizerStyle fromPreferenceValue(@Nullable final String value) {
+        for (final VisualizerStyle style : values()) {
+            if (style.preferenceValue.equals(value)) {
+                return style;
+            }
+        }
+        return CENTERED_BARS;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/AudioVisualizerView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/AudioVisualizerView.java
@@ -1,33 +1,63 @@
 package org.schabi.newpipe.views;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.LinearGradient;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.Shader;
 import android.util.AttributeSet;
 import android.view.View;
 
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 
+import org.schabi.newpipe.R;
 import org.schabi.newpipe.player.visualizer.VisualizerAudioProcessor;
+import org.schabi.newpipe.player.visualizer.VisualizerStyle;
 
-/** A lightweight spectrum view backed by decoded player audio. */
-public final class AudioVisualizerView extends View {
+/** A lightweight collection of visualizers backed by decoded player audio. */
+public final class AudioVisualizerView extends View
+        implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final int BAR_COUNT = 24;
-    private static final float MIN_BAR_HEIGHT = 0.03f;
+    private static final float MIN_LEVEL = 0.03f;
     private static final float SMOOTHING = 0.72f;
+    private static final int BLUE = Color.rgb(84, 110, 255);
+    private static final int PURPLE = Color.rgb(190, 84, 255);
+    private static final int CYAN = Color.rgb(84, 255, 218);
+    private static final int PINK = Color.rgb(255, 84, 180);
 
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint strokePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint guidePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Path path = new Path();
     private final float[] samples = new float[VisualizerAudioProcessor.SAMPLE_COUNT];
     private final float[] levels = new float[BAR_COUNT];
+    private final SharedPreferences preferences;
+    private final String stylePreferenceKey;
+
     @Nullable
     private VisualizerAudioProcessor audioProcessor;
+    private VisualizerStyle style = VisualizerStyle.CENTERED_BARS;
+    @Nullable
+    private Shader verticalGradient;
+    @Nullable
+    private Shader horizontalGradient;
+    private float amplitude;
+    private float phase;
 
     public AudioVisualizerView(final Context context, @Nullable final AttributeSet attrs) {
         super(context, attrs);
         paint.setStyle(Paint.Style.FILL);
+        strokePaint.setStyle(Paint.Style.STROKE);
+        strokePaint.setStrokeCap(Paint.Cap.ROUND);
+        strokePaint.setStrokeJoin(Paint.Join.ROUND);
+        guidePaint.setStyle(Paint.Style.STROKE);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        stylePreferenceKey = context.getString(R.string.visualizer_style_key);
+        readStyle();
     }
 
     /**
@@ -41,21 +71,133 @@ public final class AudioVisualizerView extends View {
     }
 
     @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        preferences.registerOnSharedPreferenceChangeListener(this);
+        readStyle();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        preferences.unregisterOnSharedPreferenceChangeListener(this);
+        super.onDetachedFromWindow();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences,
+                                          @Nullable final String key) {
+        if (key == null || stylePreferenceKey.equals(key)) {
+            readStyle();
+            invalidate();
+        }
+    }
+
+    private void readStyle() {
+        style = VisualizerStyle.fromPreferenceValue(preferences.getString(
+                stylePreferenceKey, VisualizerStyle.CENTERED_BARS.getPreferenceValue()));
+    }
+
+    @Override
+    protected void onSizeChanged(final int width, final int height,
+                                 final int oldWidth, final int oldHeight) {
+        super.onSizeChanged(width, height, oldWidth, oldHeight);
+        verticalGradient = new LinearGradient(0.0f, height, 0.0f, 0.0f,
+                new int[]{BLUE, PURPLE, CYAN}, null, Shader.TileMode.CLAMP);
+        horizontalGradient = new LinearGradient(0.0f, 0.0f, width, 0.0f,
+                new int[]{BLUE, CYAN, PINK}, null, Shader.TileMode.CLAMP);
+    }
+
+    @Override
     protected void onDraw(final Canvas canvas) {
         super.onDraw(canvas);
         final VisualizerAudioProcessor processor = audioProcessor;
         if (processor == null || getWidth() == 0 || getHeight() == 0) {
             return;
         }
+
         processor.copyLatestSamples(samples);
         updateLevels();
-        drawBars(canvas);
+        configurePaints();
+        drawStyle(canvas);
+        phase = (phase + 0.02f + amplitude * 0.02f) % 1.0f;
         if (getVisibility() == VISIBLE && isShown()) {
             postInvalidateOnAnimation();
         }
     }
 
+    private void configurePaints() {
+        paint.setAlpha(255);
+        paint.setShader(verticalGradient);
+        strokePaint.setAlpha(255);
+        strokePaint.setShader(horizontalGradient);
+        strokePaint.setStrokeWidth(dp(2.4f));
+        guidePaint.setShader(null);
+        guidePaint.setColor(Color.WHITE);
+        guidePaint.setAlpha(40);
+        guidePaint.setStrokeWidth(dp(1.0f));
+    }
+
+    private void drawStyle(final Canvas canvas) {
+        switch (style) {
+            case CLASSIC_BARS:
+                drawBars(canvas, BarMode.BOTTOM);
+                break;
+            case MIRRORED_BARS:
+                drawBars(canvas, BarMode.MIRRORED);
+                break;
+            case WAVEFORM:
+                drawWaveform(canvas, false, false);
+                break;
+            case FILLED_WAVEFORM:
+                drawWaveform(canvas, true, false);
+                break;
+            case OSCILLOSCOPE:
+                drawGrid(canvas);
+                drawWaveform(canvas, false, true);
+                break;
+            case SPECTRUM_LINE:
+                drawSpectrumPath(canvas, false);
+                break;
+            case MOUNTAIN:
+                drawSpectrumPath(canvas, true);
+                break;
+            case CIRCULAR_SPECTRUM:
+                drawCircularSpectrum(canvas);
+                break;
+            case RADIAL_WAVEFORM:
+                drawRadialWaveform(canvas);
+                break;
+            case EQUALIZER_BLOCKS:
+                drawEqualizerBlocks(canvas);
+                break;
+            case PARTICLES:
+                drawParticles(canvas);
+                break;
+            case PULSE_RINGS:
+                drawPulseRings(canvas);
+                break;
+            case VU_METERS:
+                drawVuMeters(canvas);
+                break;
+            case NEON_DOTS:
+                drawNeonDots(canvas);
+                break;
+            case CENTERED_BARS:
+            default:
+                drawBars(canvas, BarMode.CENTERED);
+                break;
+        }
+    }
+
     private void updateLevels() {
+        double squaredSampleSum = 0.0;
+        for (final float sample : samples) {
+            squaredSampleSum += sample * sample;
+        }
+        final float currentAmplitude = (float) Math.min(1.0,
+                Math.sqrt(squaredSampleSum / samples.length) * 3.2);
+        amplitude = Math.max(currentAmplitude, amplitude * 0.84f);
+
         for (int bar = 0; bar < BAR_COUNT; bar++) {
             final int frequencyBin = bar + 1;
             double real = 0.0;
@@ -73,21 +215,242 @@ public final class AudioVisualizerView extends View {
         }
     }
 
-    private void drawBars(final Canvas canvas) {
-        paint.setShader(new LinearGradient(0.0f, getHeight(), 0.0f, 0.0f,
-                Color.rgb(84, 110, 255), Color.rgb(84, 255, 218),
-                Shader.TileMode.CLAMP));
+    private void drawBars(final Canvas canvas, final BarMode mode) {
         final float slotWidth = getWidth() / (float) BAR_COUNT;
-        final float barWidth = slotWidth * 0.58f;
-        final float cornerRadius = barWidth / 2.0f;
+        final float barWidth = slotWidth * 0.6f;
+        final float centerY = getHeight() / 2.0f;
         for (int bar = 0; bar < BAR_COUNT; bar++) {
             final float centerX = slotWidth * (bar + 0.5f);
-            final float height = getHeight()
-                    * Math.max(MIN_BAR_HEIGHT, levels[bar]);
-            final float top = (getHeight() - height) / 2.0f;
-            final float bottom = (getHeight() + height) / 2.0f;
-            canvas.drawRoundRect(centerX - barWidth / 2.0f, top,
-                    centerX + barWidth / 2.0f, bottom, cornerRadius, cornerRadius, paint);
+            final float height = getHeight() * level(bar);
+            if (mode == BarMode.BOTTOM) {
+                drawRoundedBar(canvas, centerX, getHeight() - height, getHeight(), barWidth);
+            } else if (mode == BarMode.MIRRORED) {
+                final float gap = dp(3.0f);
+                drawRoundedBar(canvas, centerX, centerY - gap - height * 0.45f,
+                        centerY - gap, barWidth);
+                drawRoundedBar(canvas, centerX, centerY + gap,
+                        centerY + gap + height * 0.45f, barWidth);
+            } else {
+                drawRoundedBar(canvas, centerX, centerY - height / 2.0f,
+                        centerY + height / 2.0f, barWidth);
+            }
         }
+    }
+
+    private void drawRoundedBar(final Canvas canvas, final float centerX,
+                                final float top, final float bottom, final float width) {
+        canvas.drawRoundRect(centerX - width / 2.0f, top,
+                centerX + width / 2.0f, bottom,
+                width / 2.0f, width / 2.0f, paint);
+    }
+
+    private void drawWaveform(final Canvas canvas, final boolean filled,
+                              final boolean compact) {
+        final float centerY = getHeight() / 2.0f;
+        final float scale = getHeight() * (compact ? 0.28f : 0.43f);
+        path.reset();
+        path.moveTo(0.0f, centerY);
+        for (int sample = 0; sample < samples.length; sample++) {
+            final float x = sample * getWidth() / (float) (samples.length - 1);
+            path.lineTo(x, centerY - normalizedSample(sample) * scale);
+        }
+        if (filled) {
+            path.lineTo(getWidth(), centerY);
+            path.close();
+            paint.setAlpha(200);
+            canvas.drawPath(path, paint);
+            paint.setAlpha(255);
+        } else {
+            canvas.drawPath(path, strokePaint);
+        }
+    }
+
+    private void drawGrid(final Canvas canvas) {
+        for (int line = 1; line < 4; line++) {
+            final float y = line * getHeight() / 4.0f;
+            canvas.drawLine(0.0f, y, getWidth(), y, guidePaint);
+        }
+        for (int line = 1; line < 8; line++) {
+            final float x = line * getWidth() / 8.0f;
+            canvas.drawLine(x, 0.0f, x, getHeight(), guidePaint);
+        }
+    }
+
+    private void drawSpectrumPath(final Canvas canvas, final boolean filled) {
+        path.reset();
+        if (filled) {
+            path.moveTo(0.0f, getHeight());
+        }
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final float x = bar * getWidth() / (float) (BAR_COUNT - 1);
+            final float y = getHeight() * (0.94f - level(bar) * 0.88f);
+            if (bar == 0 && !filled) {
+                path.moveTo(x, y);
+            } else {
+                path.lineTo(x, y);
+            }
+        }
+        if (filled) {
+            path.lineTo(getWidth(), getHeight());
+            path.close();
+            paint.setAlpha(210);
+            canvas.drawPath(path, paint);
+            paint.setAlpha(255);
+        } else {
+            strokePaint.setStrokeWidth(dp(3.0f));
+            canvas.drawPath(path, strokePaint);
+        }
+    }
+
+    private void drawCircularSpectrum(final Canvas canvas) {
+        final float centerX = getWidth() / 2.0f;
+        final float centerY = getHeight() / 2.0f;
+        final float baseRadius = Math.min(getWidth(), getHeight()) * 0.22f;
+        final float range = Math.min(getWidth(), getHeight()) * 0.24f;
+        strokePaint.setStrokeWidth(dp(4.0f));
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final double angle = Math.PI * 2.0 * bar / BAR_COUNT - Math.PI / 2.0;
+            final float outerRadius = baseRadius + range * level(bar);
+            canvas.drawLine(centerX + (float) Math.cos(angle) * baseRadius,
+                    centerY + (float) Math.sin(angle) * baseRadius,
+                    centerX + (float) Math.cos(angle) * outerRadius,
+                    centerY + (float) Math.sin(angle) * outerRadius,
+                    strokePaint);
+        }
+    }
+
+    private void drawRadialWaveform(final Canvas canvas) {
+        final float centerX = getWidth() / 2.0f;
+        final float centerY = getHeight() / 2.0f;
+        final float baseRadius = Math.min(getWidth(), getHeight()) * 0.28f;
+        final float scale = Math.min(getWidth(), getHeight()) * 0.14f;
+        path.reset();
+        for (int sample = 0; sample <= samples.length; sample++) {
+            final int index = sample % samples.length;
+            final double angle = Math.PI * 2.0 * sample / samples.length - Math.PI / 2.0;
+            final float radius = baseRadius + normalizedSample(index) * scale;
+            final float x = centerX + (float) Math.cos(angle) * radius;
+            final float y = centerY + (float) Math.sin(angle) * radius;
+            if (sample == 0) {
+                path.moveTo(x, y);
+            } else {
+                path.lineTo(x, y);
+            }
+        }
+        path.close();
+        canvas.drawPath(path, strokePaint);
+    }
+
+    private void drawEqualizerBlocks(final Canvas canvas) {
+        final int blockCount = 12;
+        final float slotWidth = getWidth() / (float) BAR_COUNT;
+        final float blockWidth = slotWidth * 0.64f;
+        final float blockHeight = getHeight() / (float) blockCount;
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final int activeBlocks = Math.max(1, Math.round(level(bar) * blockCount));
+            final float left = slotWidth * bar + (slotWidth - blockWidth) / 2.0f;
+            for (int block = 0; block < activeBlocks; block++) {
+                final float bottom = getHeight() - block * blockHeight;
+                canvas.drawRoundRect(left, bottom - blockHeight * 0.82f,
+                        left + blockWidth, bottom - blockHeight * 0.16f,
+                        dp(1.5f), dp(1.5f), paint);
+            }
+        }
+    }
+
+    private void drawParticles(final Canvas canvas) {
+        paint.setShader(horizontalGradient);
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final float energy = level(bar);
+            final int count = 1 + Math.round(energy * 4.0f);
+            for (int particle = 0; particle < count; particle++) {
+                final float progress = (phase + bar * 0.071f + particle * 0.19f) % 1.0f;
+                final float x = (bar + 0.5f) * getWidth() / BAR_COUNT
+                        + (float) Math.sin((bar + particle) * 2.3f) * dp(5.0f);
+                final float radius = dp(1.8f + energy * 3.2f) * (1.0f - progress * 0.45f);
+                paint.setAlpha(Math.max(45, Math.round(255.0f * (1.0f - progress))));
+                canvas.drawCircle(x, getHeight() * (1.0f - progress), radius, paint);
+            }
+        }
+        paint.setAlpha(255);
+    }
+
+    private void drawPulseRings(final Canvas canvas) {
+        final float centerX = getWidth() / 2.0f;
+        final float centerY = getHeight() / 2.0f;
+        final float maximumRadius = Math.min(getWidth(), getHeight()) * 0.46f;
+        for (int ring = 0; ring < 5; ring++) {
+            final float progress = (phase + ring / 5.0f) % 1.0f;
+            strokePaint.setAlpha(Math.max(35, Math.round(255.0f * (1.0f - progress))));
+            strokePaint.setStrokeWidth(dp(2.0f + amplitude * 5.0f));
+            canvas.drawCircle(centerX, centerY,
+                    maximumRadius * (0.16f + progress * 0.78f), strokePaint);
+        }
+        strokePaint.setAlpha(255);
+    }
+
+    private void drawVuMeters(final Canvas canvas) {
+        final float margin = getWidth() * 0.08f;
+        final float width = getWidth() - margin * 2.0f;
+        final float height = Math.max(dp(18.0f), getHeight() * 0.14f);
+        drawMeter(canvas, margin, getHeight() * 0.28f, width, height,
+                averageLevel(0, BAR_COUNT / 2));
+        drawMeter(canvas, margin, getHeight() * 0.58f, width, height,
+                averageLevel(BAR_COUNT / 2, BAR_COUNT));
+    }
+
+    private void drawMeter(final Canvas canvas, final float left, final float top,
+                           final float width, final float height, final float energy) {
+        guidePaint.setStyle(Paint.Style.FILL);
+        guidePaint.setAlpha(28);
+        canvas.drawRoundRect(left, top, left + width, top + height,
+                height / 2.0f, height / 2.0f, guidePaint);
+        paint.setShader(horizontalGradient);
+        canvas.drawRoundRect(left, top, left + width * energy, top + height,
+                height / 2.0f, height / 2.0f, paint);
+        guidePaint.setStyle(Paint.Style.STROKE);
+    }
+
+    private void drawNeonDots(final Canvas canvas) {
+        final float slotWidth = getWidth() / (float) BAR_COUNT;
+        final float centerY = getHeight() / 2.0f;
+        paint.setShader(horizontalGradient);
+        for (int bar = 0; bar < BAR_COUNT; bar++) {
+            final float x = slotWidth * (bar + 0.5f);
+            final float offset = getHeight() * level(bar) * 0.44f;
+            final float radius = Math.max(dp(2.2f), slotWidth * 0.18f);
+            paint.setAlpha(70);
+            canvas.drawCircle(x, centerY - offset, radius * 2.3f, paint);
+            canvas.drawCircle(x, centerY + offset, radius * 2.3f, paint);
+            paint.setAlpha(255);
+            canvas.drawCircle(x, centerY - offset, radius, paint);
+            canvas.drawCircle(x, centerY + offset, radius, paint);
+        }
+    }
+
+    private float averageLevel(final int start, final int end) {
+        float sum = 0.0f;
+        for (int index = start; index < end; index++) {
+            sum += level(index);
+        }
+        return Math.min(1.0f, sum / Math.max(1, end - start) * 2.2f);
+    }
+
+    private float level(final int bar) {
+        return Math.max(MIN_LEVEL, levels[bar]);
+    }
+
+    private float normalizedSample(final int sample) {
+        return Math.max(-1.0f, Math.min(1.0f, samples[sample] * 2.8f));
+    }
+
+    private float dp(final float value) {
+        return value * getResources().getDisplayMetrics().density;
+    }
+
+    private enum BarMode {
+        CENTERED,
+        BOTTOM,
+        MIRRORED
     }
 }

--- a/app/src/main/res/drawable/ic_waveform.xml
+++ b/app/src/main/res/drawable/ic_waveform.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M2,12 L5,12 L7,7 L10,17 L13,3 L16,21 L19,12 L22,12"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2" />
+</vector>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -430,7 +430,7 @@
                         android:focusable="true"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:scaleType="fitCenter"
-                        android:src="@drawable/ic_headset"
+                        android:src="@drawable/ic_waveform"
                         app:tint="@color/white" />
 
                     <androidx.appcompat.widget.AppCompatImageButton

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1584,6 +1584,44 @@
     <string name="streams_notifications_channels_key">streams_notifications_channels</string>
     <string name="player_notification_screen_key">player_notification_screen</string>
 
+    <!-- Listen mode visualizer -->
+    <string name="visualizer_style_key">visualizer_style</string>
+    <string name="default_visualizer_style_value">centered_bars</string>
+    <string-array name="visualizer_style_entries">
+        <item>@string/visualizer_style_centered_bars</item>
+        <item>@string/visualizer_style_classic_bars</item>
+        <item>@string/visualizer_style_mirrored_bars</item>
+        <item>@string/visualizer_style_waveform</item>
+        <item>@string/visualizer_style_filled_waveform</item>
+        <item>@string/visualizer_style_oscilloscope</item>
+        <item>@string/visualizer_style_spectrum_line</item>
+        <item>@string/visualizer_style_mountain</item>
+        <item>@string/visualizer_style_circular_spectrum</item>
+        <item>@string/visualizer_style_radial_waveform</item>
+        <item>@string/visualizer_style_equalizer_blocks</item>
+        <item>@string/visualizer_style_particles</item>
+        <item>@string/visualizer_style_pulse_rings</item>
+        <item>@string/visualizer_style_vu_meters</item>
+        <item>@string/visualizer_style_neon_dots</item>
+    </string-array>
+    <string-array name="visualizer_style_values">
+        <item>centered_bars</item>
+        <item>classic_bars</item>
+        <item>mirrored_bars</item>
+        <item>waveform</item>
+        <item>filled_waveform</item>
+        <item>oscilloscope</item>
+        <item>spectrum_line</item>
+        <item>mountain</item>
+        <item>circular_spectrum</item>
+        <item>radial_waveform</item>
+        <item>equalizer_blocks</item>
+        <item>particles</item>
+        <item>pulse_rings</item>
+        <item>vu_meters</item>
+        <item>neon_dots</item>
+    </string-array>
+
     <!-- ExoPlayer settings -->
     <string name="exoplayer_settings_key">exoplayer_settings_key</string>
     <string name="disable_media_tunneling_key">disable_media_tunneling_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1391,6 +1391,22 @@
     <string name="equalizer">Equalizer</string>
     <string name="enter_listen_mode">Listen without video</string>
     <string name="exit_listen_mode">Return to video</string>
+    <string name="visualizer_style_title">Visualizer style</string>
+    <string name="visualizer_style_centered_bars">Centered spectrum</string>
+    <string name="visualizer_style_classic_bars">Classic bars</string>
+    <string name="visualizer_style_mirrored_bars">Mirrored bars</string>
+    <string name="visualizer_style_waveform">Waveform</string>
+    <string name="visualizer_style_filled_waveform">Filled waveform</string>
+    <string name="visualizer_style_oscilloscope">Oscilloscope</string>
+    <string name="visualizer_style_spectrum_line">Spectrum line</string>
+    <string name="visualizer_style_mountain">Mountain</string>
+    <string name="visualizer_style_circular_spectrum">Circular spectrum</string>
+    <string name="visualizer_style_radial_waveform">Radial waveform</string>
+    <string name="visualizer_style_equalizer_blocks">Equalizer blocks</string>
+    <string name="visualizer_style_particles">Particles</string>
+    <string name="visualizer_style_pulse_rings">Pulse rings</string>
+    <string name="visualizer_style_vu_meters">VU meters</string>
+    <string name="visualizer_style_neon_dots">Neon dots</string>
     <string name="equalizer_settings_key" translatable="false">equalizer_settings</string>
     <string name="equalizer_enable">Enable equalizer</string>
     <string name="equalizer_preset">Preset</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -98,6 +98,16 @@
             app:iconSpaceReserved="false"
             app:singleLineTitle="false" />
 
+        <ListPreference
+            android:defaultValue="@string/default_visualizer_style_value"
+            android:entries="@array/visualizer_style_entries"
+            android:entryValues="@array/visualizer_style_values"
+            android:key="@string/visualizer_style_key"
+            android:title="@string/visualizer_style_title"
+            app:iconSpaceReserved="false"
+            app:singleLineTitle="false"
+            app:useSimpleSummaryProvider="true" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/use_external_video_player_key"

--- a/app/src/test/java/org/schabi/newpipe/player/visualizer/VisualizerStyleTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/visualizer/VisualizerStyleTest.java
@@ -1,0 +1,28 @@
+package org.schabi.newpipe.player.visualizer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class VisualizerStyleTest {
+    @Test
+    public void exposesFifteenSelectableStyles() {
+        assertEquals(15, VisualizerStyle.values().length);
+    }
+
+    @Test
+    public void everyStyleRoundTripsThroughItsPreferenceValue() {
+        for (final VisualizerStyle style : VisualizerStyle.values()) {
+            assertEquals(style,
+                    VisualizerStyle.fromPreferenceValue(style.getPreferenceValue()));
+        }
+    }
+
+    @Test
+    public void unknownPreferenceFallsBackToCenteredBars() {
+        assertEquals(VisualizerStyle.CENTERED_BARS,
+                VisualizerStyle.fromPreferenceValue("removed_style"));
+        assertEquals(VisualizerStyle.CENTERED_BARS,
+                VisualizerStyle.fromPreferenceValue(null));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -25,6 +25,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Improvements
 
+- Added 15 selectable Listen-mode visualizers and a distinct waveform icon so Listen mode is no
+  longer confused with the Background player action.
 - Fixed History filter chips not updating the displayed watched-video list.
 - Added bulk video and audio downloads directly from local playlists; entries that already point to
   local media files are skipped.


### PR DESCRIPTION
- Replace the Listen mode headset icon with a distinct waveform icon so it is not confused with the Background action.
- Add 15 selectable visualizer styles under Video and audio player settings.
- Keep Centered spectrum as the default and apply style changes live.
- Continue driving every visualizer from decoded player audio without microphone permission.