### PR TITLE
Add pinch-to-zoom behavior setting

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -205,18 +205,18 @@ class MainPlayerGestureListener(
             player.context.resources.displayMetrics.density
 
         if (twoFingerGestureState == TwoFingerGestureState.PENDING) {
-            twoFingerGestureState = classifyTwoFingerGesture(
-                verticalMovement,
-                horizontalMovement,
-                spanChange,
-                lockThreshold,
-                twoFingerStartZoom > 1f
+            val pinchToZoomEnabled = PlayerHelper.isPinchToZoomGestureEnabled(player.context)
+            twoFingerGestureState = applyGestureSettings(
+                classifyTwoFingerGesture(
+                    verticalMovement,
+                    horizontalMovement,
+                    spanChange,
+                    lockThreshold,
+                    twoFingerStartZoom > 1f && pinchToZoomEnabled
+                ),
+                pinchToZoomEnabled,
+                PlayerHelper.isTwoFingerSpeedGestureEnabled(player.context)
             )
-            if (twoFingerGestureState == TwoFingerGestureState.SPEED &&
-                !PlayerHelper.isTwoFingerSpeedGestureEnabled(player.context)
-            ) {
-                twoFingerGestureState = TwoFingerGestureState.IGNORED
-            }
             if (twoFingerGestureState == TwoFingerGestureState.SPEED) {
                 binding.speedGestureDisplay.text =
                     PlayerHelper.formatSpeed(twoFingerStartSpeed.toDouble())
@@ -620,6 +620,29 @@ class MainPlayerGestureListener(
                     TwoFingerGestureState.SPEED
 
                 else -> TwoFingerGestureState.IGNORED
+            }
+        }
+
+        @JvmStatic
+        fun applyGestureSettings(
+            classifiedGesture: TwoFingerGestureState,
+            pinchToZoomEnabled: Boolean,
+            twoFingerSpeedEnabled: Boolean
+        ): TwoFingerGestureState {
+            return when (classifiedGesture) {
+                TwoFingerGestureState.ZOOM -> if (pinchToZoomEnabled) {
+                    classifiedGesture
+                } else {
+                    TwoFingerGestureState.IGNORED
+                }
+
+                TwoFingerGestureState.SPEED -> if (twoFingerSpeedEnabled) {
+                    classifiedGesture
+                } else {
+                    TwoFingerGestureState.IGNORED
+                }
+
+                else -> classifiedGesture
             }
         }
 

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -230,6 +230,11 @@ public final class PlayerHelper {
                 .getBoolean(context.getString(R.string.fullscreen_gesture_control_key), true);
     }
 
+    public static boolean isPinchToZoomGestureEnabled(@NonNull final Context context) {
+        return getPreferences(context)
+                .getBoolean(context.getString(R.string.pinch_to_zoom_gesture_control_key), true);
+    }
+
     public static boolean isTwoFingerSpeedGestureEnabled(@NonNull final Context context) {
         return getPreferences(context).getBoolean(
                 context.getString(R.string.two_finger_speed_gesture_control_key), false);

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -236,6 +236,7 @@
 
     <string name="swipe_seek_gesture_control_key">swipe_seek_gesture_control</string>
     <string name="fullscreen_gesture_control_key">fullscreen_gesture_control</string>
+    <string name="pinch_to_zoom_gesture_control_key">pinch_to_zoom_gesture_control</string>
     <string name="two_finger_speed_gesture_control_key">two_finger_speed_gesture_control</string>
     <string name="hold_to_speed_key">hold_to_speed</string>
     <string name="hold_to_speed_default_value">2.0</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,8 @@
     <string name="left_gesture_control_title">Left gesture action</string>
     <string name="right_gesture_control_summary">Choose gesture for right half of player screen</string>
     <string name="right_gesture_control_title">Right gesture action</string>
+    <string name="pinch_to_zoom_gesture_title">Pinch to zoom</string>
+    <string name="pinch_to_zoom_gesture_summary">Pinch with two fingers to zoom and pan the video</string>
     <string name="two_finger_speed_gesture_title">Two-finger speed gesture</string>
     <string name="two_finger_speed_gesture_summary">Swipe vertically with two fingers to change playback speed</string>
     <string name="brightness">Brightness</string>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -266,6 +266,14 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/pinch_to_zoom_gesture_control_key"
+            android:summary="@string/pinch_to_zoom_gesture_summary"
+            android:title="@string/pinch_to_zoom_gesture_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/two_finger_speed_gesture_control_key"
             android:summary="@string/two_finger_speed_gesture_summary"

--- a/app/src/test/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListenerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListenerTest.java
@@ -75,6 +75,33 @@ public class MainPlayerGestureListenerTest {
     }
 
     @Test
+    public void disabledPinchSettingIgnoresZoomGesture() {
+        assertEquals(MainPlayerGestureListener.TwoFingerGestureState.IGNORED,
+                MainPlayerGestureListener.applyGestureSettings(
+                        MainPlayerGestureListener.TwoFingerGestureState.ZOOM,
+                        false,
+                        true));
+    }
+
+    @Test
+    public void disabledPinchSettingKeepsEnabledSpeedGesture() {
+        assertEquals(MainPlayerGestureListener.TwoFingerGestureState.SPEED,
+                MainPlayerGestureListener.applyGestureSettings(
+                        MainPlayerGestureListener.TwoFingerGestureState.SPEED,
+                        false,
+                        true));
+    }
+
+    @Test
+    public void enabledPinchSettingKeepsZoomGesture() {
+        assertEquals(MainPlayerGestureListener.TwoFingerGestureState.ZOOM,
+                MainPlayerGestureListener.applyGestureSettings(
+                        MainPlayerGestureListener.TwoFingerGestureState.ZOOM,
+                        true,
+                        false));
+    }
+
+    @Test
     public void pinchZoomIsScaledAndClamped() {
         assertEquals(2f, MainPlayerGestureListener.calculateZoomScale(1f, 200f, 100f),
                 FLOAT_TOLERANCE);

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -14,8 +14,8 @@ Release history is listed newest first. The number beside each release is its An
   and visualization intentionally excluded from the driving surface.
 - Added Android Auto media resumption, a bounded Continue listening section, car-friendly content
   style hints, and time-limited browse requests for a more reliable driving experience.
-- Added continuous pinch-to-zoom from 100% to 400% and two-finger panning in the main player while
-  preserving the existing vertical two-finger playback-speed gesture.
+- Added continuous pinch-to-zoom from 100% to 400% and two-finger panning in the main player, with
+  a default-enabled Behavior setting, while preserving the vertical two-finger speed gesture.
 - Added opt-in native Android picture-in-picture for visible video playback on Android 8 and newer,
   with automatic Android 12+ entry, media-session controls, and popup-player fallback on older
   devices.


### PR DESCRIPTION
- Add a Pinch to zoom switch beside the other player gesture settings under Behavior.
- Keep pinch zoom enabled by default for existing behavior.
- Disable pinch scaling and two-finger panning when the switch is off.
- Preserve the independently configurable two-finger playback-speed gesture.