### PR TITLE
Document new playback and Android Auto features

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   <a href="#screenshots">Screenshots</a> •
   <a href="#supported-services">Services</a> •
   <a href="#features">Features</a> •
+  <a href="#android-auto">Android Auto</a> •
   <a href="#device-synchronization">Device sync</a> •
   <a href="#installation">Installation</a> •
   <a href="#building-from-source">Build</a> •
@@ -202,7 +203,12 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
 
 ### Playback
 
-- Main, background, popup, external-player, and Kodi playback
+- Main, Listen, background, popup, external-player, and Kodi playback
+- Switch a video to audio-only Listen mode without losing the queue or playback position, and choose
+  from 15 waveform, spectrum, meter, radial, and particle visualizers under **Settings > Video and
+  audio > Visualizer style**
+- Browse and resume audio safely through Android Auto, including voice search and a bounded
+  **Continue listening** section; video and visualizers are never shown on the driving surface
 - Cast compatible streams to discovered FCast and Chromecast-compatible receivers on Android 8 and
   newer, with play, pause, stop, and receiver-switching controls
 - Playback queues, repeat and shuffle controls, chapters, captions, and seek-bar thumbnail previews
@@ -212,8 +218,11 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
   for original or descriptive audio
 - Save playback speed, quality, and caption choices in per-channel playback profiles
 - Retain playback speed for live streams
-- Use swipe seeking, fullscreen volume and brightness swipes, hold-to-speed-up, an optional two-finger
-  playback-speed gesture, and swipe down to the miniplayer
+- Use swipe seeking, fullscreen volume and brightness swipes, hold-to-speed-up, configurable
+  pinch-to-zoom and two-finger panning, an optional two-finger playback-speed gesture, and swipe down
+  to the miniplayer
+- Optionally keep visible video playback in Android's native picture-in-picture window on Android 8
+  and newer
 - Optionally keep the video visible while scrolling its details page
 - Set a sleep timer using presets, a custom duration, the end of the current video, or the end of the
   queue, with optional fade-out
@@ -289,6 +298,21 @@ See [Device synchronization](#device-synchronization) for behavior, limitations,
 - Update validation for checksum, package identity, version, and signing certificate
 - Independent semantic versioning, release signing, stable builds, and separately installable nightly
   builds
+
+---
+
+## Android Auto
+
+WizeStream can appear as an audio media app in Android Auto. It provides car-safe browsing, voice
+search, playback controls, media resumption, and recent listening content. Video and Listen-mode
+visualizers remain on the phone and are not sent to the vehicle display.
+
+Stable builds installed from a trusted source should appear normally. When testing a debug, nightly,
+CI, or other sideloaded APK, Android Auto hides the app until **Unknown sources** is enabled in
+Android Auto's own developer settings. This is separate from Android's general app-install setting.
+
+See the [Android Auto guide](docs/android-auto.md) for setup, sideloaded-build testing, safety
+behavior, and troubleshooting.
 
 ---
 

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -1,0 +1,62 @@
+# Android Auto
+
+WizeStream integrates with Android Auto as an audio media app. The vehicle interface can browse
+supported WizeStream content, continue recent listening, accept supported voice-search requests,
+and control playback. For driving safety, Android Auto receives audio playback only: video and
+Listen-mode visualizers are never displayed on the vehicle screen.
+
+Android Auto support was added after WizeStream 1.8.0. Install a newer build before following this
+guide.
+
+## Normal setup
+
+1. Install a current WizeStream build and open the app at least once.
+2. Connect the phone to Android Auto by USB or wirelessly.
+3. Open Android Auto's app launcher or **Customize launcher** settings.
+4. Enable WizeStream if it is not already selected.
+
+Stable builds installed from a trusted source should be discovered automatically.
+
+## Testing a sideloaded build
+
+Android Auto normally hides apps that were not installed from a trusted source. This includes debug,
+nightly, CI, and other manually installed APKs. To test one of these builds, enable Android Auto's
+developer option for unknown sources:
+
+1. Open Android Auto settings on the phone.
+2. Open **About** and tap **Version and permission info** 10 times.
+3. Approve the prompt to enable Android Auto developer mode.
+4. Open the overflow menu and select **Developer settings**.
+5. Enable **Unknown sources**.
+6. Disconnect and reconnect Android Auto, then check **Customize launcher** again.
+
+This option is inside Android Auto. It is different from Android's general **Install unknown apps**
+permission, and it should only be enabled when testing an APK from a source you trust.
+
+## Available features
+
+- Car-safe media browsing
+- Voice-search playback for supported queries
+- Play, pause, previous, next, and queue controls
+- Media resumption after reconnecting
+- A bounded **Continue listening** section
+- Audio-only playback with no video or visualizer on the vehicle display
+
+The visualizer style selected under **Settings > Video and audio > Visualizer style** applies to
+Listen mode on the phone only.
+
+## Troubleshooting
+
+If WizeStream is still missing:
+
+- Confirm that the installed build is newer than version 1.8.0.
+- For a sideloaded APK, confirm that Android Auto developer mode and **Unknown sources** are enabled.
+- Force-stop Android Auto, reconnect the phone, and check **Customize launcher** again.
+- Open WizeStream once and start audio playback before reconnecting.
+- Update Android Auto to the latest version available for the device.
+
+When reporting a problem, include the WizeStream version, whether the build is stable or debug, the
+Android and Android Auto versions, the connection type, and whether **Unknown sources** is enabled.
+
+For Google's current testing requirements, see
+[Test Android apps for cars](https://developer.android.com/training/cars/testing).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -96,7 +96,29 @@ available or the request fails, WizeStream keeps the original title and thumbnai
 Pinch with two fingers over the main player to zoom continuously from 100% to 400%. Once enlarged,
 drag with two fingers to move around the video. Pinch back to 100% or tap the Fit/Fill/Zoom control
 to reset the custom zoom. A vertical two-finger swipe still changes playback speed when that gesture
-is enabled and the video has not already been enlarged.
+is enabled and the video has not already been enlarged. Pinch-to-zoom is enabled by default and can
+be turned off under **Settings > Video and audio > Behavior > Pinch to zoom**.
+
+## What is Listen mode and how do I change its visualizer?
+
+Tap the waveform Listen action on a video's details page to continue the same item as
+audio-only playback without losing its queue or position. The video is replaced by the selected
+visualizer while the normal player controls remain available. Choose among 15 styles under
+**Settings > Video and audio > Visualizer style**. The visualizer reads decoded player audio and
+does not require microphone permission.
+
+## Why is WizeStream missing from Android Auto?
+
+Android Auto support is available in builds newer than WizeStream 1.8.0. A stable build installed
+from a trusted source should appear as a media app. Android Auto hides debug, nightly, CI, and other
+sideloaded APKs unless its developer-only **Unknown sources** option is enabled.
+
+Open Android Auto settings, open **About**, tap **Version and permission info** 10 times, and approve
+developer mode. Then open the overflow menu, choose **Developer settings**, and enable **Unknown
+sources**. Reconnect the vehicle after changing the option. This setting belongs to Android Auto and
+is separate from Android's general permission to install unknown apps.
+
+See the [Android Auto guide](android-auto.md) for complete setup and troubleshooting steps.
 
 ## How do I cast to a TV?
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,11 +1,13 @@
-WizeStream is an independent, NewPipe-based Android streaming client with a modern interface, privacy-friendly playback, local-first features, and support for multiple services. It requires no platform account, Google framework libraries, or Google Play Services.
+WizeStream is an independent, privacy-friendly NewPipe-based Android client with a modern interface, local-first features, and multiple services. It requires no platform account or Google Play Services.
 
-Supported services include YouTube, YouTube Music, Bilibili, Niconico, PeerTube, Bandcamp, SoundCloud, and media.ccc.de.
+Services include YouTube, YouTube Music, Bilibili, Niconico, PeerTube, Bandcamp, SoundCloud, and media.ccc.de.
 
 Core features include:
 
 - Watch videos and live streams from supported services
+- Audio-only Listen mode with 15 visualizers
 - Background and popup playback
+- Android Auto browsing, voice search, controls, and resumption
 - Local playlists
 - Subscriptions without a platform account, kept separate for each service
 - Service-specific channel groups and What's New feeds with independent refresh states
@@ -20,23 +22,24 @@ Additional WizeStream features:
 - Material 3-inspired surfaces, dialogs, settings, tabs, and navigation
 - Dynamic Material You colors and manual theme color presets
 - Bottom navigation with a configurable default main tab
-- Secure peer-to-peer synchronization for subscriptions, feed groups, playlists, history, playback progress, selected settings, channel playback profiles, and completed-download metadata
-- Manual and automatic background synchronization between trusted devices on the same local network
+- Secure peer-to-peer synchronization for subscriptions, groups, playlists, history, progress, selected settings, playback profiles, and download metadata
+- Manual and automatic synchronization between trusted devices on the same network
 - "Download on this device" for synchronized download records whose media file is missing locally; media files are not transferred
 - Search filters, channel sorting, and search within channel tabs and local or remote playlists
 - Local blocking for videos, channels, and title or uploader keywords
 - Podcast tabs, per-channel playback profiles, and labeled multi-audio tracks
 - SponsorBlock, optional DeArrow titles and thumbnails, and YouTube dislike counts
 - FCast and Chromecast-compatible TV casting on Android 8 and newer
-- Player gestures, swipe-down miniplayer, optional visible-video mode, and live-speed retention
+- Player gestures, configurable pinch-to-zoom and panning, swipe-down miniplayer, optional
+  visible-video mode, native picture-in-picture, and live-speed retention
 - Embedded metadata in generated M4A, MP4, and Opus downloads
 - A separate application ID for side-by-side installation with official NewPipe
 
-WizeStream maintains its application and integrated extractor. Report WizeStream service and extractor failures to WizeStream first. Releases are available through GitHub and IzzyOnDroid.
+WizeStream maintains its app and integrated extractor. Report service and extractor failures to WizeStream first. Releases are available through GitHub and IzzyOnDroid.
 
 Storage permissions:
 
-On Android 6-9, WizeStream can optionally use a legacy storage backend instead of Android's Storage Access Framework. This mode is also used on some Fire TV devices because of a platform-specific SAF issue. In legacy mode, this allows the app to read existing files and save downloaded video, audio, captions, and exported backups. On Android 10 and newer, SAF is always used, and these storage permissions are not requested.
+On Android 6-9, WizeStream can optionally use legacy storage instead of Android's Storage Access Framework. Some Fire TV devices also use it because of a platform SAF issue. It allows reading existing files and saving downloads and backups. On Android 10 and newer, SAF is always used and these permissions are not requested.
 
 Camera permission:
 


### PR DESCRIPTION
- Document Listen mode, 15 selectable visualizers, pinch-to-zoom, native picture-in-picture, and Android Auto playback
- Add a dedicated Android Auto setup and troubleshooting guide
- Explain that sideloaded builds require Android Auto developer mode and Unknown sources
- Update the FAQ and English store description for the new features