### PR TITLE
Keep channel subscription controls visible

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.material.appbar.AppBarLayout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -37,15 +38,16 @@ class ChannelHeaderLayoutTest {
     ) {
         val root = LayoutInflater.from(context)
             .inflate(R.layout.fragment_channel, FrameLayout(context), false)
+        val appBar = root.findViewById<AppBarLayout>(R.id.app_bar_layout)
+        val bannerContainer = root.findViewById<View>(R.id.channel_banner_container)
         val banner = root.findViewById<ImageView>(R.id.channel_banner_image)
 
         measureAndLayout(root, widthPixels, heightPixels)
         if (!showBanner) {
-            banner.visibility = View.GONE
+            bannerContainer.visibility = View.GONE
             measureAndLayout(root, widthPixels, heightPixels)
         }
 
-        val metadata = root.findViewById<View>(R.id.channel_metadata)
         val metadataRow = root.findViewById<View>(R.id.channel_metadata_row)
         val avatar = root.findViewById<View>(R.id.channel_avatar_view)
         val title = root.findViewById<View>(R.id.channel_title_view)
@@ -54,14 +56,18 @@ class ChannelHeaderLayoutTest {
 
         if (showBanner) {
             assertVisibleAndMeasured(banner)
-            assertTrue(metadataRow.top >= banner.bottom)
+            assertVisibleAndMeasured(bannerContainer)
+            assertTrue(metadataRow.top >= bannerContainer.bottom)
         } else {
-            assertEquals(View.GONE, banner.visibility)
+            assertEquals(View.GONE, bannerContainer.visibility)
             assertEquals(0, metadataRow.top)
-            assertEquals(metadataRow.height, metadata.height)
         }
 
-        assertTrue(metadataRow.bottom <= metadata.height)
+        val metadataLayoutParams = metadataRow.layoutParams as AppBarLayout.LayoutParams
+        assertEquals(0, metadataLayoutParams.scrollFlags)
+        assertTrue(appBar.totalScrollRange <= bannerContainer.height)
+        assertTrue(appBar.height - appBar.totalScrollRange >= metadataRow.height)
+        assertTrue(metadataRow.bottom <= appBar.height)
 
         listOf(avatar, title, subscriberCount, subscribeButton).forEach {
             assertVisibleAndMeasured(it)

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -225,7 +225,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         binding.channelTitleView.setText(name);
         if (!ImageStrategy.shouldLoadImages()) {
             // do not waste space for the banner if it is not going to be loaded
-            binding.channelBannerImage.setVisibility(View.GONE);
+            binding.channelBannerContainer.setVisibility(View.GONE);
         }
     }
 
@@ -648,6 +648,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         setInitialData(result.getServiceId(), result.getOriginalUrl(), result.getName());
 
         if (ImageStrategy.shouldLoadImages() && !result.getBanners().isEmpty()) {
+            binding.channelBannerContainer.setVisibility(View.VISIBLE);
             binding.channelBannerImage.setVisibility(View.VISIBLE);
             CoilHelper.INSTANCE.loadBanner(binding.channelBannerImage, result.getBanners());
         } else {
@@ -655,6 +656,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
             CoilUtils.dispose(binding.channelBannerImage);
             binding.channelBannerImage.setImageDrawable(null);
             binding.channelBannerImage.setVisibility(View.GONE);
+            binding.channelBannerContainer.setVisibility(View.GONE);
         }
 
         CoilHelper.INSTANCE.loadAvatar(binding.channelAvatarView, result.getAvatars());

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -15,35 +15,30 @@
         app:elevation="0dp">
 
         <org.schabi.newpipe.views.CustomCollapsingToolbarLayout
+            android:id="@+id/channel_banner_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fitsSystemWindows="true"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
-            <LinearLayout
-                android:id="@+id/channel_metadata"
+            <ImageView
+                android:id="@+id/channel_banner_image"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:fitsSystemWindows="true"
-                android:orientation="vertical"
-                app:layout_collapseMode="parallax">
+                android:adjustViewBounds="true"
+                android:maxHeight="70dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/placeholder_channel_banner"
+                app:layout_collapseMode="parallax"
+                app:tint="@null"
+                tools:ignore="ContentDescription" />
+        </org.schabi.newpipe.views.CustomCollapsingToolbarLayout>
 
-                <ImageView
-                    android:id="@+id/channel_banner_image"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:adjustViewBounds="true"
-                    android:maxHeight="70dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/placeholder_channel_banner"
-                    app:tint="@null"
-                    tools:ignore="ContentDescription" />
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/channel_metadata_row"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:minHeight="86dp">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/channel_metadata_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="86dp">
 
                     <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/channel_avatar_view"
@@ -135,9 +130,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
-                </androidx.constraintlayout.widget.ConstraintLayout>
-            </LinearLayout>
-        </org.schabi.newpipe.views.CustomCollapsingToolbarLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
     <RelativeLayout

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Fixes
+
+- Kept channel metadata and Subscribe controls reachable while the banner collapses, including in
+  landscape and on channels without banners.
+
 ## WizeStream 1.9.0 (`1009000`)
 
 ### New features


### PR DESCRIPTION
- Keep channel avatar, metadata, subscriber count, and Subscribe controls outside the collapsing banner
- Remove the entire banner container when channel artwork is unavailable
- Extend regression coverage across portrait and landscape banner states and verify controls remain outside the app-bar scroll range
- Document the channel-header correction