### PR TITLE
Fall back from rejected Android VR AV1 streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2462,6 +2462,11 @@ public final class Player implements PlaybackListener, Listener {
                     + " (status=" + (responseCode == null ? "network" : responseCode)
                     + ", attempt=" + attempt.getNumber() + "/"
                     + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + ")");
+            getSelectedVideoStream()
+                    .filter(stream -> PlayerHttpErrorRecovery
+                            .shouldAvoidAndroidVrAv1HfrStream(error, stream))
+                    .ifPresent(stream -> videoResolver.rejectVideoStreamOnce(
+                            item.getUrl(), stream.getItag()));
             invalidateYouTubeMediaCaches(item);
             reloadPlayQueueManager();
         };

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
@@ -9,9 +9,11 @@ import androidx.annotation.Nullable;
 
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
+import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
 import java.net.UnknownHostException;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 
@@ -135,6 +137,24 @@ final class PlayerHttpErrorRecovery {
             current = current.getCause();
         }
         return false;
+    }
+
+    static boolean shouldAvoidAndroidVrAv1HfrStream(@NonNull final Throwable error,
+                                                     @Nullable final VideoStream stream) {
+        if (stream == null || stream.getFps() <= 30) {
+            return false;
+        }
+
+        final String codec = stream.getCodec();
+        final String normalizedCodec = codec == null ? "" : codec.toLowerCase(Locale.ROOT);
+        if (!normalizedCodec.contains("av01") && !normalizedCodec.contains("av1")) {
+            return false;
+        }
+
+        final String diagnostic = findSafeRequestDiagnostic(error);
+        return Integer.valueOf(403).equals(findInvalidResponseCode(error))
+                && diagnostic != null
+                && diagnostic.contains("client=ANDROID_VR");
     }
 
     @Nullable

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolver.java
@@ -26,6 +26,7 @@ import org.schabi.newpipe.util.ListHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.android.exoplayer2.C.TIME_UNSET;
 import static org.schabi.newpipe.util.ListHelper.getFilteredAudioStreams;
@@ -47,6 +48,8 @@ public class VideoPlaybackResolver implements PlaybackResolver {
     private String playbackQuality;
     @Nullable
     private String audioTrack;
+    @Nullable
+    private RejectedVideoStream rejectedVideoStream;
 
     public enum SourceType {
         LIVE_STREAM,
@@ -87,9 +90,16 @@ public class VideoPlaybackResolver implements PlaybackResolver {
         final List<MediaSource> mediaSources = new ArrayList<>();
 
         // Create video stream source
+        final Integer rejectedItag = consumeRejectedItag(info.getUrl());
+        final List<VideoStream> playableVideoStreams = withoutRejectedItag(
+                getPlayableStreams(info.getVideoStreams(), info.getServiceId()), rejectedItag);
+        final List<VideoStream> playableVideoOnlyStreams = withoutRejectedItag(
+                getPlayableStreams(info.getVideoOnlyStreams(), info.getServiceId()), rejectedItag);
         final List<VideoStream> videoStreamsList = ListHelper.getSortedStreamVideosList(context,
-                getPlayableStreams(info.getVideoStreams(), info.getServiceId()),
-                getPlayableStreams(info.getVideoOnlyStreams(), info.getServiceId()), false, true);
+                playableVideoStreams, playableVideoOnlyStreams, false, true);
+        if (rejectedItag != null) {
+            Log.w(TAG, "Falling back from rejected YouTube video itag " + rejectedItag);
+        }
         final List<AudioStream> audioStreamsList =
                 getFilteredAudioStreams(context, info.getAudioStreams());
 
@@ -207,6 +217,45 @@ public class VideoPlaybackResolver implements PlaybackResolver {
 
     public void setAudioTrack(@Nullable final String audioLanguage) {
         this.audioTrack = audioLanguage;
+    }
+
+    public synchronized void rejectVideoStreamOnce(@NonNull final String streamUrl,
+                                                    final int itag) {
+        rejectedVideoStream = new RejectedVideoStream(streamUrl, itag);
+    }
+
+    @Nullable
+    private synchronized Integer consumeRejectedItag(@NonNull final String streamUrl) {
+        if (rejectedVideoStream == null || !rejectedVideoStream.streamUrl.equals(streamUrl)) {
+            return null;
+        }
+
+        final int itag = rejectedVideoStream.itag;
+        rejectedVideoStream = null;
+        return itag;
+    }
+
+    @NonNull
+    private static List<VideoStream> withoutRejectedItag(
+            @NonNull final List<VideoStream> streams,
+            @Nullable final Integer rejectedItag) {
+        if (rejectedItag == null) {
+            return streams;
+        }
+        return streams.stream()
+                .filter(stream -> stream.getItag() != rejectedItag)
+                .collect(Collectors.toList());
+    }
+
+    private static final class RejectedVideoStream {
+        @NonNull
+        private final String streamUrl;
+        private final int itag;
+
+        private RejectedVideoStream(@NonNull final String streamUrl, final int itag) {
+            this.streamUrl = streamUrl;
+            this.itag = itag;
+        }
     }
 
     public interface QualityResolver {

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
@@ -9,7 +9,10 @@ import static org.junit.Assert.assertTrue;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 
 import org.junit.Test;
+import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.services.youtube.ItagItem;
+import org.schabi.newpipe.extractor.stream.VideoStream;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -60,6 +63,30 @@ public class PlayerHttpErrorRecoveryTest {
 
         assertEquals("status=403, client=VISIONOS, cver=1.02, itag=18, userAgent=VISIONOS",
                 PlayerHttpErrorRecovery.buildSafeErrorContext(error));
+    }
+
+    @Test
+    public void avoidsOnlyRejectedAndroidVrAv1HfrStreams() throws Exception {
+        final VideoStream av1Hfr = new VideoStream.Builder()
+                .setId("398")
+                .setContent("https://media.example.com/video", true)
+                .setMediaFormat(MediaFormat.MPEG_4)
+                .setResolution("720p HFR")
+                .setCodec("av01.0.08M.08")
+                .setFps(60)
+                .setIsVideoOnly(true)
+                .setItagItem(ItagItem.getItag(398))
+                .build();
+        final IOException androidVrDiagnostic = new IOException(
+                "YouTube media request diagnostic: client=ANDROID_VR, itag=398");
+        final Throwable rejected = invalidResponseCodeException(403, androidVrDiagnostic);
+
+        assertTrue(PlayerHttpErrorRecovery.shouldAvoidAndroidVrAv1HfrStream(rejected, av1Hfr));
+        assertFalse(PlayerHttpErrorRecovery.shouldAvoidAndroidVrAv1HfrStream(
+                invalidResponseCodeException(404, androidVrDiagnostic), av1Hfr));
+        assertFalse(PlayerHttpErrorRecovery.shouldAvoidAndroidVrAv1HfrStream(
+                invalidResponseCodeException(403, new IOException(
+                        "YouTube media request diagnostic: client=VISIONOS, itag=398")), av1Hfr));
     }
 
     @Test
@@ -122,6 +149,7 @@ public class PlayerHttpErrorRecoveryTest {
         assertTrue(recoveryMethod.indexOf("setRecovery();")
                 < recoveryMethod.indexOf("postDelayed"));
         assertTrue(recoveryMethod.contains("invalidateYouTubeMediaCaches(item)"));
+        assertTrue(recoveryMethod.contains("rejectVideoStreamOnce"));
         assertTrue(recoveryMethod.contains("changeState(STATE_PAUSED);"));
         assertFalse(recoveryMethod.contains("playQueue.error()"));
     }

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -8,6 +8,8 @@ Release history is listed newest first. The number beside each release is its An
 
 - Kept channel metadata and Subscribe controls reachable while the banner collapses, including in
   landscape and on channels without banners.
+- Fixed YouTube Android VR AV1/HFR streams repeatedly failing with HTTP 403 by temporarily falling
+  back to the nearest available stream without changing the saved quality preference.
 
 ## WizeStream 1.9.0 (`1009000`)
 


### PR DESCRIPTION
- Detect Android VR AV1/HFR playback failures that return HTTP 403.
- Exclude the rejected itag for the current item’s refreshed resolve so normal quality selection chooses the nearest available alternative.
- Preserve playback recovery position and the user’s saved quality preference.
- Add regression coverage and document the fix in the unreleased changelog.