### PR TITLE
Hide duplicate global search on channel pages

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -175,6 +175,14 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
 
             @Override
             public void onPrepareMenu(@NonNull final Menu menu) {
+                // MainFragment remains resumed underneath detail fragments and contributes its
+                // global search action to the same activity menu. A channel has its own contextual
+                // search, so showing both actions is ambiguous and the global action can navigate
+                // away to SearchFragment unexpectedly.
+                final MenuItem globalSearchItem = menu.findItem(R.id.action_search);
+                if (globalSearchItem != null) {
+                    globalSearchItem.setVisible(false);
+                }
                 menuRssButton = menu.findItem(R.id.menu_item_rss);
                 menuNotifyButton = menu.findItem(R.id.menu_item_notify);
                 updateRssButton();

--- a/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
@@ -155,6 +155,16 @@ public class ContextualSearchIntegrationTest {
     }
 
     @Test
+    public void channelContextualSearchSuppressesTheUnderlyingGlobalAction() throws Exception {
+        final String channelFragment = read(
+                "org/schabi/newpipe/fragments/list/channel/ChannelFragment.java");
+
+        assertTrue(channelFragment.contains(
+                "final MenuItem globalSearchItem = menu.findItem(R.id.action_search);"));
+        assertTrue(channelFragment.contains("globalSearchItem.setVisible(false);"));
+    }
+
+    @Test
     public void remoteSearchWaitsForInitialResultBeforeFiltering() throws Exception {
         assertSourceContains("org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java",
                 "|| currentInfo == null");

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -10,6 +10,7 @@ Release history is listed newest first. The number beside each release is its An
   landscape and on channels without banners.
 - Fixed YouTube Android VR AV1/HFR streams repeatedly failing with HTTP 403 by temporarily falling
   back to the nearest available stream without changing the saved quality preference.
+- Fixed duplicate global and contextual search actions appearing together on channel pages.
 
 ## WizeStream 1.9.0 (`1009000`)
 


### PR DESCRIPTION
- Hide the underlying global search action while a channel’s contextual search menu is active.
- Restore the normal global search automatically after leaving the channel page.
- Prevent the wrong search action from navigating unexpectedly to the global SearchFragment.
- Add regression coverage and document the fix in the unreleased changelog.