### PR TITLE
Restore channel navigation in History and local playlists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/LocalItemBuilder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalItemBuilder.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.util.OnClickGesture;
 
+import java.util.function.Consumer;
+
 /*
  * Created by Christian Schabesberger on 26.09.16.
  * <p>
@@ -29,6 +31,7 @@ public class LocalItemBuilder {
     private final Context context;
 
     private OnClickGesture<LocalItem> onSelectedListener;
+    private Consumer<LocalItem> onUploaderSelectedListener;
 
     public LocalItemBuilder(final Context context) {
         this.context = context;
@@ -44,5 +47,13 @@ public class LocalItemBuilder {
 
     public void setOnItemSelectedListener(final OnClickGesture<LocalItem> listener) {
         this.onSelectedListener = listener;
+    }
+
+    public Consumer<LocalItem> getOnUploaderSelectedListener() {
+        return onUploaderSelectedListener;
+    }
+
+    public void setOnUploaderSelectedListener(final Consumer<LocalItem> listener) {
+        onUploaderSelectedListener = listener;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
@@ -37,6 +37,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /*
@@ -109,6 +110,14 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     public void unsetSelectedListener() {
         localItemBuilder.setOnItemSelectedListener(null);
+    }
+
+    public void setUploaderSelectedListener(final Consumer<LocalItem> listener) {
+        localItemBuilder.setOnUploaderSelectedListener(listener);
+    }
+
+    public void unsetUploaderSelectedListener() {
+        localItemBuilder.setOnUploaderSelectedListener(null);
     }
 
     public void addItems(@Nullable final List<? extends LocalItem> data) {

--- a/app/src/main/java/org/schabi/newpipe/local/LocalUploaderNavigation.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalUploaderNavigation.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.local;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+import org.schabi.newpipe.database.stream.model.StreamEntity;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.util.NavigationHelper;
+import org.schabi.newpipe.util.SparseItemUtil;
+
+public final class LocalUploaderNavigation {
+    private LocalUploaderNavigation() {
+    }
+
+    public static boolean canOpenChannel(final boolean localMedia,
+                                         final String streamUrl,
+                                         final String uploaderName) {
+        return !localMedia
+                && !isBlank(streamUrl)
+                && !isBlank(uploaderName);
+    }
+
+    public static boolean canOpenChannel(@NonNull final StreamEntity stream) {
+        return canOpenChannel(stream.isLocalMedia(), stream.getUrl(), stream.getUploader());
+    }
+
+    public static void openChannel(@NonNull final Fragment fragment,
+                                   @NonNull final StreamEntity stream) {
+        if (!canOpenChannel(stream)) {
+            return;
+        }
+
+        final StreamInfoItem item = stream.toStreamInfoItem();
+        SparseItemUtil.fetchUploaderUrlIfSparse(fragment.requireContext(), stream.getServiceId(),
+                stream.getUrl(), stream.getUploaderUrl(), uploaderUrl -> {
+                    if (fragment.isAdded() && !isBlank(uploaderUrl)) {
+                        NavigationHelper.openChannelFragment(fragment, item, uploaderUrl);
+                    }
+                });
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -34,6 +34,7 @@ import org.schabi.newpipe.fragments.list.playlist.PlaylistControlViewHolder;
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.info_list.dialog.StreamDialogDefaultEntry;
 import org.schabi.newpipe.local.BaseLocalListFragment;
+import org.schabi.newpipe.local.LocalUploaderNavigation;
 import org.schabi.newpipe.local.search.ContextualSearchHelper;
 import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
@@ -160,6 +161,13 @@ public class StatisticsPlaylistFragment
     protected void initListeners() {
         super.initListeners();
 
+        itemListAdapter.setUploaderSelectedListener(selectedItem -> {
+            if (selectedItem instanceof StreamStatisticsEntry) {
+                LocalUploaderNavigation.openChannel(this,
+                        ((StreamStatisticsEntry) selectedItem).getStreamEntity());
+            }
+        });
+
         itemListAdapter.setSelectedListener(new OnClickGesture<>() {
             @Override
             public void selected(final LocalItem selectedItem) {
@@ -221,11 +229,12 @@ public class StatisticsPlaylistFragment
 
     @Override
     public void onDestroyView() {
-        super.onDestroyView();
-
         if (itemListAdapter != null) {
             itemListAdapter.unsetSelectedListener();
+            itemListAdapter.unsetUploaderSelectedListener();
         }
+
+        super.onDestroyView();
 
         headerBinding = null;
         playlistControlBinding = null;

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalItemHolder.java
@@ -1,10 +1,13 @@
 package org.schabi.newpipe.local.holder;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.local.LocalItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
@@ -38,6 +41,28 @@ public abstract class LocalItemHolder extends RecyclerView.ViewHolder {
                            final ViewGroup parent) {
         super(LayoutInflater.from(itemBuilder.getContext()).inflate(layoutId, parent, false));
         this.itemBuilder = itemBuilder;
+    }
+
+    protected void bindUploaderNavigation(@NonNull final View uploaderRoot,
+                                          @NonNull final LocalItem item,
+                                          final boolean enabled,
+                                          @NonNull final String uploaderName) {
+        if (enabled && itemBuilder.getOnUploaderSelectedListener() != null) {
+            uploaderRoot.setClickable(true);
+            uploaderRoot.setFocusable(true);
+            uploaderRoot.setContentDescription(itemBuilder.getContext().getString(
+                    R.string.open_channel, uploaderName));
+            uploaderRoot.setOnClickListener(view -> {
+                if (itemBuilder.getOnUploaderSelectedListener() != null) {
+                    itemBuilder.getOnUploaderSelectedListener().accept(item);
+                }
+            });
+        } else {
+            uploaderRoot.setOnClickListener(null);
+            uploaderRoot.setClickable(false);
+            uploaderRoot.setFocusable(false);
+            uploaderRoot.setContentDescription(null);
+        }
     }
 
     public abstract void updateFromItem(LocalItem item, HistoryRecordManager historyRecordManager,

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java
@@ -14,6 +14,7 @@ import org.schabi.newpipe.database.playlist.PlaylistStreamEntry;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.ktx.ViewUtils;
 import org.schabi.newpipe.local.LocalItemBuilder;
+import org.schabi.newpipe.local.LocalUploaderNavigation;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.Localization;
@@ -29,6 +30,7 @@ public class LocalPlaylistStreamItemHolder extends LocalItemHolder {
     public final ImageView itemThumbnailView;
     public final TextView itemVideoTitleView;
     private final ImageView itemUploaderAvatarView;
+    private final View itemUploaderRoot;
     private final TextView itemUploaderView;
     private final TextView itemAdditionalDetailsView;
     public final TextView itemDurationView;
@@ -43,6 +45,7 @@ public class LocalPlaylistStreamItemHolder extends LocalItemHolder {
         itemThumbnailView = itemView.findViewById(R.id.itemThumbnailView);
         itemVideoTitleView = itemView.findViewById(R.id.itemVideoTitleView);
         itemUploaderAvatarView = itemView.findViewById(R.id.itemUploaderAvatarView);
+        itemUploaderRoot = itemView.findViewById(R.id.itemUploaderRoot);
         itemUploaderView = itemView.findViewById(R.id.itemUploaderView);
         itemAdditionalDetailsView = itemView.findViewById(R.id.itemAdditionalDetails);
         itemDurationView = itemView.findViewById(R.id.itemDurationView);
@@ -71,6 +74,9 @@ public class LocalPlaylistStreamItemHolder extends LocalItemHolder {
                 ? View.VISIBLE : View.GONE);
         CoilHelper.INSTANCE.loadAvatar(itemUploaderAvatarView,
                 item.getStreamEntity().getUploaderAvatarUrl());
+        bindUploaderNavigation(itemUploaderRoot, item,
+                LocalUploaderNavigation.canOpenChannel(item.getStreamEntity()),
+                item.getStreamEntity().getUploader());
 
         final String sourceName = item.getStreamEntity().isLocalMedia()
                 ? itemBuilder.getContext().getString(R.string.local_media_on_device)

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalStatisticStreamItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalStatisticStreamItemHolder.java
@@ -13,6 +13,7 @@ import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.database.stream.StreamStatisticsEntry;
 import org.schabi.newpipe.ktx.ViewUtils;
 import org.schabi.newpipe.local.LocalItemBuilder;
+import org.schabi.newpipe.local.LocalUploaderNavigation;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.DependentPreferenceHelper;
 import org.schabi.newpipe.util.Localization;
@@ -47,6 +48,8 @@ public class LocalStatisticStreamItemHolder extends LocalItemHolder {
     public final ImageView itemThumbnailView;
     public final TextView itemVideoTitleView;
     public final TextView itemUploaderView;
+    private final View itemUploaderRoot;
+    private final ImageView itemUploaderAvatarView;
     public final TextView itemDurationView;
     @Nullable
     public final TextView itemAdditionalDetails;
@@ -64,6 +67,8 @@ public class LocalStatisticStreamItemHolder extends LocalItemHolder {
         itemThumbnailView = itemView.findViewById(R.id.itemThumbnailView);
         itemVideoTitleView = itemView.findViewById(R.id.itemVideoTitleView);
         itemUploaderView = itemView.findViewById(R.id.itemUploaderView);
+        itemUploaderRoot = itemView.findViewById(R.id.itemUploaderRoot);
+        itemUploaderAvatarView = itemView.findViewById(R.id.itemUploaderAvatarView);
         itemDurationView = itemView.findViewById(R.id.itemDurationView);
         itemAdditionalDetails = itemView.findViewById(R.id.itemAdditionalDetails);
         itemProgressView = itemView.findViewById(R.id.itemProgressView);
@@ -93,6 +98,11 @@ public class LocalStatisticStreamItemHolder extends LocalItemHolder {
 
         itemVideoTitleView.setText(item.getStreamEntity().getTitle());
         itemUploaderView.setText(item.getStreamEntity().getUploader());
+        CoilHelper.INSTANCE.loadAvatar(itemUploaderAvatarView,
+                item.getStreamEntity().getUploaderAvatarUrl());
+        bindUploaderNavigation(itemUploaderRoot, item,
+                LocalUploaderNavigation.canOpenChannel(item.getStreamEntity()),
+                item.getStreamEntity().getUploader());
 
         if (item.getStreamEntity().getDuration() > 0) {
             itemDurationView.

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -58,6 +58,7 @@ import org.schabi.newpipe.fragments.list.playlist.PlaylistControlViewHolder;
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.info_list.dialog.StreamDialogDefaultEntry;
 import org.schabi.newpipe.local.BaseLocalListFragment;
+import org.schabi.newpipe.local.LocalUploaderNavigation;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.local.search.ContextualSearchHelper;
 import org.schabi.newpipe.local.search.ContextualSearchable;
@@ -197,6 +198,13 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
     protected void initListeners() {
         super.initListeners();
 
+        itemListAdapter.setUploaderSelectedListener(selectedItem -> {
+            if (selectedItem instanceof PlaylistStreamEntry) {
+                LocalUploaderNavigation.openChannel(this,
+                        ((PlaylistStreamEntry) selectedItem).getStreamEntity());
+            }
+        });
+
         headerBinding.playlistTitleView.setOnClickListener(view -> createRenameDialog());
 
         itemTouchHelper = new ItemTouchHelper(getItemTouchCallback());
@@ -333,11 +341,12 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             swipeRemovalSnackbar.dismiss();
             swipeRemovalSnackbar = null;
         }
-        super.onDestroyView();
-
         if (itemListAdapter != null) {
             itemListAdapter.unsetSelectedListener();
+            itemListAdapter.unsetUploaderSelectedListener();
         }
+
+        super.onDestroyView();
 
         headerBinding = null;
         playlistControlBinding = null;

--- a/app/src/main/res/layout/list_stream_playlist_card_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_card_item.xml
@@ -78,6 +78,7 @@
         android:id="@+id/itemUploaderRoot"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:minHeight="@dimen/stream_item_uploader_touch_target"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/itemHandle"

--- a/app/src/main/res/layout/list_stream_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_grid_item.xml
@@ -74,6 +74,7 @@
         android:id="@+id/itemUploaderRoot"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:minHeight="@dimen/stream_item_uploader_touch_target"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/itemHandle"

--- a/app/src/main/res/layout/list_stream_playlist_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_item.xml
@@ -75,6 +75,7 @@
         android:id="@+id/itemUploaderRoot"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:minHeight="@dimen/stream_item_uploader_touch_target"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/itemHandle"

--- a/app/src/test/java/org/schabi/newpipe/local/LocalUploaderNavigationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/LocalUploaderNavigationTest.java
@@ -1,0 +1,65 @@
+package org.schabi.newpipe.local;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LocalUploaderNavigationTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+    private final Path resourceDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void enablesOnlyRemoteStreamsWithEnoughChannelLookupMetadata() {
+        assertTrue(LocalUploaderNavigation.canOpenChannel(
+                false, "https://example.com/watch?v=1", "Uploader"));
+        assertFalse(LocalUploaderNavigation.canOpenChannel(
+                true, "content://media/video/1", "Local folder"));
+        assertFalse(LocalUploaderNavigation.canOpenChannel(false, "", "Uploader"));
+        assertFalse(LocalUploaderNavigation.canOpenChannel(
+                false, "https://example.com/watch?v=1", "  "));
+    }
+
+    @Test
+    public void historyAndLocalPlaylistsBindAndReleaseUploaderNavigation() throws Exception {
+        final String history = read(
+                "org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java");
+        final String playlist = read(
+                "org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java");
+        final String historyHolder = read(
+                "org/schabi/newpipe/local/holder/LocalStatisticStreamItemHolder.java");
+        final String playlistHolder = read(
+                "org/schabi/newpipe/local/holder/LocalPlaylistStreamItemHolder.java");
+        final String baseHolder = read(
+                "org/schabi/newpipe/local/holder/LocalItemHolder.java");
+
+        assertTrue(history.contains("setUploaderSelectedListener"));
+        assertTrue(history.contains("unsetUploaderSelectedListener"));
+        assertTrue(playlist.contains("setUploaderSelectedListener"));
+        assertTrue(playlist.contains("unsetUploaderSelectedListener"));
+        assertTrue(historyHolder.contains("bindUploaderNavigation"));
+        assertTrue(playlistHolder.contains("bindUploaderNavigation"));
+        assertTrue(baseHolder.contains("uploaderRoot.setOnClickListener(null)"));
+        assertTrue(baseHolder.contains("uploaderRoot.setClickable(false)"));
+        assertUploaderRipple("list_stream_playlist_item.xml");
+        assertUploaderRipple("list_stream_playlist_grid_item.xml");
+        assertUploaderRipple("list_stream_playlist_card_item.xml");
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(sourceDirectory.resolve(relativePath));
+    }
+
+    private void assertUploaderRipple(final String fileName) throws Exception {
+        final String layout = Files.readString(
+                resourceDirectory.resolve("layout").resolve(fileName));
+        assertTrue(layout.contains("android:id=\"@+id/itemUploaderRoot\""));
+        assertTrue(layout.contains(
+                "android:background=\"?attr/selectableItemBackgroundBorderless\""));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -11,6 +11,7 @@ Release history is listed newest first. The number beside each release is its An
 - Fixed YouTube Android VR AV1/HFR streams repeatedly failing with HTTP 403 by temporarily falling
   back to the nearest available stream without changing the saved quality preference.
 - Fixed duplicate global and contextual search actions appearing together on channel pages.
+- Fixed channel names and avatars not opening their channels from History and local playlists.
 
 ## WizeStream 1.9.0 (`1009000`)
 


### PR DESCRIPTION
- Add shared uploader navigation for History and local-playlist items across list, grid, and card layouts.
- Resolve missing uploader URLs for older saved entries before opening their channels.
- Keep uploader actions disabled for local-device media and clear recycled-holder interaction state.
- Add channel accessibility labels, playlist ripple feedback, regression coverage, and an unreleased changelog entry.