### PR TITLE
Add date navigation to watch history

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/LocalItemListAdapterTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/LocalItemListAdapterTest.kt
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.local
 
 import android.view.View
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
@@ -43,6 +44,9 @@ class LocalItemListAdapterTest {
             assertEquals(-1, adapter.getItemIndex(0))
             assertEquals(0, adapter.getItemIndex(1))
             assertEquals(1, adapter.getItemIndex(2))
+            assertEquals(1, adapter.getAdapterPositionForItemIndex(0))
+            assertEquals(2, adapter.getAdapterPositionForItemIndex(1))
+            assertEquals(RecyclerView.NO_POSITION, adapter.getAdapterPositionForItemIndex(2))
 
             assertSame(duplicate, adapter.removeItemAt(1))
             assertEquals(listOf(first), adapter.itemsList)

--- a/app/src/androidTest/java/org/schabi/newpipe/local/history/HistoryDateFastScrollerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/history/HistoryDateFastScrollerTest.kt
@@ -1,0 +1,40 @@
+package org.schabi.newpipe.local.history
+
+import android.view.MotionEvent
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HistoryDateFastScrollerTest {
+    @Test
+    fun dragMapsTrackEndpointsToHistoryEndpoints() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val view = HistoryDateFastScroller(instrumentation.targetContext)
+            var selectedPosition = -1
+            view.setOnPositionChangedListener { selectedPosition = it }
+            view.setLabelProvider { position -> "Date $position" }
+            view.setItemCount(100)
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(48, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(1000, View.MeasureSpec.EXACTLY)
+            )
+            view.layout(0, 0, 48, 1000)
+
+            view.onTouchEvent(event(MotionEvent.ACTION_DOWN, 18f))
+            view.onTouchEvent(event(MotionEvent.ACTION_MOVE, 982f))
+
+            assertEquals(99, selectedPosition)
+            assertTrue(view.contentDescription.toString().contains("Date 99"))
+
+            view.onTouchEvent(event(MotionEvent.ACTION_UP, 982f))
+        }
+    }
+
+    private fun event(action: Int, y: Float): MotionEvent = MotionEvent.obtain(0L, 0L, action, 24f, y, 0)
+}

--- a/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
@@ -180,6 +180,19 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     /**
+     * Converts an item index to its RecyclerView adapter position.
+     *
+     * @param itemIndex index within {@link #getItemsList()}
+     * @return adapter position, or {@link RecyclerView#NO_POSITION} when invalid
+     */
+    public int getAdapterPositionForItemIndex(final int itemIndex) {
+        if (itemIndex < 0 || itemIndex >= localItems.size()) {
+            return RecyclerView.NO_POSITION;
+        }
+        return itemIndex + (hasHeader() ? 1 : 0);
+    }
+
+    /**
      * Removes the item at an exact index, preserving duplicate playlist entries correctly.
      *
      * @param itemIndex index within {@link #getItemsList()}

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
@@ -1,0 +1,322 @@
+package org.schabi.newpipe.local.history;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.drawable.GradientDrawable;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.PopupWindow;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.color.MaterialColors;
+
+import org.schabi.newpipe.R;
+
+import java.util.function.IntConsumer;
+import java.util.function.IntFunction;
+
+public final class HistoryDateFastScroller extends View {
+    private final Paint trackPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Paint thumbPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final RectF drawingRect = new RectF();
+
+    private final float trackWidth;
+    private final float thumbWidth;
+    private final float thumbHeight;
+    private final float verticalInset;
+    private final int bubbleGap;
+    private final int bubblePaddingHorizontal;
+    private final int bubblePaddingVertical;
+
+    private int itemCount;
+    private int position;
+    private boolean dragging;
+    @Nullable
+    private IntConsumer onPositionChangedListener;
+    @Nullable
+    private IntFunction<String> labelProvider;
+    @Nullable
+    private PopupWindow bubblePopup;
+    @Nullable
+    private TextView bubbleText;
+
+    public HistoryDateFastScroller(@NonNull final Context context) {
+        this(context, null);
+    }
+
+    public HistoryDateFastScroller(@NonNull final Context context,
+                                   @Nullable final AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public HistoryDateFastScroller(@NonNull final Context context,
+                                   @Nullable final AttributeSet attrs,
+                                   final int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        trackWidth = dp(3);
+        thumbWidth = dp(8);
+        thumbHeight = dp(36);
+        verticalInset = dp(18);
+        bubbleGap = Math.round(dp(8));
+        bubblePaddingHorizontal = Math.round(dp(16));
+        bubblePaddingVertical = Math.round(dp(10));
+
+        trackPaint.setColor(MaterialColors.getColor(
+                this, com.google.android.material.R.attr.colorOutline, Color.GRAY));
+        trackPaint.setAlpha(110);
+        thumbPaint.setColor(MaterialColors.getColor(
+                this, com.google.android.material.R.attr.colorPrimary, Color.DKGRAY));
+
+        setClickable(true);
+        setFocusable(true);
+    }
+
+    public void setOnPositionChangedListener(
+            @Nullable final IntConsumer onPositionChangedListener) {
+        this.onPositionChangedListener = onPositionChangedListener;
+    }
+
+    public void setLabelProvider(@Nullable final IntFunction<String> labelProvider) {
+        this.labelProvider = labelProvider;
+        updateAccessibilityDescription();
+    }
+
+    public void setItemCount(final int itemCount) {
+        this.itemCount = Math.max(0, itemCount);
+        setPosition(Math.min(position, Math.max(0, this.itemCount - 1)));
+        setEnabled(this.itemCount > 1);
+    }
+
+    public void setPosition(final int position) {
+        if (itemCount <= 1) {
+            this.position = 0;
+        } else {
+            this.position = Math.max(0, Math.min(position, itemCount - 1));
+        }
+        invalidate();
+        updateAccessibilityDescription();
+        if (dragging) {
+            updateBubble();
+        }
+    }
+
+    public void dismissBubble() {
+        dragging = false;
+        if (bubblePopup != null) {
+            bubblePopup.dismiss();
+        }
+    }
+
+    @Override
+    protected void onDraw(@NonNull final Canvas canvas) {
+        super.onDraw(canvas);
+        if (itemCount <= 1) {
+            return;
+        }
+
+        final float centerX = getWidth() / 2f;
+        final float top = verticalInset;
+        final float bottom = Math.max(top, getHeight() - verticalInset);
+        drawingRect.set(centerX - trackWidth / 2f, top,
+                centerX + trackWidth / 2f, bottom);
+        canvas.drawRoundRect(drawingRect, trackWidth / 2f, trackWidth / 2f, trackPaint);
+
+        final float thumbCenterY = top + getFraction() * (bottom - top);
+        drawingRect.set(centerX - thumbWidth / 2f, thumbCenterY - thumbHeight / 2f,
+                centerX + thumbWidth / 2f, thumbCenterY + thumbHeight / 2f);
+        canvas.drawRoundRect(drawingRect, thumbWidth / 2f, thumbWidth / 2f, thumbPaint);
+    }
+
+    @Override
+    public boolean onTouchEvent(@NonNull final MotionEvent event) {
+        if (!isEnabled() || itemCount <= 1) {
+            return false;
+        }
+
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                dragging = true;
+                requestParentDisallowIntercept(true);
+                updateFromTouch(event.getY());
+                return true;
+            case MotionEvent.ACTION_MOVE:
+                updateFromTouch(event.getY());
+                return true;
+            case MotionEvent.ACTION_UP:
+                updateFromTouch(event.getY());
+                requestParentDisallowIntercept(false);
+                dismissBubble();
+                performClick();
+                return true;
+            case MotionEvent.ACTION_CANCEL:
+                requestParentDisallowIntercept(false);
+                dismissBubble();
+                return true;
+            default:
+                return super.onTouchEvent(event);
+        }
+    }
+
+    @Override
+    public boolean performClick() {
+        super.performClick();
+        final String label = getLabel();
+        if (!label.isEmpty()) {
+            announceForAccessibility(label);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onKeyDown(final int keyCode, @NonNull final KeyEvent event) {
+        if (!isEnabled() || itemCount <= 1) {
+            return super.onKeyDown(keyCode, event);
+        }
+
+        final int step = Math.max(1, itemCount / 20);
+        if (keyCode == KeyEvent.KEYCODE_DPAD_UP) {
+            moveTo(position - step);
+            return true;
+        } else if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+            moveTo(position + step);
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        dismissBubble();
+        super.onDetachedFromWindow();
+    }
+
+    private void requestParentDisallowIntercept(final boolean disallowIntercept) {
+        final ViewParent parent = getParent();
+        if (parent != null) {
+            parent.requestDisallowInterceptTouchEvent(disallowIntercept);
+        }
+    }
+
+    private void updateFromTouch(final float y) {
+        final float availableHeight = Math.max(1f, getHeight() - 2f * verticalInset);
+        final float fraction = Math.max(0f,
+                Math.min(1f, (y - verticalInset) / availableHeight));
+        moveTo(Math.round(fraction * (itemCount - 1)));
+        updateBubble();
+    }
+
+    private void moveTo(final int targetPosition) {
+        final int boundedPosition = Math.max(0, Math.min(targetPosition, itemCount - 1));
+        if (boundedPosition == position) {
+            return;
+        }
+        position = boundedPosition;
+        invalidate();
+        updateAccessibilityDescription();
+        if (onPositionChangedListener != null) {
+            onPositionChangedListener.accept(position);
+        }
+    }
+
+    private float getFraction() {
+        return itemCount <= 1 ? 0f : position / (float) (itemCount - 1);
+    }
+
+    @NonNull
+    private String getLabel() {
+        if (labelProvider == null || itemCount == 0) {
+            return "";
+        }
+        final String label = labelProvider.apply(position);
+        return label == null ? "" : label;
+    }
+
+    private void updateAccessibilityDescription() {
+        final String label = getLabel();
+        if (!label.isEmpty()) {
+            setContentDescription(getContext().getString(
+                    R.string.history_date_fast_scroll_description, label));
+        }
+    }
+
+    private void updateBubble() {
+        final String label = getLabel();
+        if (label.isEmpty() || !isAttachedToWindow()) {
+            return;
+        }
+        ensureBubble();
+        bubbleText.setText(label);
+        bubbleText.measure(
+                MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED),
+                MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+
+        final int bubbleWidth = bubbleText.getMeasuredWidth();
+        final int bubbleHeight = bubbleText.getMeasuredHeight();
+        final int[] location = new int[2];
+        getLocationOnScreen(location);
+
+        final boolean rtl = getLayoutDirection() == LAYOUT_DIRECTION_RTL;
+        int x = rtl
+                ? location[0] + getWidth() + bubbleGap
+                : location[0] - bubbleWidth - bubbleGap;
+        final int screenWidth = getResources().getDisplayMetrics().widthPixels;
+        x = Math.max(0, Math.min(x, screenWidth - bubbleWidth));
+
+        final float thumbCenterY = verticalInset
+                + getFraction() * Math.max(1f, getHeight() - 2f * verticalInset);
+        final int y = Math.max(0,
+                Math.round(location[1] + thumbCenterY - bubbleHeight / 2f));
+
+        if (bubblePopup.isShowing()) {
+            bubblePopup.update(x, y, bubbleWidth, bubbleHeight);
+        } else {
+            bubblePopup.setWidth(bubbleWidth);
+            bubblePopup.setHeight(bubbleHeight);
+            bubblePopup.showAtLocation(getRootView(), Gravity.NO_GRAVITY, x, y);
+        }
+    }
+
+    private void ensureBubble() {
+        if (bubblePopup != null) {
+            return;
+        }
+
+        bubbleText = new TextView(getContext());
+        bubbleText.setGravity(Gravity.CENTER);
+        bubbleText.setPadding(bubblePaddingHorizontal, bubblePaddingVertical,
+                bubblePaddingHorizontal, bubblePaddingVertical);
+        bubbleText.setTextColor(MaterialColors.getColor(
+                this, com.google.android.material.R.attr.colorOnSurface, Color.WHITE));
+        bubbleText.setTextAppearance(
+                com.google.android.material.R.style.TextAppearance_Material3_TitleMedium);
+
+        final GradientDrawable background = new GradientDrawable();
+        background.setColor(MaterialColors.getColor(
+                this, com.google.android.material.R.attr.colorSurface, Color.DKGRAY));
+        background.setCornerRadius(dp(16));
+        bubbleText.setBackground(background);
+
+        bubblePopup = new PopupWindow(bubbleText,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                false);
+        bubblePopup.setTouchable(false);
+        bubblePopup.setClippingEnabled(true);
+        bubblePopup.setElevation(dp(6));
+    }
+
+    private float dp(final float value) {
+        return value * getResources().getDisplayMetrics().density;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateNavigator.java
@@ -1,0 +1,78 @@
+package org.schabi.newpipe.local.history;
+
+import androidx.annotation.NonNull;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+
+public final class HistoryDateNavigator {
+    private static final long MONTH_LABEL_MAXIMUM_SPAN_DAYS = 730;
+
+    private HistoryDateNavigator() {
+    }
+
+    /**
+     * Finds the closest date in a list sorted from newest to oldest.
+     *
+     * <p>When two entries are equally close, the newer entry is preferred.</p>
+     *
+     * @param dates descending chronological dates
+     * @param target requested date
+     * @return closest index, or {@code -1} for an empty list
+     */
+    public static int findClosestIndex(@NonNull final List<LocalDate> dates,
+                                       @NonNull final LocalDate target) {
+        if (dates.isEmpty()) {
+            return -1;
+        }
+
+        int low = 0;
+        int high = dates.size() - 1;
+        while (low <= high) {
+            final int middle = low + (high - low) / 2;
+            final int comparison = dates.get(middle).compareTo(target);
+            if (comparison == 0) {
+                return middle;
+            } else if (comparison > 0) {
+                low = middle + 1;
+            } else {
+                high = middle - 1;
+            }
+        }
+
+        if (low >= dates.size()) {
+            return dates.size() - 1;
+        }
+        if (high < 0) {
+            return 0;
+        }
+
+        final long newerDistance = Math.abs(
+                ChronoUnit.DAYS.between(dates.get(high), target));
+        final long olderDistance = Math.abs(
+                ChronoUnit.DAYS.between(dates.get(low), target));
+        return newerDistance <= olderDistance ? high : low;
+    }
+
+    public static boolean shouldUseMonthLabels(@NonNull final List<LocalDate> dates) {
+        if (dates.size() < 2) {
+            return true;
+        }
+        final LocalDate newest = dates.get(0);
+        final LocalDate oldest = dates.get(dates.size() - 1);
+        return Math.abs(ChronoUnit.DAYS.between(oldest, newest))
+                <= MONTH_LABEL_MAXIMUM_SPAN_DAYS;
+    }
+
+    @NonNull
+    public static String formatLabel(@NonNull final LocalDate date,
+                                     final boolean includeMonth,
+                                     @NonNull final Locale locale) {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
+                includeMonth ? "MMM yyyy" : "yyyy", locale);
+        return formatter.format(date);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -14,8 +14,15 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.evernote.android.state.State;
+import com.google.android.material.datepicker.CalendarConstraints;
+import com.google.android.material.datepicker.CompositeDateValidator;
+import com.google.android.material.datepicker.DateValidatorPointBackward;
+import com.google.android.material.datepicker.DateValidatorPointForward;
+import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.reactivestreams.Subscriber;
@@ -47,7 +54,10 @@ import org.schabi.newpipe.util.OnClickGesture;
 import org.schabi.newpipe.util.PlayButtonHelper;
 import org.schabi.newpipe.util.StreamListFilter;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -61,17 +71,24 @@ import io.reactivex.rxjava3.disposables.Disposable;
 public class StatisticsPlaylistFragment
         extends BaseLocalListFragment<List<StreamStatisticsEntry>, Void>
         implements PlaylistControlViewHolder, ContextualSearchable {
+    private static final int MIN_FAST_SCROLL_ITEMS = 50;
+    private static final String DATE_PICKER_TAG = "history_date_picker";
+
     private final CompositeDisposable disposables = new CompositeDisposable();
     @State
     Parcelable itemsListState;
     private StatisticSortMode sortMode = StatisticSortMode.LAST_PLAYED;
     private List<StreamStatisticsEntry> completeHistory = Collections.emptyList();
+    private List<StreamStatisticsEntry> displayedHistory = Collections.emptyList();
     private String contextualSearchQuery = "";
+    private boolean useMonthFastScrollLabels;
     @State
     StreamListFilter selectedStreamFilter = StreamListFilter.NONE;
 
+    private FragmentPlaylistBinding contentBinding;
     private StatisticPlaylistControlBinding headerBinding;
     private PlaylistControlBinding playlistControlBinding;
+    private RecyclerView.OnScrollListener historyScrollListener;
 
     /* Used for independent events */
     private Subscription databaseSubscription;
@@ -132,12 +149,16 @@ public class StatisticsPlaylistFragment
     @Override
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
-        final FragmentPlaylistBinding binding = FragmentPlaylistBinding.bind(rootView);
+        contentBinding = FragmentPlaylistBinding.bind(rootView);
+        contentBinding.historyDateFastScroller.setOnPositionChangedListener(
+                this::scrollToHistoryPosition);
+        contentBinding.historyDateFastScroller.setLabelProvider(this::getFastScrollLabel);
+
         if (selectedStreamFilter != StreamListFilter.NONE) {
-            binding.streamFilterChips.streamFilterChipGroup
+            contentBinding.streamFilterChips.streamFilterChipGroup
                     .check(selectedStreamFilter.getChipId());
         }
-        binding.streamFilterChips.streamFilterChipGroup
+        contentBinding.streamFilterChips.streamFilterChipGroup
                 .setOnCheckedStateChangeListener((group, checkedIds) -> {
                     selectedStreamFilter = StreamListFilter.fromChipId(
                             checkedIds.isEmpty() ? View.NO_ID : checkedIds.get(0));
@@ -160,6 +181,17 @@ public class StatisticsPlaylistFragment
     @Override
     protected void initListeners() {
         super.initListeners();
+
+        contentBinding.historyDateJumpButton.setOnClickListener(view -> showDatePicker());
+        historyScrollListener = new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrolled(@NonNull final RecyclerView recyclerView,
+                                   final int dx,
+                                   final int dy) {
+                updateFastScrollPosition();
+            }
+        };
+        itemsList.addOnScrollListener(historyScrollListener);
 
         itemListAdapter.setUploaderSelectedListener(selectedItem -> {
             if (selectedItem instanceof StreamStatisticsEntry) {
@@ -229,6 +261,15 @@ public class StatisticsPlaylistFragment
 
     @Override
     public void onDestroyView() {
+        if (itemsList != null && historyScrollListener != null) {
+            itemsList.removeOnScrollListener(historyScrollListener);
+        }
+        historyScrollListener = null;
+
+        if (contentBinding != null) {
+            contentBinding.historyDateFastScroller.dismissBubble();
+        }
+
         if (itemListAdapter != null) {
             itemListAdapter.unsetSelectedListener();
             itemListAdapter.unsetUploaderSelectedListener();
@@ -236,8 +277,10 @@ public class StatisticsPlaylistFragment
 
         super.onDestroyView();
 
+        contentBinding = null;
         headerBinding = null;
         playlistControlBinding = null;
+        displayedHistory = Collections.emptyList();
 
         if (databaseSubscription != null) {
             databaseSubscription.cancel();
@@ -323,11 +366,14 @@ public class StatisticsPlaylistFragment
                 });
 
         if (filteredHistory.isEmpty()) {
+            displayedHistory = Collections.emptyList();
+            updateDateNavigation();
             showEmptyState();
             return;
         }
 
-        itemListAdapter.addItems(processResult(filteredHistory));
+        displayedHistory = processResult(filteredHistory);
+        itemListAdapter.addItems(displayedHistory);
         if (itemsListState != null && itemsList.getLayoutManager() != null) {
             itemsList.getLayoutManager().onRestoreInstanceState(itemsListState);
             itemsListState = null;
@@ -337,6 +383,7 @@ public class StatisticsPlaylistFragment
 
         headerBinding.sortButton.setOnClickListener(view -> toggleSortMode());
 
+        updateDateNavigation();
         hideLoading();
     }
 
@@ -375,7 +422,159 @@ public class StatisticsPlaylistFragment
                 R.drawable.ic_filter_list);
             headerBinding.sortButtonText.setText(R.string.title_most_played);
         }
+        hideDateNavigation();
         startLoading(true);
+    }
+
+    private void hideDateNavigation() {
+        if (contentBinding == null) {
+            return;
+        }
+        contentBinding.historyDateJumpButton.setVisibility(View.GONE);
+        contentBinding.historyDateFastScroller.setVisibility(View.GONE);
+        contentBinding.historyDateFastScroller.dismissBubble();
+    }
+
+    private void updateDateNavigation() {
+        if (contentBinding == null) {
+            return;
+        }
+
+        final boolean chronological = sortMode == StatisticSortMode.LAST_PLAYED
+                && displayedHistory.size() > 1;
+        contentBinding.historyDateJumpButton.setVisibility(
+                chronological ? View.VISIBLE : View.GONE);
+
+        final boolean fastScrollVisible = chronological
+                && displayedHistory.size() >= MIN_FAST_SCROLL_ITEMS;
+        contentBinding.historyDateFastScroller.setVisibility(
+                fastScrollVisible ? View.VISIBLE : View.GONE);
+        contentBinding.historyDateFastScroller.setItemCount(displayedHistory.size());
+
+        if (!chronological) {
+            contentBinding.historyDateFastScroller.dismissBubble();
+            return;
+        }
+
+        final List<LocalDate> dates = getDisplayedHistoryDates();
+        useMonthFastScrollLabels = HistoryDateNavigator.shouldUseMonthLabels(dates);
+        itemsList.post(this::updateFastScrollPosition);
+    }
+
+    private void updateFastScrollPosition() {
+        if (contentBinding == null || displayedHistory.isEmpty()
+                || !(itemsList.getLayoutManager() instanceof LinearLayoutManager)) {
+            return;
+        }
+
+        final LinearLayoutManager layoutManager =
+                (LinearLayoutManager) itemsList.getLayoutManager();
+        int itemIndex = itemListAdapter.getItemIndex(
+                layoutManager.findFirstVisibleItemPosition());
+        if (itemIndex < 0) {
+            itemIndex = 0;
+        }
+        contentBinding.historyDateFastScroller.setPosition(itemIndex);
+    }
+
+    private void scrollToHistoryPosition(final int itemIndex) {
+        if (itemListAdapter == null || itemsList == null
+                || !(itemsList.getLayoutManager() instanceof LinearLayoutManager)) {
+            return;
+        }
+
+        final int adapterPosition =
+                itemListAdapter.getAdapterPositionForItemIndex(itemIndex);
+        if (adapterPosition == RecyclerView.NO_POSITION) {
+            return;
+        }
+
+        itemsList.stopScroll();
+        ((LinearLayoutManager) itemsList.getLayoutManager())
+                .scrollToPositionWithOffset(adapterPosition, 0);
+        contentBinding.historyDateFastScroller.setPosition(itemIndex);
+    }
+
+    private String getFastScrollLabel(final int itemIndex) {
+        if (itemIndex < 0 || itemIndex >= displayedHistory.size()) {
+            return "";
+        }
+        return HistoryDateNavigator.formatLabel(
+                displayedHistory.get(itemIndex).getLatestAccessDate().toLocalDate(),
+                useMonthFastScrollLabels,
+                org.schabi.newpipe.util.Localization.getPreferredLocale(requireContext()));
+    }
+
+    private List<LocalDate> getDisplayedHistoryDates() {
+        final List<LocalDate> dates = new ArrayList<>(displayedHistory.size());
+        for (final StreamStatisticsEntry entry : displayedHistory) {
+            dates.add(entry.getLatestAccessDate().toLocalDate());
+        }
+        return dates;
+    }
+
+    private void showDatePicker() {
+        if (sortMode != StatisticSortMode.LAST_PLAYED || displayedHistory.isEmpty()
+                || getParentFragmentManager().findFragmentByTag(DATE_PICKER_TAG) != null) {
+            return;
+        }
+
+        final List<LocalDate> dates = getDisplayedHistoryDates();
+        final LocalDate newestDate = dates.get(0);
+        final LocalDate oldestDate = dates.get(dates.size() - 1);
+        final long newestMillis = toUtcMillis(newestDate);
+        final long oldestMillis = toUtcMillis(oldestDate);
+        final int visibleIndex = getVisibleHistoryIndex();
+        final long selectedMillis = toUtcMillis(dates.get(visibleIndex));
+
+        final CalendarConstraints constraints = new CalendarConstraints.Builder()
+                .setStart(oldestMillis)
+                .setEnd(newestMillis)
+                .setOpenAt(selectedMillis)
+                .setValidator(CompositeDateValidator.allOf(Arrays.asList(
+                        DateValidatorPointForward.from(oldestMillis),
+                        DateValidatorPointBackward.before(newestMillis))))
+                .build();
+
+        final MaterialDatePicker<Long> picker = MaterialDatePicker.Builder.datePicker()
+                .setTitleText(R.string.history_jump_to_date)
+                .setCalendarConstraints(constraints)
+                .setSelection(selectedMillis)
+                .build();
+        picker.addOnPositiveButtonClickListener(selection ->
+                jumpToDate(utcMillisToDate(selection)));
+        picker.show(getParentFragmentManager(), DATE_PICKER_TAG);
+    }
+
+    private int getVisibleHistoryIndex() {
+        if (itemsList.getLayoutManager() instanceof LinearLayoutManager) {
+            final int adapterPosition = ((LinearLayoutManager) itemsList.getLayoutManager())
+                    .findFirstVisibleItemPosition();
+            final int itemIndex = itemListAdapter.getItemIndex(adapterPosition);
+            if (itemIndex >= 0 && itemIndex < displayedHistory.size()) {
+                return itemIndex;
+            }
+        }
+        return 0;
+    }
+
+    private void jumpToDate(@NonNull final LocalDate selectedDate) {
+        final int itemIndex = HistoryDateNavigator.findClosestIndex(
+                getDisplayedHistoryDates(), selectedDate);
+        if (itemIndex >= 0) {
+            scrollToHistoryPosition(itemIndex);
+        }
+    }
+
+    private static long toUtcMillis(@NonNull final LocalDate date) {
+        return date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+    }
+
+    @NonNull
+    private static LocalDate utcMillisToDate(final long millis) {
+        return java.time.Instant.ofEpochMilli(millis)
+                .atZone(ZoneOffset.UTC)
+                .toLocalDate();
     }
 
     private PlayQueue getPlayQueueStartingAt(final StreamStatisticsEntry infoItem) {

--- a/app/src/main/res/drawable/ic_calendar_month.xml
+++ b/app/src/main/res/drawable/ic_calendar_month.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.89,4 3.01,4.9 3.01,6L3,20c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2zM19,20H5V9h14v11zM7,11h5v5H7z" />
+</vector>

--- a/app/src/main/res/layout/fragment_playlist.xml
+++ b/app/src/main/res/layout/fragment_playlist.xml
@@ -28,6 +28,19 @@
             app:iconSize="20dp"
             tools:visibility="visible" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/history_date_jump_button"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:minWidth="0dp"
+            android:text="@string/history_jump_to_date"
+            android:visibility="gone"
+            app:icon="@drawable/ic_calendar_month"
+            app:iconPadding="6dp"
+            app:iconSize="20dp"
+            tools:visibility="visible" />
+
         <include
             android:id="@+id/stream_filter_chips"
             layout="@layout/list_stream_filter_chips"
@@ -43,6 +56,16 @@
         android:layout_below="@id/playlist_controls"
         android:scrollbars="vertical"
         tools:listitem="@layout/list_stream_mini_item" />
+
+    <org.schabi.newpipe.local.history.HistoryDateFastScroller
+        android:id="@+id/history_date_fast_scroller"
+        android:layout_width="48dp"
+        android:layout_height="match_parent"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_below="@id/playlist_controls"
+        android:contentDescription="@string/history_date_fast_scroll"
+        android:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/loading_progress_bar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -682,6 +682,9 @@
     <string name="delete_item_search_history">Do you want to delete this item from search history?</string>
     <string name="title_last_played">Last Played</string>
     <string name="title_most_played">Most Played</string>
+    <string name="history_jump_to_date">Jump to date</string>
+    <string name="history_date_fast_scroll">Scroll through history by date</string>
+    <string name="history_date_fast_scroll_description">History date: %1$s</string>
     <!-- Content -->
     <string name="main_page_content">Customize home</string>
     <string name="main_page_content_summary">Choose which sections appear on your home screen</string>

--- a/app/src/test/java/org/schabi/newpipe/local/history/HistoryDateNavigatorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/history/HistoryDateNavigatorTest.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.local.history;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+public class HistoryDateNavigatorTest {
+    private final List<LocalDate> dates = Arrays.asList(
+            LocalDate.of(2026, 8, 20),
+            LocalDate.of(2025, 12, 10),
+            LocalDate.of(2024, 1, 1));
+
+    @Test
+    public void findsExactAndClosestDatesInDescendingHistory() {
+        assertEquals(1, HistoryDateNavigator.findClosestIndex(
+                dates, LocalDate.of(2025, 12, 10)));
+        assertEquals(0, HistoryDateNavigator.findClosestIndex(
+                dates, LocalDate.of(2027, 1, 1)));
+        assertEquals(2, HistoryDateNavigator.findClosestIndex(
+                dates, LocalDate.of(2020, 1, 1)));
+        assertEquals(1, HistoryDateNavigator.findClosestIndex(
+                dates, LocalDate.of(2025, 11, 1)));
+        assertEquals(-1, HistoryDateNavigator.findClosestIndex(
+                Collections.emptyList(), LocalDate.of(2026, 1, 1)));
+    }
+
+    @Test
+    public void switchesBetweenMonthAndYearLabelsBasedOnHistorySpan() {
+        assertTrue(HistoryDateNavigator.shouldUseMonthLabels(Arrays.asList(
+                LocalDate.of(2026, 8, 1), LocalDate.of(2025, 1, 1))));
+        assertFalse(HistoryDateNavigator.shouldUseMonthLabels(dates));
+        assertEquals("Aug 2026", HistoryDateNavigator.formatLabel(
+                LocalDate.of(2026, 8, 1), true, Locale.US));
+        assertEquals("2026", HistoryDateNavigator.formatLabel(
+                LocalDate.of(2026, 8, 1), false, Locale.US));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,10 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### New features
+
+- Added date-aware fast scrolling and a calendar jump action for navigating large watch histories.
+
 ## WizeStream 1.9.1 (`1009001`)
 
 ### Fixes


### PR DESCRIPTION
- Add draggable date-aware fast scrolling with adaptive month and year labels.
- Add a bounded calendar jump for Last Played history with closest-date matching.
- Respect active filters and search while hiding chronological controls in Most Played and short lists.
- Support header-safe list, grid, and card navigation with RTL, accessibility, and lifecycle handling.
- Add JVM and Android regression coverage and document the feature in the changelog.