### PR TITLE
Add main tab swipe option for pinned channels

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/views/SwipeControllableViewPagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/views/SwipeControllableViewPagerTest.kt
@@ -1,0 +1,49 @@
+package org.schabi.newpipe.views
+
+import android.view.KeyEvent
+import android.view.MotionEvent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SwipeControllableViewPagerTest {
+    @Test
+    fun disabledPagerYieldsHorizontalNavigationToItsParent() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val pager = SwipeControllableViewPager(instrumentation.targetContext)
+            pager.setSwipeEnabled(false)
+
+            assertFalse(pager.isSwipeEnabled)
+            assertFalse(pager.canScrollHorizontally(-1))
+            assertFalse(pager.canScrollHorizontally(1))
+            assertFalse(
+                pager.executeKeyEvent(
+                    KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT)
+                )
+            )
+
+            val event = MotionEvent.obtain(
+                0L,
+                0L,
+                MotionEvent.ACTION_MOVE,
+                20f,
+                20f,
+                0
+            )
+            try {
+                assertFalse(pager.onInterceptTouchEvent(event))
+                assertFalse(pager.onTouchEvent(event))
+            } finally {
+                event.recycle()
+            }
+
+            pager.setSwipeEnabled(true)
+            assertTrue(pager.isSwipeEnabled)
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -221,6 +221,12 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         activity.addMenuProvider(menuProvider, getViewLifecycleOwner(), Lifecycle.State.RESUMED);
     }
 
+    @Override
+    public void useAsFrontPage(final boolean value) {
+        super.useAsFrontPage(value);
+        updateSwipeState();
+    }
+
     @Override // called from onViewCreated in BaseFragment.onViewCreated
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
@@ -228,6 +234,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
         tabAdapter = new TabAdapter(getChildFragmentManager());
         binding.viewPager.setAdapter(tabAdapter);
         binding.tabLayout.setupWithViewPager(binding.viewPager);
+        updateSwipeState();
 
         setTitle(name);
         binding.channelTitleView.setText(name);
@@ -235,6 +242,24 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
             // do not waste space for the banner if it is not going to be loaded
             binding.channelBannerContainer.setVisibility(View.GONE);
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateSwipeState();
+    }
+
+    private void updateSwipeState() {
+        if (binding == null || getContext() == null) {
+            return;
+        }
+        final boolean swipeMainTabsOnPinnedChannels = PreferenceManager
+                .getDefaultSharedPreferences(requireContext())
+                .getBoolean(getString(
+                        R.string.swipe_main_tabs_on_pinned_channels_key), true);
+        binding.viewPager.setSwipeEnabled(ChannelSwipePolicy.isChannelSwipeEnabled(
+                useAsFrontPage, swipeMainTabsOnPinnedChannels));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelSwipePolicy.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelSwipePolicy.java
@@ -1,0 +1,12 @@
+package org.schabi.newpipe.fragments.list.channel;
+
+public final class ChannelSwipePolicy {
+    private ChannelSwipePolicy() {
+    }
+
+    public static boolean isChannelSwipeEnabled(
+            final boolean useAsFrontPage,
+            final boolean swipeMainTabsOnPinnedChannels) {
+        return !useAsFrontPage || !swipeMainTabsOnPinnedChannels;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/SwipeControllableViewPager.java
+++ b/app/src/main/java/org/schabi/newpipe/views/SwipeControllableViewPager.java
@@ -1,0 +1,93 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.viewpager.widget.ViewPager;
+
+/**
+ * A {@link ViewPager} that allows enabling or disabling horizontal swipe navigation via touch.
+ */
+public class SwipeControllableViewPager extends ViewPager {
+
+    private boolean swipeEnabled = true;
+
+    public SwipeControllableViewPager(@NonNull final Context context) {
+        super(context);
+    }
+
+    public SwipeControllableViewPager(@NonNull final Context context,
+                                      @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /**
+     * Enables or disables horizontal swipe paging.
+     *
+     * @param swipeEnabled whether swiping is enabled
+     */
+    public void setSwipeEnabled(final boolean swipeEnabled) {
+        this.swipeEnabled = swipeEnabled;
+    }
+
+    /**
+     * @return whether horizontal swipe paging is currently enabled
+     */
+    public boolean isSwipeEnabled() {
+        return swipeEnabled;
+    }
+
+    @Override
+    public boolean canScrollHorizontally(final int direction) {
+        if (!swipeEnabled) {
+            return false;
+        }
+        return super.canScrollHorizontally(direction);
+    }
+
+    @Override
+    protected boolean canScroll(final View v, final boolean checkV, final int dx,
+                                final int x, final int y) {
+        if (!swipeEnabled) {
+            return false;
+        }
+        return super.canScroll(v, checkV, dx, x, y);
+    }
+
+    @Override
+    public boolean executeKeyEvent(@NonNull final KeyEvent event) {
+        if (!swipeEnabled) {
+            return false;
+        }
+        return super.executeKeyEvent(event);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(final MotionEvent ev) {
+        if (!swipeEnabled) {
+            return false;
+        }
+        try {
+            return super.onInterceptTouchEvent(ev);
+        } catch (final IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(final MotionEvent ev) {
+        if (!swipeEnabled) {
+            return false;
+        }
+        try {
+            return super.onTouchEvent(ev);
+        } catch (final IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -154,7 +154,7 @@
             app:tabSelectedTextColor="?attr/colorPrimary"
             app:tabTextColor="@color/tab_layout_material_item_color" />
 
-        <androidx.viewpager.widget.ViewPager
+        <org.schabi.newpipe.views.SwipeControllableViewPager
             android:id="@+id/view_pager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -801,6 +801,8 @@
     <string name="share_playlist">Partager la liste de lecture</string>
     <string name="video_details_list_item">- %1$s : %2$s</string>
     <string name="show_channel_tabs_summary">Choisir quels onglets seront visibles sur les pages de chaîne</string>
+    <string name="swipe_main_tabs_on_pinned_channels_title">Balayer les onglets principaux sur les chaînes épinglées</string>
+    <string name="swipe_main_tabs_on_pinned_channels_summary">Sur une chaîne épinglée, le balayage horizontal change d’onglet principal. Touchez Vidéos, Shorts, Direct ou un autre sous-onglet pour l’ouvrir</string>
     <string name="toggle_screen_orientation">Changer l’orientation de l’écran</string>
     <string name="toggle_fullscreen">Basculer en plein écran</string>
     <string name="share_playlist_with_titles">Partager avec les noms</string>

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -369,6 +369,7 @@
     </string-array>
 
     <!-- Content & History -->
+    <string name="swipe_main_tabs_on_pinned_channels_key">swipe_main_tabs_on_pinned_channels</string>
     <string name="show_channel_tabs_key">channel_tabs</string>
     <string name="show_channel_tabs_videos">show_channel_tabs_videos</string>
     <string name="show_channel_tabs_tracks">show_channel_tabs_tracks</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1239,6 +1239,8 @@
     <string name="channel_tab_about">About</string>
     <string name="show_channel_tabs">Channel tabs</string>
     <string name="show_channel_tabs_summary">What tabs are shown on the channel pages</string>
+    <string name="swipe_main_tabs_on_pinned_channels_title">Swipe between main tabs on pinned channels</string>
+    <string name="swipe_main_tabs_on_pinned_channels_summary">On pinned channel pages, horizontal swipes change the main tab; tap Videos, Shorts, Live, or other channel sub-tabs to open them</string>
     <string name="open_play_queue">Open play queue</string>
     <string name="toggle_fullscreen">Toggle fullscreen</string>
     <string name="toggle_screen_orientation">Toggle screen orientation</string>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -58,6 +58,14 @@
         app:iconSpaceReserved="false"
         app:singleLineTitle="false" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        android:key="@string/swipe_main_tabs_on_pinned_channels_key"
+        android:summary="@string/swipe_main_tabs_on_pinned_channels_summary"
+        android:title="@string/swipe_main_tabs_on_pinned_channels_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
     <PreferenceScreen
         android:fragment="org.schabi.newpipe.settings.PeertubeInstanceListFragment"
         android:key="@string/peertube_instance_setup_key"

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/channel/ChannelSwipePolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/channel/ChannelSwipePolicyTest.java
@@ -1,0 +1,24 @@
+package org.schabi.newpipe.fragments.list.channel;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ChannelSwipePolicyTest {
+    @Test
+    public void pinnedChannelUsesMainTabSwipeWhenPreferenceEnabled() {
+        assertFalse(ChannelSwipePolicy.isChannelSwipeEnabled(true, true));
+    }
+
+    @Test
+    public void pinnedChannelKeepsSubTabSwipeWhenPreferenceDisabled() {
+        assertTrue(ChannelSwipePolicy.isChannelSwipeEnabled(true, false));
+    }
+
+    @Test
+    public void dedicatedChannelAlwaysKeepsSubTabSwipe() {
+        assertTrue(ChannelSwipePolicy.isChannelSwipeEnabled(false, true));
+        assertTrue(ChannelSwipePolicy.isChannelSwipeEnabled(false, false));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -7,6 +7,7 @@ Release history is listed newest first. The number beside each release is its An
 ### New features
 
 - Added date-aware fast scrolling and a calendar jump action for navigating large watch histories.
+- Added an option to prioritize main-tab swiping when viewing pinned channels.
 
 ## WizeStream 1.9.1 (`1009001`)
 


### PR DESCRIPTION
- Fixes #68 by prioritizing main-tab swipes while viewing pinned channels.
- Keep channel sub-tabs accessible by tapping and preserve swipe navigation on dedicated channel pages.
- Add a default-enabled Content setting with English and French wording.
- Preserve the permanently visible channel metadata and Subscribe controls from PR #184.
- Add policy and gesture regression coverage for both preference states and screen contexts.
- Integrate and credit the original contribution from PR #192.