### PR TITLE
Add keyword filters for subscription notifications

### DIFF
--- a/app/schemas/org.schabi.newpipe.database.AppDatabase/22.json
+++ b/app/schemas/org.schabi.newpipe.database.AppDatabase/22.json
@@ -1,0 +1,2192 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 22,
+    "identityHash": "b8217752b28cdb82f1af428787aa4c22",
+    "entities": [
+      {
+        "tableName": "subscriptions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT, `name` TEXT, `avatar_url` TEXT, `subscriber_count` INTEGER, `description` TEXT, `notification_mode` INTEGER NOT NULL, `notification_keywords` TEXT NOT NULL DEFAULT '', `youtube_mode_mask` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subscriberCount",
+            "columnName": "subscriber_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notificationMode",
+            "columnName": "notification_mode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationKeywords",
+            "columnName": "notification_keywords",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "youtubeModeMask",
+            "columnName": "youtube_mode_mask",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscriptions_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_subscriptions_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`creation_date` INTEGER, `service_id` INTEGER NOT NULL, `search` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "creationDate",
+            "columnName": "creation_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "search",
+            "columnName": "search",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_search",
+            "unique": false,
+            "columnNames": [
+              "search"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_search` ON `${TABLE_NAME}` (`search`)"
+          }
+        ]
+      },
+      {
+        "tableName": "streams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `stream_type` TEXT NOT NULL, `duration` INTEGER NOT NULL, `uploader` TEXT NOT NULL, `uploader_url` TEXT, `thumbnail_url` TEXT, `view_count` INTEGER, `textual_upload_date` TEXT, `upload_date` INTEGER, `is_upload_date_approximation` INTEGER, `uploader_avatar_url` TEXT, `requires_membership` INTEGER NOT NULL DEFAULT 0, `source_type` TEXT NOT NULL DEFAULT 'REMOTE', `mime_type` TEXT, `local_media_id` INTEGER, `local_album` TEXT, `local_folder` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamType",
+            "columnName": "stream_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaderUrl",
+            "columnName": "uploader_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "view_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "textualUploadDate",
+            "columnName": "textual_upload_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "upload_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isUploadDateApproximation",
+            "columnName": "is_upload_date_approximation",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uploaderAvatarUrl",
+            "columnName": "uploader_avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "requiresMembership",
+            "columnName": "requires_membership",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'REMOTE'"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localMediaId",
+            "columnName": "local_media_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localAlbum",
+            "columnName": "local_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFolder",
+            "columnName": "local_folder",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_streams_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_streams_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "stream_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `access_date` INTEGER NOT NULL, `repeat_count` INTEGER NOT NULL, PRIMARY KEY(`stream_id`, `access_date`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "streamUid",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessDate",
+            "columnName": "access_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatCount",
+            "columnName": "repeat_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stream_id",
+            "access_date"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_stream_history_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_stream_history_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stream_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `progress_time` INTEGER NOT NULL, PRIMARY KEY(`stream_id`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "streamUid",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressMillis",
+            "columnName": "progress_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stream_id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `is_thumbnail_permanent` INTEGER NOT NULL, `thumbnail_stream_id` INTEGER NOT NULL, `display_index` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isThumbnailPermanent",
+            "columnName": "is_thumbnail_permanent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStreamId",
+            "columnName": "thumbnail_stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayIndex",
+            "columnName": "display_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_stream_join",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `stream_id` INTEGER NOT NULL, `join_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `join_index`), FOREIGN KEY(`playlist_id`) REFERENCES `playlists`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "playlistUid",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUid",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "join_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "join_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_stream_join_playlist_id_join_index",
+            "unique": true,
+            "columnNames": [
+              "playlist_id",
+              "join_index"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlist_stream_join_playlist_id_join_index` ON `${TABLE_NAME}` (`playlist_id`, `join_index`)"
+          },
+          {
+            "name": "index_playlist_stream_join_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_stream_join_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          },
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `service_id` INTEGER NOT NULL, `name` TEXT, `url` TEXT, `thumbnail_url` TEXT, `uploader` TEXT, `display_index` INTEGER NOT NULL, `stream_count` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderingName",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayIndex",
+            "columnName": "display_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamCount",
+            "columnName": "stream_count",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_remote_playlists_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_remote_playlists_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_id` INTEGER NOT NULL, `subscription_id` INTEGER NOT NULL, `youtube_mode_mask` INTEGER NOT NULL DEFAULT 1, PRIMARY KEY(`stream_id`, `subscription_id`, `youtube_mode_mask`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`subscription_id`) REFERENCES `subscriptions`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeModeMask",
+            "columnName": "youtube_mode_mask",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stream_id",
+            "subscription_id",
+            "youtube_mode_mask"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_subscription_id",
+            "unique": false,
+            "columnNames": [
+              "subscription_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_subscription_id` ON `${TABLE_NAME}` (`subscription_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          },
+          {
+            "table": "subscriptions",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "feed_group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon_id` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_group_sort_order",
+            "unique": false,
+            "columnNames": [
+              "sort_order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_group_sort_order` ON `${TABLE_NAME}` (`sort_order`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_group_subscription_join",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`group_id` INTEGER NOT NULL, `subscription_id` INTEGER NOT NULL, PRIMARY KEY(`group_id`, `subscription_id`), FOREIGN KEY(`group_id`) REFERENCES `feed_group`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(`subscription_id`) REFERENCES `subscriptions`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "feedGroupId",
+            "columnName": "group_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "group_id",
+            "subscription_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_group_subscription_join_subscription_id",
+            "unique": false,
+            "columnNames": [
+              "subscription_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_group_subscription_join_subscription_id` ON `${TABLE_NAME}` (`subscription_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed_group",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "group_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          },
+          {
+            "table": "subscriptions",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "feed_last_updated",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`subscription_id` INTEGER NOT NULL, `youtube_mode_mask` INTEGER NOT NULL DEFAULT 1, `last_updated` INTEGER, PRIMARY KEY(`subscription_id`, `youtube_mode_mask`), FOREIGN KEY(`subscription_id`) REFERENCES `subscriptions`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeModeMask",
+            "columnName": "youtube_mode_mask",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "subscription_id",
+            "youtube_mode_mask"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "subscriptions",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "subscription_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_sync_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `lamport_version` INTEGER NOT NULL, `record_id` TEXT NOT NULL, `change_type` TEXT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `avatar_url` TEXT, `subscriber_count` INTEGER, `description` TEXT, `youtube_mode_mask` INTEGER, `notification_mode` INTEGER, `notification_keywords` TEXT, PRIMARY KEY(`origin_peer_id`, `origin_revision`))",
+        "fields": [
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeType",
+            "columnName": "change_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatar_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subscriberCount",
+            "columnName": "subscriber_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeModeMask",
+            "columnName": "youtube_mode_mask",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationMode",
+            "columnName": "notification_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationKeywords",
+            "columnName": "notification_keywords",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin_peer_id",
+            "origin_revision"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_sync_changes_record_id",
+            "unique": false,
+            "columnNames": [
+              "record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_sync_changes_record_id` ON `${TABLE_NAME}` (`record_id`)"
+          },
+          {
+            "name": "index_subscription_sync_changes_lamport_version_origin_peer_id_origin_revision",
+            "unique": false,
+            "columnNames": [
+              "lamport_version",
+              "origin_peer_id",
+              "origin_revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_sync_changes_lamport_version_origin_peer_id_origin_revision` ON `${TABLE_NAME}` (`lamport_version`, `origin_peer_id`, `origin_revision`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_sync_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`record_id` TEXT NOT NULL, `service_id` INTEGER NOT NULL, `url` TEXT NOT NULL, `lamport_version` INTEGER NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, `youtube_mode_mask` INTEGER NOT NULL DEFAULT 1, `notification_mode` INTEGER, `notification_keywords` TEXT, PRIMARY KEY(`record_id`))",
+        "fields": [
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeModeMask",
+            "columnName": "youtube_mode_mask",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "notificationMode",
+            "columnName": "notification_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notificationKeywords",
+            "columnName": "notification_keywords",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_sync_records_service_id_url",
+            "unique": true,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_subscription_sync_records_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_sync_origin_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin_peer_id` TEXT NOT NULL, `contiguous_revision` INTEGER NOT NULL, PRIMARY KEY(`origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contiguousRevision",
+            "columnName": "contiguous_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin_peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "subscription_sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peer_id` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `acknowledged_revision` INTEGER NOT NULL, PRIMARY KEY(`peer_id`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acknowledgedRevision",
+            "columnName": "acknowledged_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peer_id",
+            "origin_peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subscription_sync_peer_state_origin_peer_id",
+            "unique": false,
+            "columnNames": [
+              "origin_peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subscription_sync_peer_state_origin_peer_id` ON `${TABLE_NAME}` (`origin_peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_sync_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `lamport_version` INTEGER NOT NULL, `record_id` TEXT NOT NULL, `record_type` TEXT NOT NULL, `parent_record_id` TEXT, `change_type` TEXT NOT NULL, `record_json` TEXT, PRIMARY KEY(`origin_peer_id`, `origin_revision`))",
+        "fields": [
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordType",
+            "columnName": "record_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentRecordId",
+            "columnName": "parent_record_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changeType",
+            "columnName": "change_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordJson",
+            "columnName": "record_json",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin_peer_id",
+            "origin_revision"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_sync_changes_record_id",
+            "unique": false,
+            "columnNames": [
+              "record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_sync_changes_record_id` ON `${TABLE_NAME}` (`record_id`)"
+          },
+          {
+            "name": "index_playlist_sync_changes_parent_record_id",
+            "unique": false,
+            "columnNames": [
+              "parent_record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_sync_changes_parent_record_id` ON `${TABLE_NAME}` (`parent_record_id`)"
+          },
+          {
+            "name": "index_playlist_sync_changes_lamport_version_origin_peer_id_origin_revision",
+            "unique": false,
+            "columnNames": [
+              "lamport_version",
+              "origin_peer_id",
+              "origin_revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_sync_changes_lamport_version_origin_peer_id_origin_revision` ON `${TABLE_NAME}` (`lamport_version`, `origin_peer_id`, `origin_revision`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_sync_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`record_id` TEXT NOT NULL, `record_type` TEXT NOT NULL, `parent_record_id` TEXT, `lamport_version` INTEGER NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, `record_json` TEXT, PRIMARY KEY(`record_id`))",
+        "fields": [
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordType",
+            "columnName": "record_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentRecordId",
+            "columnName": "parent_record_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordJson",
+            "columnName": "record_json",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_sync_records_parent_record_id",
+            "unique": false,
+            "columnNames": [
+              "parent_record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_sync_records_parent_record_id` ON `${TABLE_NAME}` (`parent_record_id`)"
+          },
+          {
+            "name": "index_playlist_sync_records_record_type",
+            "unique": false,
+            "columnNames": [
+              "record_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_sync_records_record_type` ON `${TABLE_NAME}` (`record_type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_sync_origin_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`origin_peer_id` TEXT NOT NULL, `contiguous_revision` INTEGER NOT NULL, PRIMARY KEY(`origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contiguousRevision",
+            "columnName": "contiguous_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "origin_peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peer_id` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `acknowledged_revision` INTEGER NOT NULL, PRIMARY KEY(`peer_id`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acknowledgedRevision",
+            "columnName": "acknowledged_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peer_id",
+            "origin_peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_sync_peer_state_origin_peer_id",
+            "unique": false,
+            "columnNames": [
+              "origin_peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_sync_peer_state_origin_peer_id` ON `${TABLE_NAME}` (`origin_peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_sync_local_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_record_id` TEXT NOT NULL, `playlist_uid` INTEGER NOT NULL, PRIMARY KEY(`playlist_record_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistRecordId",
+            "columnName": "playlist_record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistUid",
+            "columnName": "playlist_uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_sync_local_map_playlist_uid",
+            "unique": true,
+            "columnNames": [
+              "playlist_uid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlist_sync_local_map_playlist_uid` ON `${TABLE_NAME}` (`playlist_uid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "history_sync_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `lamport_version` INTEGER NOT NULL, `record_id` TEXT NOT NULL, `record_type` TEXT NOT NULL, `change_type` TEXT NOT NULL, `record_json` TEXT, PRIMARY KEY(`category`, `origin_peer_id`, `origin_revision`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordType",
+            "columnName": "record_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeType",
+            "columnName": "change_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordJson",
+            "columnName": "record_json",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "origin_peer_id",
+            "origin_revision"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_history_sync_changes_category_record_id",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_history_sync_changes_category_record_id` ON `${TABLE_NAME}` (`category`, `record_id`)"
+          },
+          {
+            "name": "index_history_sync_changes_category_lamport_version_origin_peer_id_origin_revision",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "lamport_version",
+              "origin_peer_id",
+              "origin_revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_history_sync_changes_category_lamport_version_origin_peer_id_origin_revision` ON `${TABLE_NAME}` (`category`, `lamport_version`, `origin_peer_id`, `origin_revision`)"
+          }
+        ]
+      },
+      {
+        "tableName": "history_sync_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `record_id` TEXT NOT NULL, `record_type` TEXT NOT NULL, `lamport_version` INTEGER NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, `record_json` TEXT, PRIMARY KEY(`category`, `record_id`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordType",
+            "columnName": "record_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordJson",
+            "columnName": "record_json",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_history_sync_records_category_record_type",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "record_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_history_sync_records_category_record_type` ON `${TABLE_NAME}` (`category`, `record_type`)"
+          }
+        ]
+      },
+      {
+        "tableName": "history_sync_origin_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `contiguous_revision` INTEGER NOT NULL, PRIMARY KEY(`category`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contiguousRevision",
+            "columnName": "contiguous_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "origin_peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "history_sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `acknowledged_revision` INTEGER NOT NULL, PRIMARY KEY(`category`, `peer_id`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acknowledgedRevision",
+            "columnName": "acknowledged_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "peer_id",
+            "origin_peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_history_sync_peer_state_category_origin_peer_id",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "origin_peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_history_sync_peer_state_category_origin_peer_id` ON `${TABLE_NAME}` (`category`, `origin_peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "structured_preference_sync_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `lamport_version` INTEGER NOT NULL, `record_id` TEXT NOT NULL, `record_type` TEXT NOT NULL, `parent_record_id` TEXT, `change_type` TEXT NOT NULL, `record_json` TEXT NOT NULL, PRIMARY KEY(`category`, `origin_peer_id`, `origin_revision`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordType",
+            "columnName": "record_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentRecordId",
+            "columnName": "parent_record_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changeType",
+            "columnName": "change_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordJson",
+            "columnName": "record_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "origin_peer_id",
+            "origin_revision"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_structured_preference_sync_changes_category_record_id",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_structured_preference_sync_changes_category_record_id` ON `${TABLE_NAME}` (`category`, `record_id`)"
+          },
+          {
+            "name": "index_structured_preference_sync_changes_category_parent_record_id",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "parent_record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_structured_preference_sync_changes_category_parent_record_id` ON `${TABLE_NAME}` (`category`, `parent_record_id`)"
+          },
+          {
+            "name": "index_structured_preference_sync_changes_category_lamport_version_origin_peer_id_origin_revision",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "lamport_version",
+              "origin_peer_id",
+              "origin_revision"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_structured_preference_sync_changes_category_lamport_version_origin_peer_id_origin_revision` ON `${TABLE_NAME}` (`category`, `lamport_version`, `origin_peer_id`, `origin_revision`)"
+          }
+        ]
+      },
+      {
+        "tableName": "structured_preference_sync_records",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `record_id` TEXT NOT NULL, `record_type` TEXT NOT NULL, `parent_record_id` TEXT, `lamport_version` INTEGER NOT NULL, `origin_peer_id` TEXT NOT NULL, `origin_revision` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, `record_json` TEXT NOT NULL, PRIMARY KEY(`category`, `record_id`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordId",
+            "columnName": "record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordType",
+            "columnName": "record_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentRecordId",
+            "columnName": "parent_record_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lamportVersion",
+            "columnName": "lamport_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originRevision",
+            "columnName": "origin_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordJson",
+            "columnName": "record_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_structured_preference_sync_records_category_record_type",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "record_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_structured_preference_sync_records_category_record_type` ON `${TABLE_NAME}` (`category`, `record_type`)"
+          },
+          {
+            "name": "index_structured_preference_sync_records_category_parent_record_id",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "parent_record_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_structured_preference_sync_records_category_parent_record_id` ON `${TABLE_NAME}` (`category`, `parent_record_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "structured_preference_sync_origin_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `contiguous_revision` INTEGER NOT NULL, PRIMARY KEY(`category`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contiguousRevision",
+            "columnName": "contiguous_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "origin_peer_id"
+          ]
+        }
+      },
+      {
+        "tableName": "structured_preference_sync_peer_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `peer_id` TEXT NOT NULL, `origin_peer_id` TEXT NOT NULL, `acknowledged_revision` INTEGER NOT NULL, PRIMARY KEY(`category`, `peer_id`, `origin_peer_id`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerId",
+            "columnName": "peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originPeerId",
+            "columnName": "origin_peer_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "acknowledgedRevision",
+            "columnName": "acknowledged_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category",
+            "peer_id",
+            "origin_peer_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_structured_preference_sync_peer_state_category_origin_peer_id",
+            "unique": false,
+            "columnNames": [
+              "category",
+              "origin_peer_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_structured_preference_sync_peer_state_category_origin_peer_id` ON `${TABLE_NAME}` (`category`, `origin_peer_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "structured_preference_sync_feed_group_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`group_record_id` TEXT NOT NULL, `group_uid` INTEGER NOT NULL, PRIMARY KEY(`group_record_id`))",
+        "fields": [
+          {
+            "fieldPath": "groupRecordId",
+            "columnName": "group_record_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupUid",
+            "columnName": "group_uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "group_record_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_structured_preference_sync_feed_group_map_group_uid",
+            "unique": true,
+            "columnNames": [
+              "group_uid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_structured_preference_sync_feed_group_map_group_uid` ON `${TABLE_NAME}` (`group_uid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "structured_preference_sync_local_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` TEXT NOT NULL, `snapshot_hash` TEXT NOT NULL, PRIMARY KEY(`category`))",
+        "fields": [
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotHash",
+            "columnName": "snapshot_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category"
+          ]
+        }
+      },
+      {
+        "tableName": "learning_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`note_id` TEXT NOT NULL, `stream_id` INTEGER NOT NULL, `timestamp_ms` INTEGER NOT NULL, `note_text` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`note_id`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "note_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMillis",
+            "columnName": "timestamp_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noteText",
+            "columnName": "note_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtEpochMillis",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtEpochMillis",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "note_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_learning_notes_stream_id_timestamp_ms",
+            "unique": false,
+            "columnNames": [
+              "stream_id",
+              "timestamp_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_notes_stream_id_timestamp_ms` ON `${TABLE_NAME}` (`stream_id`, `timestamp_ms`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "learning_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` TEXT NOT NULL, `stream_id` INTEGER NOT NULL, `started_at` INTEGER NOT NULL, `ended_at` INTEGER NOT NULL, `watched_duration_ms` INTEGER NOT NULL, `local_date` TEXT NOT NULL, `background_playback` INTEGER NOT NULL, `is_designated` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`session_id`), FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtEpochMillis",
+            "columnName": "started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAtEpochMillis",
+            "columnName": "ended_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedDurationMillis",
+            "columnName": "watched_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localDate",
+            "columnName": "local_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundPlayback",
+            "columnName": "background_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "designatedLearningContent",
+            "columnName": "is_designated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "session_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_learning_sessions_stream_id_started_at",
+            "unique": false,
+            "columnNames": [
+              "stream_id",
+              "started_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_sessions_stream_id_started_at` ON `${TABLE_NAME}` (`stream_id`, `started_at`)"
+          },
+          {
+            "name": "index_learning_sessions_local_date",
+            "unique": false,
+            "columnNames": [
+              "local_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_sessions_local_date` ON `${TABLE_NAME}` (`local_date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "learning_content_sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `source_type` TEXT NOT NULL, `local_playlist_id` INTEGER, `service_id` INTEGER, `url` TEXT, `title` TEXT, `thumbnail_url` TEXT, `created_at` INTEGER NOT NULL, PRIMARY KEY(`source_id`), FOREIGN KEY(`local_playlist_id`) REFERENCES `playlists`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPlaylistId",
+            "columnName": "local_playlist_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "service_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_learning_content_sources_local_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "local_playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_content_sources_local_playlist_id` ON `${TABLE_NAME}` (`local_playlist_id`)"
+          },
+          {
+            "name": "index_learning_content_sources_source_type",
+            "unique": false,
+            "columnNames": [
+              "source_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_content_sources_source_type` ON `${TABLE_NAME}` (`source_type`)"
+          },
+          {
+            "name": "index_learning_content_sources_service_id_url",
+            "unique": false,
+            "columnNames": [
+              "service_id",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_content_sources_service_id_url` ON `${TABLE_NAME}` (`service_id`, `url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "local_playlist_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "learning_content_streams",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `stream_id` INTEGER NOT NULL, PRIMARY KEY(`source_id`, `stream_id`), FOREIGN KEY(`source_id`) REFERENCES `learning_content_sources`(`source_id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`stream_id`) REFERENCES `streams`(`uid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamId",
+            "columnName": "stream_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id",
+            "stream_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_learning_content_streams_stream_id",
+            "unique": false,
+            "columnNames": [
+              "stream_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_learning_content_streams_stream_id` ON `${TABLE_NAME}` (`stream_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "learning_content_sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "source_id"
+            ],
+            "referencedColumns": [
+              "source_id"
+            ]
+          },
+          {
+            "table": "streams",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "stream_id"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b8217752b28cdb82f1af428787aa4c22')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/database/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/database/DatabaseMigrationTest.kt
@@ -788,6 +788,51 @@ class DatabaseMigrationTest {
         }
     }
 
+    @Test
+    fun migrateDatabaseFrom21to22AddsNotificationKeywordFilters() {
+        val database = testHelper.createDatabase(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_21
+        )
+        database.close()
+
+        val migrated = testHelper.runMigrationsAndValidate(
+            AppDatabase.DATABASE_NAME,
+            Migrations.DB_VER_22,
+            true,
+            Migrations.MIGRATION_21_22
+        )
+        migrated.query("PRAGMA table_info(subscriptions)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            val defaultIndex = cursor.getColumnIndex("dflt_value")
+            var defaultValue: String? = null
+            while (cursor.moveToNext()) {
+                if (cursor.getString(nameIndex) == "notification_keywords") {
+                    defaultValue = cursor.getString(defaultIndex)
+                }
+            }
+            assertEquals("''", defaultValue)
+        }
+        migrated.query("PRAGMA table_info(subscription_sync_changes)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            val columns = mutableSetOf<String>()
+            while (cursor.moveToNext()) {
+                columns += cursor.getString(nameIndex)
+            }
+            assertTrue(columns.contains("notification_mode"))
+            assertTrue(columns.contains("notification_keywords"))
+        }
+        migrated.query("PRAGMA table_info(subscription_sync_records)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            val columns = mutableSetOf<String>()
+            while (cursor.moveToNext()) {
+                columns += cursor.getString(nameIndex)
+            }
+            assertTrue(columns.contains("notification_mode"))
+            assertTrue(columns.contains("notification_keywords"))
+        }
+    }
+
     private fun getMigratedDatabase(): AppDatabase {
         val database: AppDatabase = Room.databaseBuilder(
             ApplicationProvider.getApplicationContext(),
@@ -802,7 +847,8 @@ class DatabaseMigrationTest {
                 Migrations.MIGRATION_17_18,
                 Migrations.MIGRATION_18_19,
                 Migrations.MIGRATION_19_20,
-                Migrations.MIGRATION_20_21
+                Migrations.MIGRATION_20_21,
+                Migrations.MIGRATION_21_22
             )
             .build()
         testHelper.closeWhenFinished(database)

--- a/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.kt
@@ -22,6 +22,7 @@ import org.schabi.newpipe.database.Migrations.MIGRATION_18_19
 import org.schabi.newpipe.database.Migrations.MIGRATION_19_20
 import org.schabi.newpipe.database.Migrations.MIGRATION_1_2
 import org.schabi.newpipe.database.Migrations.MIGRATION_20_21
+import org.schabi.newpipe.database.Migrations.MIGRATION_21_22
 import org.schabi.newpipe.database.Migrations.MIGRATION_2_3
 import org.schabi.newpipe.database.Migrations.MIGRATION_3_4
 import org.schabi.newpipe.database.Migrations.MIGRATION_4_5
@@ -61,7 +62,8 @@ object NewPipeDatabase {
             MIGRATION_17_18,
             MIGRATION_18_19,
             MIGRATION_19_20,
-            MIGRATION_20_21
+            MIGRATION_20_21,
+            MIGRATION_21_22
         ).build()
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/AppDatabase.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/AppDatabase.kt
@@ -65,7 +65,7 @@ import org.schabi.newpipe.database.sync.SubscriptionSyncRecordEntity
 
 @TypeConverters(Converters::class)
 @Database(
-    version = Migrations.DB_VER_21,
+    version = Migrations.DB_VER_22,
     entities = [
         SubscriptionEntity::class,
         SearchHistoryEntry::class,

--- a/app/src/main/java/org/schabi/newpipe/database/Migrations.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/Migrations.kt
@@ -41,6 +41,7 @@ object Migrations {
     const val DB_VER_19 = 19
     const val DB_VER_20 = 20
     const val DB_VER_21 = 21
+    const val DB_VER_22 = 22
 
     private val TAG = Migrations::class.java.getName()
     private val isDebug = MainActivity.DEBUG
@@ -799,6 +800,25 @@ object Migrations {
         db.execSQL(
             "UPDATE learning_sessions SET is_designated = 1 WHERE stream_id IN " +
                 "(SELECT stream_id FROM learning_content_streams)"
+        )
+    }
+
+    val MIGRATION_21_22 = Migration(DB_VER_21, DB_VER_22) { db ->
+        db.execSQL(
+            "ALTER TABLE `subscriptions` ADD COLUMN `notification_keywords` " +
+                "TEXT NOT NULL DEFAULT ''"
+        )
+        db.execSQL(
+            "ALTER TABLE `subscription_sync_changes` ADD COLUMN `notification_mode` INTEGER"
+        )
+        db.execSQL(
+            "ALTER TABLE `subscription_sync_changes` ADD COLUMN `notification_keywords` TEXT"
+        )
+        db.execSQL(
+            "ALTER TABLE `subscription_sync_records` ADD COLUMN `notification_mode` INTEGER"
+        )
+        db.execSQL(
+            "ALTER TABLE `subscription_sync_records` ADD COLUMN `notification_keywords` TEXT"
         )
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/database/feed/dao/FeedDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/feed/dao/FeedDAO.kt
@@ -14,7 +14,6 @@ import org.schabi.newpipe.database.feed.model.FeedGroupEntity
 import org.schabi.newpipe.database.feed.model.FeedLastUpdatedEntity
 import org.schabi.newpipe.database.stream.StreamWithState
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
-import org.schabi.newpipe.database.subscription.NotificationMode
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
 
 @Dao
@@ -364,11 +363,11 @@ abstract class FeedDAO {
 
         WHERE 
             (lu.last_updated IS NULL OR lu.last_updated < :outdatedThreshold)
-            AND s.notification_mode = :notificationMode
+            AND s.notification_mode IN (:notificationModes)
         """
     )
-    abstract fun getOutdatedWithNotificationMode(
+    abstract fun getOutdatedWithNotificationModes(
         outdatedThreshold: OffsetDateTime,
-        @NotificationMode notificationMode: Int
+        notificationModes: List<Int>
     ): Flowable<List<SubscriptionEntity>>
 }

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/NotificationMode.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/NotificationMode.kt
@@ -8,11 +8,16 @@ package org.schabi.newpipe.database.subscription
 
 import androidx.annotation.IntDef
 
-@IntDef(NotificationMode.Companion.DISABLED, NotificationMode.Companion.ENABLED)
+@IntDef(
+    NotificationMode.Companion.DISABLED,
+    NotificationMode.Companion.ENABLED,
+    NotificationMode.Companion.KEYWORDS_ONLY
+)
 @Retention(AnnotationRetention.SOURCE)
 annotation class NotificationMode {
     companion object {
         const val DISABLED = 0
-        const val ENABLED = 1 // other values reserved for the future
+        const val ENABLED = 1
+        const val KEYWORDS_ONLY = 2
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/subscription/SubscriptionEntity.kt
@@ -52,6 +52,9 @@ data class SubscriptionEntity(
     @ColumnInfo(name = SUBSCRIPTION_NOTIFICATION_MODE)
     var notificationMode: Int = 0,
 
+    @ColumnInfo(name = SUBSCRIPTION_NOTIFICATION_KEYWORDS, defaultValue = "''")
+    var notificationKeywords: String = "",
+
     @ColumnInfo(name = SUBSCRIPTION_YOUTUBE_MODE_MASK, defaultValue = "1")
     var youtubeModeMask: Int = YOUTUBE_MODE_REGULAR
 ) {
@@ -77,6 +80,7 @@ data class SubscriptionEntity(
         const val SUBSCRIPTION_SUBSCRIBER_COUNT: String = "subscriber_count"
         const val SUBSCRIPTION_DESCRIPTION: String = "description"
         const val SUBSCRIPTION_NOTIFICATION_MODE: String = "notification_mode"
+        const val SUBSCRIPTION_NOTIFICATION_KEYWORDS: String = "notification_keywords"
         const val SUBSCRIPTION_YOUTUBE_MODE_MASK: String = "youtube_mode_mask"
 
         const val YOUTUBE_SERVICE_ID: Int = 0

--- a/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncEntities.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncEntities.kt
@@ -61,7 +61,13 @@ data class SubscriptionSyncChangeEntity(
     val description: String?,
 
     @ColumnInfo(name = YOUTUBE_MODE_MASK)
-    val youtubeModeMask: Int?
+    val youtubeModeMask: Int?,
+
+    @ColumnInfo(name = NOTIFICATION_MODE)
+    val notificationMode: Int?,
+
+    @ColumnInfo(name = NOTIFICATION_KEYWORDS)
+    val notificationKeywords: String?
 ) {
     companion object {
         const val TABLE_NAME = "subscription_sync_changes"
@@ -77,6 +83,8 @@ data class SubscriptionSyncChangeEntity(
         const val SUBSCRIBER_COUNT = "subscriber_count"
         const val DESCRIPTION = "description"
         const val YOUTUBE_MODE_MASK = "youtube_mode_mask"
+        const val NOTIFICATION_MODE = "notification_mode"
+        const val NOTIFICATION_KEYWORDS = "notification_keywords"
     }
 }
 
@@ -116,7 +124,13 @@ data class SubscriptionSyncRecordEntity(
     val isDeleted: Boolean,
 
     @ColumnInfo(name = YOUTUBE_MODE_MASK, defaultValue = "1")
-    val youtubeModeMask: Int
+    val youtubeModeMask: Int,
+
+    @ColumnInfo(name = NOTIFICATION_MODE)
+    val notificationMode: Int?,
+
+    @ColumnInfo(name = NOTIFICATION_KEYWORDS)
+    val notificationKeywords: String?
 ) {
     companion object {
         const val TABLE_NAME = "subscription_sync_records"
@@ -128,6 +142,8 @@ data class SubscriptionSyncRecordEntity(
         const val ORIGIN_REVISION = "origin_revision"
         const val IS_DELETED = "is_deleted"
         const val YOUTUBE_MODE_MASK = "youtube_mode_mask"
+        const val NOTIFICATION_MODE = "notification_mode"
+        const val NOTIFICATION_KEYWORDS = "notification_keywords"
     }
 }
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
@@ -17,7 +17,6 @@ import org.schabi.newpipe.database.feed.model.FeedGroupEntity
 import org.schabi.newpipe.database.feed.model.FeedLastUpdatedEntity
 import org.schabi.newpipe.database.stream.StreamWithState
 import org.schabi.newpipe.database.stream.model.StreamEntity
-import org.schabi.newpipe.database.subscription.NotificationMode
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.stream.StreamType
@@ -69,10 +68,10 @@ class FeedDatabaseManager(context: Context) {
         outdatedThreshold
     )
 
-    fun outdatedSubscriptionsWithNotificationMode(
+    fun outdatedSubscriptionsWithNotificationModes(
         outdatedThreshold: OffsetDateTime,
-        @NotificationMode notificationMode: Int
-    ) = feedTable.getOutdatedWithNotificationMode(outdatedThreshold, notificationMode)
+        notificationModes: List<Int>
+    ) = feedTable.getOutdatedWithNotificationModes(outdatedThreshold, notificationModes)
 
     fun notLoadedCount(
         groupId: Long = FeedGroupEntity.GROUP_ALL_ID,

--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationKeywordFilter.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationKeywordFilter.kt
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.feed.notifications
+
+import java.util.Locale
+import org.schabi.newpipe.database.subscription.NotificationMode
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+
+/** Literal, case-insensitive title matching for per-channel notification filters. */
+object NotificationKeywordFilter {
+    const val MAX_TERMS = 25
+    const val MAX_TERM_LENGTH = 100
+    const val MAX_ENCODED_LENGTH = 2048
+
+    fun normalize(input: String): String = input.lineSequence()
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .distinctBy { it.lowercase(Locale.ROOT) }
+        .joinToString("\n")
+
+    fun terms(encoded: String): List<String> = normalize(encoded).lineSequence()
+        .filter(String::isNotEmpty)
+        .toList()
+
+    fun isValid(encoded: String): Boolean {
+        val parsed = terms(encoded)
+        return encoded.length <= MAX_ENCODED_LENGTH &&
+            parsed.isNotEmpty() &&
+            parsed.size <= MAX_TERMS &&
+            parsed.all { it.length <= MAX_TERM_LENGTH }
+    }
+
+    fun matches(title: String, encoded: String): Boolean {
+        val normalizedTitle = title.lowercase(Locale.ROOT)
+        return terms(encoded).any { term ->
+            normalizedTitle.contains(term.lowercase(Locale.ROOT))
+        }
+    }
+
+    fun filter(
+        streams: List<StreamInfoItem>,
+        @NotificationMode mode: Int,
+        encoded: String
+    ): List<StreamInfoItem> = when (mode) {
+        NotificationMode.ENABLED -> streams
+        NotificationMode.KEYWORDS_ONLY -> streams.filter { matches(it.name, encoded) }
+        else -> emptyList()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/notifications/NotificationWorker.kt
@@ -46,10 +46,14 @@ class NotificationWorker(
         )
             .doOnSubscribe { showLoadingFeedForegroundNotification() }
             .map { feed ->
-                // filter out feedUpdateInfo items (i.e. channels) with nothing new
                 feed.mapNotNull {
-                    it.value?.takeIf { feedUpdateInfo ->
-                        feedUpdateInfo.newStreams.isNotEmpty()
+                    it.value?.let { feedUpdateInfo ->
+                        feedUpdateInfo.newStreams = NotificationKeywordFilter.filter(
+                            feedUpdateInfo.newStreams,
+                            feedUpdateInfo.notificationMode,
+                            feedUpdateInfo.notificationKeywords
+                        )
+                        feedUpdateInfo.takeIf { update -> update.newStreams.isNotEmpty() }
                     }
                 }
             }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -90,9 +90,9 @@ class FeedLoadManager(private val context: Context) {
          */
         val outdatedSubscriptions = when {
             groupId == GROUP_NOTIFICATION_ENABLED ->
-                feedDatabaseManager.outdatedSubscriptionsWithNotificationMode(
+                feedDatabaseManager.outdatedSubscriptionsWithNotificationModes(
                     outdatedThreshold,
-                    NotificationMode.ENABLED
+                    listOf(NotificationMode.ENABLED, NotificationMode.KEYWORDS_ONLY)
                 )
 
             scope == null && groupId == FeedGroupEntity.GROUP_ALL_ID ->
@@ -441,7 +441,7 @@ class FeedLoadManager(private val context: Context) {
     companion object {
 
         /**
-         * Constant used to check for updates of subscriptions with [NotificationMode.ENABLED].
+         * Constant used to check subscriptions with any enabled notification mode.
          */
         const val GROUP_NOTIFICATION_ENABLED = -2L
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedUpdateInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedUpdateInfo.kt
@@ -17,6 +17,7 @@ data class FeedUpdateInfo(
     val uid: Long,
     @NotificationMode
     val notificationMode: Int,
+    val notificationKeywords: String,
     val name: String,
     val avatarUrl: String?,
     val url: String,
@@ -36,6 +37,7 @@ data class FeedUpdateInfo(
     ) : this(
         uid = subscription.uid,
         notificationMode = subscription.notificationMode,
+        notificationKeywords = subscription.notificationKeywords,
         name = info.name,
         avatarUrl = (info as? ChannelInfo)?.avatars?.let {
             // if the newly fetched info is not from fast feed, then it contains updated avatars

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -68,6 +68,7 @@ class SubscriptionManager(context: Context) {
             subscriptionTable.getSubscriptionDirect(entity.serviceId, requireNotNull(entity.url))
                 ?.let { existing ->
                     entity.notificationMode = existing.notificationMode
+                    entity.notificationKeywords = existing.notificationKeywords
                     entity.youtubeModeMask = existing.youtubeModeMask or
                         currentYoutubeModeMask
                 }
@@ -108,15 +109,37 @@ class SubscriptionManager(context: Context) {
 
     fun updateNotificationMode(serviceId: Int, url: String, @NotificationMode mode: Int): Completable {
         return subscriptionTable().getSubscription(serviceId, url)
+            .flatMapCompletable { entity ->
+                updateNotificationSettings(
+                    serviceId,
+                    url,
+                    mode,
+                    entity.notificationKeywords
+                )
+            }
+    }
+
+    fun updateNotificationSettings(
+        serviceId: Int,
+        url: String,
+        @NotificationMode mode: Int,
+        keywords: String
+    ): Completable {
+        return subscriptionTable().getSubscription(serviceId, url)
             .flatMapCompletable { entity: SubscriptionEntity ->
-                Completable.fromAction {
+                val notificationsWereDisabled =
+                    entity.notificationMode == NotificationMode.DISABLED
+                val update = Completable.fromAction {
                     entity.notificationMode = mode
+                    entity.notificationKeywords = keywords
                     subscriptionTable().update(entity)
-                }.apply {
-                    if (mode != NotificationMode.DISABLED) {
-                        // notifications have just been enabled, mark all streams as "old"
-                        andThen(rememberAllStreams(entity))
-                    }
+                    recordSubscriptionUpsert(entity)
+                }
+                if (notificationsWereDisabled && mode != NotificationMode.DISABLED) {
+                    // Notifications have just been enabled, mark all streams as "old".
+                    update.andThen(rememberAllStreams(entity))
+                } else {
+                    update
                 }
             }
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigAdapter.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigAdapter.kt
@@ -5,9 +5,11 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import org.schabi.newpipe.R
 import org.schabi.newpipe.database.subscription.NotificationMode
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.databinding.ItemNotificationConfigBinding
+import org.schabi.newpipe.local.feed.notifications.NotificationKeywordFilter
 import org.schabi.newpipe.settings.notifications.NotificationModeConfigAdapter.SubscriptionHolder
 
 /**
@@ -16,7 +18,7 @@ import org.schabi.newpipe.settings.notifications.NotificationModeConfigAdapter.S
  * and provides the needed data structures and methods for this task.
  */
 class NotificationModeConfigAdapter(
-    private val listener: ModeToggleListener
+    private val listener: ConfigureListener
 ) : ListAdapter<SubscriptionItem, SubscriptionHolder>(DiffCallback) {
     override fun onCreateViewHolder(parent: ViewGroup, i: Int): SubscriptionHolder {
         return SubscriptionHolder(
@@ -31,7 +33,14 @@ class NotificationModeConfigAdapter(
 
     fun update(newData: List<SubscriptionEntity>) {
         val items = newData.map {
-            SubscriptionItem(it.uid, it.name!!, it.notificationMode, it.serviceId, it.url!!)
+            SubscriptionItem(
+                it.uid,
+                it.name!!,
+                it.notificationMode,
+                it.notificationKeywords,
+                it.serviceId,
+                it.url!!
+            )
         }
         submitList(items)
     }
@@ -41,18 +50,27 @@ class NotificationModeConfigAdapter(
     ) : RecyclerView.ViewHolder(itemBinding.root) {
         init {
             itemView.setOnClickListener {
-                val mode = if (itemBinding.root.isChecked) {
-                    NotificationMode.DISABLED
-                } else {
-                    NotificationMode.ENABLED
+                val position = bindingAdapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    listener.onConfigure(currentList[position])
                 }
-                listener.onModeChange(bindingAdapterPosition, mode)
             }
         }
 
         fun bind(data: SubscriptionItem) {
-            itemBinding.root.text = data.title
-            itemBinding.root.isChecked = data.notificationMode != NotificationMode.DISABLED
+            itemBinding.title.text = data.title
+            itemBinding.summary.text = when (data.notificationMode) {
+                NotificationMode.ENABLED -> itemView.context.getString(
+                    R.string.notification_mode_all_uploads
+                )
+
+                NotificationMode.KEYWORDS_ONLY -> itemView.context.getString(
+                    R.string.notification_keywords_summary,
+                    NotificationKeywordFilter.terms(data.notificationKeywords).joinToString(", ")
+                )
+
+                else -> itemView.context.getString(R.string.notification_mode_disabled)
+            }
         }
     }
 
@@ -66,19 +84,22 @@ class NotificationModeConfigAdapter(
         }
 
         override fun getChangePayload(oldItem: SubscriptionItem, newItem: SubscriptionItem): Any? {
-            return if (oldItem.notificationMode != newItem.notificationMode) {
-                newItem.notificationMode
+            return if (
+                oldItem.notificationMode != newItem.notificationMode ||
+                oldItem.notificationKeywords != newItem.notificationKeywords
+            ) {
+                newItem
             } else {
                 super.getChangePayload(oldItem, newItem)
             }
         }
     }
 
-    fun interface ModeToggleListener {
+    fun interface ConfigureListener {
         /**
          * Triggered when the UI representation of a notification mode is changed.
          */
-        fun onModeChange(position: Int, @NotificationMode mode: Int)
+        fun onConfigure(item: SubscriptionItem)
     }
 }
 
@@ -87,6 +108,7 @@ data class SubscriptionItem(
     val title: String,
     @NotificationMode
     val notificationMode: Int,
+    val notificationKeywords: String,
     val serviceId: Int,
     val url: String
 )

--- a/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigFragment.kt
@@ -8,14 +8,18 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.subscription.NotificationMode
+import org.schabi.newpipe.databinding.DialogNotificationFilterBinding
 import org.schabi.newpipe.databinding.FragmentChannelsNotificationsBinding
+import org.schabi.newpipe.local.feed.notifications.NotificationKeywordFilter
 import org.schabi.newpipe.local.subscription.SubscriptionManager
 
 /**
@@ -53,11 +57,7 @@ class NotificationModeConfigFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        adapter = NotificationModeConfigAdapter { position, mode ->
-            // Notification mode has been changed via the UI.
-            // Now change it in the database.
-            updateNotificationMode(adapter.currentList[position], mode)
-        }
+        adapter = NotificationModeConfigAdapter(::showNotificationConfigDialog)
         binding.recyclerView.adapter = adapter
         loader?.dispose()
         loader = subscriptionManager.subscriptions()
@@ -105,6 +105,76 @@ class NotificationModeConfigFragment : Fragment() {
     private fun updateNotificationMode(item: SubscriptionItem, @NotificationMode mode: Int) {
         disposables.add(
             subscriptionManager.updateNotificationMode(item.serviceId, item.url, mode)
+                .subscribeOn(Schedulers.io())
+                .subscribe()
+        )
+    }
+
+    private fun showNotificationConfigDialog(item: SubscriptionItem) {
+        val dialogBinding = DialogNotificationFilterBinding.inflate(layoutInflater)
+        dialogBinding.keywords.setText(item.notificationKeywords)
+        when (item.notificationMode) {
+            NotificationMode.ENABLED -> dialogBinding.modeAll.isChecked = true
+            NotificationMode.KEYWORDS_ONLY -> dialogBinding.modeKeywords.isChecked = true
+            else -> dialogBinding.modeDisabled.isChecked = true
+        }
+
+        fun updateKeywordVisibility() {
+            dialogBinding.keywordsLayout.visibility = if (dialogBinding.modeKeywords.isChecked) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
+        }
+        dialogBinding.modeGroup.setOnCheckedChangeListener { _, _ ->
+            dialogBinding.keywordsLayout.error = null
+            updateKeywordVisibility()
+        }
+        updateKeywordVisibility()
+
+        val dialog = MaterialAlertDialogBuilder(requireContext())
+            .setTitle(item.title)
+            .setView(dialogBinding.root)
+            .setNegativeButton(R.string.cancel, null)
+            .setPositiveButton(R.string.save, null)
+            .create()
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val mode = when (dialogBinding.modeGroup.checkedRadioButtonId) {
+                    R.id.mode_all -> NotificationMode.ENABLED
+                    R.id.mode_keywords -> NotificationMode.KEYWORDS_ONLY
+                    else -> NotificationMode.DISABLED
+                }
+                val normalizedKeywords = NotificationKeywordFilter.normalize(
+                    dialogBinding.keywords.text?.toString().orEmpty()
+                )
+                if (
+                    mode == NotificationMode.KEYWORDS_ONLY &&
+                    !NotificationKeywordFilter.isValid(normalizedKeywords)
+                ) {
+                    dialogBinding.keywordsLayout.error =
+                        getString(R.string.notification_keywords_invalid)
+                    return@setOnClickListener
+                }
+                updateNotificationSettings(item, mode, normalizedKeywords)
+                dialog.dismiss()
+            }
+        }
+        dialog.show()
+    }
+
+    private fun updateNotificationSettings(
+        item: SubscriptionItem,
+        @NotificationMode mode: Int,
+        keywords: String
+    ) {
+        disposables.add(
+            subscriptionManager.updateNotificationSettings(
+                item.serviceId,
+                item.url,
+                mode,
+                keywords
+            )
                 .subscribeOn(Schedulers.io())
                 .subscribe()
         )

--- a/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncModels.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncModels.kt
@@ -8,7 +8,9 @@ package org.schabi.newpipe.sync
 import io.libp2p.core.PeerId
 import java.security.MessageDigest
 import kotlinx.serialization.Serializable
+import org.schabi.newpipe.database.subscription.NotificationMode
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
+import org.schabi.newpipe.local.feed.notifications.NotificationKeywordFilter
 
 internal const val SUBSCRIPTION_SYNC_PROTOCOL_ID = "/wizestream/subscriptions/1.0.0"
 internal const val SUBSCRIPTION_SYNC_VERSION = 1
@@ -34,16 +36,23 @@ internal data class SyncedSubscription(
     val avatarUrl: String? = null,
     val subscriberCount: Long? = null,
     val description: String? = null,
-    val youtubeModeMask: Int = SubscriptionEntity.YOUTUBE_MODE_REGULAR
+    val youtubeModeMask: Int = SubscriptionEntity.YOUTUBE_MODE_REGULAR,
+    val notificationMode: Int? = null,
+    val notificationKeywords: String? = null
 ) {
-    internal fun toEntity() = SubscriptionEntity(
+    internal fun toEntity(existing: SubscriptionEntity? = null) = SubscriptionEntity(
         serviceId = serviceId,
         url = url,
         name = name,
         avatarUrl = avatarUrl,
         subscriberCount = subscriberCount,
         description = description,
-        youtubeModeMask = youtubeModeMask
+        youtubeModeMask = youtubeModeMask,
+        notificationMode = notificationMode
+            ?: existing?.notificationMode
+            ?: NotificationMode.DISABLED,
+        notificationKeywords = notificationKeywords
+            ?: existing?.notificationKeywords.orEmpty()
     )
 
     companion object {
@@ -55,7 +64,9 @@ internal data class SyncedSubscription(
                 avatarUrl = entity.avatarUrl?.take(MAX_SUBSCRIPTION_AVATAR_URL_LENGTH),
                 subscriberCount = entity.subscriberCount,
                 description = entity.description?.take(MAX_SUBSCRIPTION_DESCRIPTION_LENGTH),
-                youtubeModeMask = entity.youtubeModeMask
+                youtubeModeMask = entity.youtubeModeMask,
+                notificationMode = entity.notificationMode,
+                notificationKeywords = entity.notificationKeywords
             )
         }
     }
@@ -308,7 +319,23 @@ internal object SubscriptionSyncValidation {
             (subscription.description?.length ?: 0) >
             MAX_SUBSCRIPTION_DESCRIPTION_LENGTH ||
             subscription.youtubeModeMask < SubscriptionEntity.YOUTUBE_MODE_REGULAR ||
-            subscription.youtubeModeMask > SubscriptionEntity.YOUTUBE_MODE_ALL
+            subscription.youtubeModeMask > SubscriptionEntity.YOUTUBE_MODE_ALL ||
+            subscription.notificationMode?.let {
+                it !in NotificationMode.DISABLED..NotificationMode.KEYWORDS_ONLY
+            } == true ||
+            subscription.notificationKeywords?.let { keywords ->
+                keywords != NotificationKeywordFilter.normalize(keywords) ||
+                    (
+                        keywords.isNotEmpty() &&
+                            !NotificationKeywordFilter.isValid(keywords)
+                        )
+            } == true ||
+            (
+                subscription.notificationMode == NotificationMode.KEYWORDS_ONLY &&
+                    !NotificationKeywordFilter.isValid(
+                        subscription.notificationKeywords.orEmpty()
+                    )
+                )
         ) {
             throw SubscriptionSyncException("Subscription metadata is invalid")
         }

--- a/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncStore.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/SubscriptionSyncStore.kt
@@ -62,7 +62,13 @@ internal class RoomSubscriptionSyncStore private constructor(
                     requireNotNull(subscription.url)
                 )
                 val record = syncRecords[recordId]
-                if (record == null || record.isDeleted) {
+                if (
+                    record == null ||
+                    record.isDeleted ||
+                    record.youtubeModeMask != subscription.youtubeModeMask ||
+                    record.notificationMode != subscription.notificationMode ||
+                    record.notificationKeywords != subscription.notificationKeywords
+                ) {
                     recordLocalUpsertInTransaction(subscription)
                 }
             }
@@ -180,14 +186,11 @@ internal class RoomSubscriptionSyncStore private constructor(
 
                     when (change.type) {
                         SubscriptionChangeType.UPSERT -> {
-                            val incoming = requireNotNull(change.subscription).toEntity()
                             val existing = subscriptionDao.getSubscriptionDirect(
-                                incoming.serviceId,
-                                requireNotNull(incoming.url)
+                                change.serviceId,
+                                change.url
                             )
-                            if (existing != null) {
-                                incoming.notificationMode = existing.notificationMode
-                            }
+                            val incoming = requireNotNull(change.subscription).toEntity(existing)
                             subscriptionDao.upsertAll(listOf(incoming))
                             if (existing == null) {
                                 added += 1
@@ -227,7 +230,9 @@ internal class RoomSubscriptionSyncStore private constructor(
         if (
             currentRecord != null &&
             !currentRecord.isDeleted &&
-            currentRecord.youtubeModeMask == syncedSubscription.youtubeModeMask
+            currentRecord.youtubeModeMask == syncedSubscription.youtubeModeMask &&
+            currentRecord.notificationMode == syncedSubscription.notificationMode &&
+            currentRecord.notificationKeywords == syncedSubscription.notificationKeywords
         ) {
             return
         }
@@ -360,7 +365,9 @@ internal class RoomSubscriptionSyncStore private constructor(
                 subscriberCount = subscriberCount,
                 description = description,
                 youtubeModeMask = youtubeModeMask
-                    ?: SubscriptionEntity.YOUTUBE_MODE_REGULAR
+                    ?: SubscriptionEntity.YOUTUBE_MODE_REGULAR,
+                notificationMode = notificationMode,
+                notificationKeywords = notificationKeywords
             )
         } else {
             null
@@ -379,7 +386,9 @@ internal class RoomSubscriptionSyncStore private constructor(
         avatarUrl = subscription?.avatarUrl,
         subscriberCount = subscription?.subscriberCount,
         description = subscription?.description,
-        youtubeModeMask = subscription?.youtubeModeMask
+        youtubeModeMask = subscription?.youtubeModeMask,
+        notificationMode = subscription?.notificationMode,
+        notificationKeywords = subscription?.notificationKeywords
     )
 
     private fun SubscriptionChange.toRecordEntity() = SubscriptionSyncRecordEntity(
@@ -391,7 +400,9 @@ internal class RoomSubscriptionSyncStore private constructor(
         originRevision = originRevision,
         isDeleted = type == SubscriptionChangeType.DELETE,
         youtubeModeMask = subscription?.youtubeModeMask
-            ?: SubscriptionEntity.YOUTUBE_MODE_REGULAR
+            ?: SubscriptionEntity.YOUTUBE_MODE_REGULAR,
+        notificationMode = subscription?.notificationMode,
+        notificationKeywords = subscription?.notificationKeywords
     )
 
     private val SubscriptionSyncRecordEntity.versionStamp: SubscriptionVersionStamp

--- a/app/src/main/res/layout/dialog_notification_filter.xml
+++ b/app/src/main/res/layout/dialog_notification_filter.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="8dp">
+
+    <RadioGroup
+        android:id="@+id/mode_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/mode_disabled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/notification_mode_disabled" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/mode_all"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/notification_mode_all_uploads" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/mode_keywords"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/notification_mode_keywords_only" />
+    </RadioGroup>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/keywords_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:hint="@string/notification_keywords_hint"
+        app:errorEnabled="true"
+        app:helperText="@string/notification_keywords_help">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/keywords"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="top|start"
+            android:inputType="textCapSentences|textMultiLine"
+            android:maxLength="2048"
+            android:minLines="4" />
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_notification_config.xml
+++ b/app/src/main/res/layout/item_notification_config.xml
@@ -1,18 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="?listPreferredItemHeightSmall"
+    android:layout_height="wrap_content"
     android:background="?selectableItemBackground"
-    android:ellipsize="end"
     android:gravity="center_vertical"
-    android:maxLines="2"
+    android:minHeight="?listPreferredItemHeightSmall"
     android:orientation="horizontal"
     android:paddingStart="?listPreferredItemPaddingStart"
+    android:paddingTop="10dp"
     android:paddingEnd="?listPreferredItemPaddingEnd"
-    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-    android:textColor="?attr/colorOnSurface"
-    android:drawableTint="@color/settings_control_tint"
-    android:drawableEnd="?android:listChoiceIndicatorMultiple"
-    tools:text="@tools:sample/lorem[4]" />
+    android:paddingBottom="10dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:textColor="?attr/colorOnSurface"
+            tools:text="Automotive Channel" />
+
+        <TextView
+            android:id="@+id/summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            tools:text="Matching keywords only · 07K, VW 2.5L" />
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:contentDescription="@string/edit_notification_filter"
+        android:src="@drawable/ic_edit"
+        app:tint="?attr/colorOnSurfaceVariant" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -896,6 +896,14 @@
     <!-- Notifications settings -->
     <string name="enable_streams_notifications_title">New streams notifications</string>
     <string name="enable_streams_notifications_summary">Notify about new streams from subscriptions</string>
+    <string name="edit_notification_filter">Edit notification filter</string>
+    <string name="notification_mode_disabled">Notifications disabled</string>
+    <string name="notification_mode_all_uploads">All uploads</string>
+    <string name="notification_mode_keywords_only">Matching keywords only</string>
+    <string name="notification_keywords_hint">Keywords or phrases</string>
+    <string name="notification_keywords_help">Enter one keyword or phrase per line. A title matching any line will notify you.</string>
+    <string name="notification_keywords_invalid">Enter between 1 and 25 keywords or phrases, with no line longer than 100 characters.</string>
+    <string name="notification_keywords_summary">Matching keywords only · %1$s</string>
     <string name="streams_notifications_interval_title">Checking frequency</string>
     <string name="streams_notifications_network_title">Required network connection</string>
     <string name="any_network">Any network</string>

--- a/app/src/test/java/org/schabi/newpipe/local/feed/notifications/NotificationKeywordFilterTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/notifications/NotificationKeywordFilterTest.kt
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.feed.notifications
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.schabi.newpipe.database.subscription.NotificationMode
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class NotificationKeywordFilterTest {
+    @Test
+    fun `normalization trims removes blank lines and deduplicates ignoring case`() {
+        assertEquals(
+            "07K\nVW 2.5L\n5-cylinder",
+            NotificationKeywordFilter.normalize(
+                " 07K \n\nVW 2.5L\n07k\n 5-cylinder "
+            )
+        )
+    }
+
+    @Test
+    fun `phrases match titles case insensitively with any-term semantics`() {
+        val filters = "07K\nVW 2.5L"
+
+        assertTrue(NotificationKeywordFilter.matches("Why the vw 2.5l is reliable", filters))
+        assertTrue(NotificationKeywordFilter.matches("Rebuilding an 07k Passat", filters))
+        assertFalse(NotificationKeywordFilter.matches("Fixing a BMW E46", filters))
+    }
+
+    @Test
+    fun `keyword mode filters only notification candidates`() {
+        val matching = stream("Why the VW 2.5L is reliable")
+        val unrelated = stream("Fixing a Ford Focus")
+
+        assertEquals(
+            listOf(matching),
+            NotificationKeywordFilter.filter(
+                listOf(matching, unrelated),
+                NotificationMode.KEYWORDS_ONLY,
+                "07K\nVW 2.5L"
+            )
+        )
+        assertEquals(
+            listOf(matching, unrelated),
+            NotificationKeywordFilter.filter(
+                listOf(matching, unrelated),
+                NotificationMode.ENABLED,
+                "07K"
+            )
+        )
+        assertTrue(
+            NotificationKeywordFilter.filter(
+                listOf(matching),
+                NotificationMode.DISABLED,
+                "07K"
+            ).isEmpty()
+        )
+    }
+
+    @Test
+    fun `keyword-only filters reject empty and oversized input`() {
+        assertFalse(NotificationKeywordFilter.isValid(""))
+        assertFalse(NotificationKeywordFilter.isValid("a".repeat(101)))
+        assertFalse(
+            NotificationKeywordFilter.isValid(
+                (1..26).joinToString("\n") { "term-$it" }
+            )
+        )
+        assertTrue(NotificationKeywordFilter.isValid("engine\ntransmission"))
+    }
+
+    private fun stream(title: String) = StreamInfoItem(
+        0,
+        "https://example.com/${title.hashCode()}",
+        title,
+        StreamType.VIDEO_STREAM
+    )
+}

--- a/app/src/test/java/org/schabi/newpipe/sync/SubscriptionSyncEngineTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/SubscriptionSyncEngineTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.schabi.newpipe.database.subscription.NotificationMode
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
 
 class SubscriptionSyncEngineTest {
@@ -105,6 +106,30 @@ class SubscriptionSyncEngineTest {
         assertEquals(
             SubscriptionEntity.YOUTUBE_MODE_ALL,
             tabletStore.youtubeModeMask(PHONE_URL)
+        )
+    }
+
+    @Test
+    fun `notification keyword settings synchronize with subscriptions`() {
+        val phoneStore = newStore()
+        val tabletStore = newStore()
+        val phone = SubscriptionSyncEngine(phoneStore)
+        val tablet = SubscriptionSyncEngine(tabletStore)
+        phoneStore.recordLocalUpsert(
+            SubscriptionEntity(
+                serviceId = SERVICE_ID,
+                url = PHONE_URL,
+                name = "Automotive channel",
+                notificationMode = NotificationMode.KEYWORDS_ONLY,
+                notificationKeywords = "07K\nVW 2.5L"
+            )
+        )
+
+        synchronize(phone, phoneStore, tablet, tabletStore)
+
+        assertEquals(
+            NotificationMode.KEYWORDS_ONLY to "07K\nVW 2.5L",
+            tabletStore.notificationSettings(PHONE_URL)
         )
     }
 

--- a/app/src/test/java/org/schabi/newpipe/sync/TestSubscriptionSyncStore.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/TestSubscriptionSyncStore.kt
@@ -25,6 +25,12 @@ internal class TestSubscriptionSyncStore(
         return subscriptions.values.firstOrNull { it.url == url }?.youtubeModeMask
     }
 
+    fun notificationSettings(url: String): Pair<Int?, String?>? {
+        return subscriptions.values.firstOrNull { it.url == url }?.let {
+            it.notificationMode to it.notificationKeywords
+        }
+    }
+
     override fun reconcileLocalSubscriptions() = Unit
 
     override fun recordLocalUpsert(subscription: SubscriptionEntity) {

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,7 @@ Release history is listed newest first. The number beside each release is its An
 
 ### New features
 
+- Added per-channel keyword and phrase filters for new-stream notifications.
 - Added date-aware fast scrolling and a calendar jump action for navigating large watch histories.
 - Added an option to prioritize main-tab swiping when viewing pinned channels.
 


### PR DESCRIPTION
- Adds per-channel Off, All uploads, and Matching keywords only notification modes
- Matches titles locally using case-insensitive literal keywords or phrases with any-term semantics
- Keeps subscription feeds unchanged and filters only notification candidates and summary counts
- Persists keyword rules through database backups and device subscription synchronization
- Adds Room migration, settings validation, matcher tests, synchronization coverage, and changelog documentation
- Closes #194