### PR TITLE
Fix Material You colors with black theme

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -199,7 +199,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
     private void applyPlayerSeekBarColor() {
         final int playerSeekBarColor = ThemeHelper.resolveColorFromAttr(
-                context, R.attr.colorPrimaryFixedDim);
+                binding.playbackSeekBar.getContext(), R.attr.colorPrimaryFixedDim);
         final ColorStateList playerSeekBarColorStateList =
                 ColorStateList.valueOf(playerSeekBarColor);
 

--- a/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ThemeHelper.java
@@ -43,6 +43,7 @@ public final class ThemeHelper {
     public static void applyThemeColor(final Context context) {
         if (shouldApplyDynamicColors(context)) {
             DynamicColors.applyToActivityIfAvailable((Activity) context);
+            applyBlackSurfaceOverlay(context);
         } else {
             applyThemeColorOverlay(context);
         }
@@ -60,8 +61,13 @@ public final class ThemeHelper {
 
     public static boolean shouldApplyDynamicColors(final Context context) {
         return context instanceof Activity
-                && isFollowSystemThemeColor(context)
-                && !isBlackThemeSelected(context);
+                && isFollowSystemThemeColor(context);
+    }
+
+    private static void applyBlackSurfaceOverlay(final Context context) {
+        if (isBlackThemeSelected(context)) {
+            context.getTheme().applyStyle(R.style.ThemeOverlay_wizestream_BlackSurfaces, true);
+        }
     }
 
     public static void applyThemeColorOverlay(final Context context) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -145,6 +145,15 @@
     <style name="Base.BlackTheme" parent="Base.V21.BlackTheme" />
     <style name="BlackTheme" parent="Base.BlackTheme"/>
 
+    <!-- Preserve AMOLED-black surfaces after Material You supplies the accent palette. -->
+    <style name="ThemeOverlay_wizestream_BlackSurfaces">
+        <item name="android:windowBackground">@color/black_background_color</item>
+        <item name="windowBackground">@color/black_background_color</item>
+        <item name="android:statusBarColor">@color/black_background_color</item>
+        <item name="android:navigationBarColor">@color/black_background_color</item>
+        <item name="colorSurface">@color/black_background_color</item>
+    </style>
+
 
     <!-- Theme color preset overlays -->
     <style name="ThemeOverlay_wizestream_ThemeColor_wizestream">

--- a/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
@@ -1,0 +1,57 @@
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ThemeColorIntegrationTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+    private final Path resourceDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void blackThemeKeepsDynamicAccentsAndRestoresOnlyBlackSurfaces() throws Exception {
+        final String helper = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/util/ThemeHelper.java"));
+        final String styles = Files.readString(resourceDirectory.resolve("values/styles.xml"));
+        final String blackOverlay = styleBody(styles,
+                "ThemeOverlay_wizestream_BlackSurfaces");
+
+        assertTrue(helper.contains("&& isFollowSystemThemeColor(context);"));
+        assertFalse(helper.contains("&& !isBlackThemeSelected(context)"));
+        assertTrue(helper.indexOf("DynamicColors.applyToActivityIfAvailable((Activity) context);")
+                < helper.indexOf("applyBlackSurfaceOverlay(context);"));
+        assertTrue(blackOverlay.contains(
+                "<item name=\"colorSurface\">@color/black_background_color</item>"));
+        assertFalse(blackOverlay.contains("colorPrimary"));
+        assertFalse(blackOverlay.contains("colorSecondary"));
+    }
+
+    @Test
+    public void playerSeekBarUsesItsThemedViewContext() throws Exception {
+        final String playerUi = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/ui/VideoPlayerUi.java"));
+
+        assertTrue(playerUi.contains(
+                "binding.playbackSeekBar.getContext(), R.attr.colorPrimaryFixedDim"));
+        assertFalse(playerUi.contains("context, R.attr.colorPrimaryFixedDim"));
+    }
+
+    private String styleBody(final String styles, final String styleName) {
+        final String openingTag = "<style name=\"" + styleName + "\">";
+        final int start = styles.indexOf(openingTag);
+        if (start < 0) {
+            throw new AssertionError("Missing style: " + styleName);
+        }
+        final int end = styles.indexOf("</style>", start);
+        if (end < 0) {
+            throw new AssertionError("Unclosed style: " + styleName);
+        }
+        return styles.substring(start, end);
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Fixes
+
+- Fixed Material You wallpaper colors falling back to green with the Black night theme, while
+  preserving true-black surfaces, and made the player seek bar follow the selected accent color.
+
 ### New features
 
 - Added per-channel keyword and phrase filters for new-stream notifications.


### PR DESCRIPTION
- Fixes #193 by allowing wallpaper-derived Material You colors with the Black night theme.
- Preserve true-black window, status-bar, navigation-bar, and surface backgrounds without replacing dynamic accent roles.
- Resolve the player seek bar accent from its themed view instead of the playback service context.
- Add regression coverage for dynamic-color application order, black-surface isolation, and player accent resolution.
- Document the correction in the changelog.