### PR TITLE
Add optional MP3 audio downloads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -288,6 +288,7 @@ dependencies {
     // Third-party libraries
     implementation(libs.livefront.bridge)
     implementation(libs.evernote.statesaver.core)
+    implementation(libs.ntbl.lame)
     kapt(libs.evernote.statesaver.compiler)
 
     // HTML parser

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -20,6 +20,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.RadioGroup;
 import android.widget.SeekBar;
 import android.widget.Toast;
@@ -82,6 +83,7 @@ import java.util.Optional;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import us.shandian.giga.get.MissionRecoveryInfo;
+import us.shandian.giga.postprocessing.Mp3OutputOptions;
 import us.shandian.giga.postprocessing.Postprocessing;
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.service.DownloadManagerService;
@@ -109,6 +111,14 @@ public class DownloadDialog extends DialogFragment
     int selectedAudioIndex = 0; // default to the first item
     @State
     int selectedSubtitleIndex = 0; // default to the first item
+    @State
+    int selectedAudioOutputIndex = 0;
+    @State
+    int selectedMp3BitrateIndex = 1;
+
+    private static final int AUDIO_OUTPUT_ORIGINAL = 0;
+    private static final int AUDIO_OUTPUT_MP3 = 1;
+    private static final int[] MP3_BITRATES = {128, 192, 256, 320};
 
     private StoredDirectoryHelper mainStorageAudio = null;
     private StoredDirectoryHelper mainStorageVideo = null;
@@ -308,7 +318,23 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.qualitySpinner.setOnItemSelectedListener(this);
         dialogBinding.audioStreamSpinner.setOnItemSelectedListener(this);
         dialogBinding.audioTrackSpinner.setOnItemSelectedListener(this);
+        dialogBinding.audioOutputFormatSpinner.setOnItemSelectedListener(this);
+        dialogBinding.mp3BitrateSpinner.setOnItemSelectedListener(this);
         dialogBinding.videoAudioGroup.setOnCheckedChangeListener(this);
+
+        final ArrayAdapter<CharSequence> outputFormatAdapter = ArrayAdapter.createFromResource(
+                requireContext(), R.array.audio_output_format_entries,
+                android.R.layout.simple_spinner_item);
+        outputFormatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        dialogBinding.audioOutputFormatSpinner.setAdapter(outputFormatAdapter);
+        dialogBinding.audioOutputFormatSpinner.setSelection(selectedAudioOutputIndex);
+
+        final ArrayAdapter<CharSequence> bitrateAdapter = ArrayAdapter.createFromResource(
+                requireContext(), R.array.mp3_bitrate_entries,
+                android.R.layout.simple_spinner_item);
+        bitrateAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        dialogBinding.mp3BitrateSpinner.setAdapter(bitrateAdapter);
+        dialogBinding.mp3BitrateSpinner.setSelection(selectedMp3BitrateIndex);
 
         initToolbar(dialogBinding.toolbarLayout.toolbar);
         setupDownloadOptions();
@@ -432,6 +458,9 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.audioTrackSpinner.setVisibility(
                 wrappedAudioTracks.size() > 1 ? View.VISIBLE : View.GONE);
         dialogBinding.audioTrackPresentInVideoText.setVisibility(View.GONE);
+        dialogBinding.audioOutputFormatLabel.setVisibility(View.VISIBLE);
+        dialogBinding.audioOutputFormatSpinner.setVisibility(View.VISIBLE);
+        updateMp3BitrateVisibility();
     }
 
     private void setupVideoSpinner() {
@@ -444,6 +473,7 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.qualitySpinner.setVisibility(View.VISIBLE);
         setRadioButtonsState(true);
         dialogBinding.audioStreamSpinner.setVisibility(View.GONE);
+        hideAudioOutputOptions();
         onVideoStreamSelected();
     }
 
@@ -466,6 +496,7 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.qualitySpinner.setVisibility(View.VISIBLE);
         setRadioButtonsState(true);
         dialogBinding.audioStreamSpinner.setVisibility(View.GONE);
+        hideAudioOutputOptions();
         dialogBinding.audioTrackSpinner.setVisibility(View.GONE);
         dialogBinding.audioTrackPresentInVideoText.setVisibility(View.GONE);
     }
@@ -601,6 +632,12 @@ public class DownloadDialog extends DialogFragment
             }
         } else if (parentId == R.id.audio_stream_spinner) {
             selectedAudioIndex = position;
+            updateMp3BitrateVisibility();
+        } else if (parentId == R.id.audio_output_format_spinner) {
+            selectedAudioOutputIndex = position;
+            updateMp3BitrateVisibility();
+        } else if (parentId == R.id.mp3_bitrate_spinner) {
+            selectedMp3BitrateIndex = position;
         }
     }
 
@@ -695,6 +732,37 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.subtitleButton.setEnabled(enabled);
     }
 
+    private void hideAudioOutputOptions() {
+        dialogBinding.audioOutputFormatLabel.setVisibility(View.GONE);
+        dialogBinding.audioOutputFormatSpinner.setVisibility(View.GONE);
+        dialogBinding.mp3BitrateLabel.setVisibility(View.GONE);
+        dialogBinding.mp3BitrateSpinner.setVisibility(View.GONE);
+    }
+
+    private void updateMp3BitrateVisibility() {
+        if (dialogBinding == null) {
+            return;
+        }
+        final boolean visible = selectedAudioOutputIndex == AUDIO_OUTPUT_MP3
+                && audioStreamsAdapter != null
+                && selectedAudioIndex >= 0
+                && selectedAudioIndex < audioStreamsAdapter.getCount()
+                && audioStreamsAdapter.getItem(selectedAudioIndex).getFormat() != MediaFormat.MP3;
+        dialogBinding.mp3BitrateLabel.setVisibility(visible ? View.VISIBLE : View.GONE);
+        dialogBinding.mp3BitrateSpinner.setVisibility(visible ? View.VISIBLE : View.GONE);
+    }
+
+    private boolean isMp3OutputSelected() {
+        return selectedAudioOutputIndex == AUDIO_OUTPUT_MP3;
+    }
+
+    private int getSelectedMp3Bitrate() {
+        if (selectedMp3BitrateIndex < 0 || selectedMp3BitrateIndex >= MP3_BITRATES.length) {
+            return Mp3OutputOptions.DEFAULT_BITRATE_KBPS;
+        }
+        return MP3_BITRATES[selectedMp3BitrateIndex];
+    }
+
     private StreamInfoWrapper<AudioStream> getWrappedAudioStreams() {
         if (selectedAudioTrackIndex < 0 || selectedAudioTrackIndex > wrappedAudioTracks.size()) {
             return StreamInfoWrapper.empty();
@@ -753,7 +821,7 @@ public class DownloadDialog extends DialogFragment
         final StoredDirectoryHelper mainStorage;
         final MediaFormat format;
         final String selectedMediaType;
-        final long size;
+        long size;
 
         // first, build the filename and get the output folder (if possible)
         // later, run a very very very large file checking logic
@@ -766,7 +834,14 @@ public class DownloadDialog extends DialogFragment
             mainStorage = mainStorageAudio;
             format = audioStreamsAdapter.getItem(selectedAudioIndex).getFormat();
             size = getWrappedAudioStreams().getSizeInBytes(selectedAudioIndex);
-            if (format == MediaFormat.WEBMA_OPUS) {
+            if (isMp3OutputSelected()) {
+                mimeTmp = MediaFormat.MP3.mimeType;
+                filenameTmp += MediaFormat.MP3.getSuffix();
+                if (Mp3DownloadPolicy.shouldTranscode(true, format)) {
+                    size = Mp3OutputOptions.estimateRequiredBytes(size,
+                            currentInfo.getDuration(), getSelectedMp3Bitrate());
+                }
+            } else if (format == MediaFormat.WEBMA_OPUS) {
                 mimeTmp = "audio/ogg";
                 filenameTmp += "opus";
             } else if (format != null) {
@@ -1049,7 +1124,11 @@ public class DownloadDialog extends DialogFragment
             kind = 'a';
             selectedStream = audioStreamsAdapter.getItem(selectedAudioIndex);
 
-            if (selectedStream.getFormat() == MediaFormat.M4A) {
+            if (Mp3DownloadPolicy.shouldTranscode(isMp3OutputSelected(),
+                    selectedStream.getFormat())) {
+                psName = Postprocessing.ALGORITHM_MP3_FROM_AUDIO;
+                psArgs = new String[] {String.valueOf(getSelectedMp3Bitrate())};
+            } else if (selectedStream.getFormat() == MediaFormat.M4A) {
                 psName = Postprocessing.ALGORITHM_M4A_NO_DASH;
             } else if (selectedStream.getFormat() == MediaFormat.WEBMA_OPUS) {
                 psName = Postprocessing.ALGORITHM_OGG_FROM_WEBM_DEMUXER;

--- a/app/src/main/java/org/schabi/newpipe/download/Mp3DownloadPolicy.java
+++ b/app/src/main/java/org/schabi/newpipe/download/Mp3DownloadPolicy.java
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.download;
+
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.extractor.MediaFormat;
+
+final class Mp3DownloadPolicy {
+    private Mp3DownloadPolicy() {
+    }
+
+    static boolean shouldTranscode(final boolean mp3OutputSelected,
+                                   @Nullable final MediaFormat sourceFormat) {
+        return mp3OutputSelected && sourceFormat != MediaFormat.MP3;
+    }
+}

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -525,6 +525,10 @@ public class DownloadMission extends Mission {
      */
     @Override
     public boolean delete() {
+        running = false;
+        for (final Thread thread : threads) {
+            thread.interrupt();
+        }
         if (psAlgorithm != null) psAlgorithm.cleanupTemporalDir();
 
         notify(DownloadManagerService.MESSAGE_DELETED);
@@ -607,6 +611,10 @@ public class DownloadMission extends Mission {
      */
     public boolean isPsRunning() {
         return psAlgorithm != null && (psState == 1 || psState == 3);
+    }
+
+    public boolean isConvertingToMp3() {
+        return isPsRunning() && psAlgorithm.isMp3Conversion();
     }
 
     /**

--- a/app/src/main/java/us/shandian/giga/postprocessing/Id3MetadataWriter.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Id3MetadataWriter.java
@@ -1,0 +1,72 @@
+package us.shandian.giga.postprocessing;
+
+import androidx.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+final class Id3MetadataWriter {
+    private Id3MetadataWriter() {
+    }
+
+    static void write(final OutputStream output,
+                      @Nullable final String title,
+                      @Nullable final String artist,
+                      @Nullable final String sourceUrl) throws IOException {
+        final ByteArrayOutputStream frames = new ByteArrayOutputStream();
+        writeTextFrame(frames, "TIT2", title);
+        writeTextFrame(frames, "TPE1", artist);
+        writeUrlFrame(frames, sourceUrl);
+
+        final byte[] payload = frames.toByteArray();
+        output.write(new byte[] {'I', 'D', '3', 4, 0, 0});
+        output.write(toSynchsafe(payload.length));
+        output.write(payload);
+    }
+
+    private static void writeTextFrame(final OutputStream output,
+                                       final String id,
+                                       @Nullable final String value) throws IOException {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        final byte[] text = value.getBytes(StandardCharsets.UTF_8);
+        writeFrameHeader(output, id, text.length + 1);
+        output.write(3);
+        output.write(text);
+    }
+
+    private static void writeUrlFrame(final OutputStream output,
+                                      @Nullable final String value) throws IOException {
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        final byte[] description = "Source".getBytes(StandardCharsets.UTF_8);
+        final byte[] url = value.getBytes(StandardCharsets.UTF_8);
+        writeFrameHeader(output, "WXXX", description.length + url.length + 2);
+        output.write(3);
+        output.write(description);
+        output.write(0);
+        output.write(url);
+    }
+
+    private static void writeFrameHeader(final OutputStream output,
+                                         final String id,
+                                         final int size) throws IOException {
+        output.write(id.getBytes(StandardCharsets.US_ASCII));
+        output.write(toSynchsafe(size));
+        output.write(0);
+        output.write(0);
+    }
+
+    private static byte[] toSynchsafe(final int value) {
+        return new byte[] {
+                (byte) ((value >>> 21) & 0x7F),
+                (byte) ((value >>> 14) & 0x7F),
+                (byte) ((value >>> 7) & 0x7F),
+                (byte) (value & 0x7F)
+        };
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/JavaLamePcmEncoder.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/JavaLamePcmEncoder.java
@@ -1,0 +1,84 @@
+package us.shandian.giga.postprocessing;
+
+import co.ntbl.lame.mp3.Lame;
+import co.ntbl.lame.mp3.MPEGMode;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+final class JavaLamePcmEncoder implements Closeable {
+    private static final int QUALITY = 5;
+    private static final int SAMPLES_PER_CHUNK = 8_192;
+
+    private final int channels;
+    private final Lame lame;
+    private final OutputStream output;
+    private final byte[] encoded = new byte[SAMPLES_PER_CHUNK * 5 / 4 + 7_200];
+
+    JavaLamePcmEncoder(final int sampleRate,
+                       final int channels,
+                       final int bitrateKbps,
+                       final OutputStream output) {
+        if (channels < 1 || channels > 2) {
+            throw new IllegalArgumentException("MP3 output supports mono or stereo PCM");
+        }
+        this.channels = channels;
+        this.output = output;
+        this.lame = new Lame();
+        lame.getFlags().setInNumChannels(channels);
+        lame.getFlags().setInSampleRate(sampleRate);
+        if (sampleRate < 32_000) {
+            // MPEG-1 supports the complete 128-320 kbps range; LAME performs the resampling.
+            lame.getFlags().setOutSampleRate(32_000);
+        }
+        lame.getFlags().setMode(channels == 1 ? MPEGMode.MONO : MPEGMode.JOINT_STEREO);
+        lame.getFlags().setBitRate(bitrateKbps);
+        lame.getFlags().setQuality(QUALITY);
+        lame.getFlags().setFindReplayGain(true);
+        lame.getFlags().setWriteId3tagAutomatic(false);
+        lame.getId3().init(lame.getFlags());
+        final int result = lame.initParams();
+        if (result < 0) {
+            lame.close();
+            throw new IllegalArgumentException("Unsupported LAME encoder parameters: " + result);
+        }
+    }
+
+    void encode(final ByteBuffer pcm) throws IOException {
+        pcm.order(ByteOrder.LITTLE_ENDIAN);
+        final int frameCount = pcm.remaining() / (Short.BYTES * channels);
+        int framesRemaining = frameCount;
+        while (framesRemaining > 0) {
+            final int frames = Math.min(framesRemaining, SAMPLES_PER_CHUNK);
+            final float[] left = new float[frames];
+            final float[] right = new float[frames];
+            for (int i = 0; i < frames; i++) {
+                left[i] = pcm.getShort() * 65_536.0f;
+                right[i] = channels == 2 ? pcm.getShort() * 65_536.0f : left[i];
+            }
+            final int written = lame.encodeBuffer(left, right, frames, encoded);
+            if (written < 0) {
+                throw new IOException("LAME encoding failed: " + written);
+            }
+            output.write(encoded, 0, written);
+            framesRemaining -= frames;
+        }
+    }
+
+    void finish() throws IOException {
+        final int written = lame.encodeFlush(encoded);
+        if (written < 0) {
+            throw new IOException("LAME flush failed: " + written);
+        }
+        output.write(encoded, 0, written);
+        output.flush();
+    }
+
+    @Override
+    public void close() {
+        lame.close();
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp3FromAudio.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp3FromAudio.java
@@ -1,0 +1,219 @@
+package us.shandian.giga.postprocessing;
+
+import android.media.AudioFormat;
+import android.media.MediaCodec;
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.streams.io.SharpStream;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+
+final class Mp3FromAudio extends Postprocessing {
+    private static final long CODEC_TIMEOUT_US = 10_000;
+    private static final int COPY_BUFFER_SIZE = 128 * 1_024;
+
+    Mp3FromAudio() {
+        super(false, false, ALGORITHM_MP3_FROM_AUDIO);
+    }
+
+    @Override
+    int process(final SharpStream out, final SharpStream... sources) throws IOException {
+        final int bitrate = Mp3OutputOptions.parseBitrate(
+                getArgumentAt(0, String.valueOf(Mp3OutputOptions.DEFAULT_BITRATE_KBPS)));
+        final File outputFile = getTemporalFile();
+        if (outputFile == null) {
+            throw new IOException("MP3 conversion temporary file is unavailable");
+        }
+        final long estimatedOutputBytes = Mp3OutputOptions.estimateOutputBytes(
+                streamInfo == null ? 0 : streamInfo.getDuration(), bitrate);
+        final File parent = outputFile.getParentFile();
+        if (parent != null && estimatedOutputBytes > 0
+                && parent.getUsableSpace() <= estimatedOutputBytes) {
+            throw new IOException("Not enough temporary storage for MP3 conversion");
+        }
+
+        try {
+            transcode(outputFile, bitrate);
+            replaceDownloadedFile(outputFile);
+            getMission().length = getMission().storage.length();
+            getMission().done = getMission().length;
+            return OK_RESULT;
+        } finally {
+            //noinspection ResultOfMethodCallIgnored
+            outputFile.delete();
+        }
+    }
+
+    private void transcode(@NonNull final File outputFile, final int bitrate) throws IOException {
+        final MediaExtractor extractor = new MediaExtractor();
+        MediaCodec decoder = null;
+        try (SharpStreamMediaDataSource source = new SharpStreamMediaDataSource(
+                getMission().storage.getStream(), getMission().storage.length());
+             FileOutputStream output = new FileOutputStream(outputFile)) {
+            extractor.setDataSource(source);
+            final int audioTrack = findAudioTrack(extractor);
+            extractor.selectTrack(audioTrack);
+            final MediaFormat inputFormat = extractor.getTrackFormat(audioTrack);
+            final String mime = inputFormat.getString(MediaFormat.KEY_MIME);
+            if (mime == null) {
+                throw new IOException("Downloaded audio has no decoder MIME type");
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                inputFormat.setInteger(MediaFormat.KEY_PCM_ENCODING,
+                        AudioFormat.ENCODING_PCM_16BIT);
+            }
+
+            Id3MetadataWriter.write(output,
+                    streamInfo == null ? null : streamInfo.getName(),
+                    streamInfo == null ? null : streamInfo.getUploaderName(),
+                    streamInfo == null ? null : streamInfo.getUrl());
+
+            decoder = MediaCodec.createDecoderByType(mime);
+            decoder.configure(inputFormat, null, null, 0);
+            decoder.start();
+            final long durationUs = inputFormat.containsKey(MediaFormat.KEY_DURATION)
+                    ? inputFormat.getLong(MediaFormat.KEY_DURATION) : -1;
+            decodeToMp3(extractor, decoder, output, bitrate, durationUs);
+        } finally {
+            extractor.release();
+            if (decoder != null) {
+                try {
+                    decoder.stop();
+                } catch (final IllegalStateException ignored) {
+                    // The decoder may not have reached the started state.
+                }
+                decoder.release();
+            }
+        }
+    }
+
+    private int findAudioTrack(final MediaExtractor extractor) throws IOException {
+        for (int i = 0; i < extractor.getTrackCount(); i++) {
+            final String mime = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME);
+            if (mime != null && mime.startsWith("audio/")) {
+                return i;
+            }
+        }
+        throw new IOException("Downloaded file contains no audio track");
+    }
+
+    private void decodeToMp3(final MediaExtractor extractor,
+                             final MediaCodec decoder,
+                             final FileOutputStream output,
+                             final int bitrate,
+                             final long durationUs) throws IOException {
+        final MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
+        boolean inputEnded = false;
+        boolean outputEnded = false;
+        JavaLamePcmEncoder encoder = null;
+
+        try {
+            while (!outputEnded) {
+                throwIfInterrupted();
+                if (!inputEnded) {
+                    final int inputIndex = decoder.dequeueInputBuffer(CODEC_TIMEOUT_US);
+                    if (inputIndex >= 0) {
+                        final ByteBuffer input = decoder.getInputBuffer(inputIndex);
+                        if (input == null) {
+                            throw new IOException("Audio decoder returned no input buffer");
+                        }
+                        input.clear();
+                        final int sampleSize = extractor.readSampleData(input, 0);
+                        if (sampleSize < 0) {
+                            decoder.queueInputBuffer(inputIndex, 0, 0, 0,
+                                    MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+                            inputEnded = true;
+                        } else {
+                            decoder.queueInputBuffer(inputIndex, 0, sampleSize,
+                                    extractor.getSampleTime(), 0);
+                            extractor.advance();
+                        }
+                    }
+                }
+
+                final int outputIndex = decoder.dequeueOutputBuffer(info, CODEC_TIMEOUT_US);
+                if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                    final MediaFormat outputFormat = decoder.getOutputFormat();
+                    final int pcmEncoding = outputFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)
+                            ? outputFormat.getInteger(MediaFormat.KEY_PCM_ENCODING)
+                            : AudioFormat.ENCODING_PCM_16BIT;
+                    if (pcmEncoding != AudioFormat.ENCODING_PCM_16BIT) {
+                        throw new IOException("Unsupported decoder PCM encoding: " + pcmEncoding);
+                    }
+                    encoder = new JavaLamePcmEncoder(
+                            outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
+                            outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT),
+                            bitrate,
+                            output);
+                } else if (outputIndex >= 0) {
+                    final ByteBuffer decoded = decoder.getOutputBuffer(outputIndex);
+                    if (decoded == null) {
+                        throw new IOException("Audio decoder returned no output buffer");
+                    }
+                    if (encoder == null) {
+                        final MediaFormat outputFormat = decoder.getOutputFormat(outputIndex);
+                        encoder = new JavaLamePcmEncoder(
+                                outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
+                                outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT),
+                                bitrate,
+                                output);
+                    }
+                    if (info.size > 0 && (info.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
+                        decoded.position(info.offset);
+                        decoded.limit(info.offset + info.size);
+                        encoder.encode(decoded.slice());
+                        reportProgress(info.presentationTimeUs, durationUs);
+                    }
+                    outputEnded = (info.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0;
+                    decoder.releaseOutputBuffer(outputIndex, false);
+                }
+            }
+            if (encoder == null) {
+                throw new IOException("Audio decoder produced no PCM output");
+            }
+            encoder.finish();
+        } finally {
+            if (encoder != null) {
+                encoder.close();
+            }
+        }
+    }
+
+    private void reportProgress(final long presentationTimeUs, final long durationUs) {
+        if (durationUs <= 0 || presentationTimeUs < 0) {
+            return;
+        }
+        final long sourceLength = getMission().storage.length();
+        getMission().length = sourceLength;
+        getMission().done = Math.min(sourceLength, (long) (sourceLength
+                * Math.min(1.0d, (double) presentationTimeUs / durationUs)));
+    }
+
+    private void replaceDownloadedFile(final File converted) throws IOException {
+        try (FileInputStream input = new FileInputStream(converted);
+             SharpStream target = getMission().storage.openAndTruncateStream()) {
+            final byte[] buffer = new byte[COPY_BUFFER_SIZE];
+            int read;
+            while ((read = input.read(buffer)) >= 0) {
+                throwIfInterrupted();
+                target.write(buffer, 0, read);
+            }
+            target.flush();
+        }
+    }
+
+    private static void throwIfInterrupted() throws InterruptedIOException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedIOException("MP3 conversion was cancelled");
+        }
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp3OutputOptions.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp3OutputOptions.java
@@ -1,0 +1,43 @@
+package us.shandian.giga.postprocessing;
+
+import androidx.annotation.NonNull;
+
+import java.util.Set;
+
+public final class Mp3OutputOptions {
+    public static final int DEFAULT_BITRATE_KBPS = 192;
+    public static final Set<Integer> SUPPORTED_BITRATES = Set.of(128, 192, 256, 320);
+
+    private Mp3OutputOptions() {
+    }
+
+    public static int parseBitrate(@NonNull final String value) {
+        try {
+            final int bitrate = Integer.parseInt(value);
+            return SUPPORTED_BITRATES.contains(bitrate) ? bitrate : DEFAULT_BITRATE_KBPS;
+        } catch (final NumberFormatException ignored) {
+            return DEFAULT_BITRATE_KBPS;
+        }
+    }
+
+    public static long estimateOutputBytes(final long durationSeconds, final int bitrateKbps) {
+        if (durationSeconds <= 0 || !SUPPORTED_BITRATES.contains(bitrateKbps)) {
+            return 0;
+        }
+        return durationSeconds * bitrateKbps * 1_000L / 8L;
+    }
+
+    public static long estimateRequiredBytes(final long sourceBytes,
+                                             final long durationSeconds,
+                                             final int bitrateKbps) {
+        final long outputBytes = estimateOutputBytes(durationSeconds, bitrateKbps);
+        if (sourceBytes <= 0 || outputBytes <= 0) {
+            return Math.max(sourceBytes, outputBytes);
+        }
+        try {
+            return Math.addExact(sourceBytes, outputBytes);
+        } catch (final ArithmeticException ignored) {
+            return Long.MAX_VALUE;
+        }
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
@@ -30,6 +30,7 @@ public abstract class Postprocessing implements Serializable {
     public transient static final String ALGORITHM_MP4_FROM_DASH_MUXER = "mp4D-mp4";
     public transient static final String ALGORITHM_M4A_NO_DASH = "mp4D-m4a";
     public transient static final String ALGORITHM_OGG_FROM_WEBM_DEMUXER = "webm-ogg-d";
+    public transient static final String ALGORITHM_MP3_FROM_AUDIO = "audio-mp3";
 
     public static Postprocessing getAlgorithm(@NonNull String algorithmName, String[] args,
                                               StreamInfo streamInfo) {
@@ -50,6 +51,9 @@ public abstract class Postprocessing implements Serializable {
                 break;
             case ALGORITHM_OGG_FROM_WEBM_DEMUXER:
                 instance = new OggFromWebmDemuxer();
+                break;
+            case ALGORITHM_MP3_FROM_AUDIO:
+                instance = new Mp3FromAudio();
                 break;
             /*case "example-algorithm":
                 instance = new ExampleAlgorithm();*/
@@ -84,6 +88,18 @@ public abstract class Postprocessing implements Serializable {
     private transient DownloadMission mission;
 
     private transient File tempFile;
+
+    protected final DownloadMission getMission() {
+        return mission;
+    }
+
+    protected final File getTemporalFile() {
+        return tempFile;
+    }
+
+    public final boolean isMp3Conversion() {
+        return ALGORITHM_MP3_FROM_AUDIO.equals(name);
+    }
 
     Postprocessing(boolean reserveSpace, boolean worksOnSameFile, String algorithmName) {
         this.reserveSpace = reserveSpace;

--- a/app/src/main/java/us/shandian/giga/postprocessing/SharpStreamMediaDataSource.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/SharpStreamMediaDataSource.java
@@ -1,0 +1,48 @@
+package us.shandian.giga.postprocessing;
+
+import android.media.MediaDataSource;
+
+import org.schabi.newpipe.streams.io.SharpStream;
+
+import java.io.IOException;
+
+final class SharpStreamMediaDataSource extends MediaDataSource {
+    private final SharpStream stream;
+    private final long size;
+    private long position;
+
+    SharpStreamMediaDataSource(final SharpStream stream, final long size) {
+        this.stream = stream;
+        this.size = size;
+    }
+
+    @Override
+    public synchronized int readAt(final long requestedPosition,
+                                   final byte[] buffer,
+                                   final int offset,
+                                   final int count) throws IOException {
+        if (requestedPosition < 0 || requestedPosition >= size) {
+            return -1;
+        }
+        if (position != requestedPosition) {
+            stream.seek(requestedPosition);
+            position = requestedPosition;
+        }
+        final int read = stream.read(buffer, offset, (int) Math.min(count, size - position));
+        if (read <= 0) {
+            return -1;
+        }
+        position += read;
+        return read;
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public void close() {
+        stream.close();
+    }
+}

--- a/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
+++ b/app/src/main/java/us/shandian/giga/ui/adapter/MissionAdapter.java
@@ -298,7 +298,8 @@ public class MissionAdapter extends Adapter<ViewHolder> implements Handler.Callb
         } else if (!mission.running) {
             state = mission.enqueued ? R.string.queued : R.string.paused;
         } else if (mission.isPsRunning()) {
-            state = R.string.post_processing;
+            state = mission.isConvertingToMp3()
+                    ? R.string.converting_to_mp3 : R.string.post_processing;
         } else if (mission.isRecovering()) {
             state = R.string.recovering;
         } else {

--- a/app/src/main/res/layout/download_dialog.xml
+++ b/app/src/main/res/layout/download_dialog.xml
@@ -8,11 +8,21 @@
         android:id="@+id/toolbar_layout"
         layout="@layout/toolbar_layout" />
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar_layout"
+        android:fillViewport="true">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/file_name_text_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/toolbar_layout"
+        android:layout_alignParentTop="true"
         android:layout_marginLeft="24dp"
         android:layout_marginTop="12dp"
         android:layout_marginRight="24dp"
@@ -105,10 +115,54 @@
         tools:visibility="gone" />
 
     <org.schabi.newpipe.views.NewPipeTextView
+        android:id="@+id/audio_output_format_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/audio_stream_spinner"
+        android:layout_marginLeft="24dp"
+        android:layout_marginRight="24dp"
+        android:text="@string/audio_output_format"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        tools:visibility="gone" />
+
+    <Spinner
+        android:id="@+id/audio_output_format_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/audio_output_format_label"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="12dp"
+        android:minWidth="150dp"
+        tools:visibility="gone" />
+
+    <org.schabi.newpipe.views.NewPipeTextView
+        android:id="@+id/mp3_bitrate_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/audio_output_format_spinner"
+        android:layout_marginLeft="24dp"
+        android:layout_marginRight="24dp"
+        android:text="@string/mp3_quality"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        tools:visibility="gone" />
+
+    <Spinner
+        android:id="@+id/mp3_bitrate_spinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/mp3_bitrate_label"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="12dp"
+        android:minWidth="150dp"
+        tools:visibility="gone" />
+
+    <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/audio_track_present_in_video_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/audio_stream_spinner"
+        android:layout_below="@+id/mp3_bitrate_spinner"
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"
         android:layout_marginBottom="12dp"
@@ -171,5 +225,8 @@
         android:text="@string/streams_not_yet_supported_removed"
         android:textColor="?attr/colorOnSurfaceVariant"
         android:textSize="12sp" />
+
+        </RelativeLayout>
+    </ScrollView>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -944,6 +944,21 @@
     <string name="paused">paused</string>
     <string name="queued">queued</string>
     <string name="post_processing">post-processing</string>
+    <string name="converting_to_mp3">converting to MP3</string>
+    <string name="audio_output_format">Output format</string>
+    <string name="original_format_recommended">Original format (recommended)</string>
+    <string name="mp3_format">MP3</string>
+    <string name="mp3_quality">MP3 quality</string>
+    <string-array name="audio_output_format_entries">
+        <item>@string/original_format_recommended</item>
+        <item>@string/mp3_format</item>
+    </string-array>
+    <string-array name="mp3_bitrate_entries" translatable="false">
+        <item>128 kbps</item>
+        <item>192 kbps</item>
+        <item>256 kbps</item>
+        <item>320 kbps</item>
+    </string-array>
     <string name="recovering">recovering</string>
     <string name="enqueue">Enqueue</string>
     <string name="permission_denied">Action denied by the system</string>

--- a/app/src/test/java/org/schabi/newpipe/download/Mp3DownloadPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/download/Mp3DownloadPolicyTest.java
@@ -1,0 +1,21 @@
+package org.schabi.newpipe.download;
+
+import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.MediaFormat;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Mp3DownloadPolicyTest {
+    @Test
+    void transcodesM4aAndOpusOnlyWhenMp3IsSelected() {
+        assertTrue(Mp3DownloadPolicy.shouldTranscode(true, MediaFormat.M4A));
+        assertTrue(Mp3DownloadPolicy.shouldTranscode(true, MediaFormat.WEBMA_OPUS));
+        assertFalse(Mp3DownloadPolicy.shouldTranscode(false, MediaFormat.M4A));
+    }
+
+    @Test
+    void keepsNativeMp3WithoutAnotherLossyConversion() {
+        assertFalse(Mp3DownloadPolicy.shouldTranscode(true, MediaFormat.MP3));
+    }
+}

--- a/app/src/test/java/us/shandian/giga/postprocessing/Id3MetadataWriterTest.java
+++ b/app/src/test/java/us/shandian/giga/postprocessing/Id3MetadataWriterTest.java
@@ -1,0 +1,27 @@
+package us.shandian.giga.postprocessing;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Id3MetadataWriterTest {
+    @Test
+    void writesTitleArtistAndSourceUrlFrames() throws Exception {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        Id3MetadataWriter.write(output, "Title", "Uploader", "https://example.test/video");
+
+        final byte[] bytes = output.toByteArray();
+        assertEquals("ID3", new String(bytes, 0, 3, StandardCharsets.US_ASCII));
+        assertEquals(4, bytes[3]);
+        final String tag = new String(bytes, StandardCharsets.ISO_8859_1);
+        assertTrue(tag.contains("TIT2"));
+        assertTrue(tag.contains("TPE1"));
+        assertTrue(tag.contains("WXXX"));
+        assertTrue(tag.contains("https://example.test/video"));
+    }
+}

--- a/app/src/test/java/us/shandian/giga/postprocessing/JavaLamePcmEncoderTest.java
+++ b/app/src/test/java/us/shandian/giga/postprocessing/JavaLamePcmEncoderTest.java
@@ -1,0 +1,38 @@
+package us.shandian.giga.postprocessing;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JavaLamePcmEncoderTest {
+    @Test
+    void encodesStereoPcmToMp3Frames() throws Exception {
+        final int sampleRate = 44_100;
+        final ByteBuffer pcm = ByteBuffer.allocate(sampleRate * 2 * Short.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        for (int i = 0; i < sampleRate; i++) {
+            final short sample = (short) (Math.sin(2.0d * Math.PI * 440.0d * i / sampleRate)
+                    * Short.MAX_VALUE / 2.0d);
+            pcm.putShort(sample);
+            pcm.putShort(sample);
+        }
+        pcm.flip();
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        try (JavaLamePcmEncoder encoder = new JavaLamePcmEncoder(
+                sampleRate, 2, 192, output)) {
+            encoder.encode(pcm);
+            encoder.finish();
+        }
+
+        final byte[] mp3 = output.toByteArray();
+        assertTrue(mp3.length > 10_000);
+        assertEquals(0xFF, mp3[0] & 0xFF);
+        assertEquals(0xE0, mp3[1] & 0xE0);
+    }
+}

--- a/app/src/test/java/us/shandian/giga/postprocessing/Mp3OutputOptionsTest.java
+++ b/app/src/test/java/us/shandian/giga/postprocessing/Mp3OutputOptionsTest.java
@@ -1,0 +1,26 @@
+package us.shandian.giga.postprocessing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Mp3OutputOptionsTest {
+    @Test
+    void parsesSupportedBitratesAndFallsBackForInvalidValues() {
+        assertEquals(128, Mp3OutputOptions.parseBitrate("128"));
+        assertEquals(320, Mp3OutputOptions.parseBitrate("320"));
+        assertEquals(Mp3OutputOptions.DEFAULT_BITRATE_KBPS,
+                Mp3OutputOptions.parseBitrate("500"));
+        assertEquals(Mp3OutputOptions.DEFAULT_BITRATE_KBPS,
+                Mp3OutputOptions.parseBitrate("invalid"));
+    }
+
+    @Test
+    void estimatesConversionStorageForSourceAndOutput() {
+        assertEquals(14_400_000L,
+                Mp3OutputOptions.estimateOutputBytes(600, 192));
+        assertEquals(24_400_000L,
+                Mp3OutputOptions.estimateRequiredBytes(10_000_000L, 600, 192));
+    }
+
+}

--- a/app/src/test/java/us/shandian/giga/postprocessing/PostprocessingMp3RestoreTest.java
+++ b/app/src/test/java/us/shandian/giga/postprocessing/PostprocessingMp3RestoreTest.java
@@ -1,0 +1,15 @@
+package us.shandian.giga.postprocessing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostprocessingMp3RestoreTest {
+    @Test
+    void restoresMp3PostprocessorByItsPersistedAlgorithmName() {
+        final Postprocessing restored = Postprocessing.getAlgorithm(
+                Postprocessing.ALGORITHM_MP3_FROM_AUDIO, new String[] {"256"}, null);
+
+        assertTrue(restored.isMp3Conversion());
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -11,6 +11,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### New features
 
+- Added optional on-device MP3 audio downloads at 128, 192, 256, or 320 kbps, with conversion
+  progress, cancellation-safe temporary files, and title, uploader, and source URL metadata.
 - Added per-channel keyword and phrase filters for new-stream notifications.
 - Added date-aware fast scrolling and a calendar jump action for navigating large watch histories.
 - Added an option to prioritize main-tab swiping when viewing pinned channels.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ espresso = "3.7.0"
 exoplayer = "2.19.1"
 fragment = "1.8.9"
 groupie = "2.10.1"
+javaLame = "1.0.0"
 jsoup = "1.22.2"
 junit = "4.13.2"
 junit-ext = "1.3.0"
@@ -146,6 +147,7 @@ newpipe-filepicker = { module = "com.github.TeamNewPipe:NoNonsense-FilePicker", 
 newpipe-nanojson = { module = "com.github.TeamNewPipe:nanojson", version.ref = "teamnewpipe-nanojson" }
 noties-markwon-core = { module = "io.noties.markwon:core", version.ref = "markwon" }
 noties-markwon-linkify = { module = "io.noties.markwon:linkify", version.ref = "markwon" }
+ntbl-lame = { module = "co.ntbl:lame", version.ref = "javaLame" }
 ocpsoft-prettytime = { module = "org.ocpsoft.prettytime:prettytime", version.ref = "prettytime" }
 pinterest-ktlint = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }
 puppycrawl-checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }


### PR DESCRIPTION
- Closes #187
- Adds MP3 as an optional audio-download output while keeping the original stream format as the recommended default
- Offers 128, 192, 256, and 320 kbps MP3 quality choices
- Decodes M4A and Opus with Android media codecs and encodes with the compact architecture-independent LAME Java core instead of bundling FFmpeg
- Shows a dedicated converting-to-MP3 state and date-independent conversion progress
- Checks destination and temporary storage before conversion
- Writes ID3 title, uploader/artist, and source URL metadata
- Keeps downloaded source bytes untouched until conversion succeeds and cleans temporary output on cancellation or failure
- Avoids re-encoding streams that are already MP3
- Adds policy, storage-estimation, ID3, encoder, and persisted-postprocessor regression tests
- Updates the unreleased changelog