### PR TITLE
Improve history date navigation and performance

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/history/HistoryDateFastScrollerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/history/HistoryDateFastScrollerTest.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,7 +18,9 @@ class HistoryDateFastScrollerTest {
         instrumentation.runOnMainSync {
             val view = HistoryDateFastScroller(instrumentation.targetContext)
             var selectedPosition = -1
+            val dragStates = mutableListOf<Boolean>()
             view.setOnPositionChangedListener { selectedPosition = it }
+            view.setOnDragStateChangedListener { dragStates += it }
             view.setLabelProvider { position -> "Date $position" }
             view.setItemCount(100)
             view.measure(
@@ -27,12 +30,15 @@ class HistoryDateFastScrollerTest {
             view.layout(0, 0, 48, 1000)
 
             view.onTouchEvent(event(MotionEvent.ACTION_DOWN, 18f))
+            assertTrue(view.isDragging)
             view.onTouchEvent(event(MotionEvent.ACTION_MOVE, 982f))
 
             assertEquals(99, selectedPosition)
             assertTrue(view.contentDescription.toString().contains("Date 99"))
 
             view.onTouchEvent(event(MotionEvent.ACTION_UP, 982f))
+            assertFalse(view.isDragging)
+            assertEquals(listOf(true, false), dragStates)
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
@@ -23,9 +23,9 @@ import com.google.android.material.color.MaterialColors;
 
 import org.schabi.newpipe.R;
 
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
-import java.util.function.Consumer;
 
 public final class HistoryDateFastScroller extends View {
     private final Paint trackPaint = new Paint(Paint.ANTI_ALIAS_FLAG);

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
@@ -25,6 +25,7 @@ import org.schabi.newpipe.R;
 
 import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
+import java.util.function.Consumer;
 
 public final class HistoryDateFastScroller extends View {
     private final Paint trackPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -46,6 +47,8 @@ public final class HistoryDateFastScroller extends View {
     private IntConsumer onPositionChangedListener;
     @Nullable
     private IntFunction<String> labelProvider;
+    @Nullable
+    private Consumer<Boolean> onDragStateChangedListener;
     @Nullable
     private PopupWindow bubblePopup;
     @Nullable
@@ -92,6 +95,15 @@ public final class HistoryDateFastScroller extends View {
         updateAccessibilityDescription();
     }
 
+    public void setOnDragStateChangedListener(
+            @Nullable final Consumer<Boolean> onDragStateChangedListener) {
+        this.onDragStateChangedListener = onDragStateChangedListener;
+    }
+
+    public boolean isDragging() {
+        return dragging;
+    }
+
     public void setItemCount(final int itemCount) {
         this.itemCount = Math.max(0, itemCount);
         setPosition(Math.min(position, Math.max(0, this.itemCount - 1)));
@@ -112,7 +124,7 @@ public final class HistoryDateFastScroller extends View {
     }
 
     public void dismissBubble() {
-        dragging = false;
+        setDragging(false);
         if (bubblePopup != null) {
             bubblePopup.dismiss();
         }
@@ -146,7 +158,7 @@ public final class HistoryDateFastScroller extends View {
 
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
-                dragging = true;
+                setDragging(true);
                 requestParentDisallowIntercept(true);
                 updateFromTouch(event.getY());
                 return true;
@@ -199,6 +211,16 @@ public final class HistoryDateFastScroller extends View {
     protected void onDetachedFromWindow() {
         dismissBubble();
         super.onDetachedFromWindow();
+    }
+
+    private void setDragging(final boolean dragging) {
+        if (this.dragging == dragging) {
+            return;
+        }
+        this.dragging = dragging;
+        if (onDragStateChangedListener != null) {
+            onDragStateChangedListener.accept(dragging);
+        }
     }
 
     private void requestParentDisallowIntercept(final boolean disallowIntercept) {

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateNavigator.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateNavigator.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Locale;
 
 public final class HistoryDateNavigator {
-    private static final long MONTH_LABEL_MAXIMUM_SPAN_DAYS = 730;
-
     private HistoryDateNavigator() {
     }
 
@@ -57,22 +55,9 @@ public final class HistoryDateNavigator {
         return newerDistance <= olderDistance ? high : low;
     }
 
-    public static boolean shouldUseMonthLabels(@NonNull final List<LocalDate> dates) {
-        if (dates.size() < 2) {
-            return true;
-        }
-        final LocalDate newest = dates.get(0);
-        final LocalDate oldest = dates.get(dates.size() - 1);
-        return Math.abs(ChronoUnit.DAYS.between(oldest, newest))
-                <= MONTH_LABEL_MAXIMUM_SPAN_DAYS;
-    }
-
     @NonNull
     public static String formatLabel(@NonNull final LocalDate date,
-                                     final boolean includeMonth,
                                      @NonNull final Locale locale) {
-        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
-                includeMonth ? "MMM yyyy" : "yyyy", locale);
-        return formatter.format(date);
+        return DateTimeFormatter.ofPattern("MMM yyyy", locale).format(date);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -65,13 +65,16 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class StatisticsPlaylistFragment
         extends BaseLocalListFragment<List<StreamStatisticsEntry>, Void>
         implements PlaylistControlViewHolder, ContextualSearchable {
     private static final int MIN_FAST_SCROLL_ITEMS = 50;
+    private static final long FAST_SCROLL_HIDE_DELAY_MILLIS = 1_800L;
     private static final String DATE_PICKER_TAG = "history_date_picker";
 
     private final CompositeDisposable disposables = new CompositeDisposable();
@@ -80,8 +83,9 @@ public class StatisticsPlaylistFragment
     private StatisticSortMode sortMode = StatisticSortMode.LAST_PLAYED;
     private List<StreamStatisticsEntry> completeHistory = Collections.emptyList();
     private List<StreamStatisticsEntry> displayedHistory = Collections.emptyList();
+    private List<LocalDate> displayedHistoryDates = Collections.emptyList();
     private String contextualSearchQuery = "";
-    private boolean useMonthFastScrollLabels;
+    private boolean dateFastScrollEnabled;
     @State
     StreamListFilter selectedStreamFilter = StreamListFilter.NONE;
 
@@ -89,25 +93,53 @@ public class StatisticsPlaylistFragment
     private StatisticPlaylistControlBinding headerBinding;
     private PlaylistControlBinding playlistControlBinding;
     private RecyclerView.OnScrollListener historyScrollListener;
+    private Disposable historyProcessingDisposable;
+
+    private final Runnable hideFastScrollerRunnable = () -> {
+        if (contentBinding != null && dateFastScrollEnabled
+                && !contentBinding.historyDateFastScroller.isDragging()) {
+            contentBinding.historyDateFastScroller.setVisibility(View.GONE);
+        }
+    };
 
     /* Used for independent events */
     private Subscription databaseSubscription;
     private HistoryRecordManager recordManager;
 
-    private List<StreamStatisticsEntry> processResult(final List<StreamStatisticsEntry> results) {
-        final Comparator<StreamStatisticsEntry> comparator;
-        switch (sortMode) {
-            case LAST_PLAYED:
-                comparator = Comparator.comparing(StreamStatisticsEntry::getLatestAccessDate);
-                break;
-            case MOST_PLAYED:
-                comparator = Comparator.comparingLong(StreamStatisticsEntry::getWatchCount);
-                break;
-            default:
-                return null;
+    @NonNull
+    private static HistoryViewData processHistory(
+            @NonNull final List<StreamStatisticsEntry> completeHistory,
+            @NonNull final StreamListFilter selectedStreamFilter,
+            @NonNull final String contextualSearchQuery,
+            @NonNull final StatisticSortMode sortMode) {
+        final List<StreamStatisticsEntry> historyMatchingFilter = new ArrayList<>();
+        for (final StreamStatisticsEntry item : completeHistory) {
+            if (StreamListFilter.matches(selectedStreamFilter, item)) {
+                historyMatchingFilter.add(item);
+            }
         }
-        Collections.sort(results, comparator.reversed());
-        return results;
+
+        final List<StreamStatisticsEntry> filteredHistory = ContextualSearchHelper.filter(
+                historyMatchingFilter,
+                contextualSearchQuery,
+                item -> new String[]{
+                        item.getStreamEntity().getTitle(),
+                        item.getStreamEntity().getUploader()
+                });
+
+        final Comparator<StreamStatisticsEntry> comparator;
+        if (sortMode == StatisticSortMode.LAST_PLAYED) {
+            comparator = Comparator.comparing(StreamStatisticsEntry::getLatestAccessDate);
+        } else {
+            comparator = Comparator.comparingLong(StreamStatisticsEntry::getWatchCount);
+        }
+        filteredHistory.sort(comparator.reversed());
+
+        final List<LocalDate> dates = new ArrayList<>(filteredHistory.size());
+        for (final StreamStatisticsEntry entry : filteredHistory) {
+            dates.add(entry.getLatestAccessDate().toLocalDate());
+        }
+        return new HistoryViewData(filteredHistory, dates);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -153,6 +185,13 @@ public class StatisticsPlaylistFragment
         contentBinding.historyDateFastScroller.setOnPositionChangedListener(
                 this::scrollToHistoryPosition);
         contentBinding.historyDateFastScroller.setLabelProvider(this::getFastScrollLabel);
+        contentBinding.historyDateFastScroller.setOnDragStateChangedListener(dragging -> {
+            if (dragging) {
+                showFastScroller();
+            } else {
+                scheduleFastScrollerHide();
+            }
+        });
 
         if (selectedStreamFilter != StreamListFilter.NONE) {
             contentBinding.streamFilterChips.streamFilterChipGroup
@@ -189,6 +228,19 @@ public class StatisticsPlaylistFragment
                                    final int dx,
                                    final int dy) {
                 updateFastScrollPosition();
+                if (dy != 0) {
+                    showFastScroller();
+                }
+            }
+
+            @Override
+            public void onScrollStateChanged(@NonNull final RecyclerView recyclerView,
+                                             final int newState) {
+                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    scheduleFastScrollerHide();
+                } else {
+                    showFastScroller();
+                }
             }
         };
         itemsList.addOnScrollListener(historyScrollListener);
@@ -267,7 +319,12 @@ public class StatisticsPlaylistFragment
         historyScrollListener = null;
 
         if (contentBinding != null) {
+            contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
             contentBinding.historyDateFastScroller.dismissBubble();
+        }
+        if (historyProcessingDisposable != null) {
+            historyProcessingDisposable.dispose();
+            historyProcessingDisposable = null;
         }
 
         if (itemListAdapter != null) {
@@ -281,6 +338,8 @@ public class StatisticsPlaylistFragment
         headerBinding = null;
         playlistControlBinding = null;
         displayedHistory = Collections.emptyList();
+        displayedHistoryDates = Collections.emptyList();
+        dateFastScrollEnabled = false;
 
         if (databaseSubscription != null) {
             databaseSubscription.cancel();
@@ -345,34 +404,44 @@ public class StatisticsPlaylistFragment
         }
 
         playlistControlBinding.getRoot().setVisibility(View.VISIBLE);
-
-        itemListAdapter.clearStreamItemList();
         setEmptyStateMessage(ContextualSearchHelper.isActive(contextualSearchQuery)
                 ? R.string.search_no_results : R.string.empty_view_no_videos);
+        showLoading();
 
-        final List<StreamStatisticsEntry> historyMatchingFilter = new ArrayList<>();
-        for (final StreamStatisticsEntry item : completeHistory) {
-            if (StreamListFilter.matches(selectedStreamFilter, item)) {
-                historyMatchingFilter.add(item);
-            }
+        if (historyProcessingDisposable != null) {
+            historyProcessingDisposable.dispose();
         }
 
-        final List<StreamStatisticsEntry> filteredHistory = ContextualSearchHelper.filter(
-                historyMatchingFilter,
-                contextualSearchQuery,
-                item -> new String[]{
-                        item.getStreamEntity().getTitle(),
-                        item.getStreamEntity().getUploader()
-                });
+        final List<StreamStatisticsEntry> historySnapshot =
+                new ArrayList<>(completeHistory);
+        final StreamListFilter filterSnapshot = selectedStreamFilter;
+        final String querySnapshot = contextualSearchQuery;
+        final StatisticSortMode sortModeSnapshot = sortMode;
 
-        if (filteredHistory.isEmpty()) {
-            displayedHistory = Collections.emptyList();
+        historyProcessingDisposable = Single.fromCallable(() -> processHistory(
+                        historySnapshot, filterSnapshot, querySnapshot, sortModeSnapshot))
+                .subscribeOn(Schedulers.computation())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::applyProcessedHistory,
+                        throwable -> showError(new ErrorInfo(throwable,
+                                UserAction.SOMETHING_ELSE, "Processing history")));
+    }
+
+    private void applyProcessedHistory(@NonNull final HistoryViewData historyViewData) {
+        if (itemListAdapter == null || contentBinding == null) {
+            return;
+        }
+
+        itemListAdapter.clearStreamItemList();
+        displayedHistory = historyViewData.entries;
+        displayedHistoryDates = historyViewData.dates;
+
+        if (displayedHistory.isEmpty()) {
             updateDateNavigation();
             showEmptyState();
             return;
         }
 
-        displayedHistory = processResult(filteredHistory);
         itemListAdapter.addItems(displayedHistory);
         if (itemsListState != null && itemsList.getLayoutManager() != null) {
             itemsList.getLayoutManager().onRestoreInstanceState(itemsListState);
@@ -380,7 +449,6 @@ public class StatisticsPlaylistFragment
         }
 
         PlayButtonHelper.initPlaylistControlClickListener(activity, playlistControlBinding, this);
-
         headerBinding.sortButton.setOnClickListener(view -> toggleSortMode());
 
         updateDateNavigation();
@@ -423,16 +491,21 @@ public class StatisticsPlaylistFragment
             headerBinding.sortButtonText.setText(R.string.title_most_played);
         }
         hideDateNavigation();
-        startLoading(true);
+        showFilteredHistory();
     }
 
     private void hideDateNavigation() {
+        dateFastScrollEnabled = false;
         if (contentBinding == null) {
             return;
         }
         contentBinding.historyDateJumpButton.setVisibility(View.GONE);
+        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
         contentBinding.historyDateFastScroller.setVisibility(View.GONE);
         contentBinding.historyDateFastScroller.dismissBubble();
+        if (itemsList != null) {
+            itemsList.setVerticalScrollBarEnabled(true);
+        }
     }
 
     private void updateDateNavigation() {
@@ -445,20 +518,37 @@ public class StatisticsPlaylistFragment
         contentBinding.historyDateJumpButton.setVisibility(
                 chronological ? View.VISIBLE : View.GONE);
 
-        final boolean fastScrollVisible = chronological
+        dateFastScrollEnabled = chronological
                 && displayedHistory.size() >= MIN_FAST_SCROLL_ITEMS;
-        contentBinding.historyDateFastScroller.setVisibility(
-                fastScrollVisible ? View.VISIBLE : View.GONE);
+        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
+        contentBinding.historyDateFastScroller.setVisibility(View.GONE);
         contentBinding.historyDateFastScroller.setItemCount(displayedHistory.size());
+        itemsList.setVerticalScrollBarEnabled(!dateFastScrollEnabled);
 
         if (!chronological) {
             contentBinding.historyDateFastScroller.dismissBubble();
             return;
         }
 
-        final List<LocalDate> dates = getDisplayedHistoryDates();
-        useMonthFastScrollLabels = HistoryDateNavigator.shouldUseMonthLabels(dates);
         itemsList.post(this::updateFastScrollPosition);
+    }
+
+    private void showFastScroller() {
+        if (!dateFastScrollEnabled || contentBinding == null) {
+            return;
+        }
+        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
+        contentBinding.historyDateFastScroller.setVisibility(View.VISIBLE);
+    }
+
+    private void scheduleFastScrollerHide() {
+        if (!dateFastScrollEnabled || contentBinding == null
+                || contentBinding.historyDateFastScroller.isDragging()) {
+            return;
+        }
+        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
+        contentBinding.historyDateFastScroller.postDelayed(
+                hideFastScrollerRunnable, FAST_SCROLL_HIDE_DELAY_MILLIS);
     }
 
     private void updateFastScrollPosition() {
@@ -496,36 +586,26 @@ public class StatisticsPlaylistFragment
     }
 
     private String getFastScrollLabel(final int itemIndex) {
-        if (itemIndex < 0 || itemIndex >= displayedHistory.size()) {
+        if (itemIndex < 0 || itemIndex >= displayedHistoryDates.size()) {
             return "";
         }
         return HistoryDateNavigator.formatLabel(
-                displayedHistory.get(itemIndex).getLatestAccessDate().toLocalDate(),
-                useMonthFastScrollLabels,
+                displayedHistoryDates.get(itemIndex),
                 org.schabi.newpipe.util.Localization.getPreferredLocale(requireContext()));
     }
 
-    private List<LocalDate> getDisplayedHistoryDates() {
-        final List<LocalDate> dates = new ArrayList<>(displayedHistory.size());
-        for (final StreamStatisticsEntry entry : displayedHistory) {
-            dates.add(entry.getLatestAccessDate().toLocalDate());
-        }
-        return dates;
-    }
-
     private void showDatePicker() {
-        if (sortMode != StatisticSortMode.LAST_PLAYED || displayedHistory.isEmpty()
+        if (sortMode != StatisticSortMode.LAST_PLAYED || displayedHistoryDates.isEmpty()
                 || getParentFragmentManager().findFragmentByTag(DATE_PICKER_TAG) != null) {
             return;
         }
 
-        final List<LocalDate> dates = getDisplayedHistoryDates();
-        final LocalDate newestDate = dates.get(0);
-        final LocalDate oldestDate = dates.get(dates.size() - 1);
+        final LocalDate newestDate = displayedHistoryDates.get(0);
+        final LocalDate oldestDate = displayedHistoryDates.get(displayedHistoryDates.size() - 1);
         final long newestMillis = toUtcMillis(newestDate);
         final long oldestMillis = toUtcMillis(oldestDate);
         final int visibleIndex = getVisibleHistoryIndex();
-        final long selectedMillis = toUtcMillis(dates.get(visibleIndex));
+        final long selectedMillis = toUtcMillis(displayedHistoryDates.get(visibleIndex));
 
         final CalendarConstraints constraints = new CalendarConstraints.Builder()
                 .setStart(oldestMillis)
@@ -560,7 +640,7 @@ public class StatisticsPlaylistFragment
 
     private void jumpToDate(@NonNull final LocalDate selectedDate) {
         final int itemIndex = HistoryDateNavigator.findClosestIndex(
-                getDisplayedHistoryDates(), selectedDate);
+                displayedHistoryDates, selectedDate);
         if (itemIndex >= 0) {
             scrollToHistoryPosition(itemIndex);
         }
@@ -669,6 +749,17 @@ public class StatisticsPlaylistFragment
             }
         }
         return new LocalMediaPlayQueue(queueItems, index);
+    }
+
+    private static final class HistoryViewData {
+        private final List<StreamStatisticsEntry> entries;
+        private final List<LocalDate> dates;
+
+        private HistoryViewData(@NonNull final List<StreamStatisticsEntry> entries,
+                                @NonNull final List<LocalDate> dates) {
+            this.entries = entries;
+            this.dates = dates;
+        }
     }
 
     private enum StatisticSortMode {

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -412,7 +412,6 @@ public class StatisticsPlaylistFragment
         playlistControlBinding.getRoot().setVisibility(View.VISIBLE);
         setEmptyStateMessage(ContextualSearchHelper.isActive(contextualSearchQuery)
                 ? R.string.search_no_results : R.string.empty_view_no_videos);
-        showLoading();
 
         if (historyProcessingDisposable != null) {
             historyProcessingDisposable.dispose();

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -61,6 +61,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -112,20 +113,25 @@ public class StatisticsPlaylistFragment
             @NonNull final StreamListFilter selectedStreamFilter,
             @NonNull final String contextualSearchQuery,
             @NonNull final StatisticSortMode sortMode) {
-        final List<StreamStatisticsEntry> historyMatchingFilter = new ArrayList<>();
+        final String normalizedQuery = contextualSearchQuery.toLowerCase(Locale.ROOT);
+        final List<StreamStatisticsEntry> filteredHistory = new ArrayList<>();
         for (final StreamStatisticsEntry item : completeHistory) {
-            if (StreamListFilter.matches(selectedStreamFilter, item)) {
-                historyMatchingFilter.add(item);
+            if (!StreamListFilter.matches(selectedStreamFilter, item)) {
+                continue;
             }
+            if (!normalizedQuery.isEmpty()) {
+                final String title = item.getStreamEntity().getTitle();
+                final String uploader = item.getStreamEntity().getUploader();
+                final boolean matchesTitle = title != null
+                        && title.toLowerCase(Locale.ROOT).contains(normalizedQuery);
+                final boolean matchesUploader = uploader != null
+                        && uploader.toLowerCase(Locale.ROOT).contains(normalizedQuery);
+                if (!matchesTitle && !matchesUploader) {
+                    continue;
+                }
+            }
+            filteredHistory.add(item);
         }
-
-        final List<StreamStatisticsEntry> filteredHistory = ContextualSearchHelper.filter(
-                historyMatchingFilter,
-                contextualSearchQuery,
-                item -> new String[]{
-                        item.getStreamEntity().getTitle(),
-                        item.getStreamEntity().getUploader()
-                });
 
         final Comparator<StreamStatisticsEntry> comparator;
         if (sortMode == StatisticSortMode.LAST_PLAYED) {

--- a/app/src/test/java/org/schabi/newpipe/local/history/HistoryDateNavigatorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/history/HistoryDateNavigatorTest.java
@@ -1,7 +1,6 @@
 package org.schabi.newpipe.local.history;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 

--- a/app/src/test/java/org/schabi/newpipe/local/history/HistoryDateNavigatorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/history/HistoryDateNavigatorTest.java
@@ -1,7 +1,6 @@
 package org.schabi.newpipe.local.history;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -33,13 +32,20 @@ public class HistoryDateNavigatorTest {
     }
 
     @Test
-    public void switchesBetweenMonthAndYearLabelsBasedOnHistorySpan() {
-        assertTrue(HistoryDateNavigator.shouldUseMonthLabels(Arrays.asList(
-                LocalDate.of(2026, 8, 1), LocalDate.of(2025, 1, 1))));
-        assertFalse(HistoryDateNavigator.shouldUseMonthLabels(dates));
+    public void alwaysFormatsMonthAndYear() {
         assertEquals("Aug 2026", HistoryDateNavigator.formatLabel(
-                LocalDate.of(2026, 8, 1), true, Locale.US));
-        assertEquals("2026", HistoryDateNavigator.formatLabel(
-                LocalDate.of(2026, 8, 1), false, Locale.US));
+                LocalDate.of(2026, 8, 1), Locale.US));
+    }
+
+    @Test
+    public void findsDateInTenThousandEntryHistory() {
+        final List<LocalDate> largeHistory = new java.util.ArrayList<>(10_000);
+        final LocalDate newest = LocalDate.of(2026, 8, 23);
+        for (int index = 0; index < 10_000; index++) {
+            largeHistory.add(newest.minusDays(index));
+        }
+
+        assertEquals(7_654, HistoryDateNavigator.findClosestIndex(
+                largeHistory, newest.minusDays(7_654)));
     }
 }

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
+- Made history date scrolling transient, consistently show month and year, and process large
+  histories without blocking the interface or unnecessarily reloading the database.
 - Fixed Material You wallpaper colors falling back to green with the Black night theme, while
   preserving true-black surfaces, and made the player seek bar follow the selected accent color.
 


### PR DESCRIPTION
- Closes #195
- Disables the native History scrollbar whenever date-aware fast scrolling is available
- Shows the date scroller only during scrolling and briefly after scrolling stops
- Keeps the scroller visible while it is being dragged
- Always displays month and year in the floating date label
- Moves filtering, searching, sorting, and date preparation off the main thread
- Normalizes search text once and combines filtering into one pass
- Reuses cached dates for scrolling and calendar jumps
- Changes sort mode without re-querying the history database
- Adds regression coverage for drag state, month/year labels, and 10,000-entry date lookup
- Updates the unreleased changelog