### PR TITLE
Add x86_64 APK release support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,19 @@ jobs:
           "$AAPT" dump resources "$APK_PATH" > "$RUNNER_TEMP/release-resources.txt"
           grep -q "layout/list_search_no_results" "$RUNNER_TEMP/release-resources.txt"
           grep -q "layout/list_empty_view_subscriptions" "$RUNNER_TEMP/release-resources.txt"
+          scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
+
+      - name: Build and verify x86_64 release APK
+        run: |
+          rm -rf app/build/outputs/apk/release
+          ./gradlew assembleRelease --rerun-tasks --stacktrace -DskipFormatKtlint -PreleaseAbi=x86_64
+          APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
+          test -s "$APK_PATH"
+          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
+          "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/x86-64-release-badging.txt"
+          grep -q "package: name='org.wisso.newpipematerial'" "$RUNNER_TEMP/x86-64-release-badging.txt"
+          grep -q "application-label:'WizeStream'" "$RUNNER_TEMP/x86-64-release-badging.txt"
+          scripts/verify-apk-abis.sh "$APK_PATH" x86_64
 
       - name: Verify debug APK identity
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,11 @@ jobs:
           "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/release-apk-badging.txt"
           grep -q "package: name='org.wisso.newpipematerial'" "$RUNNER_TEMP/release-apk-badging.txt"
           grep -q "application-label:'WizeStream'" "$RUNNER_TEMP/release-apk-badging.txt"
+          scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
+          APKSIGNER="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/apksigner"
+          "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
 
-      - name: "Rename APK"
+      - name: "Prepare ARM APK"
         id: release_info
         run: |
           VERSION_NAME="$(jq -r ".elements[0].versionName" "app/build/outputs/apk/release/output-metadata.json")"
@@ -91,7 +94,8 @@ jobs:
           fi
 
           APK_NAME="wizestream_v${VERSION_NAME}.apk"
-          APK_PATH="app/build/outputs/apk/release/${APK_NAME}"
+          mkdir -p dist
+          APK_PATH="dist/${APK_NAME}"
           CHANGELOG_PATH="fastlane/metadata/android/en-US/changelogs/${VERSION_CODE}.txt"
 
           mv app/build/outputs/apk/release/*.apk "$APK_PATH"
@@ -108,12 +112,51 @@ jobs:
           echo "Release tag: $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
           echo "Changelog: $CHANGELOG_PATH" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Upload APK"
+      - name: Build signed x86_64 release APK
+        env:
+          WIZESTREAM_RELEASE_STORE_FILE: ${{ runner.temp }}/wizestream-release.keystore
+          WIZESTREAM_RELEASE_STORE_PASSWORD: ${{ secrets.WIZESTREAM_RELEASE_STORE_PASSWORD || secrets.NEWPIPE_MATERIAL_RELEASE_STORE_PASSWORD }}
+          WIZESTREAM_RELEASE_KEY_ALIAS: ${{ secrets.WIZESTREAM_RELEASE_KEY_ALIAS || secrets.NEWPIPE_MATERIAL_RELEASE_KEY_ALIAS }}
+          WIZESTREAM_RELEASE_KEY_PASSWORD: ${{ secrets.WIZESTREAM_RELEASE_KEY_PASSWORD || secrets.NEWPIPE_MATERIAL_RELEASE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          ./gradlew clean assembleRelease --stacktrace -PreleaseAbi=x86_64
+
+      - name: Prepare and verify x86_64 APK
+        id: x86_release_info
+        run: |
+          set -euo pipefail
+          VERSION_NAME="$(jq -r ".elements[0].versionName" "app/build/outputs/apk/release/output-metadata.json")"
+          VERSION_CODE="$(jq -r ".elements[0].versionCode" "app/build/outputs/apk/release/output-metadata.json")"
+
+          test "$VERSION_NAME" = "${{ steps.release_info.outputs.version_name }}"
+          test "$VERSION_CODE" = "${{ steps.release_info.outputs.version_code }}"
+
+          APK_NAME="wizestream_v${VERSION_NAME}_x86_64.apk"
+          APK_PATH="dist/${APK_NAME}"
+          mv app/build/outputs/apk/release/*.apk "$APK_PATH"
+
+          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
+          "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/x86-64-release-badging.txt"
+          grep -q "package: name='org.wisso.newpipematerial'" "$RUNNER_TEMP/x86-64-release-badging.txt"
+          grep -q "application-label:'WizeStream'" "$RUNNER_TEMP/x86-64-release-badging.txt"
+          scripts/verify-apk-abis.sh "$APK_PATH" x86_64
+
+          APKSIGNER="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/apksigner"
+          "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
+
+          echo "apk_name=$APK_NAME" >> "$GITHUB_OUTPUT"
+          echo "apk_path=$APK_PATH" >> "$GITHUB_OUTPUT"
+          echo "x86_64 APK: $APK_NAME" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Upload APKs"
         if: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_target == 'artifacts' || inputs.release_target == 'all') }}
         uses: actions/upload-artifact@v7
         with:
-          name: wizestream-signed-release-apk
-          path: ${{ steps.release_info.outputs.apk_path }}
+          name: wizestream-signed-release-apks
+          path: |
+            ${{ steps.release_info.outputs.apk_path }}
+            ${{ steps.x86_release_info.outputs.apk_path }}
 
       - name: "Validate changelog"
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
@@ -128,6 +171,8 @@ jobs:
           target_commitish: pipe
           name: WizeStream ${{ steps.release_info.outputs.version_name }}
           body_path: ${{ steps.release_info.outputs.changelog_path }}
-          files: ${{ steps.release_info.outputs.apk_path }}
+          files: |
+            ${{ steps.release_info.outputs.apk_path }}
+            ${{ steps.x86_release_info.outputs.apk_path }}
           fail_on_unmatched_files: true
           make_latest: true

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,11 +31,20 @@ Build the debug APK and run JVM checks:
 scripts/build.sh debug
 ```
 
-Build a release APK:
+Build the default ARM64/ARMv7 release APK:
 
 ```bash
 scripts/build.sh release
 ```
+
+Build the x86_64 release APK for Waydroid and Android-x86:
+
+```bash
+scripts/build.sh release -PreleaseAbi=x86_64
+```
+
+The `releaseAbi` property accepts `arm` (the default) or `x86_64`. Published releases build
+both targets from the same tagged source and sign them with the same release key.
 
 Run Android instrumented tests:
 
@@ -79,7 +88,9 @@ WIZESTREAM_RELEASE_KEY_PASSWORD
 
 The legacy `NEWPIPE_MATERIAL_RELEASE_*` names remain accepted as fallbacks so existing CI secrets and local build environments continue to work during migration.
 
-The resulting APK is written under `app/build/outputs/apk/release/`.
+The resulting APK is written under `app/build/outputs/apk/release/`. The release workflow
+publishes the existing `wizestream_vX.Y.Z.apk` ARM asset and a separate
+`wizestream_vX.Y.Z_x86_64.apk` asset so ARM downloads do not increase in size.
 
 ## Reproducible release rule
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,16 @@ Install WizeStream through an F-Droid-compatible client from the IzzyOnDroid rep
 
 Install WizeStream from this repository's GitHub releases or signed build artifacts when available.
 
+Releases provide two APKs:
+
+- `wizestream_vX.Y.Z.apk` supports ARM64 and ARMv7 Android devices.
+- `wizestream_vX.Y.Z_x86_64.apk` supports 64-bit Intel and AMD Android environments, including
+  Waydroid and Android-x86.
+
+Waydroid runs the Android application on Linux; this APK is not a native Linux desktop build. The
+separate native desktop project is available at
+[WizeStream Desktop](https://github.com/wizdom13/WizeStream-Desktop).
+
 Releases: https://github.com/wizdom13/WizeStream/releases
 
 WizeStream uses a different application ID from official NewPipe, so both apps can be installed side by side:
@@ -431,6 +441,7 @@ Other build modes:
 
 ```bash
 scripts/build.sh release
+scripts/build.sh release -PreleaseAbi=x86_64
 scripts/build.sh connected
 scripts/build.sh checkstyle
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,15 @@ val hasReleaseSigningConfig = listOf(
     releaseKeyPassword
 ).all { !it.isNullOrBlank() }
 
+val releaseAbi = providers.gradleProperty("releaseAbi").orElse("arm").get()
+val releaseAbiFilters = when (releaseAbi) {
+    "arm" -> setOf("arm64-v8a", "armeabi-v7a")
+    "x86_64" -> setOf("x86_64")
+    else -> throw GradleException(
+        "Unsupported releaseAbi '$releaseAbi'. Expected 'arm' or 'x86_64'."
+    )
+}
+
 kotlin {
     jvmToolchain(21)
     compilerOptions {
@@ -93,7 +102,7 @@ configure<ApplicationExtension> {
 
         release {
             ndk {
-                abiFilters += setOf("arm64-v8a", "armeabi-v7a")
+                abiFilters += releaseAbiFilters
             }
             if (hasReleaseSigningConfig) {
                 signingConfig = signingConfigs.getByName("release")

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -15,6 +15,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### New features
 
+- Added separate x86_64 release APKs for Waydroid and Android-x86 environments while keeping the
+  existing ARM release download unchanged.
 - Added optional on-device MP3 audio downloads at 128, 192, 256, or 320 kbps, with conversion
   progress, cancellation-safe temporary files, and title, uploader, and source URL metadata.
 - Added per-channel keyword and phrase filters for new-stream notifications.

--- a/scripts/verify-apk-abis.sh
+++ b/scripts/verify-apk-abis.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# < 2 )); then
+    echo "Usage: $0 <apk> <expected-abi> [expected-abi ...]" >&2
+    exit 2
+fi
+
+apk_path="$1"
+shift
+
+test -s "$apk_path"
+
+actual_file="$(mktemp)"
+expected_file="$(mktemp)"
+trap 'rm -f "$actual_file" "$expected_file"' EXIT
+
+unzip -Z1 "$apk_path" \
+    | sed -n 's#^lib/\([^/]*\)/[^/][^/]*\.so$#\1#p' \
+    | sort -u > "$actual_file"
+printf '%s\n' "$@" | sort -u > "$expected_file"
+
+if [[ ! -s "$actual_file" ]]; then
+    echo "No native libraries were found in $apk_path; the APK is architecture-independent."
+    exit 0
+fi
+
+if ! diff -u "$expected_file" "$actual_file"; then
+    echo "APK native-library ABIs do not match the expected release target." >&2
+    exit 1
+fi
+
+echo "Verified APK ABIs: $(paste -sd, "$actual_file")"


### PR DESCRIPTION
- Closes #205
- Keeps the existing ARM64 and ARMv7 release APK unchanged
- Adds a separately built and signed x86_64 APK for Waydroid and Android-x86
- Selects release ABIs through a validated Gradle property
- Builds the x86_64 release configuration in pull-request CI
- Verifies packaged native-library ABIs for both release targets
- Verifies the signature and application identity of both published APKs
- Publishes both APKs from the same tagged source and version
- Documents the correct release asset and clarifies that Waydroid is not a native desktop build
- Updates the unreleased changelog