### PR TITLE
Publish separate x86_64 release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,18 +73,6 @@ jobs:
           grep -q "layout/list_empty_view_subscriptions" "$RUNNER_TEMP/release-resources.txt"
           scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
 
-      - name: Build and verify x86_64 release APK
-        run: |
-          rm -rf app/build/outputs/apk/release
-          ./gradlew assembleRelease --rerun-tasks --stacktrace -DskipFormatKtlint -PreleaseAbi=x86_64
-          APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
-          test -s "$APK_PATH"
-          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
-          "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/x86-64-release-badging.txt"
-          grep -q "package: name='org.wisso.newpipematerial'" "$RUNNER_TEMP/x86-64-release-badging.txt"
-          grep -q "application-label:'WizeStream'" "$RUNNER_TEMP/x86-64-release-badging.txt"
-          scripts/verify-apk-abis.sh "$APK_PATH" x86_64
-
       - name: Verify debug APK identity
         run: |
           APK_PATH="$(find app/build/outputs/apk/debug -name '*.apk' | head -n 1)"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -178,13 +178,8 @@ jobs:
           mkdir -p dist
           arm_apk_path="dist/$ARM_APK_NAME"
           x86_apk_path="dist/$X86_APK_NAME"
-          arm_checksum_path="${arm_apk_path}.sha256"
-          x86_checksum_path="${x86_apk_path}.sha256"
-
           cp "$RUNNER_TEMP/wizestream-nightly-arm.apk" "$arm_apk_path"
           cp "$RUNNER_TEMP/wizestream-nightly-x86_64.apk" "$x86_apk_path"
-          sha256sum "$arm_apk_path" > "$arm_checksum_path"
-          sha256sum "$x86_apk_path" > "$x86_checksum_path"
 
           build_tools="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)"
           aapt="$ANDROID_HOME/build-tools/$build_tools/aapt"
@@ -207,9 +202,7 @@ jobs:
 
           {
             echo "arm_apk_path=$arm_apk_path"
-            echo "arm_checksum_path=$arm_checksum_path"
             echo "x86_apk_path=$x86_apk_path"
-            echo "x86_checksum_path=$x86_checksum_path"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish immutable prerelease
@@ -222,9 +215,7 @@ jobs:
           VERSION_SUFFIX: ${{ steps.metadata.outputs.version_suffix }}
           SOURCE_SHA: ${{ steps.metadata.outputs.source_sha }}
           ARM_APK_PATH: ${{ steps.assets.outputs.arm_apk_path }}
-          ARM_CHECKSUM_PATH: ${{ steps.assets.outputs.arm_checksum_path }}
           X86_APK_PATH: ${{ steps.assets.outputs.x86_apk_path }}
-          X86_CHECKSUM_PATH: ${{ steps.assets.outputs.x86_checksum_path }}
         shell: bash
         run: |
           set -euo pipefail
@@ -248,9 +239,7 @@ jobs:
             --title "WizeStream Nightly ${BUILD_DATE}" \
             --notes-file "$RUNNER_TEMP/nightly-release-notes.md" \
             "$ARM_APK_PATH" \
-            "$ARM_CHECKSUM_PATH" \
-            "$X86_APK_PATH" \
-            "$X86_CHECKSUM_PATH"
+            "$X86_APK_PATH"
 
       - name: Remove nightlies beyond retention limit
         if: steps.existing.outputs.skip != 'true'
@@ -287,9 +276,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wizestream-nightly-${{ steps.metadata.outputs.build_date }}-${{ steps.metadata.outputs.short_sha }}-arm
-          path: |
-            ${{ steps.assets.outputs.arm_apk_path }}
-            ${{ steps.assets.outputs.arm_checksum_path }}
+          path: ${{ steps.assets.outputs.arm_apk_path }}
           retention-days: 14
 
       - name: Upload x86_64 workflow artifact
@@ -297,7 +284,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: wizestream-nightly-${{ steps.metadata.outputs.build_date }}-${{ steps.metadata.outputs.short_sha }}-x86-64
-          path: |
-            ${{ steps.assets.outputs.x86_apk_path }}
-            ${{ steps.assets.outputs.x86_checksum_path }}
+          path: ${{ steps.assets.outputs.x86_apk_path }}
           retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,8 @@ jobs:
           short_sha="${source_sha::7}"
           nightly_tag="nightly-${build_date}-${short_sha}"
           version_suffix="-nightly.${build_date}.${short_sha}"
-          apk_name="WizeStream-nightly-${build_date}-${short_sha}.apk"
+          arm_apk_name="WizeStream-nightly-${build_date}-${short_sha}.apk"
+          x86_apk_name="WizeStream-nightly-${build_date}-${short_sha}-x86_64.apk"
 
           {
             echo "source_sha=$source_sha"
@@ -60,7 +61,8 @@ jobs:
             echo "short_sha=$short_sha"
             echo "nightly_tag=$nightly_tag"
             echo "version_suffix=$version_suffix"
-            echo "apk_name=$apk_name"
+            echo "arm_apk_name=$arm_apk_name"
+            echo "x86_apk_name=$x86_apk_name"
           } >> "$GITHUB_OUTPUT"
 
       - name: Skip unchanged source commit
@@ -137,7 +139,7 @@ jobs:
             echo "WIZESTREAM_RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD"
           } >> "$GITHUB_ENV"
 
-      - name: Build optimized nightly APK
+      - name: Build optimized nightly APKs
         if: steps.existing.outputs.skip != 'true'
         env:
           VERSION_CODE: ${{ steps.metadata.outputs.version_code }}
@@ -145,40 +147,69 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           scripts/build.sh nightly \
             -DversionCodeOverride="$VERSION_CODE" \
             -DversionNameSuffix="$VERSION_SUFFIX"
+
+          arm_source="$(find app/build/outputs/apk/nightly -type f -name '*.apk' | head -n 1)"
+          test -s "$arm_source"
+          cp "$arm_source" "$RUNNER_TEMP/wizestream-nightly-arm.apk"
+
+          scripts/build.sh nightly \
+            -DversionCodeOverride="$VERSION_CODE" \
+            -DversionNameSuffix="$VERSION_SUFFIX" \
+            -PreleaseAbi=x86_64
+
+          x86_source="$(find app/build/outputs/apk/nightly -type f -name '*.apk' | head -n 1)"
+          test -s "$x86_source"
+          cp "$x86_source" "$RUNNER_TEMP/wizestream-nightly-x86_64.apk"
 
       - name: Prepare and verify release assets
         if: steps.existing.outputs.skip != 'true'
         id: assets
         env:
-          APK_NAME: ${{ steps.metadata.outputs.apk_name }}
+          ARM_APK_NAME: ${{ steps.metadata.outputs.arm_apk_name }}
+          X86_APK_NAME: ${{ steps.metadata.outputs.x86_apk_name }}
         shell: bash
         run: |
           set -euo pipefail
 
-          source_apk="$(find app/build/outputs/apk/nightly -type f -name '*.apk' | head -n 1)"
-          test -n "$source_apk"
-
           mkdir -p dist
-          apk_path="dist/$APK_NAME"
-          checksum_path="${apk_path}.sha256"
-          cp "$source_apk" "$apk_path"
-          sha256sum "$apk_path" > "$checksum_path"
+          arm_apk_path="dist/$ARM_APK_NAME"
+          x86_apk_path="dist/$X86_APK_NAME"
+          arm_checksum_path="${arm_apk_path}.sha256"
+          x86_checksum_path="${x86_apk_path}.sha256"
+
+          cp "$RUNNER_TEMP/wizestream-nightly-arm.apk" "$arm_apk_path"
+          cp "$RUNNER_TEMP/wizestream-nightly-x86_64.apk" "$x86_apk_path"
+          sha256sum "$arm_apk_path" > "$arm_checksum_path"
+          sha256sum "$x86_apk_path" > "$x86_checksum_path"
 
           build_tools="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)"
           aapt="$ANDROID_HOME/build-tools/$build_tools/aapt"
           apksigner="$ANDROID_HOME/build-tools/$build_tools/apksigner"
 
-          "$aapt" dump badging "$apk_path" | tee "$RUNNER_TEMP/nightly-apk-badging.txt"
-          grep -q "package: name='org.wisso.newpipematerial.nightly'" "$RUNNER_TEMP/nightly-apk-badging.txt"
-          grep -q "application-label:'WizeStream Nightly'" "$RUNNER_TEMP/nightly-apk-badging.txt"
-          "$apksigner" verify --verbose --print-certs "$apk_path"
+          verify_identity() {
+            local apk_path="$1"
+            local badging_path="$2"
+            "$aapt" dump badging "$apk_path" | tee "$badging_path"
+            grep -q "package: name='org.wisso.newpipematerial.nightly'" "$badging_path"
+            grep -q "application-label:'WizeStream Nightly'" "$badging_path"
+            "$apksigner" verify --verbose --print-certs "$apk_path"
+          }
+
+          verify_identity "$arm_apk_path" "$RUNNER_TEMP/nightly-arm-badging.txt"
+          scripts/verify-apk-abis.sh "$arm_apk_path" arm64-v8a armeabi-v7a
+
+          verify_identity "$x86_apk_path" "$RUNNER_TEMP/nightly-x86-64-badging.txt"
+          scripts/verify-apk-abis.sh "$x86_apk_path" x86_64
 
           {
-            echo "apk_path=$apk_path"
-            echo "checksum_path=$checksum_path"
+            echo "arm_apk_path=$arm_apk_path"
+            echo "arm_checksum_path=$arm_checksum_path"
+            echo "x86_apk_path=$x86_apk_path"
+            echo "x86_checksum_path=$x86_checksum_path"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish immutable prerelease
@@ -190,8 +221,10 @@ jobs:
           VERSION_CODE: ${{ steps.metadata.outputs.version_code }}
           VERSION_SUFFIX: ${{ steps.metadata.outputs.version_suffix }}
           SOURCE_SHA: ${{ steps.metadata.outputs.source_sha }}
-          APK_PATH: ${{ steps.assets.outputs.apk_path }}
-          CHECKSUM_PATH: ${{ steps.assets.outputs.checksum_path }}
+          ARM_APK_PATH: ${{ steps.assets.outputs.arm_apk_path }}
+          ARM_CHECKSUM_PATH: ${{ steps.assets.outputs.arm_checksum_path }}
+          X86_APK_PATH: ${{ steps.assets.outputs.x86_apk_path }}
+          X86_CHECKSUM_PATH: ${{ steps.assets.outputs.x86_checksum_path }}
         shell: bash
         run: |
           set -euo pipefail
@@ -214,8 +247,10 @@ jobs:
             --prerelease \
             --title "WizeStream Nightly ${BUILD_DATE}" \
             --notes-file "$RUNNER_TEMP/nightly-release-notes.md" \
-            "$APK_PATH" \
-            "$CHECKSUM_PATH"
+            "$ARM_APK_PATH" \
+            "$ARM_CHECKSUM_PATH" \
+            "$X86_APK_PATH" \
+            "$X86_CHECKSUM_PATH"
 
       - name: Remove nightlies beyond retention limit
         if: steps.existing.outputs.skip != 'true'
@@ -253,6 +288,8 @@ jobs:
         with:
           name: wizestream-nightly-${{ steps.metadata.outputs.build_date }}-${{ steps.metadata.outputs.short_sha }}
           path: |
-            ${{ steps.assets.outputs.apk_path }}
-            ${{ steps.assets.outputs.checksum_path }}
+            ${{ steps.assets.outputs.arm_apk_path }}
+            ${{ steps.assets.outputs.arm_checksum_path }}
+            ${{ steps.assets.outputs.x86_apk_path }}
+            ${{ steps.assets.outputs.x86_checksum_path }}
           retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -282,14 +282,22 @@ jobs:
               "$releases_file"
           )
 
-      - name: Upload workflow artifact
+      - name: Upload ARM workflow artifact
         if: steps.existing.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: wizestream-nightly-${{ steps.metadata.outputs.build_date }}-${{ steps.metadata.outputs.short_sha }}
+          name: wizestream-nightly-${{ steps.metadata.outputs.build_date }}-${{ steps.metadata.outputs.short_sha }}-arm
           path: |
             ${{ steps.assets.outputs.arm_apk_path }}
             ${{ steps.assets.outputs.arm_checksum_path }}
+          retention-days: 14
+
+      - name: Upload x86_64 workflow artifact
+        if: steps.existing.outputs.skip != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: wizestream-nightly-${{ steps.metadata.outputs.build_date }}-${{ steps.metadata.outputs.short_sha }}-x86-64
+          path: |
             ${{ steps.assets.outputs.x86_apk_path }}
             ${{ steps.assets.outputs.x86_checksum_path }}
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,14 +149,19 @@ jobs:
           echo "apk_path=$APK_PATH" >> "$GITHUB_OUTPUT"
           echo "x86_64 APK: $APK_NAME" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Upload APKs"
+      - name: "Upload ARM APK artifact"
         if: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_target == 'artifacts' || inputs.release_target == 'all') }}
         uses: actions/upload-artifact@v7
         with:
-          name: wizestream-signed-release-apks
-          path: |
-            ${{ steps.release_info.outputs.apk_path }}
-            ${{ steps.x86_release_info.outputs.apk_path }}
+          name: wizestream-signed-release-arm-apk
+          path: ${{ steps.release_info.outputs.apk_path }}
+
+      - name: "Upload x86_64 APK artifact"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_target == 'artifacts' || inputs.release_target == 'all') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: wizestream-signed-release-x86-64-apk
+          path: ${{ steps.x86_release_info.outputs.apk_path }}
 
       - name: "Validate changelog"
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}

--- a/docs/nightly-builds.md
+++ b/docs/nightly-builds.md
@@ -6,9 +6,9 @@ Successful builds are published as prereleases in:
 
 - https://github.com/wizdom13/WizeStream_Nightly/releases
 
-Every nightly publishes separate ARM64/ARMv7 and x86_64 APKs with matching SHA-256 checksum
-files. Use the filename ending in `-x86_64.apk` for Waydroid or another 64-bit Intel or AMD
-Android environment; use the standard filename on ARM devices.
+Every nightly publishes two direct APK files: one for ARM64/ARMv7 and one for x86_64. Use the
+filename ending in `-x86_64.apk` for Waydroid or another 64-bit Intel or AMD Android environment;
+use the standard filename on ARM devices.
 
 The workflow skips publishing when the checked-out `pipe` commit already has a nightly release.
 

--- a/docs/nightly-builds.md
+++ b/docs/nightly-builds.md
@@ -67,4 +67,5 @@ nightly-20260714-dc108a3
 
 ## Retention
 
-The workflow keeps the newest 14 nightly prereleases and deletes older releases and their tags. The duplicate GitHub Actions artifact is retained for 14 days.
+The workflow keeps the newest 14 nightly prereleases and deletes older releases and their tags.
+The separate ARM and x86_64 GitHub Actions artifacts are retained for 14 days.

--- a/docs/nightly-builds.md
+++ b/docs/nightly-builds.md
@@ -6,6 +6,10 @@ Successful builds are published as prereleases in:
 
 - https://github.com/wizdom13/WizeStream_Nightly/releases
 
+Every nightly publishes separate ARM64/ARMv7 and x86_64 APKs with matching SHA-256 checksum
+files. Use the filename ending in `-x86_64.apk` for Waydroid or another 64-bit Intel or AMD
+Android environment; use the standard filename on ARM devices.
+
 The workflow skips publishing when the checked-out `pipe` commit already has a nightly release.
 
 ## Nightly identity


### PR DESCRIPTION
- Extends the merged x86_64 support to automated nightly releases
- Keeps the existing ARM stable and nightly filenames unchanged
- Builds x86_64 APKs only in stable-release and nightly-release workflows
- Removes the expensive x86_64 release rebuild from pull-request CI
- Attaches exactly two direct APK files to each stable and nightly GitHub Release
- Publishes the standard APK for ARM64 and ARMv7 devices
- Publishes a separately named x86_64 APK for Waydroid and Android-x86
- Keeps ARM and x86_64 GitHub Actions artifacts separate when artifacts are requested
- Verifies identity, signature, and packaged ABIs for both release targets
- Documents how to choose the correct nightly APK