### PR TITLE
Fix clipped bottom navigation after player transitions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
@@ -146,14 +146,8 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
             return;
         }
 
-        final float expandedFraction;
-        if (slideOffset != null) {
-            expandedFraction = PlayerSheetTransitionCalculator
-                    .clampExpandedFraction(slideOffset);
-        } else {
-            expandedFraction = state == STATE_EXPANDED ? 1.0f : 0.0f;
-        }
-
+        final float expandedFraction = PlayerSheetTransitionCalculator
+                .expandedFractionForState(state, slideOffset);
         updateBottomNavigationAppearance(bottomNavigation, expandedFraction);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/PlayerSheetTransitionCalculator.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/PlayerSheetTransitionCalculator.java
@@ -1,5 +1,14 @@
 package org.schabi.newpipe.player.gesture;
 
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_DRAGGING;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_SETTLING;
+
+import androidx.annotation.Nullable;
+
 final class PlayerSheetTransitionCalculator {
     private PlayerSheetTransitionCalculator() {
     }
@@ -15,6 +24,20 @@ final class PlayerSheetTransitionCalculator {
 
     static float clampExpandedFraction(final float expandedFraction) {
         return Math.max(0.0f, Math.min(1.0f, expandedFraction));
+    }
+
+    static float expandedFractionForState(final int state,
+                                          @Nullable final Float slideOffset) {
+        if (state == STATE_COLLAPSED || state == STATE_HIDDEN) {
+            return 0.0f;
+        }
+        if (state == STATE_EXPANDED || state == STATE_HALF_EXPANDED) {
+            return 1.0f;
+        }
+        if ((state == STATE_DRAGGING || state == STATE_SETTLING) && slideOffset != null) {
+            return clampExpandedFraction(slideOffset);
+        }
+        return 0.0f;
     }
 
     static float bottomNavigationTranslation(final int bottomNavigationHeight,

--- a/app/src/test/java/org/schabi/newpipe/player/gesture/PlayerSheetTransitionCalculatorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/gesture/PlayerSheetTransitionCalculatorTest.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.player.gesture;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+
 import org.junit.Test;
 
 public class PlayerSheetTransitionCalculatorTest {
@@ -28,5 +30,35 @@ public class PlayerSheetTransitionCalculatorTest {
                 PlayerSheetTransitionCalculator.bottomNavigationTranslation(72, 0.5f), 0.0f);
         assertEquals(72.0f,
                 PlayerSheetTransitionCalculator.bottomNavigationTranslation(72, 2.0f), 0.0f);
+    }
+
+    @Test
+    public void stableCollapsedAndHiddenStatesIgnoreLateSlideOffsets() {
+        assertEquals(0.0f,
+                PlayerSheetTransitionCalculator.expandedFractionForState(
+                        BottomSheetBehavior.STATE_COLLAPSED, 0.65f), 0.0f);
+        assertEquals(0.0f,
+                PlayerSheetTransitionCalculator.expandedFractionForState(
+                        BottomSheetBehavior.STATE_HIDDEN, 0.65f), 0.0f);
+    }
+
+    @Test
+    public void stableExpandedStatesIgnoreLateSlideOffsets() {
+        assertEquals(1.0f,
+                PlayerSheetTransitionCalculator.expandedFractionForState(
+                        BottomSheetBehavior.STATE_EXPANDED, 0.2f), 0.0f);
+        assertEquals(1.0f,
+                PlayerSheetTransitionCalculator.expandedFractionForState(
+                        BottomSheetBehavior.STATE_HALF_EXPANDED, 0.2f), 0.0f);
+    }
+
+    @Test
+    public void activePlayerTransitionsFollowTheCurrentSlideOffset() {
+        assertEquals(0.35f,
+                PlayerSheetTransitionCalculator.expandedFractionForState(
+                        BottomSheetBehavior.STATE_DRAGGING, 0.35f), 0.0f);
+        assertEquals(0.75f,
+                PlayerSheetTransitionCalculator.expandedFractionForState(
+                        BottomSheetBehavior.STATE_SETTLING, 0.75f), 0.0f);
     }
 }

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -8,6 +8,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
+- Fixed the bottom navigation occasionally remaining translated off-screen after an interrupted
+  player-sheet transition, leaving a clipped blank area until the app was restarted.
 - Fixed NewPipe subscription imports failing completely when one channel is unavailable; valid
   channels now import independently and the result reports imported and skipped counts.
 - Made history date scrolling transient, consistently show month and year, and process large


### PR DESCRIPTION
- Make stable player-sheet states authoritative for bottom-navigation visibility.
- Ignore late slide offsets after the player sheet has collapsed, hidden, expanded, or half-expanded.
- Preserve smooth navigation translation only while the player sheet is actively dragging or settling.
- Add regression tests for interrupted and out-of-order player-sheet callbacks.
- Include the correction in the WizeStream 1.10.0 changelog.