### PR TITLE
Polish History date scrollbar

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/history/HistoryDateFastScrollerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/history/HistoryDateFastScrollerTest.kt
@@ -4,6 +4,7 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.math.roundToInt
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -12,6 +13,28 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class HistoryDateFastScrollerTest {
+    @Test
+    fun trackStaysNearThePhysicalScreenEdgeInLtrAndRtl() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val density = instrumentation.targetContext.resources.displayMetrics.density
+            val width = (48 * density).roundToInt()
+            val view = HistoryDateFastScroller(instrumentation.targetContext)
+            view.layout(0, 0, width, (400 * density).roundToInt())
+
+            assertEquals(
+                width - 8 * density,
+                view.getTrackCenterXForLayoutDirection(View.LAYOUT_DIRECTION_LTR),
+                0.5f
+            )
+            assertEquals(
+                8 * density,
+                view.getTrackCenterXForLayoutDirection(View.LAYOUT_DIRECTION_RTL),
+                0.5f
+            )
+        }
+    }
+
     @Test
     fun dragMapsTrackEndpointsToHistoryEndpoints() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/HistoryDateFastScroller.java
@@ -36,6 +36,7 @@ public final class HistoryDateFastScroller extends View {
     private final float thumbWidth;
     private final float thumbHeight;
     private final float verticalInset;
+    private final float edgeInset;
     private final int bubbleGap;
     private final int bubblePaddingHorizontal;
     private final int bubblePaddingVertical;
@@ -71,6 +72,7 @@ public final class HistoryDateFastScroller extends View {
         thumbWidth = dp(8);
         thumbHeight = dp(36);
         verticalInset = dp(18);
+        edgeInset = dp(8);
         bubbleGap = Math.round(dp(8));
         bubblePaddingHorizontal = Math.round(dp(16));
         bubblePaddingVertical = Math.round(dp(10));
@@ -137,7 +139,7 @@ public final class HistoryDateFastScroller extends View {
             return;
         }
 
-        final float centerX = getWidth() / 2f;
+        final float centerX = getTrackCenterX();
         final float top = verticalInset;
         final float bottom = Math.max(top, getHeight() - verticalInset);
         drawingRect.set(centerX - trackWidth / 2f, top,
@@ -251,6 +253,18 @@ public final class HistoryDateFastScroller extends View {
         }
     }
 
+    private float getTrackCenterX() {
+        return getTrackCenterXForLayoutDirection(getLayoutDirection());
+    }
+
+    float getTrackCenterXForLayoutDirection(final int layoutDirection) {
+        final float minimumCenter = thumbWidth / 2f;
+        final float insetCenter = Math.max(minimumCenter,
+                Math.min(edgeInset, getWidth() - minimumCenter));
+        return layoutDirection == LAYOUT_DIRECTION_RTL
+                ? insetCenter : getWidth() - insetCenter;
+    }
+
     private float getFraction() {
         return itemCount <= 1 ? 0f : position / (float) (itemCount - 1);
     }
@@ -289,9 +303,11 @@ public final class HistoryDateFastScroller extends View {
         getLocationOnScreen(location);
 
         final boolean rtl = getLayoutDirection() == LAYOUT_DIRECTION_RTL;
+        final float trackCenterX = getTrackCenterX();
         int x = rtl
-                ? location[0] + getWidth() + bubbleGap
-                : location[0] - bubbleWidth - bubbleGap;
+                ? Math.round(location[0] + trackCenterX + thumbWidth / 2f + bubbleGap)
+                : Math.round(location[0] + trackCenterX - thumbWidth / 2f
+                        - bubbleGap - bubbleWidth);
         final int screenWidth = getResources().getDisplayMetrics().widthPixels;
         x = Math.max(0, Math.min(x, screenWidth - bubbleWidth));
 

--- a/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/history/StatisticsPlaylistFragment.java
@@ -76,6 +76,8 @@ public class StatisticsPlaylistFragment
         implements PlaylistControlViewHolder, ContextualSearchable {
     private static final int MIN_FAST_SCROLL_ITEMS = 50;
     private static final long FAST_SCROLL_HIDE_DELAY_MILLIS = 1_800L;
+    private static final long FAST_SCROLL_FADE_IN_MILLIS = 140L;
+    private static final long FAST_SCROLL_FADE_OUT_MILLIS = 220L;
     private static final String DATE_PICKER_TAG = "history_date_picker";
 
     private final CompositeDisposable disposables = new CompositeDisposable();
@@ -96,12 +98,7 @@ public class StatisticsPlaylistFragment
     private RecyclerView.OnScrollListener historyScrollListener;
     private Disposable historyProcessingDisposable;
 
-    private final Runnable hideFastScrollerRunnable = () -> {
-        if (contentBinding != null && dateFastScrollEnabled
-                && !contentBinding.historyDateFastScroller.isDragging()) {
-            contentBinding.historyDateFastScroller.setVisibility(View.GONE);
-        }
-    };
+    private final Runnable hideFastScrollerRunnable = this::hideFastScrollerAnimated;
 
     /* Used for independent events */
     private Subscription databaseSubscription;
@@ -325,7 +322,7 @@ public class StatisticsPlaylistFragment
         historyScrollListener = null;
 
         if (contentBinding != null) {
-            contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
+            hideFastScrollerImmediately();
             contentBinding.historyDateFastScroller.dismissBubble();
         }
         if (historyProcessingDisposable != null) {
@@ -505,8 +502,7 @@ public class StatisticsPlaylistFragment
             return;
         }
         contentBinding.historyDateJumpButton.setVisibility(View.GONE);
-        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
-        contentBinding.historyDateFastScroller.setVisibility(View.GONE);
+        hideFastScrollerImmediately();
         contentBinding.historyDateFastScroller.dismissBubble();
         if (itemsList != null) {
             itemsList.setVerticalScrollBarEnabled(true);
@@ -525,8 +521,7 @@ public class StatisticsPlaylistFragment
 
         dateFastScrollEnabled = chronological
                 && displayedHistory.size() >= MIN_FAST_SCROLL_ITEMS;
-        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
-        contentBinding.historyDateFastScroller.setVisibility(View.GONE);
+        hideFastScrollerImmediately();
         contentBinding.historyDateFastScroller.setItemCount(displayedHistory.size());
         itemsList.setVerticalScrollBarEnabled(!dateFastScrollEnabled);
 
@@ -542,8 +537,55 @@ public class StatisticsPlaylistFragment
         if (!dateFastScrollEnabled || contentBinding == null) {
             return;
         }
-        contentBinding.historyDateFastScroller.removeCallbacks(hideFastScrollerRunnable);
-        contentBinding.historyDateFastScroller.setVisibility(View.VISIBLE);
+        final HistoryDateFastScroller fastScroller =
+                contentBinding.historyDateFastScroller;
+        fastScroller.removeCallbacks(hideFastScrollerRunnable);
+        fastScroller.animate().cancel();
+        fastScroller.animate().withEndAction(null);
+        if (fastScroller.getVisibility() != View.VISIBLE) {
+            fastScroller.setAlpha(0f);
+            fastScroller.setVisibility(View.VISIBLE);
+        }
+        fastScroller.animate()
+                .alpha(1f)
+                .setDuration(FAST_SCROLL_FADE_IN_MILLIS)
+                .start();
+    }
+
+    private void hideFastScrollerAnimated() {
+        if (!dateFastScrollEnabled || contentBinding == null) {
+            return;
+        }
+        final HistoryDateFastScroller fastScroller =
+                contentBinding.historyDateFastScroller;
+        if (fastScroller.isDragging() || fastScroller.getVisibility() != View.VISIBLE) {
+            return;
+        }
+        final FragmentPlaylistBinding bindingAtStart = contentBinding;
+        fastScroller.animate().cancel();
+        fastScroller.animate()
+                .alpha(0f)
+                .setDuration(FAST_SCROLL_FADE_OUT_MILLIS)
+                .withEndAction(() -> {
+                    if (contentBinding == bindingAtStart && !fastScroller.isDragging()) {
+                        fastScroller.setVisibility(View.GONE);
+                        fastScroller.setAlpha(1f);
+                    }
+                })
+                .start();
+    }
+
+    private void hideFastScrollerImmediately() {
+        if (contentBinding == null) {
+            return;
+        }
+        final HistoryDateFastScroller fastScroller =
+                contentBinding.historyDateFastScroller;
+        fastScroller.removeCallbacks(hideFastScrollerRunnable);
+        fastScroller.animate().cancel();
+        fastScroller.animate().withEndAction(null);
+        fastScroller.setAlpha(1f);
+        fastScroller.setVisibility(View.GONE);
     }
 
     private void scheduleFastScrollerHide() {

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -17,6 +17,11 @@ Release history is listed newest first. The number beside each release is its An
 - Fixed Material You wallpaper colors falling back to green with the Black night theme, while
   preserving true-black surfaces, and made the player seek bar follow the selected accent color.
 
+### Improvements
+
+- Moved the History date scrollbar closer to the screen edge while preserving its accessible touch
+  target, and added smooth cancellable fade transitions.
+
 ### New features
 
 - Added separate x86_64 release APKs for Waydroid and Android-x86 environments while keeping the

--- a/fastlane/metadata/android/en-US/changelogs/1010000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1010000.txt
@@ -5,3 +5,4 @@ WizeStream 1.10.0
 - Added x86_64 release APKs for Waydroid and Android-x86.
 - Improved pinned-channel tab swiping.
 - Fixed subscription imports, History navigation performance, and Material You colors with the Black theme.
+- Polished the History scrollbar placement and animations.


### PR DESCRIPTION
- Move the visible History date scrollbar track to an 8 dp physical-edge inset while preserving its 48 dp touch target
- Mirror the placement correctly in RTL layouts and anchor the date bubble to the visible track
- Add cancellable fade-in and fade-out transitions
- Keep the scrollbar visible while dragging and make it gone after fading to prevent invisible touch interception
- Add LTR and RTL placement regression coverage
- Update the 1.10.0 changelog and Play release notes
- Refs #195