### PR TITLE
Stop deleted downloads immediately

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -274,11 +274,19 @@ public class DownloadMission extends Mission {
     }
 
 
-    private void notify(int what) {
-        mHandler.obtainMessage(what, this).sendToTarget();
+    private void notify(final int what) {
+        if (deleted && what != DownloadManagerService.MESSAGE_DELETED) {
+            return;
+        }
+        if (mHandler != null) {
+            mHandler.obtainMessage(what, this).sendToTarget();
+        }
     }
 
-    synchronized void notifyProgress(long deltaLen) {
+    synchronized void notifyProgress(final long deltaLen) {
+        if (deleted) {
+            return;
+        }
         if (unknownLength) {
             length += deltaLen;// Update length before proceeding
         }
@@ -315,6 +323,9 @@ public class DownloadMission extends Mission {
     }
 
     public synchronized void notifyError(int code, Exception err) {
+        if (deleted) {
+            return;
+        }
         Log.e(TAG, "notifyError() code = " + code, err);
         if (err != null && err.getCause() instanceof ErrnoException) {
             int errno = ((ErrnoException) err.getCause()).errno;
@@ -362,6 +373,9 @@ public class DownloadMission extends Mission {
     }
 
     synchronized void notifyFinished() {
+        if (deleted) {
+            return;
+        }
         if (current < urls.length) {
             if (++finishCount < threads.length) return;
 
@@ -428,7 +442,7 @@ public class DownloadMission extends Mission {
      * Start downloading with multiple threads.
      */
     public void start() {
-        if (running || isFinished() || urls.length < 1) return;
+        if (deleted || running || isFinished() || urls.length < 1) return;
 
         // ensure that the previous state is completely paused.
         joinForThreads(10000);
@@ -521,22 +535,45 @@ public class DownloadMission extends Mission {
     }
 
     /**
-     * Removes the downloaded file and the meta file
+     * Stops this mission and removes its metadata, optionally deleting the partial file.
+     *
+     * @param alsoDeleteFile whether the partially downloaded output should also be removed
+     * @return whether all requested cleanup operations succeeded
      */
-    @Override
-    public boolean delete() {
+    public boolean cancel(final boolean alsoDeleteFile) {
+        if (deleted) {
+            return true;
+        }
+
+        deleted = true;
         running = false;
+        enqueued = false;
+
+        if (init != null) {
+            init.interrupt();
+        }
         for (final Thread thread : threads) {
             thread.interrupt();
         }
-        if (psAlgorithm != null) psAlgorithm.cleanupTemporalDir();
+        if (psAlgorithm != null) {
+            psAlgorithm.cleanupTemporalDir();
+        }
 
         notify(DownloadManagerService.MESSAGE_DELETED);
 
-        boolean res = deleteThisFromFile();
+        boolean result = deleteThisFromFile();
+        if (alsoDeleteFile && !super.delete()) {
+            result = false;
+        }
+        return result;
+    }
 
-        if (!super.delete()) return false;
-        return res;
+    /**
+     * Removes the downloaded file and the meta file.
+     */
+    @Override
+    public boolean delete() {
+        return cancel(true);
     }
 
 
@@ -755,9 +792,12 @@ public class DownloadMission extends Mission {
 
     private boolean deleteThisFromFile() {
         synchronized (LOCK) {
-            boolean res = metadata.delete();
+            if (metadata == null) {
+                return true;
+            }
+            final boolean result = metadata.delete();
             metadata = null;
-            return res;
+            return result;
         }
     }
 

--- a/app/src/main/java/us/shandian/giga/service/DownloadManager.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManager.java
@@ -292,12 +292,14 @@ public class DownloadManager {
         synchronized (this) {
             if (mission instanceof DownloadMission) {
                 mMissionsPending.remove(mission);
+                ((DownloadMission) mission).cancel(alsoDeleteFile);
             } else if (mission instanceof FinishedMission) {
                 mMissionsFinished.remove(mission);
                 mFinishedMissionStore.deleteMission(mission);
-            }
-
-            if (alsoDeleteFile) {
+                if (alsoDeleteFile) {
+                    mission.delete();
+                }
+            } else if (alsoDeleteFile) {
                 mission.delete();
             }
         }

--- a/app/src/main/java/us/shandian/giga/ui/common/Deleter.java
+++ b/app/src/main/java/us/shandian/giga/ui/common/Deleter.java
@@ -15,7 +15,7 @@ import org.schabi.newpipe.R;
 import java.util.ArrayList;
 import java.util.Optional;
 
-import kotlin.Pair;
+import us.shandian.giga.get.DownloadMission;
 import us.shandian.giga.get.FinishedMission;
 import us.shandian.giga.get.Mission;
 import us.shandian.giga.service.DownloadManager;
@@ -32,8 +32,7 @@ public class Deleter {
     private static final int DELAY_RESUME = 400;// ms
 
     private Snackbar snackbar;
-    // list of missions to be deleted, and whether to also delete the corresponding file
-    private ArrayList<Pair<Mission, Boolean>> items;
+    private ArrayList<PendingDeletion> items;
     private boolean running = true;
 
     private final Context mContext;
@@ -54,7 +53,7 @@ public class Deleter {
         items = new ArrayList<>(2);
     }
 
-    public void append(Mission item, boolean alsoDeleteFile) {
+    public void append(final Mission item, final boolean alsoDeleteFile) {
         /* If a mission is removed from the list while the Snackbar for a previously
          * removed item is still showing, commit the action for the previous item
          * immediately. This prevents Snackbars from stacking up in reverse order.
@@ -62,14 +61,19 @@ public class Deleter {
         mHandler.removeCallbacksAndMessages(COMMIT);
         commit();
 
+        final PendingDeletion pendingDeletion =
+                PendingDeletion.capture(item, alsoDeleteFile);
         mIterator.hide(item);
-        items.add(0, new Pair<>(item, alsoDeleteFile));
+        pendingDeletion.suspend(mDownloadManager);
+        items.add(0, pendingDeletion);
 
         show();
     }
 
     private void forget() {
-        mIterator.unHide(items.remove(0).getFirst());
+        final PendingDeletion pendingDeletion = items.remove(0);
+        mIterator.unHide(pendingDeletion.mission);
+        pendingDeletion.restore(mDownloadManager);
         mAdapter.applyChanges();
 
         show();
@@ -88,8 +92,8 @@ public class Deleter {
         if (items.size() < 1) return;
 
         final Optional<String> fileToBeDeleted = items.stream()
-                .filter(Pair::getSecond)
-                .map(p -> p.getFirst().storage.getName())
+                .filter(pendingDeletion -> pendingDeletion.alsoDeleteFile)
+                .map(pendingDeletion -> pendingDeletion.mission.storage.getName())
                 .findFirst();
 
         String msg;
@@ -113,13 +117,12 @@ public class Deleter {
         if (items.size() < 1) return;
 
         while (items.size() > 0) {
-            Pair<Mission, Boolean> missionAndAlsoDeleteFile = items.remove(0);
-            Mission mission = missionAndAlsoDeleteFile.getFirst();
-            boolean alsoDeleteFile = missionAndAlsoDeleteFile.getSecond();
+            final PendingDeletion pendingDeletion = items.remove(0);
+            final Mission mission = pendingDeletion.mission;
             if (mission.deleted) continue;
 
             mIterator.unHide(mission);
-            mDownloadManager.deleteMission(mission, alsoDeleteFile);
+            mDownloadManager.deleteMission(mission, pendingDeletion.alsoDeleteFile);
 
             if (mission instanceof FinishedMission) {
                 mContext.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, mission.storage.getUri()));
@@ -154,11 +157,60 @@ public class Deleter {
 
         pause();
 
-        for (Pair<Mission, Boolean> missionAndAlsoDeleteFile : items) {
-            Mission mission = missionAndAlsoDeleteFile.getFirst();
-            boolean alsoDeleteFile = missionAndAlsoDeleteFile.getSecond();
-            mDownloadManager.deleteMission(mission, alsoDeleteFile);
+        for (final PendingDeletion pendingDeletion : items) {
+            mDownloadManager.deleteMission(
+                    pendingDeletion.mission, pendingDeletion.alsoDeleteFile);
         }
         items = null;
+    }
+
+    static final class PendingDeletion {
+        private final Mission mission;
+        private final boolean alsoDeleteFile;
+        private final boolean wasRunning;
+        private final boolean wasEnqueued;
+
+        private PendingDeletion(final Mission mission,
+                                final boolean alsoDeleteFile,
+                                final boolean wasRunning,
+                                final boolean wasEnqueued) {
+            this.mission = mission;
+            this.alsoDeleteFile = alsoDeleteFile;
+            this.wasRunning = wasRunning;
+            this.wasEnqueued = wasEnqueued;
+        }
+
+        static PendingDeletion capture(final Mission mission,
+                                       final boolean alsoDeleteFile) {
+            if (mission instanceof DownloadMission) {
+                final DownloadMission downloadMission = (DownloadMission) mission;
+                return new PendingDeletion(mission, alsoDeleteFile,
+                        downloadMission.running, downloadMission.enqueued);
+            }
+            return new PendingDeletion(mission, alsoDeleteFile, false, false);
+        }
+
+        void suspend(final DownloadManager downloadManager) {
+            if (!(mission instanceof DownloadMission)) {
+                return;
+            }
+            final DownloadMission downloadMission = (DownloadMission) mission;
+            if (downloadMission.running) {
+                downloadManager.pauseMission(downloadMission);
+            } else if (downloadMission.enqueued) {
+                downloadMission.setEnqueued(false);
+            }
+        }
+
+        void restore(final DownloadManager downloadManager) {
+            if (!(mission instanceof DownloadMission) || mission.deleted) {
+                return;
+            }
+            final DownloadMission downloadMission = (DownloadMission) mission;
+            downloadMission.setEnqueued(wasEnqueued);
+            if (wasRunning) {
+                downloadManager.resumeMission(downloadMission);
+            }
+        }
     }
 }

--- a/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package us.shandian.giga.get;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+import us.shandian.giga.postprocessing.Postprocessing;
+
+public class DownloadMissionDeletionTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void cancelWithoutDeletingFileStopsEveryWorkerAndPreservesOutput()
+            throws Exception {
+        final TestMission testMission = mission();
+        final Thread initializer = mock(Thread.class);
+        final Thread worker = mock(Thread.class);
+        final Postprocessing postprocessing = mock(Postprocessing.class);
+        testMission.mission.init = initializer;
+        testMission.mission.threads = new Thread[]{worker};
+        testMission.mission.psAlgorithm = postprocessing;
+        testMission.mission.running = true;
+        testMission.mission.enqueued = true;
+
+        assertTrue(testMission.mission.cancel(false));
+
+        assertFalse(testMission.mission.running);
+        assertFalse(testMission.mission.enqueued);
+        assertTrue(testMission.mission.deleted);
+        assertFalse(testMission.metadata.exists());
+        verify(initializer).interrupt();
+        verify(worker).interrupt();
+        verify(postprocessing).cleanupTemporalDir();
+        verify(testMission.storage, never()).delete();
+    }
+
+    @Test
+    public void cancelWithDeletingFileRemovesOutput() throws Exception {
+        final TestMission testMission = mission();
+        when(testMission.storage.delete()).thenReturn(true);
+
+        assertTrue(testMission.mission.cancel(true));
+
+        assertTrue(testMission.mission.deleted);
+        assertFalse(testMission.metadata.exists());
+        verify(testMission.storage).delete();
+    }
+
+    @Test
+    public void repeatedCancellationDoesNotDeleteOutputTwice() throws Exception {
+        final TestMission testMission = mission();
+        when(testMission.storage.delete()).thenReturn(true);
+
+        assertTrue(testMission.mission.cancel(true));
+        assertTrue(testMission.mission.cancel(true));
+
+        verify(testMission.storage).delete();
+    }
+
+    private TestMission mission() throws Exception {
+        final org.schabi.newpipe.streams.io.StoredFileHelper storage =
+                mock(org.schabi.newpipe.streams.io.StoredFileHelper.class);
+        final DownloadMission mission =
+                new DownloadMission(new String[]{"https://example.com/video"}, storage, 'v', null);
+        final File metadata = temporaryFolder.newFile();
+        mission.metadata = metadata;
+        return new TestMission(mission, storage, metadata);
+    }
+
+    private static final class TestMission {
+        private final DownloadMission mission;
+        private final org.schabi.newpipe.streams.io.StoredFileHelper storage;
+        private final File metadata;
+
+        private TestMission(
+                final DownloadMission mission,
+                final org.schabi.newpipe.streams.io.StoredFileHelper storage,
+                final File metadata
+        ) {
+            this.mission = mission;
+            this.storage = storage;
+            this.metadata = metadata;
+        }
+    }
+}

--- a/app/src/test/java/us/shandian/giga/ui/common/DeleterPendingDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/ui/common/DeleterPendingDeletionTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package us.shandian.giga.ui.common;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import us.shandian.giga.get.DownloadMission;
+import us.shandian.giga.service.DownloadManager;
+import us.shandian.giga.ui.common.Deleter.PendingDeletion;
+
+public class DeleterPendingDeletionTest {
+    @Test
+    public void runningDownloadIsPausedAndRestored() {
+        final DownloadMission mission = mock(DownloadMission.class);
+        final DownloadManager manager = mock(DownloadManager.class);
+        mission.running = true;
+        mission.enqueued = true;
+
+        final PendingDeletion deletion = PendingDeletion.capture(mission, true);
+        deletion.suspend(manager);
+        deletion.restore(manager);
+
+        verify(manager).pauseMission(mission);
+        verify(mission).setEnqueued(true);
+        verify(manager).resumeMission(mission);
+    }
+
+    @Test
+    public void queuedDownloadIsDequeuedAndRestoredWithoutStarting() {
+        final DownloadMission mission = mock(DownloadMission.class);
+        final DownloadManager manager = mock(DownloadManager.class);
+        mission.running = false;
+        mission.enqueued = true;
+
+        final PendingDeletion deletion = PendingDeletion.capture(mission, false);
+        deletion.suspend(manager);
+        deletion.restore(manager);
+
+        verify(mission).setEnqueued(false);
+        verify(mission).setEnqueued(true);
+        verify(manager, never()).pauseMission(mission);
+        verify(manager, never()).resumeMission(mission);
+    }
+
+    @Test
+    public void deletedDownloadIsNotRestored() {
+        final DownloadMission mission = mock(DownloadMission.class);
+        final DownloadManager manager = mock(DownloadManager.class);
+        mission.running = true;
+        mission.enqueued = true;
+        mission.deleted = true;
+
+        final PendingDeletion deletion = PendingDeletion.capture(mission, true);
+        deletion.restore(manager);
+
+        verify(mission, never()).setEnqueued(true);
+        verify(manager, never()).resumeMission(mission);
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Fixes
+
+- Stopped active or queued downloads immediately when their entries are deleted, while preserving
+  the previous state when the deletion is undone.
+
 ## WizeStream 1.10.0 (`1010000`)
 
 ### Fixes


### PR DESCRIPTION
- Pause active downloads and dequeue queued downloads as soon as deletion begins
- Restore the exact previous running and queued state when Undo is selected
- Always cancel initializer, download, recovery, and post-processing work when deletion is committed
- Preserve the partial output for Delete entry and remove it for Delete
- Ignore progress, error, and completion callbacks after a mission is deleted
- Make repeated cancellation idempotent
- Add regression tests for worker cleanup, file preservation, file deletion, and Undo state
- Update the changelog
- Fixes #216