### PR TITLE
Restore audio downloads from muxed MP4 streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -115,6 +115,8 @@ public class DownloadDialog extends DialogFragment
     int selectedAudioOutputIndex = 0;
     @State
     int selectedMp3BitrateIndex = 1;
+    @State
+    int muxedAudioFallbackVideoIndex = -1;
 
     private static final int AUDIO_OUTPUT_ORIGINAL = 0;
     private static final int AUDIO_OUTPUT_MP3 = 1;
@@ -175,11 +177,8 @@ public class DownloadDialog extends DialogFragment
 
         final List<AudioStream> audioStreams =
                 getStreamsOfSpecifiedDelivery(info.getAudioStreams(), PROGRESSIVE_HTTP);
-        final List<List<AudioStream>> groupedAudioStreams =
-                ListHelper.getGroupedAudioStreams(context, audioStreams);
-        this.wrappedAudioTracks = new AudioTracksWrapper(groupedAudioStreams, context);
-        this.selectedAudioTrackIndex =
-                ListHelper.getDefaultAudioTrackGroup(context, groupedAudioStreams);
+        final List<List<AudioStream>> groupedAudioStreams = new ArrayList<>(
+                ListHelper.getGroupedAudioStreams(context, audioStreams));
 
         // TODO: Adapt this code when the downloader support other types of stream deliveries
         final List<VideoStream> videoStreams = ListHelper.getSortedStreamVideosList(
@@ -189,8 +188,21 @@ public class DownloadDialog extends DialogFragment
                 false,
                 // If there are multiple languages available, prefer streams without audio
                 // to allow language selection
-                wrappedAudioTracks.size() > 1
+                groupedAudioStreams.size() > 1
         );
+
+        if (groupedAudioStreams.isEmpty()) {
+            muxedAudioFallbackVideoIndex =
+                    MuxedAudioFallbackPolicy.findFallbackVideoIndex(videoStreams);
+            if (muxedAudioFallbackVideoIndex >= 0) {
+                groupedAudioStreams.add(List.of(MuxedAudioFallbackPolicy.createFallbackAudioStream(
+                        videoStreams.get(muxedAudioFallbackVideoIndex))));
+            }
+        }
+
+        this.wrappedAudioTracks = new AudioTracksWrapper(groupedAudioStreams, context);
+        this.selectedAudioTrackIndex =
+                ListHelper.getDefaultAudioTrackGroup(context, groupedAudioStreams);
 
         this.wrappedVideoStreams = new StreamInfoWrapper<>(videoStreams, context);
         this.wrappedSubtitleStreams = new StreamInfoWrapper<>(
@@ -259,6 +271,8 @@ public class DownloadDialog extends DialogFragment
      */
     private void updateSecondaryStreams() {
         final StreamInfoWrapper<AudioStream> audioStreams = getWrappedAudioStreams();
+        final StreamInfoWrapper<AudioStream> secondaryAudioStreams = hasMuxedAudioFallback()
+                ? StreamInfoWrapper.empty() : audioStreams;
         final var secondaryStreams = new SparseArrayCompat<SecondaryStreamHelper<AudioStream>>(4);
         final List<VideoStream> videoStreams = wrappedVideoStreams.getStreamsList();
         wrappedVideoStreams.resetInfo();
@@ -268,10 +282,11 @@ public class DownloadDialog extends DialogFragment
                 continue;
             }
             final AudioStream audioStream = SecondaryStreamHelper.getAudioStreamFor(
-                    context, audioStreams.getStreamsList(), videoStreams.get(i));
+                    context, secondaryAudioStreams.getStreamsList(), videoStreams.get(i));
 
             if (audioStream != null) {
-                secondaryStreams.append(i, new SecondaryStreamHelper<>(audioStreams, audioStream));
+                secondaryStreams.append(i,
+                        new SecondaryStreamHelper<>(secondaryAudioStreams, audioStream));
             } else if (DEBUG) {
                 final MediaFormat mediaFormat = videoStreams.get(i).getFormat();
                 if (mediaFormat != null) {
@@ -457,7 +472,10 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.audioStreamSpinner.setVisibility(View.VISIBLE);
         dialogBinding.audioTrackSpinner.setVisibility(
                 wrappedAudioTracks.size() > 1 ? View.VISIBLE : View.GONE);
-        dialogBinding.audioTrackPresentInVideoText.setVisibility(View.GONE);
+        dialogBinding.audioTrackPresentInVideoText.setText(
+                R.string.audio_extracted_from_video_notice);
+        dialogBinding.audioTrackPresentInVideoText.setVisibility(
+                hasMuxedAudioFallback() ? View.VISIBLE : View.GONE);
         dialogBinding.audioOutputFormatLabel.setVisibility(View.VISIBLE);
         dialogBinding.audioOutputFormatSpinner.setVisibility(View.VISIBLE);
         updateMp3BitrateVisibility();
@@ -480,6 +498,7 @@ public class DownloadDialog extends DialogFragment
     private void onVideoStreamSelected() {
         final boolean isVideoOnly = videoStreamsAdapter.getItem(selectedVideoIndex).isVideoOnly();
 
+        dialogBinding.audioTrackPresentInVideoText.setText(R.string.audio_track_present_in_video);
         dialogBinding.audioTrackSpinner.setVisibility(
                 isVideoOnly && wrappedAudioTracks.size() > 1 ? View.VISIBLE : View.GONE);
         dialogBinding.audioTrackPresentInVideoText.setVisibility(
@@ -768,6 +787,17 @@ public class DownloadDialog extends DialogFragment
             return StreamInfoWrapper.empty();
         }
         return wrappedAudioTracks.getTracksList().get(selectedAudioTrackIndex);
+    }
+
+    private boolean hasMuxedAudioFallback() {
+        return muxedAudioFallbackVideoIndex >= 0
+                && muxedAudioFallbackVideoIndex < wrappedVideoStreams.getStreamsList().size();
+    }
+
+    @Nullable
+    private VideoStream getMuxedAudioFallbackSource() {
+        return hasMuxedAudioFallback()
+                ? wrappedVideoStreams.getStreamsList().get(muxedAudioFallbackVideoIndex) : null;
     }
 
     private int getSubtitleIndexBy(@NonNull final List<SubtitlesStream> streams) {
@@ -1109,6 +1139,7 @@ public class DownloadDialog extends DialogFragment
         }
 
         final Stream selectedStream;
+        final Stream recoveryStream;
         Stream secondaryStream = null;
         final char kind;
         int threads = dialogBinding.threads.getProgress() + 1;
@@ -1123,11 +1154,16 @@ public class DownloadDialog extends DialogFragment
         if (checkedRadioButtonId == R.id.audio_button) {
             kind = 'a';
             selectedStream = audioStreamsAdapter.getItem(selectedAudioIndex);
+            final VideoStream muxedAudioFallbackSource = getMuxedAudioFallbackSource();
+            recoveryStream = muxedAudioFallbackSource == null
+                    ? selectedStream : muxedAudioFallbackSource;
 
             if (Mp3DownloadPolicy.shouldTranscode(isMp3OutputSelected(),
                     selectedStream.getFormat())) {
                 psName = Postprocessing.ALGORITHM_MP3_FROM_AUDIO;
                 psArgs = new String[] {String.valueOf(getSelectedMp3Bitrate())};
+            } else if (muxedAudioFallbackSource != null) {
+                psName = Postprocessing.ALGORITHM_M4A_FROM_MP4_DEMUXER;
             } else if (selectedStream.getFormat() == MediaFormat.M4A) {
                 psName = Postprocessing.ALGORITHM_M4A_NO_DASH;
             } else if (selectedStream.getFormat() == MediaFormat.WEBMA_OPUS) {
@@ -1136,6 +1172,7 @@ public class DownloadDialog extends DialogFragment
         } else if (checkedRadioButtonId == R.id.video_button) {
             kind = 'v';
             selectedStream = videoStreamsAdapter.getItem(selectedVideoIndex);
+            recoveryStream = selectedStream;
 
             final SecondaryStreamHelper<AudioStream> secondary = videoStreamsAdapter
                     .getAllSecondary()
@@ -1163,6 +1200,7 @@ public class DownloadDialog extends DialogFragment
             threads = 1; // use unique thread for subtitles due small file size
             kind = 's';
             selectedStream = subtitleStreamsAdapter.getItem(selectedSubtitleIndex);
+            recoveryStream = selectedStream;
 
             if (selectedStream.getFormat() == MediaFormat.TTML) {
                 psName = Postprocessing.ALGORITHM_TTML_CONVERTER;
@@ -1179,7 +1217,7 @@ public class DownloadDialog extends DialogFragment
             urls = new String[] {
                     selectedStream.getContent()
             };
-            recoveryInfo = List.of(new MissionRecoveryInfo(selectedStream));
+            recoveryInfo = List.of(new MissionRecoveryInfo(recoveryStream));
         } else {
             if (secondaryStream.getDeliveryMethod() != PROGRESSIVE_HTTP) {
                 throw new IllegalArgumentException("Unsupported stream delivery format"

--- a/app/src/main/java/org/schabi/newpipe/download/MuxedAudioFallbackPolicy.java
+++ b/app/src/main/java/org/schabi/newpipe/download/MuxedAudioFallbackPolicy.java
@@ -1,0 +1,65 @@
+package org.schabi.newpipe.download;
+
+import static org.schabi.newpipe.extractor.stream.DeliveryMethod.PROGRESSIVE_HTTP;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+
+import java.util.List;
+
+final class MuxedAudioFallbackPolicy {
+    private MuxedAudioFallbackPolicy() {
+    }
+
+    static int findFallbackVideoIndex(@NonNull final List<VideoStream> streams) {
+        int selectedIndex = -1;
+        int selectedHeight = Integer.MAX_VALUE;
+        for (int i = 0; i < streams.size(); i++) {
+            final VideoStream stream = streams.get(i);
+            if (stream.isVideoOnly()
+                    || stream.getFormat() != MediaFormat.MPEG_4
+                    || stream.getDeliveryMethod() != PROGRESSIVE_HTTP) {
+                continue;
+            }
+
+            final int height = getHeight(stream);
+            if (selectedIndex < 0 || height < selectedHeight) {
+                selectedIndex = i;
+                selectedHeight = height;
+            }
+        }
+        return selectedIndex;
+    }
+
+    @NonNull
+    static AudioStream createFallbackAudioStream(@NonNull final VideoStream source) {
+        return new AudioStream.Builder()
+                .setId("muxed-audio:" + source.getId())
+                .setContent(source.getContent(), source.isUrl())
+                .setMediaFormat(MediaFormat.M4A)
+                .setDeliveryMethod(PROGRESSIVE_HTTP)
+                .setAverageBitrate(AudioStream.UNKNOWN_BITRATE)
+                .build();
+    }
+
+    private static int getHeight(@NonNull final VideoStream stream) {
+        if (stream.getHeight() > 0) {
+            return stream.getHeight();
+        }
+        final String resolution = stream.getResolution();
+        if (resolution != null) {
+            final int progressiveMarker = resolution.indexOf('p');
+            if (progressiveMarker > 0) {
+                try {
+                    return Integer.parseInt(resolution.substring(0, progressiveMarker));
+                } catch (final NumberFormatException ignored) {
+                    // Treat malformed resolutions as unknown and prefer any known smaller stream.
+                }
+            }
+        }
+        return Integer.MAX_VALUE;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/MaxHeightScrollView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/MaxHeightScrollView.java
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ScrollView;
+
+import androidx.annotation.Nullable;
+
+public final class MaxHeightScrollView extends ScrollView {
+    private static final float MAX_SCREEN_HEIGHT_FRACTION = 0.72f;
+
+    public MaxHeightScrollView(final Context context, @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
+        final int maximumHeight = Math.round(
+                getResources().getDisplayMetrics().heightPixels * MAX_SCREEN_HEIGHT_FRACTION);
+        final int availableHeight = MeasureSpec.getSize(heightMeasureSpec);
+        final int cappedHeight = MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.UNSPECIFIED
+                ? maximumHeight : Math.min(maximumHeight, availableHeight);
+        super.onMeasure(widthMeasureSpec,
+                MeasureSpec.makeMeasureSpec(cappedHeight, MeasureSpec.AT_MOST));
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/M4aFromMp4Demuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/M4aFromMp4Demuxer.java
@@ -1,0 +1,144 @@
+package us.shandian.giga.postprocessing;
+
+import android.media.MediaCodec;
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
+import android.media.MediaMuxer;
+
+import org.schabi.newpipe.streams.io.SharpStream;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+
+class M4aFromMp4Demuxer extends Postprocessing {
+    private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
+    private static final int COPY_BUFFER_SIZE = 128 * 1024;
+
+    M4aFromMp4Demuxer() {
+        super(false, false, ALGORITHM_M4A_FROM_MP4_DEMUXER);
+    }
+
+    @Override
+    int process(final SharpStream out, final SharpStream... sources) throws IOException {
+        final File outputFile = getTemporalFile();
+        if (outputFile == null) {
+            throw new IOException("M4A extraction temporary file is unavailable");
+        }
+        final File parent = outputFile.getParentFile();
+        if (parent != null && parent.getUsableSpace() <= getMission().storage.length()) {
+            throw new IOException("Not enough temporary storage for M4A extraction");
+        }
+
+        try {
+            extractAudio(outputFile);
+            replaceDownloadedFile(outputFile);
+            getMission().length = getMission().storage.length();
+            getMission().done = getMission().length;
+            return OK_RESULT;
+        } finally {
+            //noinspection ResultOfMethodCallIgnored
+            outputFile.delete();
+        }
+    }
+
+    private void extractAudio(final File outputFile) throws IOException {
+        final MediaExtractor extractor = new MediaExtractor();
+        MediaMuxer muxer = null;
+        boolean muxerStarted = false;
+        try (SharpStreamMediaDataSource source = new SharpStreamMediaDataSource(
+                getMission().storage.getStream(), getMission().storage.length())) {
+            extractor.setDataSource(source);
+            final int audioTrack = findAudioTrack(extractor);
+            extractor.selectTrack(audioTrack);
+            final MediaFormat inputFormat = extractor.getTrackFormat(audioTrack);
+            final long durationUs = inputFormat.containsKey(MediaFormat.KEY_DURATION)
+                    ? inputFormat.getLong(MediaFormat.KEY_DURATION) : -1;
+            final int bufferSize = inputFormat.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)
+                    ? Math.max(DEFAULT_BUFFER_SIZE,
+                            inputFormat.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE))
+                    : DEFAULT_BUFFER_SIZE;
+
+            muxer = new MediaMuxer(outputFile.getAbsolutePath(),
+                    MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
+            final int outputTrack = muxer.addTrack(inputFormat);
+            muxer.start();
+            muxerStarted = true;
+
+            final ByteBuffer buffer = ByteBuffer.allocateDirect(bufferSize);
+            final MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
+            while (true) {
+                throwIfInterrupted();
+                buffer.clear();
+                final int size = extractor.readSampleData(buffer, 0);
+                if (size < 0) {
+                    break;
+                }
+                info.set(0, size, extractor.getSampleTime(), extractor.getSampleFlags());
+                muxer.writeSampleData(outputTrack, buffer, info);
+                reportProgress(info.presentationTimeUs, durationUs);
+                extractor.advance();
+            }
+        } finally {
+            extractor.release();
+            if (muxer != null) {
+                if (muxerStarted) {
+                    muxer.stop();
+                }
+                muxer.release();
+            }
+        }
+    }
+
+    private static int findAudioTrack(final MediaExtractor extractor) throws IOException {
+        final String[] trackMimes = new String[extractor.getTrackCount()];
+        for (int i = 0; i < trackMimes.length; i++) {
+            trackMimes[i] = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME);
+        }
+        final int audioTrack = findAudioTrackIndex(trackMimes);
+        if (audioTrack < 0) {
+            throw new IOException("Downloaded MP4 contains no audio track");
+        }
+        return audioTrack;
+    }
+
+    static int findAudioTrackIndex(final String... trackMimes) {
+        for (int i = 0; i < trackMimes.length; i++) {
+            if (trackMimes[i] != null && trackMimes[i].startsWith("audio/")) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void reportProgress(final long presentationTimeUs, final long durationUs) {
+        if (durationUs <= 0 || presentationTimeUs < 0) {
+            return;
+        }
+        final long sourceLength = getMission().storage.length();
+        getMission().length = sourceLength;
+        getMission().done = Math.min(sourceLength, (long) (sourceLength
+                * Math.min(1.0d, (double) presentationTimeUs / durationUs)));
+    }
+
+    private void replaceDownloadedFile(final File extracted) throws IOException {
+        try (FileInputStream input = new FileInputStream(extracted);
+             SharpStream target = getMission().storage.openAndTruncateStream()) {
+            final byte[] buffer = new byte[COPY_BUFFER_SIZE];
+            int read;
+            while ((read = input.read(buffer)) >= 0) {
+                throwIfInterrupted();
+                target.write(buffer, 0, read);
+            }
+            target.flush();
+        }
+    }
+
+    private static void throwIfInterrupted() throws InterruptedIOException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedIOException("M4A extraction was cancelled");
+        }
+    }
+}

--- a/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
@@ -29,6 +29,7 @@ public abstract class Postprocessing implements Serializable {
     public transient static final String ALGORITHM_WEBM_MUXER = "webm";
     public transient static final String ALGORITHM_MP4_FROM_DASH_MUXER = "mp4D-mp4";
     public transient static final String ALGORITHM_M4A_NO_DASH = "mp4D-m4a";
+    public transient static final String ALGORITHM_M4A_FROM_MP4_DEMUXER = "mp4-m4a-d";
     public transient static final String ALGORITHM_OGG_FROM_WEBM_DEMUXER = "webm-ogg-d";
     public transient static final String ALGORITHM_MP3_FROM_AUDIO = "audio-mp3";
 
@@ -48,6 +49,9 @@ public abstract class Postprocessing implements Serializable {
                 break;
             case ALGORITHM_M4A_NO_DASH:
                 instance = new M4aNoDash();
+                break;
+            case ALGORITHM_M4A_FROM_MP4_DEMUXER:
+                instance = new M4aFromMp4Demuxer();
                 break;
             case ALGORITHM_OGG_FROM_WEBM_DEMUXER:
                 instance = new OggFromWebmDemuxer();

--- a/app/src/main/res/layout/download_dialog.xml
+++ b/app/src/main/res/layout/download_dialog.xml
@@ -1,18 +1,18 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:background="?attr/colorSurface">
 
     <include
         android:id="@+id/toolbar_layout"
         layout="@layout/toolbar_layout" />
 
-    <ScrollView
+    <org.schabi.newpipe.views.MaxHeightScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_below="@id/toolbar_layout"
-        android:fillViewport="true">
+        android:fillViewport="false">
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -227,6 +227,6 @@
         android:textSize="12sp" />
 
         </RelativeLayout>
-    </ScrollView>
+    </org.schabi.newpipe.views.MaxHeightScrollView>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1209,6 +1209,7 @@
     <string name="toggle_all">Toggle all</string>
     <string name="streams_not_yet_supported_removed">Streams which are not yet supported by the downloader are not shown</string>
     <string name="audio_track_present_in_video">An audio track should be already present in this stream</string>
+    <string name="audio_extracted_from_video_notice">Audio will be extracted from the smallest compatible video stream</string>
     <string name="selected_stream_external_player_not_supported">The selected stream is not supported by external players</string>
     <string name="no_audio_streams_available_for_external_players">No audio streams are available for external players</string>
     <string name="no_video_streams_available_for_external_players">No video streams are available for external players</string>

--- a/app/src/test/java/org/schabi/newpipe/download/MuxedAudioFallbackPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/download/MuxedAudioFallbackPolicyTest.java
@@ -1,0 +1,65 @@
+package org.schabi.newpipe.download;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.schabi.newpipe.extractor.stream.DeliveryMethod.DASH;
+import static org.schabi.newpipe.extractor.stream.DeliveryMethod.PROGRESSIVE_HTTP;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+
+import java.util.List;
+
+public class MuxedAudioFallbackPolicyTest {
+    @Test
+    public void selectsSmallestProgressiveMuxedMp4() {
+        final List<VideoStream> streams = List.of(
+                video("720", MediaFormat.MPEG_4, "720p", false, PROGRESSIVE_HTTP),
+                video("360", MediaFormat.MPEG_4, "360p", false, PROGRESSIVE_HTTP),
+                video("1080-video-only", MediaFormat.MPEG_4, "1080p", true,
+                        PROGRESSIVE_HTTP),
+                video("144-webm", MediaFormat.WEBM, "144p", false, PROGRESSIVE_HTTP),
+                video("240-dash", MediaFormat.MPEG_4, "240p", false, DASH));
+
+        assertEquals(1, MuxedAudioFallbackPolicy.findFallbackVideoIndex(streams));
+    }
+
+    @Test
+    public void returnsNoFallbackWithoutCompatibleMuxedMp4() {
+        assertEquals(-1, MuxedAudioFallbackPolicy.findFallbackVideoIndex(List.of(
+                video("video-only", MediaFormat.MPEG_4, "360p", true, PROGRESSIVE_HTTP),
+                video("webm", MediaFormat.WEBM, "144p", false, PROGRESSIVE_HTTP))));
+    }
+
+    @Test
+    public void createsM4aViewOfMuxedSource() {
+        final VideoStream source = video("18", MediaFormat.MPEG_4, "360p", false,
+                PROGRESSIVE_HTTP);
+
+        final AudioStream fallback = MuxedAudioFallbackPolicy.createFallbackAudioStream(source);
+
+        assertEquals("muxed-audio:18", fallback.getId());
+        assertEquals(source.getContent(), fallback.getContent());
+        assertTrue(fallback.isUrl());
+        assertEquals(MediaFormat.M4A, fallback.getFormat());
+        assertEquals(PROGRESSIVE_HTTP, fallback.getDeliveryMethod());
+    }
+
+    private static VideoStream video(final String id,
+                                     final MediaFormat format,
+                                     final String resolution,
+                                     final boolean videoOnly,
+                                     final org.schabi.newpipe.extractor.stream.DeliveryMethod
+                                             deliveryMethod) {
+        return new VideoStream.Builder()
+                .setId(id)
+                .setContent("https://example.com/" + id, true)
+                .setMediaFormat(format)
+                .setDeliveryMethod(deliveryMethod)
+                .setResolution(resolution)
+                .setIsVideoOnly(videoOnly)
+                .build();
+    }
+}

--- a/app/src/test/java/us/shandian/giga/postprocessing/M4aFromMp4DemuxerTest.java
+++ b/app/src/test/java/us/shandian/giga/postprocessing/M4aFromMp4DemuxerTest.java
@@ -1,0 +1,18 @@
+package us.shandian.giga.postprocessing;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+public class M4aFromMp4DemuxerTest {
+    @Test
+    public void findsAudioTrackAfterVideoTrack() {
+        assertEquals(1, M4aFromMp4Demuxer.findAudioTrackIndex(
+                "video/avc", "audio/mp4a-latm"));
+    }
+
+    @Test
+    public void returnsMinusOneWhenAudioTrackIsMissing() {
+        assertEquals(-1, M4aFromMp4Demuxer.findAudioTrackIndex(
+                "video/avc", "text/vtt"));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,9 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
+- Restored audio downloads when only muxed MP4 streams are available and made the download dialog
+  fit its content while remaining scrollable on smaller screens.
+
 - Stopped active or queued downloads immediately when their entries are deleted, while preserving
   the previous state when the deletion is undone.
 


### PR DESCRIPTION
- Restores the Audio option when no supported standalone audio stream is available
- Uses the smallest compatible progressive muxed MP4 as a transient fallback
- Extracts AAC to M4A without re-encoding for Original output
- Reuses the existing MP3 conversion pipeline for MP3 output
- Preserves recovery metadata, cancellation, progress, and temporary-file cleanup
- Makes the download dialog content-sized with an internal height-capped scroller
- Adds fallback-selection and audio-track regression tests

Fixes #215