### PR TITLE
Restore channel banner visibility

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/fragments/list/channel/ChannelHeaderLayoutTest.kt
@@ -14,6 +14,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.schabi.newpipe.R
+import org.schabi.newpipe.views.ChannelAppBarLayout
 
 @RunWith(AndroidJUnit4::class)
 class ChannelHeaderLayoutTest {
@@ -42,9 +43,14 @@ class ChannelHeaderLayoutTest {
         val bannerContainer = root.findViewById<View>(R.id.channel_banner_container)
         val banner = root.findViewById<ImageView>(R.id.channel_banner_image)
 
+        assertTrue(appBar is ChannelAppBarLayout)
+        assertEquals(View.GONE, bannerContainer.visibility)
         measureAndLayout(root, widthPixels, heightPixels)
-        if (!showBanner) {
-            bannerContainer.visibility = View.GONE
+
+        if (showBanner) {
+            // Channel banners arrive asynchronously with ChannelInfo. Exercise the real transition
+            // from no reserved banner space to a newly visible, measured banner.
+            bannerContainer.visibility = View.VISIBLE
             measureAndLayout(root, widthPixels, heightPixels)
         }
 

--- a/app/src/main/java/org/schabi/newpipe/views/ChannelAppBarLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ChannelAppBarLayout.java
@@ -1,0 +1,62 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.appbar.AppBarLayout;
+
+import org.schabi.newpipe.R;
+
+/**
+ * App bar used by channel pages to reveal a banner when it becomes available asynchronously.
+ *
+ * <p>The channel banner starts hidden so the header does not reserve empty space while channel
+ * metadata is loading. When a real banner is shown for the first time, this app bar expands once
+ * to prevent a restored/stale collapsed offset from keeping the newly loaded banner off-screen.
+ * Normal user scrolling is preserved after that first reveal.</p>
+ */
+public final class ChannelAppBarLayout extends AppBarLayout {
+    @Nullable
+    private View bannerContainer;
+    private boolean bannerWasVisible;
+
+    public ChannelAppBarLayout(@NonNull final Context context) {
+        super(context);
+    }
+
+    public ChannelAppBarLayout(@NonNull final Context context,
+                               @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        bannerContainer = findViewById(R.id.channel_banner_container);
+        bannerWasVisible = isBannerVisible();
+    }
+
+    @Override
+    protected void onLayout(final boolean changed, final int left, final int top,
+                            final int right, final int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        final boolean bannerVisible = isBannerVisible();
+        if (bannerVisible && !bannerWasVisible) {
+            // Run after this layout pass so AppBarLayout has already recomputed its scroll range
+            // with the newly visible banner.
+            post(() -> setExpanded(true, false));
+        }
+        bannerWasVisible = bannerVisible;
+    }
+
+    private boolean isBannerVisible() {
+        return bannerContainer != null
+                && bannerContainer.getVisibility() == View.VISIBLE
+                && bannerContainer.getHeight() > 0;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/ChannelAppBarLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ChannelAppBarLayout.java
@@ -46,12 +46,16 @@ public final class ChannelAppBarLayout extends AppBarLayout {
         super.onLayout(changed, left, top, right, bottom);
 
         final boolean bannerVisible = isBannerVisible();
-        if (bannerVisible && !bannerWasVisible) {
+        if (shouldExpandForBanner(bannerWasVisible, bannerVisible)) {
             // Run after this layout pass so AppBarLayout has already recomputed its scroll range
             // with the newly visible banner.
             post(() -> setExpanded(true, false));
         }
         bannerWasVisible = bannerVisible;
+    }
+
+    static boolean shouldExpandForBanner(final boolean wasVisible, final boolean isVisible) {
+        return !wasVisible && isVisible;
     }
 
     private boolean isBannerVisible() {

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -7,7 +7,7 @@
 
     <!-- since ToolbarTheme sets the tint to icons, it would make images all white,
     therefore app:tint="@null" is used to undo that setting -->
-    <com.google.android.material.appbar.AppBarLayout
+    <org.schabi.newpipe.views.ChannelAppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -19,7 +19,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fitsSystemWindows="true"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+            android:visibility="gone"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            tools:visibility="visible">
 
             <ImageView
                 android:id="@+id/channel_banner_image"
@@ -131,7 +133,7 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.appbar.AppBarLayout>
+    </org.schabi.newpipe.views.ChannelAppBarLayout>
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/test/java/org/schabi/newpipe/views/ChannelAppBarLayoutPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/views/ChannelAppBarLayoutPolicyTest.java
@@ -1,0 +1,16 @@
+package org.schabi.newpipe.views;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ChannelAppBarLayoutPolicyTest {
+    @Test
+    public void expandsOnlyWhenBannerBecomesVisible() {
+        assertTrue(ChannelAppBarLayout.shouldExpandForBanner(false, true));
+        assertFalse(ChannelAppBarLayout.shouldExpandForBanner(false, false));
+        assertFalse(ChannelAppBarLayout.shouldExpandForBanner(true, true));
+        assertFalse(ChannelAppBarLayout.shouldExpandForBanner(true, false));
+    }
+}


### PR DESCRIPTION
- Starts channel banner space hidden until a real banner is available
- Expands the channel AppBar once when a newly loaded banner first becomes visible so stale collapsed offsets cannot keep it hidden
- Preserves normal banner collapsing after the initial reveal and keeps channel metadata and Subscribe controls pinned
- Extends channel header coverage for the asynchronous hidden-to-visible banner transition and the expansion policy