### PR TITLE
Keep captions accessible on small screens

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayerSecondaryControlsLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayerSecondaryControlsLayoutTest.kt
@@ -1,0 +1,70 @@
+package org.schabi.newpipe.player.ui
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.HorizontalScrollView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.R
+
+@RunWith(AndroidJUnit4::class)
+class PlayerSecondaryControlsLayoutTest {
+    @Test
+    fun captionControlStaysVisibleAtNarrowPhoneWidth() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val context = ContextThemeWrapper(instrumentation.targetContext, R.style.LightTheme)
+            val root = LayoutInflater.from(context)
+                .inflate(R.layout.player, FrameLayout(context), false)
+
+            val secondaryControls =
+                root.findViewById<HorizontalScrollView>(R.id.secondaryControls)
+            val caption = root.findViewById<View>(R.id.captionTextView)
+
+            secondaryControls.visibility = View.VISIBLE
+            caption.visibility = View.VISIBLE
+
+            // Stress the row with every optional secondary action visible. Captions must remain in
+            // the initial viewport while later actions are still reachable by horizontal scrolling.
+            listOf(
+                R.id.playWithKodi,
+                R.id.openInBrowser,
+                R.id.share,
+                R.id.learningNoteButton,
+                R.id.sleepTimerButton,
+                R.id.equalizerButton,
+                R.id.listenModeButton,
+                R.id.switchMute,
+                R.id.fullScreenButton
+            ).forEach { root.findViewById<View>(it).visibility = View.VISIBLE }
+
+            measureAndLayout(root, dp(context, 320), dp(context, 180))
+
+            val content = secondaryControls.getChildAt(0)
+            val captionContainer = caption.parent as View
+            val captionRightInContent = captionContainer.left + caption.right
+
+            assertEquals(0, secondaryControls.scrollX)
+            assertTrue(caption.width >= dp(context, 50))
+            assertTrue(captionRightInContent <= secondaryControls.width)
+            assertTrue(content.width > secondaryControls.width)
+        }
+    }
+
+    private fun measureAndLayout(root: View, widthPixels: Int, heightPixels: Int) {
+        val width = View.MeasureSpec.makeMeasureSpec(widthPixels, View.MeasureSpec.EXACTLY)
+        val height = View.MeasureSpec.makeMeasureSpec(heightPixels, View.MeasureSpec.EXACTLY)
+        root.measure(width, height)
+        root.layout(0, 0, root.measuredWidth, root.measuredHeight)
+    }
+
+    private fun dp(context: Context, value: Int): Int =
+        (value * context.resources.displayMetrics.density).toInt()
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayerSecondaryControlsLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayerSecondaryControlsLayoutTest.kt
@@ -24,10 +24,12 @@ class PlayerSecondaryControlsLayoutTest {
             val root = LayoutInflater.from(context)
                 .inflate(R.layout.player, FrameLayout(context), false)
 
+            val playbackControlRoot = root.findViewById<View>(R.id.playbackControlRoot)
             val secondaryControls =
                 root.findViewById<HorizontalScrollView>(R.id.secondaryControls)
             val caption = root.findViewById<View>(R.id.captionTextView)
 
+            playbackControlRoot.visibility = View.VISIBLE
             secondaryControls.visibility = View.VISIBLE
             caption.visibility = View.VISIBLE
 
@@ -65,6 +67,7 @@ class PlayerSecondaryControlsLayoutTest {
         root.layout(0, 0, root.measuredWidth, root.measuredHeight)
     }
 
-    private fun dp(context: Context, value: Int): Int =
-        (value * context.resources.displayMetrics.density).toInt()
+    private fun dp(context: Context, value: Int): Int {
+        return (value * context.resources.displayMetrics.density).toInt()
+    }
 }

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -284,186 +284,194 @@
 
                 </LinearLayout>
 
-                <LinearLayout
+                <HorizontalScrollView
                     android:id="@+id/secondaryControls"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="top"
+                    android:fillViewport="true"
+                    android:overScrollMode="ifContentScrolls"
+                    android:scrollbars="none"
                     android:visibility="invisible"
                     tools:ignore="RtlHardcoded"
                     tools:visibility="visible">
 
-                    <org.schabi.newpipe.views.NewPipeTextView
-                        android:id="@+id/resizeTextView"
+                    <LinearLayout
                         android:layout_width="wrap_content"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackground"
-                        android:gravity="center"
-                        android:minWidth="50dp"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:textColor="@android:color/white"
-                        android:textStyle="bold"
-                        tools:ignore="HardcodedText,RtlHardcoded"
-                        tools:text="FIT" />
-
-                    <FrameLayout
-                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_weight="3">
+                        android:gravity="top"
+                        android:orientation="horizontal">
 
                         <org.schabi.newpipe.views.NewPipeTextView
-                            android:id="@+id/captionTextView"
+                            android:id="@+id/resizeTextView"
                             android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
+                            android:layout_height="35dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackground"
-                            android:ellipsize="end"
-                            android:gravity="center|left"
-                            android:lines="1"
+                            android:gravity="center"
                             android:minWidth="50dp"
-                            android:minHeight="35dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:textColor="@android:color/white"
                             android:textStyle="bold"
-                            tools:ignore="RelativeOverlap,RtlHardcoded"
-                            tools:text="English" />
+                            tools:ignore="HardcodedText,RtlHardcoded"
+                            tools:text="FIT" />
 
-                    </FrameLayout>
+                        <FrameLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content">
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/playWithKodi"
-                        android:layout_width="wrap_content"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/play_with_kodi_title"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitXY"
-                        android:src="@drawable/ic_cast"
-                        app:tint="@color/white"
-                        tools:ignore="RtlHardcoded" />
+                            <org.schabi.newpipe.views.NewPipeTextView
+                                android:id="@+id/captionTextView"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="8dp"
+                                android:background="?attr/selectableItemBackground"
+                                android:ellipsize="end"
+                                android:gravity="center|left"
+                                android:lines="1"
+                                android:minWidth="50dp"
+                                android:minHeight="35dp"
+                                android:padding="@dimen/player_main_buttons_padding"
+                                android:textColor="@android:color/white"
+                                android:textStyle="bold"
+                                tools:ignore="RelativeOverlap,RtlHardcoded"
+                                tools:text="English" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/openInBrowser"
-                        android:layout_width="wrap_content"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/open_in_browser"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitXY"
-                        android:src="@drawable/ic_language"
-                        app:tint="@color/white"
-                        tools:ignore="RtlHardcoded" />
+                        </FrameLayout>
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/share"
-                        android:layout_width="wrap_content"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/share"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitXY"
-                        android:src="@drawable/ic_share"
-                        app:tint="@color/white"
-                        tools:ignore="RtlHardcoded" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/playWithKodi"
+                            android:layout_width="wrap_content"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/play_with_kodi_title"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitXY"
+                            android:src="@drawable/ic_cast"
+                            app:tint="@color/white"
+                            tools:ignore="RtlHardcoded" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/learningNoteButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/learning_note_add"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitCenter"
-                        android:src="@drawable/ic_edit"
-                        android:visibility="gone"
-                        app:tint="@color/white" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/openInBrowser"
+                            android:layout_width="wrap_content"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/open_in_browser"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitXY"
+                            android:src="@drawable/ic_language"
+                            app:tint="@color/white"
+                            tools:ignore="RtlHardcoded" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/sleepTimerButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/sleep_timer"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitCenter"
-                        android:src="@drawable/ic_sleep_timer"
-                        app:tint="@color/white" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/share"
+                            android:layout_width="wrap_content"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/share"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitXY"
+                            android:src="@drawable/ic_share"
+                            app:tint="@color/white"
+                            tools:ignore="RtlHardcoded" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/equalizerButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/equalizer"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitCenter"
-                        android:src="@drawable/ic_equalizer"
-                        app:tint="@color/white" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/learningNoteButton"
+                            android:layout_width="35dp"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/learning_note_add"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/ic_edit"
+                            android:visibility="gone"
+                            app:tint="@color/white" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/listenModeButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
-                        android:layout_marginEnd="8dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/enter_listen_mode"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitCenter"
-                        android:src="@drawable/ic_waveform"
-                        app:tint="@color/white" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/sleepTimerButton"
+                            android:layout_width="35dp"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/sleep_timer"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/ic_sleep_timer"
+                            app:tint="@color/white" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/switchMute"
-                        android:layout_width="wrap_content"
-                        android:layout_height="37dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/mute"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitXY"
-                        android:src="@drawable/ic_volume_off"
-                        app:tint="@color/white"
-                        tools:ignore="RtlHardcoded" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/equalizerButton"
+                            android:layout_width="35dp"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/equalizer"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/ic_equalizer"
+                            app:tint="@color/white" />
 
-                    <androidx.appcompat.widget.AppCompatImageButton
-                        android:id="@+id/fullScreenButton"
-                        android:layout_width="40dp"
-                        android:layout_height="40dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:clickable="true"
-                        android:contentDescription="@string/toggle_fullscreen"
-                        android:focusable="true"
-                        android:padding="@dimen/player_main_buttons_padding"
-                        android:scaleType="fitCenter"
-                        android:src="@drawable/ic_fullscreen"
-                        android:visibility="gone"
-                        app:tint="@color/white"
-                        tools:ignore="RtlHardcoded"
-                        tools:visibility="visible" />
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/listenModeButton"
+                            android:layout_width="35dp"
+                            android:layout_height="35dp"
+                            android:layout_marginEnd="8dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/enter_listen_mode"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/ic_waveform"
+                            app:tint="@color/white" />
 
-                </LinearLayout>
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/switchMute"
+                            android:layout_width="wrap_content"
+                            android:layout_height="37dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/mute"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitXY"
+                            android:src="@drawable/ic_volume_off"
+                            app:tint="@color/white"
+                            tools:ignore="RtlHardcoded" />
+
+                        <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/fullScreenButton"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:clickable="true"
+                            android:contentDescription="@string/toggle_fullscreen"
+                            android:focusable="true"
+                            android:padding="@dimen/player_main_buttons_padding"
+                            android:scaleType="fitCenter"
+                            android:src="@drawable/ic_fullscreen"
+                            android:visibility="gone"
+                            app:tint="@color/white"
+                            tools:ignore="RtlHardcoded"
+                            tools:visibility="visible" />
+
+                    </LinearLayout>
+                </HorizontalScrollView>
 
                 <org.schabi.newpipe.views.NewPipeTextView
                     android:id="@+id/sleepTimerCountdown"


### PR DESCRIPTION
- Makes the expanded secondary player controls horizontally scrollable when they exceed the available width
- Keeps Resize and Captions at the start of the row so Captions remains immediately visible on narrow phones
- Removes the zero-width weighted caption slot that could collapse when newer fixed-width controls filled the row
- Preserves every existing secondary player action and normal wide-screen behavior
- Adds a 320 dp regression test with all optional secondary controls visible to verify Captions stays in the initial viewport while later controls remain reachable by scrolling
- Fixes #212