### PR TITLE
Fix YouTube cross-client playback fallback

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeDiagnosticStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeDiagnosticStreamExtractor.java
@@ -65,6 +65,8 @@ public final class YoutubeDiagnosticStreamExtractor
                 "androidStreamingData", requestedVideoId);
         appendClient(summary, "ios", "iosPlayerResponse",
                 "iosStreamingData", requestedVideoId);
+        appendClient(summary, "visionos", "visionOsPlayerResponse",
+                "visionOsStreamingData", requestedVideoId);
         appendClient(summary, "safari", "safariPlayerResponse",
                 "safariStreamingData", requestedVideoId);
         appendClient(summary, "tvhtml5", "tvHtml5EmbedPlayerResponse",

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1514,17 +1514,17 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     }
 
     private boolean hasUsablePlaybackData(@Nonnull final JsonObject response) {
-        return hasUsablePlaybackData(response.getObject(STREAMING_DATA));
+        return hasUsableStreamingData(response.getObject(STREAMING_DATA));
     }
 
     private boolean hasAnyUsablePlaybackData() {
         return Arrays.asList(visionOsStreamingData, safariStreamingData, iosStreamingData,
                         tvHtml5SimplyEmbedStreamingData, androidStreamingData, webStreamingData)
                 .stream()
-                .anyMatch(this::hasUsablePlaybackData);
+                .anyMatch(this::hasUsableStreamingData);
     }
 
-    private boolean hasUsablePlaybackData(@Nullable final JsonObject streamingData) {
+    private boolean hasUsableStreamingData(@Nullable final JsonObject streamingData) {
         if (streamingData == null || streamingData.isEmpty()) {
             return false;
         }
@@ -1569,7 +1569,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             if (streamingData == null || streamingData.isEmpty()) {
                 continue;
             }
-            if (hasUsablePlaybackData(streamingData)) {
+            if (hasUsableStreamingData(streamingData)) {
                 return false;
             }
             final JsonArray adaptive = streamingData.getArray(ADAPTIVE_FORMATS);

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -79,6 +79,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
     private JsonObject androidPlayerResponse;
     private JsonObject iosPlayerResponse;
+    private JsonObject visionOsPlayerResponse;
     private JsonObject safariPlayerResponse;
     private JsonObject tvHtml5EmbedPlayerResponse;
 
@@ -1362,6 +1363,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         playerResponse = null;
         androidPlayerResponse = null;
         iosPlayerResponse = null;
+        visionOsPlayerResponse = null;
         safariPlayerResponse = null;
         tvHtml5EmbedPlayerResponse = null;
         androidStreamingData = null;
@@ -1490,15 +1492,16 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         // Keep the authoritative response deterministic: prefer the Android response used for
         // playback upstream, then deliberate playback fallbacks. WEB is fetched for metadata by
         // YoutubeParsingHelper and must not replace playback state with a temporary reload error.
-        for (final JsonObject response : Arrays.asList(androidPlayerResponse, safariPlayerResponse,
-                iosPlayerResponse, tvHtml5EmbedPlayerResponse)) {
+        for (final JsonObject response : Arrays.asList(androidPlayerResponse,
+                visionOsPlayerResponse, safariPlayerResponse, iosPlayerResponse,
+                tvHtml5EmbedPlayerResponse)) {
             if (response == null || isPlayerResponseNotValid(response, videoId)) {
                 continue;
             }
             final JsonObject playabilityStatus = response.getObject("playabilityStatus");
             final String status = playabilityStatus.getString("status");
             if ((status == null || status.equalsIgnoreCase("ok"))
-                    && hasUsablePlaybackData(response)) {
+                    && (hasUsablePlaybackData(response) || hasAnyUsablePlaybackData())) {
                 playerResponse = response;
                 if (isNullOrEmpty(playerCaptionsTracklistRenderer)) {
                     playerCaptionsTracklistRenderer = response.getObject("captions")
@@ -1511,7 +1514,17 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     }
 
     private boolean hasUsablePlaybackData(@Nonnull final JsonObject response) {
-        final JsonObject streamingData = response.getObject(STREAMING_DATA);
+        return hasUsablePlaybackData(response.getObject(STREAMING_DATA));
+    }
+
+    private boolean hasAnyUsablePlaybackData() {
+        return Arrays.asList(visionOsStreamingData, safariStreamingData, iosStreamingData,
+                        tvHtml5SimplyEmbedStreamingData, androidStreamingData, webStreamingData)
+                .stream()
+                .anyMatch(this::hasUsablePlaybackData);
+    }
+
+    private boolean hasUsablePlaybackData(@Nullable final JsonObject streamingData) {
         if (streamingData == null || streamingData.isEmpty()) {
             return false;
         }
@@ -1537,8 +1550,9 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     private void selectPrimaryErrorResponse(@Nonnull final String videoId) {
         // If no playable response exists after all deliberate fallbacks, report the primary
         // client's genuine playability error through the existing checkPlayabilityStatus logic.
-        for (final JsonObject response : Arrays.asList(androidPlayerResponse, safariPlayerResponse,
-                iosPlayerResponse, tvHtml5EmbedPlayerResponse)) {
+        for (final JsonObject response : Arrays.asList(androidPlayerResponse,
+                visionOsPlayerResponse, safariPlayerResponse, iosPlayerResponse,
+                tvHtml5EmbedPlayerResponse)) {
             if (response != null && !isPlayerResponseNotValid(response, videoId)) {
                 playerResponse = response;
                 return;
@@ -1547,26 +1561,22 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     }
 
     private boolean isSabrOnlyResponse() {
-        for (final JsonObject sd : Arrays.asList(
+        boolean foundSabrData = false;
+        for (final JsonObject streamingData : Arrays.asList(
                 safariStreamingData, androidStreamingData,
                 visionOsStreamingData, iosStreamingData, webStreamingData,
                 tvHtml5SimplyEmbedStreamingData)) {
-            if (sd == null) {
+            if (streamingData == null || streamingData.isEmpty()) {
                 continue;
             }
-            final JsonArray adaptive = sd.getArray(ADAPTIVE_FORMATS);
-            if (adaptive == null || adaptive.isEmpty()) {
-                continue;
+            if (hasUsablePlaybackData(streamingData)) {
+                return false;
             }
-            for (int i = 0; i < adaptive.size(); i++) {
-                final JsonObject fmt = adaptive.getObject(i);
-                if (fmt.has("url") || fmt.has(SIGNATURE_CIPHER) || fmt.has(CIPHER)) {
-                    return false;
-                }
-            }
-            return true;
+            final JsonArray adaptive = streamingData.getArray(ADAPTIVE_FORMATS);
+            foundSabrData |= (adaptive != null && !adaptive.isEmpty())
+                    || !isNullOrEmpty(streamingData.getString("serverAbrStreamingUrl"));
         }
-        return false;
+        return foundSabrData;
     }
 
 
@@ -1797,7 +1807,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             @Override
             public void onSuccess(final Response response) {
                 try {
-                    final JsonObject visionOsPlayerResponse = JsonUtils.toJsonObject(
+                    visionOsPlayerResponse = JsonUtils.toJsonObject(
                             getValidJsonResponseBody(response));
                     if (isPlayerResponseNotValid(visionOsPlayerResponse, videoId)) {
                         return;

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractorTest.java
@@ -46,6 +46,37 @@ public class YoutubeStreamExtractorTest {
         assertEquals(5, countOccurrences(source, "getPreferredStreamingData()"));
     }
 
+    @Test
+    public void playableMetadataCanUseConventionalStreamsFromAnotherClient()
+            throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/extractor/services/youtube/extractors/"
+                        + "YoutubeStreamExtractor.java"));
+
+        assertTrue(source.contains("private JsonObject visionOsPlayerResponse;"));
+        assertTrue(source.contains("visionOsPlayerResponse = JsonUtils.toJsonObject("));
+        assertTrue(source.contains("hasUsablePlaybackData(response)"
+                + " || hasAnyUsablePlaybackData()"));
+        assertTrue(source.contains("visionOsPlayerResponse, safariPlayerResponse"));
+        assertTrue(source.contains("if (hasUsableStreamingData(streamingData)) {"
+                + System.lineSeparator() + "                return false;"));
+        assertTrue(source.contains("return foundSabrData;"));
+    }
+
+    @Test
+    public void diagnosticsIncludeVisionOsFallback() throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/extractor/services/youtube/extractors/"
+                        + "YoutubeDiagnosticStreamExtractor.java"));
+
+        assertTrue(source.contains("\"visionos\", \"visionOsPlayerResponse\""));
+        assertTrue(source.contains("\"visionOsStreamingData\", requestedVideoId"));
+    }
+
     private static int countOccurrences(final String source, final String value) {
         int count = 0;
         int offset = 0;

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Fixes
+
+- Fixed videos being reported unavailable when YouTube rejected the Android client but returned
+  valid metadata and conventional streams through separate fallback clients.
+
 ## WizeStream 1.10.1 (`1010001`)
 
 ### Improvements


### PR DESCRIPTION
- Retain the validated VisionOS player response and include it in playable-response selection
- Allow valid YouTube metadata and conventional stream URLs to come from separate fallback clients
- Check every collected client response before classifying playback data as SABR-only
- Extend extractor diagnostics with VisionOS response and streaming-data details
- Add regression coverage for the fallback combination reported in issue #227
- Document the playback availability fix in the unreleased changelog