### PR TITLE
Bound persistent database growth

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
@@ -7,8 +7,8 @@ package org.schabi.newpipe.database
 
 import android.content.Context
 import io.reactivex.rxjava3.core.Single
-import java.util.concurrent.Callable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import java.util.concurrent.Callable
 import org.schabi.newpipe.NewPipeDatabase
 import org.schabi.newpipe.sync.DeviceSyncManager
 

--- a/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.database
+
+import android.content.Context
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.sync.DeviceSyncManager
+
+data class DatabaseCleanupResult(
+    val feedRows: Int,
+    val feedUpdateRows: Int,
+    val orphanStreamRows: Int,
+    val syncRows: Int
+) {
+    val deletedRows: Int
+        get() = feedRows + feedUpdateRows + orphanStreamRows + syncRows
+}
+
+class DatabaseMaintenanceManager(context: Context) {
+    private val applicationContext = context.applicationContext
+    private val database = NewPipeDatabase.getInstance(applicationContext)
+
+    fun clearPersistentCaches(): Single<DatabaseCleanupResult> {
+        return Single.fromCallable {
+            val result = database.runInTransaction<DatabaseCleanupResult> {
+                val feedRows = database.feedDAO().deleteAll()
+                val feedUpdateRows = database.feedDAO().deleteAllLastUpdated()
+                val orphanStreamRows = database.streamDAO().deleteOrphans()
+                val syncRows = resetSyncJournalsWhenUnpaired()
+                DatabaseCleanupResult(
+                    feedRows,
+                    feedUpdateRows,
+                    orphanStreamRows,
+                    syncRows
+                )
+            }
+            database.openHelper.writableDatabase.apply {
+                query("PRAGMA wal_checkpoint(TRUNCATE)").close()
+                execSQL("PRAGMA optimize")
+            }
+            result
+        }.subscribeOn(Schedulers.io())
+    }
+
+    fun compactUnpairedSyncJournals(): Single<Int> {
+        return Single.fromCallable {
+            database.runInTransaction<Int> {
+                resetSyncJournalsWhenUnpaired()
+            }
+        }.subscribeOn(Schedulers.io())
+    }
+
+    private fun resetSyncJournalsWhenUnpaired(): Int {
+        if (DeviceSyncManager.hasTrustedPeers(applicationContext)) {
+            return 0
+        }
+
+        val subscriptionDao = database.subscriptionSyncDAO()
+        val historyDao = database.historySyncDAO()
+        return subscriptionDao.deleteAllChanges() +
+            subscriptionDao.deleteAllRecords() +
+            subscriptionDao.deleteAllOriginStates() +
+            historyDao.deleteAllChanges() +
+            historyDao.deleteAllRecords() +
+            historyDao.deleteAllOriginStates() +
+            historyDao.deleteAllPeerStates()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
@@ -7,6 +7,7 @@ package org.schabi.newpipe.database
 
 import android.content.Context
 import io.reactivex.rxjava3.core.Single
+import java.util.concurrent.Callable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.NewPipeDatabase
 import org.schabi.newpipe.sync.DeviceSyncManager
@@ -27,7 +28,7 @@ class DatabaseMaintenanceManager(context: Context) {
 
     fun clearPersistentCaches(): Single<DatabaseCleanupResult> {
         return Single.fromCallable {
-            val result = database.runInTransaction<DatabaseCleanupResult> {
+            val result = database.runInTransaction(Callable {
                 val feedRows = database.feedDAO().deleteAll()
                 val feedUpdateRows = database.feedDAO().deleteAllLastUpdated()
                 val orphanStreamRows = database.streamDAO().deleteOrphans()
@@ -38,7 +39,7 @@ class DatabaseMaintenanceManager(context: Context) {
                     orphanStreamRows,
                     syncRows
                 )
-            }
+            })
             database.openHelper.writableDatabase.apply {
                 query("PRAGMA wal_checkpoint(TRUNCATE)").close()
                 execSQL("PRAGMA optimize")
@@ -49,9 +50,9 @@ class DatabaseMaintenanceManager(context: Context) {
 
     fun compactUnpairedSyncJournals(): Single<Int> {
         return Single.fromCallable {
-            database.runInTransaction<Int> {
+            database.runInTransaction(Callable {
                 resetSyncJournalsWhenUnpaired()
-            }
+            })
         }.subscribeOn(Schedulers.io())
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/feed/dao/FeedDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/feed/dao/FeedDAO.kt
@@ -21,6 +21,9 @@ abstract class FeedDAO {
     @Query("DELETE FROM feed")
     abstract fun deleteAll(): Int
 
+    @Query("DELETE FROM feed_last_updated")
+    abstract fun deleteAllLastUpdated(): Int
+
     /**
      * @param groupId          the group id to get feed streams of; use
      *                         [FeedGroupEntity.GROUP_ALL_ID] to not filter by group

--- a/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
@@ -125,6 +125,9 @@ abstract class StreamDAO : BasicDAO<StreamEntity> {
         NOT EXISTS (SELECT 1 FROM stream_history sh
         WHERE sh.stream_id = streams.uid)
 
+        AND NOT EXISTS (SELECT 1 FROM stream_state ss
+        WHERE ss.stream_id = streams.uid)
+
         AND NOT EXISTS (SELECT 1 FROM playlist_stream_join ps
         WHERE ps.stream_id = streams.uid)
 

--- a/app/src/main/java/org/schabi/newpipe/database/sync/HistorySyncDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/sync/HistorySyncDAO.kt
@@ -128,6 +128,18 @@ abstract class HistorySyncDAO {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun upsertPeerState(state: HistorySyncPeerStateEntity)
 
+    @Query("DELETE FROM history_sync_changes")
+    abstract fun deleteAllChanges(): Int
+
+    @Query("DELETE FROM history_sync_records")
+    abstract fun deleteAllRecords(): Int
+
+    @Query("DELETE FROM history_sync_origin_state")
+    abstract fun deleteAllOriginStates(): Int
+
+    @Query("DELETE FROM history_sync_peer_state")
+    abstract fun deleteAllPeerStates(): Int
+
     @Query(
         """
         DELETE FROM history_sync_peer_state

--- a/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/sync/SubscriptionSyncDAO.kt
@@ -82,6 +82,15 @@ abstract class SubscriptionSyncDAO {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun upsertPeerState(state: SubscriptionSyncPeerStateEntity)
 
+    @Query("DELETE FROM subscription_sync_changes")
+    abstract fun deleteAllChanges(): Int
+
+    @Query("DELETE FROM subscription_sync_records")
+    abstract fun deleteAllRecords(): Int
+
+    @Query("DELETE FROM subscription_sync_origin_state")
+    abstract fun deleteAllOriginStates(): Int
+
     @Query("DELETE FROM subscription_sync_peer_state")
     abstract fun deleteAllPeerStates()
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/HistorySettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/HistorySettingsFragment.java
@@ -11,6 +11,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.schabi.newpipe.DownloaderImpl;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.database.DatabaseMaintenanceManager;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.ReCaptchaActivity;
@@ -28,6 +29,7 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
     private String playbackStatesClearKey;
     private String searchHistoryClearKey;
     private HistoryRecordManager recordManager;
+    private DatabaseMaintenanceManager maintenanceManager;
     private CompositeDisposable disposables;
 
     @Override
@@ -39,6 +41,7 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
         playbackStatesClearKey = getString(R.string.clear_playback_states_key);
         searchHistoryClearKey = getString(R.string.clear_search_history_key);
         recordManager = new HistoryRecordManager(getActivity());
+        maintenanceManager = new DatabaseMaintenanceManager(requireContext());
         disposables = new CompositeDisposable();
 
         final Preference clearCookiePref = requirePreference(R.string.clear_cookie_key);
@@ -61,8 +64,15 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
     public boolean onPreferenceTreeClick(final Preference preference) {
         if (preference.getKey().equals(cacheWipeKey)) {
             InfoCache.getInstance().clearCache();
-            Toast.makeText(requireContext(),
-                    R.string.metadata_cache_wipe_complete_notice, Toast.LENGTH_SHORT).show();
+            disposables.add(maintenanceManager.clearPersistentCaches()
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(
+                            result -> Toast.makeText(requireContext(),
+                                    R.string.metadata_cache_wipe_complete_notice,
+                                    Toast.LENGTH_SHORT).show(),
+                            throwable -> ErrorUtil.openActivity(requireContext(),
+                                    new ErrorInfo(throwable, UserAction.DELETE_FROM_HISTORY,
+                                            "Clear persistent caches"))));
         } else if (preference.getKey().equals(viewsHistoryClearKey)) {
             openDeleteWatchHistoryDialog(requireContext(), recordManager, disposables);
         } else if (preference.getKey().equals(playbackStatesClearKey)) {

--- a/app/src/main/java/org/schabi/newpipe/settings/HistorySettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/HistorySettingsFragment.java
@@ -90,8 +90,11 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
         return recordManager.deleteCompleteStreamStateHistory()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        howManyDeleted -> Toast.makeText(context,
-                                R.string.watch_history_states_deleted,  Toast.LENGTH_SHORT).show(),
+                        howManyDeleted -> {
+                            Toast.makeText(context, R.string.watch_history_states_deleted,
+                                    Toast.LENGTH_SHORT).show();
+                            compactUnpairedSyncJournals(context);
+                        },
                         throwable -> ErrorUtil.openActivity(context,
                                 new ErrorInfo(throwable, UserAction.DELETE_FROM_HISTORY,
                                         "Delete playback states")));
@@ -102,8 +105,11 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
         return recordManager.deleteWholeStreamHistory()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        howManyDeleted -> Toast.makeText(context,
-                                R.string.watch_history_deleted, Toast.LENGTH_SHORT).show(),
+                        howManyDeleted -> {
+                            Toast.makeText(context, R.string.watch_history_deleted,
+                                    Toast.LENGTH_SHORT).show();
+                            compactUnpairedSyncJournals(context);
+                        },
                         throwable -> ErrorUtil.openActivity(context,
                                 new ErrorInfo(throwable, UserAction.DELETE_FROM_HISTORY,
                                         "Delete from history")));
@@ -125,11 +131,23 @@ public class HistorySettingsFragment extends BasePreferenceFragment {
         return recordManager.deleteCompleteSearchHistory()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        howManyDeleted -> Toast.makeText(context,
-                                R.string.search_history_deleted, Toast.LENGTH_SHORT).show(),
+                        howManyDeleted -> {
+                            Toast.makeText(context, R.string.search_history_deleted,
+                                    Toast.LENGTH_SHORT).show();
+                            compactUnpairedSyncJournals(context);
+                        },
                         throwable -> ErrorUtil.openActivity(context,
                                 new ErrorInfo(throwable, UserAction.DELETE_FROM_HISTORY,
                                         "Delete search history")));
+    }
+
+    private static void compactUnpairedSyncJournals(@NonNull final Context context) {
+        new DatabaseMaintenanceManager(context).compactUnpairedSyncJournals()
+                .subscribe(
+                        ignored -> { },
+                        throwable -> ErrorUtil.openActivity(context,
+                                new ErrorInfo(throwable, UserAction.DELETE_FROM_HISTORY,
+                                        "Compact synchronization journals")));
     }
 
     public static void openDeleteWatchHistoryDialog(@NonNull final Context context,

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
+- Bounded persistent database growth by clearing feed caches and unreferenced stream metadata,
+  compacting inactive sync journals while preserving paired-device synchronization state.
 - Fixed videos being reported unavailable when YouTube rejected the Android client but returned
   valid metadata and conventional streams through separate fallback clients.
 


### PR DESCRIPTION
- Clear persistent feed rows, feed refresh timestamps, and genuinely orphaned stream metadata through the existing metadata-cache action.
- Preserve streams referenced by playback positions, history, playlists, feeds, and Learning Mode data.
- Compact subscription and history sync journals only when no trusted peers exist, preserving active paired-device synchronization state.
- Checkpoint the write-ahead log and optimize SQLite after manual cache maintenance.
- Compact inactive sync journals after local history-clearing operations and document the fix in the changelog.