### PR TITLE
Fix database maintenance Kotlin formatting

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
@@ -28,7 +28,8 @@ class DatabaseMaintenanceManager(context: Context) {
 
     fun clearPersistentCaches(): Single<DatabaseCleanupResult> {
         return Single.fromCallable {
-            val result = database.runInTransaction(Callable {
+            val result = database.runInTransaction(
+                Callable {
                 val feedRows = database.feedDAO().deleteAll()
                 val feedUpdateRows = database.feedDAO().deleteAllLastUpdated()
                 val orphanStreamRows = database.streamDAO().deleteOrphans()
@@ -39,7 +40,8 @@ class DatabaseMaintenanceManager(context: Context) {
                     orphanStreamRows,
                     syncRows
                 )
-            })
+                }
+            )
             database.openHelper.writableDatabase.apply {
                 query("PRAGMA wal_checkpoint(TRUNCATE)").close()
                 execSQL("PRAGMA optimize")
@@ -50,9 +52,11 @@ class DatabaseMaintenanceManager(context: Context) {
 
     fun compactUnpairedSyncJournals(): Single<Int> {
         return Single.fromCallable {
-            database.runInTransaction(Callable {
-                resetSyncJournalsWhenUnpaired()
-            })
+            database.runInTransaction(
+                Callable {
+                    resetSyncJournalsWhenUnpaired()
+                }
+            )
         }.subscribeOn(Schedulers.io())
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/DatabaseMaintenanceManager.kt
@@ -30,16 +30,16 @@ class DatabaseMaintenanceManager(context: Context) {
         return Single.fromCallable {
             val result = database.runInTransaction(
                 Callable {
-                val feedRows = database.feedDAO().deleteAll()
-                val feedUpdateRows = database.feedDAO().deleteAllLastUpdated()
-                val orphanStreamRows = database.streamDAO().deleteOrphans()
-                val syncRows = resetSyncJournalsWhenUnpaired()
-                DatabaseCleanupResult(
-                    feedRows,
-                    feedUpdateRows,
-                    orphanStreamRows,
-                    syncRows
-                )
+                    val feedRows = database.feedDAO().deleteAll()
+                    val feedUpdateRows = database.feedDAO().deleteAllLastUpdated()
+                    val orphanStreamRows = database.streamDAO().deleteOrphans()
+                    val syncRows = resetSyncJournalsWhenUnpaired()
+                    DatabaseCleanupResult(
+                        feedRows,
+                        feedUpdateRows,
+                        orphanStreamRows,
+                        syncRows
+                    )
                 }
             )
             database.openHelper.writableDatabase.apply {


### PR DESCRIPTION
- Wrap both Room transaction `Callable` arguments according to the project’s Kotlin formatting rules.
- Align the persistent-cleanup transaction body without changing runtime behavior.
- Resolve the four `standard:wrapping` violations that failed the merged build.