### PR TITLE
Restore conventional YouTube stream extraction

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -47,6 +47,7 @@ import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.channel.ChannelTabInfo;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.kiosk.KioskInfo;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
@@ -72,6 +73,8 @@ public final class ExtractorHelper {
     private static final String TAG = ExtractorHelper.class.getSimpleName();
     private static final String RETURN_YOUTUBE_DISLIKE_VOTES_URL =
             "https://returnyoutubedislikeapi.com/votes?videoId=";
+    private static final String YOUTUBE_RELOAD_REQUIRED_MESSAGE =
+            "The page needs to be reloaded.";
     private static final InfoCache CACHE = InfoCache.getInstance();
 
     private ExtractorHelper() {
@@ -230,10 +233,29 @@ public final class ExtractorHelper {
     @NonNull
     private static StreamInfo getStreamInfoFromNetwork(final int serviceId,
                                                        final String url) throws Exception {
-        final StreamInfo streamInfo = StreamInfo.getInfo(NewPipe.getService(serviceId), url);
+        StreamInfo streamInfo;
+        try {
+            streamInfo = StreamInfo.getInfo(NewPipe.getService(serviceId), url);
+        } catch (final ContentNotAvailableException error) {
+            if (!isTransientYouTubeReloadError(serviceId, error)) {
+                throw error;
+            }
+            Log.i(TAG, "Retrying YouTube extraction after a transient reload response");
+            streamInfo = StreamInfo.getInfo(NewPipe.getService(serviceId), url);
+        }
         backfillYouTubeRatingsAndViewCount(serviceId, streamInfo);
         backfillYouTubeUploaderAvatarFromChannel(serviceId, streamInfo);
         return streamInfo;
+    }
+
+    static boolean isTransientYouTubeReloadError(
+            final int serviceId,
+            @Nullable final ContentNotAvailableException error) {
+        return serviceId == ServiceList.YouTube.getServiceId()
+                && error != null
+                && error.getMessage() != null
+                && YOUTUBE_RELOAD_REQUIRED_MESSAGE.equalsIgnoreCase(
+                        error.getMessage().trim());
     }
 
     private static void backfillYouTubeRatingsAndViewCount(final int serviceId,

--- a/app/src/test/java/org/schabi/newpipe/util/ExtractorHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ExtractorHelperTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,6 +29,26 @@ public class ExtractorHelperTest {
                 "https://example.com/avatar.jpg"));
         assertFalse(ExtractorHelper.shouldBackfillYouTubePlaylistUploaderAvatar(
                 youtubeServiceId + 1, "https://example.com/channel/test", ""));
+    }
+
+    @Test
+    public void youtubeReloadResponseIsRetried() {
+        assertTrue(ExtractorHelper.isTransientYouTubeReloadError(
+                ServiceList.YouTube.getServiceId(),
+                new ContentNotAvailableException("The page needs to be reloaded.")));
+    }
+
+    @Test
+    public void genuineAvailabilityErrorsAreNotRetried() {
+        final int youtubeServiceId = ServiceList.YouTube.getServiceId();
+
+        assertFalse(ExtractorHelper.isTransientYouTubeReloadError(
+                youtubeServiceId,
+                new ContentNotAvailableException("This video is private")));
+        assertFalse(ExtractorHelper.isTransientYouTubeReloadError(
+                youtubeServiceId + 1,
+                new ContentNotAvailableException("The page needs to be reloaded.")));
+        assertFalse(ExtractorHelper.isTransientYouTubeReloadError(youtubeServiceId, null));
     }
 
     @Test

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
+- Automatically retry transient YouTube player responses that request a page reload before
+  showing a playback error.
 - Bounded persistent database growth by clearing feed caches and unreferenced stream metadata,
   compacting inactive sync journals while preserving paired-device synchronization state.
 - Fixed videos being reported unavailable when YouTube rejected the Android client but returned


### PR DESCRIPTION
- Update WizeStream’s obsolete visionOS identity from client 1.02 and visionOS 25.6 to the current official NewPipeExtractor identity: client 1.04 on visionOS 26.6.
- Restore the conventional visionOS stream path used successfully by current NewPipe before Safari’s SABR-only response becomes relevant.
- Retry extraction once with a fresh extractor only when YouTube returns the exact transient page-reload response.
- Preserve immediate failures for private, restricted, paid, unavailable, and other genuine content errors.
- Add regression coverage for both the current visionOS identity and the narrow retry classification, and document the recovery in the changelog.