### PR TITLE
Update YouTube visionOS extraction client

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstants.java
@@ -130,8 +130,8 @@ final class ClientsConstants {
 
     static final String VISIONOS_CLIENT_ID = "101";
     static final String VISIONOS_CLIENT_NAME = "VISIONOS";
-    static final String VISIONOS_CLIENT_VERSION = "1.02";
-    static final String VISIONOS_DEVICE_MODEL = "RealityDevice14,1";
-    static final String VISIONOS_VERSION = "25.6.0.23O471";
-    static final String VISIONOS_USER_AGENT_VERSION = "25_6_0";
+    static final String VISIONOS_CLIENT_VERSION = "1.04";
+    static final String VISIONOS_DEVICE_MODEL = "RealityDevice17,1";
+    static final String VISIONOS_VERSION = "26.6.0.23O770";
+    static final String VISIONOS_USER_AGENT_VERSION = "26_6_0";
 }

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstantsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/ClientsConstantsTest.java
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.extractor.services.youtube;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ClientsConstantsTest {
+    @Test
+    public void visionOsIdentityMatchesCurrentOfficialClient() {
+        assertEquals("1.04", ClientsConstants.VISIONOS_CLIENT_VERSION);
+        assertEquals("RealityDevice17,1", ClientsConstants.VISIONOS_DEVICE_MODEL);
+        assertEquals("26.6.0.23O770", ClientsConstants.VISIONOS_VERSION);
+        assertEquals("26_6_0", ClientsConstants.VISIONOS_USER_AGENT_VERSION);
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,8 +6,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
-- Automatically retry transient YouTube player responses that request a page reload before
-  showing a playback error.
+- Restored conventional YouTube playback for videos rejected by the obsolete visionOS client,
+  with one fresh retry for genuinely transient page-reload responses.
 - Bounded persistent database growth by clearing feed caches and unreferenced stream metadata,
   compacting inactive sync journals while preserving paired-device synchronization state.
 - Fixed videos being reported unavailable when YouTube rejected the Android client but returned


### PR DESCRIPTION
- Update WizeStream’s obsolete visionOS identity from client 1.02 and visionOS 25.6 to the current official NewPipeExtractor identity: client 1.04 on visionOS 26.6.
- Restore the conventional visionOS stream path used successfully by current NewPipe before Safari’s SABR-only response becomes relevant.
- Add regression coverage that keeps the visionOS identity synchronized with the known-working official extractor values.
- Update the changelog to distinguish the conventional-client correction from the already merged transient retry.