### PR TITLE
Align YouTube player request localization

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1356,7 +1356,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             throws IOException, ExtractionException {
 
         final String videoId = getId();
-        final Localization localization = new Localization("en");
+        final Localization localization = getExtractorLocalization();
         final ContentCountry contentCountry = getExtractorContentCountry();
 
         errors.clear();

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,8 +6,8 @@ Release history is listed newest first. The number beside each release is its An
 
 ### Fixes
 
-- Restored conventional YouTube playback for videos rejected by the obsolete visionOS client,
-  with one fresh retry for genuinely transient page-reload responses.
+- Restored conventional YouTube playback by aligning the visionOS identity and regional
+  request context with current NewPipeExtractor behavior, with one fresh retry for transient errors.
 - Bounded persistent database growth by clearing feed caches and unreferenced stream metadata,
   compacting inactive sync journals while preserving paired-device synchronization state.
 - Fixed videos being reported unavailable when YouTube rejected the Android client but returned


### PR DESCRIPTION
- Replace the hardcoded English localization in YouTube stream extraction with the extractor’s actual content localization.
- Keep the visionOS user agent, request language, and regional country context consistent, matching current official NewPipeExtractor behavior.
- Preserve the existing client fallback sequence and bounded transient retry.
- Correct the changelog description to cover both the visionOS identity and request-context alignment.