### PR TITLE
Keep manifest-only YouTube lives refreshing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -202,6 +202,12 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
 
         try {
             final StreamInfoTag tag = StreamInfoTag.of(info);
+            // Manifest-only YouTube lives can expose a finite DASH DVR window whose declared end
+            // is only a few seconds beyond the initial live edge. HLS keeps refreshing its media
+            // playlist, so prefer it for this narrow fallback path.
+            if (shouldPreferHlsForManifestOnlyYoutubeLive(info)) {
+                return buildLiveMediaSource(dataSource, info.getHlsUrl(), C.CONTENT_TYPE_HLS, tag);
+            }
             // Prefer DASH over HLS because of an exoPlayer bug that causes the background player to
             // also fetch the video stream even if it is supposed to just fetch the audio stream.
             if (!info.getDashMpdUrl().isEmpty()) {
@@ -217,6 +223,14 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
         }
 
         return null;
+    }
+
+    static boolean shouldPreferHlsForManifestOnlyYoutubeLive(final StreamInfo info) {
+        return info.getServiceId() == ServiceList.YouTube.getServiceId()
+                && StreamTypeUtil.isLiveStream(info.getStreamType())
+                && info.getAudioStreams().isEmpty()
+                && info.getVideoStreams().isEmpty()
+                && !info.getHlsUrl().isEmpty();
     }
 
     static MediaSource buildLiveMediaSource(final PlayerDataSource dataSource,

--- a/app/src/test/java/org/schabi/newpipe/player/resolver/PlaybackResolverLiveManifestTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/resolver/PlaybackResolverLiveManifestTest.java
@@ -1,0 +1,46 @@
+package org.schabi.newpipe.player.resolver;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.ServiceList;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.extractor.stream.VideoStream;
+
+import java.util.Collections;
+
+public class PlaybackResolverLiveManifestTest {
+    @Test
+    public void manifestOnlyYoutubeLivePrefersRefreshableHls() {
+        final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
+
+        assertTrue(PlaybackResolver.shouldPreferHlsForManifestOnlyYoutubeLive(info));
+    }
+
+    @Test
+    public void youtubeLiveWithDirectStreamsRetainsDashPreference() {
+        final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
+        info.setVideoStreams(Collections.singletonList(mock(VideoStream.class)));
+
+        assertFalse(PlaybackResolver.shouldPreferHlsForManifestOnlyYoutubeLive(info));
+    }
+
+    @Test
+    public void nonYoutubeManifestOnlyLiveRetainsDashPreference() {
+        final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId() + 1);
+
+        assertFalse(PlaybackResolver.shouldPreferHlsForManifestOnlyYoutubeLive(info));
+    }
+
+    private static StreamInfo createLiveInfo(final int serviceId) {
+        final StreamInfo info = new StreamInfo(serviceId, "live", "https://example.com/live",
+                "Live stream");
+        info.setStreamType(StreamType.LIVE_STREAM);
+        info.setDashMpdUrl("https://example.com/live.mpd");
+        info.setHlsUrl("https://example.com/live.m3u8");
+        return info;
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -10,6 +10,8 @@ Release history is listed newest first. The number beside each release is its An
 
 - Restored live playback when a service provides only an HLS or DASH manifest without separate
   audio or video stream entries.
+- Kept manifest-only YouTube live streams playing by preferring their refreshable HLS source over
+  a finite DASH DVR window.
 - Fixed selected bottom-navigation labels occasionally being truncated until the app was
   restarted.
 

--- a/fastlane/metadata/android/en-US/changelogs/1010003.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1010003.txt
@@ -1,2 +1,3 @@
 • Restored live streams that provide playback through HLS or DASH manifests.
+• Kept manifest-only YouTube live streams playing instead of freezing at the DASH window edge.
 • Fixed selected bottom-navigation labels occasionally being truncated until restart.


### PR DESCRIPTION
- Prefer refreshable HLS playback for manifest-only YouTube live streams when both HLS and a finite DASH DVR window are available.
- Preserve the existing DASH preference for live streams that still expose direct audio/video formats and retain DASH as the manifest fallback.
- Add regression coverage for YouTube manifest-only, direct-stream, and non-YouTube selection behavior.
- Update the WizeStream 1.10.3 release and store changelogs.