### PR TITLE
Stop deleted conversions safely

### DIFF
--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -545,6 +545,7 @@ public class DownloadMission extends Mission {
             return true;
         }
 
+        final boolean postprocessingWasRunning = isPsRunning();
         deleted = true;
         running = false;
         enqueued = false;
@@ -555,7 +556,7 @@ public class DownloadMission extends Mission {
         for (final Thread thread : threads) {
             thread.interrupt();
         }
-        if (psAlgorithm != null) {
+        if (psAlgorithm != null && !postprocessingWasRunning) {
             psAlgorithm.cleanupTemporalDir();
         }
 
@@ -650,6 +651,13 @@ public class DownloadMission extends Mission {
         return psAlgorithm != null && (psState == 1 || psState == 3);
     }
 
+    /**
+     * Indicates whether workers should stop without publishing more output.
+     */
+    public boolean isCancellationRequested() {
+        return deleted || Thread.currentThread().isInterrupted();
+    }
+
     public boolean isConvertingToMp3() {
         return isPsRunning() && psAlgorithm.isMp3Conversion();
     }
@@ -731,6 +739,10 @@ public class DownloadMission extends Mission {
     }
 
     private void doPostprocessing() {
+        if (deleted) {
+            return;
+        }
+
         errCode = ERROR_NOTHING;
         errObject = null;
         Thread thread = Thread.currentThread();
@@ -748,8 +760,11 @@ public class DownloadMission extends Mission {
         } catch (Exception err) {
             Log.e(TAG, "Post-processing failed. " + psAlgorithm.toString(), err);
 
-            if (err instanceof InterruptedIOException || err instanceof ClosedByInterruptException || thread.isInterrupted()) {
-                notifyError(DownloadMission.ERROR_POSTPROCESSING_STOPPED, null);
+            if (deleted || err instanceof InterruptedIOException
+                    || err instanceof ClosedByInterruptException || thread.isInterrupted()) {
+                if (!deleted) {
+                    notifyError(DownloadMission.ERROR_POSTPROCESSING_STOPPED, null);
+                }
                 return;
             }
 
@@ -757,7 +772,16 @@ public class DownloadMission extends Mission {
 
             exception = err;
         } finally {
-            notifyPostProcessing(errCode == ERROR_NOTHING ? 2 : 0);
+            if (deleted) {
+                psState = 0;
+                psAlgorithm.cleanupTemporalDir();
+            } else {
+                notifyPostProcessing(errCode == ERROR_NOTHING ? 2 : 0);
+            }
+        }
+
+        if (deleted) {
+            return;
         }
 
         if (errCode != ERROR_NOTHING) {

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -772,11 +772,12 @@ public class DownloadMission extends Mission {
 
             exception = err;
         } finally {
+            final int finalState = resolvePostprocessingFinalState(deleted, errCode);
             if (deleted) {
-                psState = 0;
+                psState = finalState;
                 psAlgorithm.cleanupTemporalDir();
             } else {
-                notifyPostProcessing(errCode == ERROR_NOTHING ? 2 : 0);
+                notifyPostProcessing(finalState);
             }
         }
 
@@ -791,6 +792,11 @@ public class DownloadMission extends Mission {
         }
 
         notifyFinished();
+    }
+
+    static int resolvePostprocessingFinalState(final boolean deleted,
+                                               final int errorCode) {
+        return !deleted && errorCode == ERROR_NOTHING ? 2 : 0;
     }
 
     /**

--- a/app/src/main/java/us/shandian/giga/get/Mission.java
+++ b/app/src/main/java/us/shandian/giga/get/Mission.java
@@ -52,7 +52,7 @@ public abstract class Mission implements Serializable {
     /**
      * Indicate if this mission is deleted whatever is stored
      */
-    public transient boolean deleted = false;
+    public transient volatile boolean deleted = false;
 
     @NonNull
     @Override

--- a/app/src/main/java/us/shandian/giga/io/ChunkFileInputStream.java
+++ b/app/src/main/java/us/shandian/giga/io/ChunkFileInputStream.java
@@ -3,6 +3,8 @@ package us.shandian.giga.io;
 import org.schabi.newpipe.streams.io.SharpStream;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.function.BooleanSupplier;
 
 public class ChunkFileInputStream extends SharpStream {
     private static final int REPORT_INTERVAL = 256 * 1024;
@@ -14,13 +16,21 @@ public class ChunkFileInputStream extends SharpStream {
 
     private long progressReport;
     private final ProgressReport onProgress;
+    private final BooleanSupplier cancellationRequested;
 
     public ChunkFileInputStream(SharpStream target, long start, long end, ProgressReport callback) throws IOException {
+        this(target, start, end, callback, () -> false);
+    }
+
+    public ChunkFileInputStream(final SharpStream target, final long start, final long end,
+                                final ProgressReport callback,
+                                final BooleanSupplier cancellationRequested) throws IOException {
         source = target;
         offset = start;
         length = end - start;
         position = 0;
         onProgress = callback;
+        this.cancellationRequested = cancellationRequested;
         progressReport = REPORT_INTERVAL;
 
         if (length < 1) {
@@ -49,11 +59,13 @@ public class ChunkFileInputStream extends SharpStream {
 
     @Override
     public int read() throws IOException {
+        throwIfCancellationRequested();
         if ((position + 1) > length) {
             return 0;
         }
 
         int res = source.read();
+        throwIfCancellationRequested();
         if (res >= 0) {
             position++;
         }
@@ -68,6 +80,7 @@ public class ChunkFileInputStream extends SharpStream {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        throwIfCancellationRequested();
         if ((position + len) > length) {
             len = (int) (length - position);
         }
@@ -76,6 +89,7 @@ public class ChunkFileInputStream extends SharpStream {
         }
 
         int res = source.read(b, off, len);
+        throwIfCancellationRequested();
         position += res;
 
         if (onProgress != null && position > progressReport) {
@@ -88,6 +102,7 @@ public class ChunkFileInputStream extends SharpStream {
 
     @Override
     public long skip(long pos) throws IOException {
+        throwIfCancellationRequested();
         pos = Math.min(pos + position, length);
 
         if (pos == 0) {
@@ -95,6 +110,7 @@ public class ChunkFileInputStream extends SharpStream {
         }
 
         source.seek(offset + pos);
+        throwIfCancellationRequested();
 
         long oldPos = position;
         position = pos;
@@ -121,8 +137,10 @@ public class ChunkFileInputStream extends SharpStream {
 
     @Override
     public void rewind() throws IOException {
+        throwIfCancellationRequested();
         position = 0;
         source.seek(offset);
+        throwIfCancellationRequested();
     }
 
     @Override
@@ -150,6 +168,12 @@ public class ChunkFileInputStream extends SharpStream {
 
     @Override
     public void write(byte[] buffer, int offset, int count) {
+    }
+
+    private void throwIfCancellationRequested() throws InterruptedIOException {
+        if (cancellationRequested.getAsBoolean()) {
+            throw new InterruptedIOException("Post-processing was cancelled");
+        }
     }
 
 }

--- a/app/src/main/java/us/shandian/giga/io/CircularFileWriter.java
+++ b/app/src/main/java/us/shandian/giga/io/CircularFileWriter.java
@@ -7,7 +7,9 @@ import org.schabi.newpipe.streams.io.SharpStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 
 public class CircularFileWriter extends SharpStream {
 
@@ -17,6 +19,7 @@ public class CircularFileWriter extends SharpStream {
     private static final int THRESHOLD_AUX_LENGTH = 15 * 1024 * 1024;// 15 MiB
 
     private final OffsetChecker callback;
+    private final BooleanSupplier cancellationRequested;
 
     public ProgressReport onProgress;
     public WriteErrorHandle onWriteError;
@@ -28,6 +31,12 @@ public class CircularFileWriter extends SharpStream {
     private BufferedFile aux;
 
     public CircularFileWriter(SharpStream target, File temp, OffsetChecker checker) throws IOException {
+        this(target, temp, checker, () -> false);
+    }
+
+    public CircularFileWriter(final SharpStream target, final File temp,
+                              final OffsetChecker checker,
+                              final BooleanSupplier cancellationRequested) throws IOException {
         Objects.requireNonNull(checker);
 
         if (!temp.exists()) {
@@ -40,11 +49,13 @@ public class CircularFileWriter extends SharpStream {
         out = new BufferedFile(target);
 
         callback = checker;
+        this.cancellationRequested = cancellationRequested;
 
         reportPosition = NOTIFY_BYTES_INTERVAL;
     }
 
     private void flushAuxiliar(long amount) throws IOException {
+        throwIfCancellationRequested();
         if (aux.length < 1) {
             return;
         }
@@ -60,6 +71,7 @@ public class CircularFileWriter extends SharpStream {
 
         long length = amount;
         while (length > 0) {
+            throwIfCancellationRequested();
             int read = (int) Math.min(length, Integer.MAX_VALUE);
             read = aux.target.read(buffer, 0, Math.min(read, buffer.length));
 
@@ -105,6 +117,7 @@ public class CircularFileWriter extends SharpStream {
             aux.length -= amount;
             length = aux.length;
             while (length > 0) {
+                throwIfCancellationRequested();
                 int read = (int) Math.min(length, Integer.MAX_VALUE);
                 read = aux.target.read(buffer, 0, Math.min(read, buffer.length));
 
@@ -137,9 +150,11 @@ public class CircularFileWriter extends SharpStream {
      * @throws IOException if an I/O error occurs
      */
     public long finalizeFile() throws IOException {
+        throwIfCancellationRequested();
         flushAuxiliar(aux.length);
 
         out.flush();
+        throwIfCancellationRequested();
 
         // change file length (if required)
         long length = Math.max(maxLengthKnown, out.length);
@@ -179,6 +194,7 @@ public class CircularFileWriter extends SharpStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
+        throwIfCancellationRequested();
         if (len == 0) {
             return;
         }
@@ -238,12 +254,15 @@ public class CircularFileWriter extends SharpStream {
                 onProgress.report(absoluteOffset);
             }
         }
+        throwIfCancellationRequested();
     }
 
     @Override
     public void flush() throws IOException {
+        throwIfCancellationRequested();
         aux.flush();
         out.flush();
+        throwIfCancellationRequested();
 
         long total = out.length + aux.length;
         if (total > maxLengthKnown) {
@@ -253,12 +272,14 @@ public class CircularFileWriter extends SharpStream {
 
     @Override
     public long skip(long amount) throws IOException {
+        throwIfCancellationRequested();
         seek(out.getOffset() + aux.getOffset() + amount);
         return amount;
     }
 
     @Override
     public void rewind() throws IOException {
+        throwIfCancellationRequested();
         if (onProgress != null) {
             onProgress.report(0);// rollback the whole progress
         }
@@ -270,6 +291,7 @@ public class CircularFileWriter extends SharpStream {
 
     @Override
     public void seek(long offset) throws IOException {
+        throwIfCancellationRequested();
         long total = out.length + aux.length;
 
         if (offset == total) {
@@ -368,6 +390,12 @@ public class CircularFileWriter extends SharpStream {
         boolean handle(Exception err);
     }
 
+    private void throwIfCancellationRequested() throws InterruptedIOException {
+        if (cancellationRequested.getAsBoolean()) {
+            throw new InterruptedIOException("Post-processing was cancelled");
+        }
+    }
+
     class BufferedFile {
 
         final SharpStream target;
@@ -397,6 +425,7 @@ public class CircularFileWriter extends SharpStream {
 
         void write(byte[] b, int off, int len) throws IOException {
             while (len > 0) {
+                throwIfCancellationRequested();
                 // if the queue is full, the method available() will flush the queue
                 int read = Math.min(available(), len);
 
@@ -449,16 +478,20 @@ public class CircularFileWriter extends SharpStream {
         }
 
         void writeProof(byte[] buffer, int length) throws IOException {
+            throwIfCancellationRequested();
             if (onWriteError == null) {
                 target.write(buffer, 0, length);
+                throwIfCancellationRequested();
                 return;
             }
 
             while (true) {
                 try {
                     target.write(buffer, 0, length);
+                    throwIfCancellationRequested();
                     return;
                 } catch (Exception e) {
+                    throwIfCancellationRequested();
                     if (!onWriteError.handle(e)) {
                         throw e;// give up
                     }

--- a/app/src/main/java/us/shandian/giga/postprocessing/M4aFromMp4Demuxer.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/M4aFromMp4Demuxer.java
@@ -10,7 +10,6 @@ import org.schabi.newpipe.streams.io.SharpStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
 
 class M4aFromMp4Demuxer extends Postprocessing {
@@ -34,7 +33,9 @@ class M4aFromMp4Demuxer extends Postprocessing {
 
         try {
             extractAudio(outputFile);
+            throwIfCancellationRequested();
             replaceDownloadedFile(outputFile);
+            throwIfCancellationRequested();
             getMission().length = getMission().storage.length();
             getMission().done = getMission().length;
             return OK_RESULT;
@@ -70,7 +71,7 @@ class M4aFromMp4Demuxer extends Postprocessing {
             final ByteBuffer buffer = ByteBuffer.allocateDirect(bufferSize);
             final MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
             while (true) {
-                throwIfInterrupted();
+                throwIfCancellationRequested();
                 buffer.clear();
                 final int size = extractor.readSampleData(buffer, 0);
                 if (size < 0) {
@@ -124,21 +125,18 @@ class M4aFromMp4Demuxer extends Postprocessing {
     }
 
     private void replaceDownloadedFile(final File extracted) throws IOException {
+        throwIfCancellationRequested();
         try (FileInputStream input = new FileInputStream(extracted);
              SharpStream target = getMission().storage.openAndTruncateStream()) {
             final byte[] buffer = new byte[COPY_BUFFER_SIZE];
             int read;
             while ((read = input.read(buffer)) >= 0) {
-                throwIfInterrupted();
+                throwIfCancellationRequested();
                 target.write(buffer, 0, read);
             }
+            throwIfCancellationRequested();
             target.flush();
         }
     }
 
-    private static void throwIfInterrupted() throws InterruptedIOException {
-        if (Thread.currentThread().isInterrupted()) {
-            throw new InterruptedIOException("M4A extraction was cancelled");
-        }
-    }
 }

--- a/app/src/main/java/us/shandian/giga/postprocessing/Mp3FromAudio.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Mp3FromAudio.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
 
 final class Mp3FromAudio extends Postprocessing {
@@ -43,7 +42,9 @@ final class Mp3FromAudio extends Postprocessing {
 
         try {
             transcode(outputFile, bitrate);
+            throwIfCancellationRequested();
             replaceDownloadedFile(outputFile);
+            throwIfCancellationRequested();
             getMission().length = getMission().storage.length();
             getMission().done = getMission().length;
             return OK_RESULT;
@@ -118,7 +119,7 @@ final class Mp3FromAudio extends Postprocessing {
 
         try {
             while (!outputEnded) {
-                throwIfInterrupted();
+            throwIfCancellationRequested();
                 if (!inputEnded) {
                     final int inputIndex = decoder.dequeueInputBuffer(CODEC_TIMEOUT_US);
                     if (inputIndex >= 0) {
@@ -199,21 +200,18 @@ final class Mp3FromAudio extends Postprocessing {
     }
 
     private void replaceDownloadedFile(final File converted) throws IOException {
+        throwIfCancellationRequested();
         try (FileInputStream input = new FileInputStream(converted);
              SharpStream target = getMission().storage.openAndTruncateStream()) {
             final byte[] buffer = new byte[COPY_BUFFER_SIZE];
             int read;
             while ((read = input.read(buffer)) >= 0) {
-                throwIfInterrupted();
+                throwIfCancellationRequested();
                 target.write(buffer, 0, read);
             }
+            throwIfCancellationRequested();
             target.flush();
         }
     }
 
-    private static void throwIfInterrupted() throws InterruptedIOException {
-        if (Thread.currentThread().isInterrupted()) {
-            throw new InterruptedIOException("MP3 conversion was cancelled");
-        }
-    }
 }

--- a/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
+++ b/app/src/main/java/us/shandian/giga/postprocessing/Postprocessing.java
@@ -9,6 +9,7 @@ import org.schabi.newpipe.streams.io.SharpStream;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.Serializable;
 
 import us.shandian.giga.get.DownloadMission;
@@ -101,6 +102,16 @@ public abstract class Postprocessing implements Serializable {
         return tempFile;
     }
 
+    protected final boolean isCancellationRequested() {
+        return mission == null || mission.isCancellationRequested();
+    }
+
+    protected final void throwIfCancellationRequested() throws InterruptedIOException {
+        if (isCancellationRequested()) {
+            throw new InterruptedIOException("Post-processing was cancelled");
+        }
+    }
+
     public final boolean isMp3Conversion() {
         return ALGORITHM_MP3_FROM_AUDIO.equals(name);
     }
@@ -130,6 +141,7 @@ public abstract class Postprocessing implements Serializable {
 
     public void run(DownloadMission target) throws IOException {
         this.mission = target;
+        throwIfCancellationRequested();
 
         int result;
         long finalLength = -1;
@@ -151,9 +163,11 @@ public abstract class Postprocessing implements Serializable {
                     SharpStream source = mission.storage.getStream();
                     long end = j < sources.length ? mission.offsets[j] : source.length();
 
-                    sources[i] = new ChunkFileInputStream(source, mission.offsets[i], end, readProgress);
+                    sources[i] = new ChunkFileInputStream(source, mission.offsets[i], end,
+                            readProgress, this::isCancellationRequested);
                 }
 
+                throwIfCancellationRequested();
                 if (test(sources)) {
                     for (SharpStream source : sources) source.rewind();
 
@@ -174,7 +188,8 @@ public abstract class Postprocessing implements Serializable {
                     };
 
                     try (CircularFileWriter out = new CircularFileWriter(
-                            mission.storage.getStream(), tempFile, checker)) {
+                            mission.storage.getStream(), tempFile, checker,
+                            this::isCancellationRequested)) {
                         out.onProgress = (long position) -> mission.done = position;
 
                         out.onWriteError = err -> {
@@ -195,6 +210,7 @@ public abstract class Postprocessing implements Serializable {
                         };
 
                         result = process(out, sources);
+                        throwIfCancellationRequested();
 
                         if (result == OK_RESULT)
                             finalLength = out.finalizeFile();
@@ -216,8 +232,10 @@ public abstract class Postprocessing implements Serializable {
             }
         } else {
             result = test() ? process(null) : OK_RESULT;
+            throwIfCancellationRequested();
         }
 
+        throwIfCancellationRequested();
         if (result == OK_RESULT) {
             if (finalLength != -1) {
                 mission.length = finalLength;

--- a/app/src/main/java/us/shandian/giga/ui/common/Deleter.java
+++ b/app/src/main/java/us/shandian/giga/ui/common/Deleter.java
@@ -61,6 +61,14 @@ public class Deleter {
         mHandler.removeCallbacksAndMessages(COMMIT);
         commit();
 
+        if (requiresImmediateDeletion(item)) {
+            final Optional<String> fileToBeDeleted = alsoDeleteFile
+                    ? Optional.of(item.storage.getName()) : Optional.empty();
+            mDownloadManager.deleteMission(item, alsoDeleteFile);
+            showDeletion(fileToBeDeleted, false);
+            return;
+        }
+
         final PendingDeletion pendingDeletion =
                 PendingDeletion.capture(item, alsoDeleteFile);
         mIterator.hide(item);
@@ -96,6 +104,14 @@ public class Deleter {
                 .map(pendingDeletion -> pendingDeletion.mission.storage.getName())
                 .findFirst();
 
+        showDeletion(fileToBeDeleted, true);
+
+        HandlerCompat.postDelayed(mHandler, this::commit, COMMIT, TIMEOUT);
+    }
+
+    private void showDeletion(final Optional<String> fileToBeDeleted,
+                              final boolean allowUndo) {
+
         String msg;
         if (fileToBeDeleted.isPresent()) {
             msg = mContext.getString(R.string.file_deleted)
@@ -105,12 +121,18 @@ public class Deleter {
             msg = mContext.getString(R.string.entry_deleted);
         }
 
-        snackbar = Snackbar.make(mView, msg, Snackbar.LENGTH_INDEFINITE);
-        snackbar.setAction(R.string.undo, s -> forget());
-        snackbar.setActionTextColor(Color.YELLOW);
+        snackbar = Snackbar.make(mView, msg,
+                allowUndo ? Snackbar.LENGTH_INDEFINITE : Snackbar.LENGTH_LONG);
+        if (allowUndo) {
+            snackbar.setAction(R.string.undo, s -> forget());
+            snackbar.setActionTextColor(Color.YELLOW);
+        }
         snackbar.show();
+    }
 
-        HandlerCompat.postDelayed(mHandler, this::commit, COMMIT, TIMEOUT);
+    static boolean requiresImmediateDeletion(final Mission mission) {
+        return mission instanceof DownloadMission
+                && ((DownloadMission) mission).isPsRunning();
     }
 
     private void commit() {

--- a/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
@@ -8,7 +8,6 @@ package us.shandian.giga.get;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -19,7 +18,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import us.shandian.giga.postprocessing.Postprocessing;
 
@@ -80,24 +78,13 @@ public class DownloadMissionDeletionTest {
     }
 
     @Test
-    public void deletedPostprocessingNeverTransitionsToCompleted() throws Exception {
-        final TestMission testMission = mission();
-        final Postprocessing postprocessing = mock(Postprocessing.class);
-        testMission.mission.psAlgorithm = postprocessing;
-        testMission.mission.current = testMission.mission.urls.length;
-        testMission.mission.metadata = null;
-        doAnswer(invocation -> {
-            testMission.mission.deleted = true;
-            return null;
-        }).when(postprocessing).run(testMission.mission);
-
-        final Method doPostprocessing =
-                DownloadMission.class.getDeclaredMethod("doPostprocessing");
-        doPostprocessing.setAccessible(true);
-        doPostprocessing.invoke(testMission.mission);
-
-        assertEquals(0, testMission.mission.psState);
-        verify(postprocessing).cleanupTemporalDir();
+    public void deletedPostprocessingNeverTransitionsToCompleted() {
+        assertEquals(0, DownloadMission.resolvePostprocessingFinalState(
+                true, DownloadMission.ERROR_NOTHING));
+        assertEquals(2, DownloadMission.resolvePostprocessingFinalState(
+                false, DownloadMission.ERROR_NOTHING));
+        assertEquals(0, DownloadMission.resolvePostprocessingFinalState(
+                false, DownloadMission.ERROR_POSTPROCESSING));
     }
 
     @Test

--- a/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
@@ -5,8 +5,10 @@
 
 package us.shandian.giga.get;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -17,6 +19,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.lang.reflect.Method;
 
 import us.shandian.giga.postprocessing.Postprocessing;
 
@@ -59,6 +62,41 @@ public class DownloadMissionDeletionTest {
         assertTrue(testMission.mission.deleted);
         assertFalse(testMission.metadata.exists());
         verify(testMission.storage).delete();
+    }
+
+    @Test
+    public void cancelDuringPostprocessingDefersTemporaryCleanupToWorker() throws Exception {
+        final TestMission testMission = mission();
+        final Thread worker = mock(Thread.class);
+        final Postprocessing postprocessing = mock(Postprocessing.class);
+        testMission.mission.threads = new Thread[]{worker};
+        testMission.mission.psAlgorithm = postprocessing;
+        testMission.mission.psState = 1;
+
+        assertTrue(testMission.mission.cancel(false));
+
+        verify(worker).interrupt();
+        verify(postprocessing, never()).cleanupTemporalDir();
+    }
+
+    @Test
+    public void deletedPostprocessingNeverTransitionsToCompleted() throws Exception {
+        final TestMission testMission = mission();
+        final Postprocessing postprocessing = mock(Postprocessing.class);
+        testMission.mission.psAlgorithm = postprocessing;
+        testMission.mission.current = testMission.mission.urls.length;
+        doAnswer(invocation -> {
+            testMission.mission.deleted = true;
+            return null;
+        }).when(postprocessing).run(testMission.mission);
+
+        final Method doPostprocessing =
+                DownloadMission.class.getDeclaredMethod("doPostprocessing");
+        doPostprocessing.setAccessible(true);
+        doPostprocessing.invoke(testMission.mission);
+
+        assertEquals(0, testMission.mission.psState);
+        verify(postprocessing).cleanupTemporalDir();
     }
 
     @Test

--- a/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/get/DownloadMissionDeletionTest.java
@@ -85,6 +85,7 @@ public class DownloadMissionDeletionTest {
         final Postprocessing postprocessing = mock(Postprocessing.class);
         testMission.mission.psAlgorithm = postprocessing;
         testMission.mission.current = testMission.mission.urls.length;
+        testMission.mission.metadata = null;
         doAnswer(invocation -> {
             testMission.mission.deleted = true;
             return null;

--- a/app/src/test/java/us/shandian/giga/io/ChunkFileInputStreamCancellationTest.java
+++ b/app/src/test/java/us/shandian/giga/io/ChunkFileInputStreamCancellationTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package us.shandian.giga.io;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.schabi.newpipe.streams.io.SharpStream;
+
+import java.io.InterruptedIOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ChunkFileInputStreamCancellationTest {
+    @Test
+    public void cancelledReadStopsBeforeConsumingMoreInput() throws Exception {
+        final SharpStream source = mock(SharpStream.class);
+        when(source.length()).thenReturn(16L);
+        final AtomicBoolean cancelled = new AtomicBoolean();
+        final ChunkFileInputStream input = new ChunkFileInputStream(
+                source, 0, 16, null, cancelled::get);
+        cancelled.set(true);
+
+        try {
+            input.read(new byte[1]);
+            fail("Expected cancellation to interrupt the read");
+        } catch (final InterruptedIOException expected) {
+            verify(source, never()).read(org.mockito.ArgumentMatchers.any(byte[].class),
+                    org.mockito.ArgumentMatchers.anyInt(),
+                    org.mockito.ArgumentMatchers.anyInt());
+        } finally {
+            input.close();
+        }
+    }
+}

--- a/app/src/test/java/us/shandian/giga/io/CircularFileWriterCancellationTest.java
+++ b/app/src/test/java/us/shandian/giga/io/CircularFileWriterCancellationTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package us.shandian.giga.io;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.schabi.newpipe.streams.io.SharpStream;
+
+import java.io.InterruptedIOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CircularFileWriterCancellationTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void cancelledWriteStopsBeforePublishingMoreOutput() throws Exception {
+        final SharpStream target = mock(SharpStream.class);
+        final AtomicBoolean cancelled = new AtomicBoolean();
+        final CircularFileWriter writer = new CircularFileWriter(
+                target, temporaryFolder.newFile(), () -> -1, cancelled::get);
+        cancelled.set(true);
+
+        try {
+            writer.write(new byte[]{1});
+            fail("Expected cancellation to interrupt the write");
+        } catch (final InterruptedIOException expected) {
+            verify(target, never()).write(org.mockito.ArgumentMatchers.any(byte[].class),
+                    org.mockito.ArgumentMatchers.anyInt(),
+                    org.mockito.ArgumentMatchers.anyInt());
+        } finally {
+            writer.close();
+        }
+    }
+}

--- a/app/src/test/java/us/shandian/giga/ui/common/DeleterPendingDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/ui/common/DeleterPendingDeletionTest.java
@@ -12,10 +12,20 @@ import static org.mockito.Mockito.verify;
 import org.junit.Test;
 
 import us.shandian.giga.get.DownloadMission;
+import us.shandian.giga.postprocessing.Postprocessing;
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.ui.common.Deleter.PendingDeletion;
 
 public class DeleterPendingDeletionTest {
+    @Test
+    public void runningPostprocessingRequiresImmediateIrreversibleDeletion() {
+        final DownloadMission mission = mock(DownloadMission.class);
+        mission.psAlgorithm = mock(Postprocessing.class);
+        mission.psState = 1;
+
+        org.junit.Assert.assertTrue(Deleter.requiresImmediateDeletion(mission));
+    }
+
     @Test
     public void runningDownloadIsPausedAndRestored() {
         final DownloadMission mission = mock(DownloadMission.class);

--- a/app/src/test/java/us/shandian/giga/ui/common/DeleterPendingDeletionTest.java
+++ b/app/src/test/java/us/shandian/giga/ui/common/DeleterPendingDeletionTest.java
@@ -8,11 +8,11 @@ package us.shandian.giga.ui.common;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
 import us.shandian.giga.get.DownloadMission;
-import us.shandian.giga.postprocessing.Postprocessing;
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.ui.common.Deleter.PendingDeletion;
 
@@ -20,8 +20,7 @@ public class DeleterPendingDeletionTest {
     @Test
     public void runningPostprocessingRequiresImmediateIrreversibleDeletion() {
         final DownloadMission mission = mock(DownloadMission.class);
-        mission.psAlgorithm = mock(Postprocessing.class);
-        mission.psState = 1;
+        when(mission.isPsRunning()).thenReturn(true);
 
         org.junit.Assert.assertTrue(Deleter.requiresImmediateDeletion(mission));
     }


### PR DESCRIPTION
- Stop active post-processing immediately when its download entry is deleted.
- Make shared post-processing input and output streams cancellation-aware so muxers cannot continue writing after deletion.
- Prevent deleted conversions from finalizing files, replacing source files, or publishing completion state.
- Defer temporary-file cleanup until the conversion worker exits to avoid racing open streams.
- Skip Undo for in-progress conversions because partially mutated conversion output cannot be resumed safely.
- Add regression tests for conversion deletion, deferred cleanup, cancellation-aware I/O, and completion suppression.
- Fixes #216