### PR TITLE
Make release APK builds reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   build-and-test-jvm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -54,30 +54,21 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 21.0.12+1
           distribution: temurin
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Build APKs and run JVM tests
-        run: ./gradlew assembleDebug lintDebug testDebugUnitTest assembleRelease --stacktrace -DskipFormatKtlint
-
-      - name: Verify release packaged resources
-        run: |
-          APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
-          test -s "$APK_PATH"
-          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
-          "$AAPT" dump resources "$APK_PATH" > "$RUNNER_TEMP/release-resources.txt"
-          grep -q "layout/list_search_no_results" "$RUNNER_TEMP/release-resources.txt"
-          grep -q "layout/list_empty_view_subscriptions" "$RUNNER_TEMP/release-resources.txt"
-          scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
+      - name: Build debug APK and run JVM tests
+        run: ./gradlew assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint
 
       - name: Verify debug APK identity
         run: |
           APK_PATH="$(find app/build/outputs/apk/debug -name '*.apk' | head -n 1)"
           test -n "$APK_PATH"
-          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
+          BUILD_TOOLS_VERSION="$(sed -n 's/^androidBuildToolsVersion=//p' gradle/reproducible-build.properties)"
+          AAPT="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt"
           "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/debug-apk-badging.txt"
           grep -q "package: name='org.wisso.newpipematerial.debug'" "$RUNNER_TEMP/debug-apk-badging.txt"
           grep -q "application-label:'WizeStream Debug'" "$RUNNER_TEMP/debug-apk-badging.txt"
@@ -88,8 +79,51 @@ jobs:
           name: wizestream-debug-apk
           path: app/build/outputs/apk/debug/*.apk
 
+  reproducible-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create and checkout branch
+        if: github.event_name == 'pull_request'
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: git checkout -B "$BRANCH"
+
+      - name: Set up pinned JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21.0.12+1
+          distribution: temurin
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build release APK twice and compare SHA-256
+        run: scripts/reproducible-build.sh --verify --output-dir "$RUNNER_TEMP/reproducible-release"
+
+      - name: Verify release packaged resources
+        run: |
+          APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
+          test -s "$APK_PATH"
+          BUILD_TOOLS_VERSION="$(sed -n 's/^androidBuildToolsVersion=//p' gradle/reproducible-build.properties)"
+          AAPT="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt"
+          "$AAPT" dump resources "$APK_PATH" > "$RUNNER_TEMP/release-resources.txt"
+          grep -q "layout/list_search_no_results" "$RUNNER_TEMP/release-resources.txt"
+          grep -q "layout/list_empty_view_subscriptions" "$RUNNER_TEMP/release-resources.txt"
+          scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
+
+      - name: Upload reproducibility result
+        uses: actions/upload-artifact@v7
+        with:
+          name: wizestream-reproducible-release
+          path: ${{ runner.temp }}/reproducible-release/**
+
   test-android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -108,7 +142,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 21.0.12+1
           distribution: temurin
 
       - name: Set up Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21.0.12+1
+          java-version: 21.0.12+8.0.LTS
           distribution: temurin
 
       - name: Set up Gradle
@@ -96,7 +96,7 @@ jobs:
       - name: Set up pinned JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21.0.12+1
+          java-version: 21.0.12+8.0.LTS
           distribution: temurin
 
       - name: Set up Gradle
@@ -142,7 +142,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21.0.12+1
+          java-version: 21.0.12+8.0.LTS
           distribution: temurin
 
       - name: Set up Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
 
     steps:
       - name: Check out release source
@@ -32,9 +33,12 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 21.0.12+1
           distribution: temurin
           cache: gradle
+
+      - name: Validate pinned release toolchain
+        run: scripts/validate-reproducible-toolchain.sh
 
       - name: Write release keystore
         env:
@@ -47,7 +51,7 @@ jobs:
           fi
           printf '%s' "${RELEASE_KEYSTORE_BASE64}" | base64 -d > "$RUNNER_TEMP/wizestream-release.keystore"
 
-      - name: Build signed release APK
+      - name: Build signed release APK twice and compare SHA-256
         env:
           WIZESTREAM_RELEASE_STORE_FILE: ${{ runner.temp }}/wizestream-release.keystore
           WIZESTREAM_RELEASE_STORE_PASSWORD: ${{ secrets.WIZESTREAM_RELEASE_STORE_PASSWORD || secrets.NEWPIPE_MATERIAL_RELEASE_STORE_PASSWORD }}
@@ -61,19 +65,22 @@ jobs:
             echo "Missing one or more WizeStream release signing secrets" >&2
             exit 1
           fi
-          ./gradlew clean assembleRelease --stacktrace
+          scripts/reproducible-build.sh \
+            --verify \
+            --output-dir "$RUNNER_TEMP/reproducible-arm"
 
       - name: Verify release APK identity
         run: |
           set -euo pipefail
           APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
           test -n "$APK_PATH"
-          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
+          BUILD_TOOLS_VERSION="$(sed -n 's/^androidBuildToolsVersion=//p' gradle/reproducible-build.properties)"
+          AAPT="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt"
           "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/release-apk-badging.txt"
           grep -q "package: name='org.wisso.newpipematerial'" "$RUNNER_TEMP/release-apk-badging.txt"
           grep -q "application-label:'WizeStream'" "$RUNNER_TEMP/release-apk-badging.txt"
           scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
-          APKSIGNER="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/apksigner"
+          APKSIGNER="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/apksigner"
           "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
 
       - name: "Prepare ARM APK"
@@ -112,7 +119,7 @@ jobs:
           echo "Release tag: $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
           echo "Changelog: $CHANGELOG_PATH" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Build signed x86_64 release APK
+      - name: Build signed x86_64 release APK twice and compare SHA-256
         env:
           WIZESTREAM_RELEASE_STORE_FILE: ${{ runner.temp }}/wizestream-release.keystore
           WIZESTREAM_RELEASE_STORE_PASSWORD: ${{ secrets.WIZESTREAM_RELEASE_STORE_PASSWORD || secrets.NEWPIPE_MATERIAL_RELEASE_STORE_PASSWORD }}
@@ -120,7 +127,11 @@ jobs:
           WIZESTREAM_RELEASE_KEY_PASSWORD: ${{ secrets.WIZESTREAM_RELEASE_KEY_PASSWORD || secrets.NEWPIPE_MATERIAL_RELEASE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          ./gradlew clean assembleRelease --stacktrace -PreleaseAbi=x86_64
+          scripts/reproducible-build.sh \
+            --verify \
+            --output-dir "$RUNNER_TEMP/reproducible-x86-64" \
+            -- \
+            -PreleaseAbi=x86_64
 
       - name: Prepare and verify x86_64 APK
         id: x86_release_info
@@ -136,13 +147,14 @@ jobs:
           APK_PATH="dist/${APK_NAME}"
           mv app/build/outputs/apk/release/*.apk "$APK_PATH"
 
-          AAPT="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/aapt"
+          BUILD_TOOLS_VERSION="$(sed -n 's/^androidBuildToolsVersion=//p' gradle/reproducible-build.properties)"
+          AAPT="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt"
           "$AAPT" dump badging "$APK_PATH" | tee "$RUNNER_TEMP/x86-64-release-badging.txt"
           grep -q "package: name='org.wisso.newpipematerial'" "$RUNNER_TEMP/x86-64-release-badging.txt"
           grep -q "application-label:'WizeStream'" "$RUNNER_TEMP/x86-64-release-badging.txt"
           scripts/verify-apk-abis.sh "$APK_PATH" x86_64
 
-          APKSIGNER="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/apksigner"
+          APKSIGNER="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/apksigner"
           "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
 
           echo "apk_name=$APK_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 21.0.12+1
+          java-version: 21.0.12+8.0.LTS
           distribution: temurin
           cache: gradle
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@ release tag therefore records and builds the application and service extraction 
 ## Requirements
 
 - Git
-- Eclipse Temurin JDK 21.0.12+1
+- Eclipse Temurin JDK 21.0.12+8
 - Android SDK platform 36.1 and Build Tools 36.1.0
 - Android NDK 28.2.13676358
 - Accepted Android SDK licenses

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,9 +8,17 @@ release tag therefore records and builds the application and service extraction 
 ## Requirements
 
 - Git
-- JDK 21
-- Android SDK with the required platform and build tools
+- Eclipse Temurin JDK 21.0.12+1
+- Android SDK platform 36.1 and Build Tools 36.1.0
+- Android NDK 28.2.13676358
 - Accepted Android SDK licenses
+
+The exact toolchain is recorded in `gradle/reproducible-build.properties`. Install the pinned
+Android components with:
+
+```bash
+sdkmanager "platforms;android-36.1" "build-tools;36.1.0" "ndk;28.2.13676358"
+```
 
 ## Clone the exact source
 
@@ -37,6 +45,12 @@ Build the default ARM64/ARMv7 release APK:
 scripts/build.sh release
 ```
 
+Build it twice from clean state and require identical SHA-256 hashes:
+
+```bash
+scripts/reproducible-build.sh --verify
+```
+
 Build the x86_64 release APK for Waydroid and Android-x86:
 
 ```bash
@@ -45,6 +59,11 @@ scripts/build.sh release -PreleaseAbi=x86_64
 
 The `releaseAbi` property accepts `arm` (the default) or `x86_64`. Published releases build
 both targets from the same tagged source and sign them with the same release key.
+
+The release build runs R8 in a dedicated JVM with one active processor. Other Gradle work keeps
+its normal parallelism. Build and configuration caches are disabled by the reproducible entry
+point, the locale and timezone are fixed, and `SOURCE_DATE_EPOCH` comes from the checked-out
+commit. A verified APK and its `SHA256SUMS` file are written to `dist/reproducible/`.
 
 Run Android instrumented tests:
 
@@ -97,3 +116,7 @@ publishes the existing `wizestream_vX.Y.Z.apk` ARM asset and a separate
 Every published WizeStream APK must be built from the exact commit referenced by its release tag.
 That commit includes the integrated extractor source under `app/src/main/java`. An APK must not be
 replaced with one built from a newer untagged commit; publish a new version and tag instead.
+
+Pull-request CI builds the release APK twice and fails when the SHA-256 hashes differ. The release
+workflow applies the same check to both the signed ARM and x86_64 APKs before either asset can be
+published.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@
 
 import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.tasks.testing.Test
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
@@ -31,7 +32,7 @@ val hasReleaseSigningConfig = listOf(
     releaseKeyPassword
 ).all { !it.isNullOrBlank() }
 
-val reproducibleBuildProperties = java.util.Properties().apply {
+val reproducibleBuildProperties = Properties().apply {
     rootProject.file("gradle/reproducible-build.properties")
         .inputStream()
         .use { load(it) }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,12 @@ val hasReleaseSigningConfig = listOf(
     releaseKeyPassword
 ).all { !it.isNullOrBlank() }
 
+val reproducibleBuildProperties = java.util.Properties().apply {
+    rootProject.file("gradle/reproducible-build.properties")
+        .inputStream()
+        .use { load(it) }
+}
+
 val releaseAbi = providers.gradleProperty("releaseAbi").orElse("arm").get()
 val releaseAbiFilters = when (releaseAbi) {
     "arm" -> setOf("arm64-v8a", "armeabi-v7a")
@@ -51,6 +57,9 @@ kotlin {
 }
 
 configure<ApplicationExtension> {
+    buildToolsVersion = reproducibleBuildProperties.getProperty("androidBuildToolsVersion")
+    ndkVersion = reproducibleBuildProperties.getProperty("androidNdkVersion")
+
     compileSdk {
         version = release(ANDROID_COMPILE_SDK_MAJOR) {
             minorApiLevel = ANDROID_COMPILE_SDK_MINOR

--- a/gradle/reproducible-build.properties
+++ b/gradle/reproducible-build.properties
@@ -1,0 +1,7 @@
+# Toolchain used by scripts/reproducible-build.sh and release CI.
+jdkVersion=21.0.12
+jdkDistributionVersion=21.0.12+1
+androidGradlePluginVersion=9.2.1
+androidPlatform=android-36.1
+androidBuildToolsVersion=36.1.0
+androidNdkVersion=28.2.13676358

--- a/gradle/reproducible-build.properties
+++ b/gradle/reproducible-build.properties
@@ -1,6 +1,6 @@
 # Toolchain used by scripts/reproducible-build.sh and release CI.
 jdkVersion=21.0.12
-jdkDistributionVersion=21.0.12+1
+jdkDistributionVersion=21.0.12+8.0.LTS
 androidGradlePluginVersion=9.2.1
 androidPlatform=android-36.1
 androidBuildToolsVersion=36.1.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ case "$MODE" in
         exec ./gradlew clean assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint "$@"
         ;;
     release)
-        exec ./gradlew clean assembleRelease --stacktrace -DskipFormatKtlint "$@"
+        exec "$ROOT_DIR/scripts/reproducible-build.sh" "$@"
         ;;
     nightly)
         exec ./gradlew \

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERIFY=false
+OUTPUT_DIR="$ROOT_DIR/dist/reproducible"
+GRADLE_ARGS=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --verify)
+            VERIFY=true
+            ;;
+        --output-dir)
+            if [ "$#" -lt 2 ]; then
+                echo "--output-dir requires a directory" >&2
+                exit 2
+            fi
+            OUTPUT_DIR="$2"
+            shift
+            ;;
+        --)
+            shift
+            GRADLE_ARGS+=("$@")
+            break
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--verify] [--output-dir DIR] [-- extra Gradle arguments]"
+            exit 0
+            ;;
+        *)
+            GRADLE_ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
+
+"$ROOT_DIR/scripts/validate-reproducible-toolchain.sh"
+
+SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+export SOURCE_DATE_EPOCH
+export TZ=UTC
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+build_once() {
+    local destination="$1"
+    local apk_paths=()
+
+    ./gradlew \
+        --no-daemon \
+        --no-build-cache \
+        --no-configuration-cache \
+        clean assembleRelease \
+        --stacktrace \
+        -DskipFormatKtlint \
+        "${GRADLE_ARGS[@]}"
+
+    mapfile -t apk_paths < <(find app/build/outputs/apk/release -maxdepth 1 -type f -name '*.apk' | sort)
+    if [ "${#apk_paths[@]}" -ne 1 ]; then
+        echo "Expected exactly one release APK, found ${#apk_paths[@]}" >&2
+        exit 1
+    fi
+    cp "${apk_paths[0]}" "$destination"
+}
+
+mkdir -p "$OUTPUT_DIR"
+
+if [ "$VERIFY" = true ]; then
+    build_once "$TMP_DIR/first.apk"
+    build_once "$TMP_DIR/second.apk"
+
+    FIRST_SHA256="$(sha256sum "$TMP_DIR/first.apk" | cut -d ' ' -f 1)"
+    SECOND_SHA256="$(sha256sum "$TMP_DIR/second.apk" | cut -d ' ' -f 1)"
+
+    if [ "$FIRST_SHA256" != "$SECOND_SHA256" ]; then
+        cp "$TMP_DIR/first.apk" "$OUTPUT_DIR/first.apk"
+        cp "$TMP_DIR/second.apk" "$OUTPUT_DIR/second.apk"
+        printf 'Non-reproducible release APKs:\n  first  %s\n  second %s\n' \
+            "$FIRST_SHA256" "$SECOND_SHA256" >&2
+        exit 1
+    fi
+
+    cp "$TMP_DIR/second.apk" "$OUTPUT_DIR/release.apk"
+    printf '%s  release.apk\n' "$SECOND_SHA256" > "$OUTPUT_DIR/SHA256SUMS"
+    printf 'Reproducible release APK: %s\n' "$SECOND_SHA256"
+else
+    build_once "$OUTPUT_DIR/release.apk"
+    sha256sum "$OUTPUT_DIR/release.apk" | sed 's# .*/#  #' > "$OUTPUT_DIR/SHA256SUMS"
+    cat "$OUTPUT_DIR/SHA256SUMS"
+fi

--- a/scripts/validate-reproducible-toolchain.sh
+++ b/scripts/validate-reproducible-toolchain.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_FILE="$ROOT_DIR/gradle/reproducible-build.properties"
+
+property() {
+    local key="$1"
+    local value
+    value="$(sed -n "s/^${key}=//p" "$CONFIG_FILE")"
+    if [ -z "$value" ]; then
+        echo "Missing ${key} in ${CONFIG_FILE}" >&2
+        exit 1
+    fi
+    printf '%s' "$value"
+}
+
+EXPECTED_JAVA_VERSION="$(property jdkVersion)"
+EXPECTED_AGP_VERSION="$(property androidGradlePluginVersion)"
+ANDROID_PLATFORM="$(property androidPlatform)"
+ANDROID_BUILD_TOOLS_VERSION="$(property androidBuildToolsVersion)"
+ANDROID_NDK_VERSION="$(property androidNdkVersion)"
+
+ACTUAL_JAVA_VERSION="$(java -XshowSettings:properties -version 2>&1 \
+    | sed -n 's/^ *java.version = //p' \
+    | head -n 1)"
+if [ "$ACTUAL_JAVA_VERSION" != "$EXPECTED_JAVA_VERSION" ]; then
+    echo "JDK mismatch: expected ${EXPECTED_JAVA_VERSION}, found ${ACTUAL_JAVA_VERSION:-unknown}" >&2
+    exit 1
+fi
+
+SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [ -z "$SDK_ROOT" ]; then
+    echo "ANDROID_HOME or ANDROID_SDK_ROOT must point to the Android SDK" >&2
+    exit 1
+fi
+
+test -s "$SDK_ROOT/platforms/$ANDROID_PLATFORM/android.jar" || {
+    echo "Missing Android platform ${ANDROID_PLATFORM} under ${SDK_ROOT}" >&2
+    exit 1
+}
+
+for tool in aapt apksigner zipalign; do
+    test -x "$SDK_ROOT/build-tools/$ANDROID_BUILD_TOOLS_VERSION/$tool" || {
+        echo "Missing Build Tools ${ANDROID_BUILD_TOOLS_VERSION} executable: ${tool}" >&2
+        exit 1
+    }
+done
+
+NDK_PROPERTIES="$SDK_ROOT/ndk/$ANDROID_NDK_VERSION/source.properties"
+test -s "$NDK_PROPERTIES" || {
+    echo "Missing Android NDK ${ANDROID_NDK_VERSION} under ${SDK_ROOT}" >&2
+    exit 1
+}
+
+ACTUAL_NDK_VERSION="$(sed -n 's/^Pkg.Revision *= *//p' "$NDK_PROPERTIES" | head -n 1)"
+if [ "$ACTUAL_NDK_VERSION" != "$ANDROID_NDK_VERSION" ]; then
+    echo "NDK mismatch: expected ${ANDROID_NDK_VERSION}, found ${ACTUAL_NDK_VERSION:-unknown}" >&2
+    exit 1
+fi
+
+ACTUAL_AGP_VERSION="$(sed -n 's/^agp = "\([^"]*\)"/\1/p' "$ROOT_DIR/gradle/libs.versions.toml")"
+if [ "$ACTUAL_AGP_VERSION" != "$EXPECTED_AGP_VERSION" ]; then
+    echo "AGP mismatch: reproducible config expects ${EXPECTED_AGP_VERSION}, version catalog uses ${ACTUAL_AGP_VERSION:-unknown}" >&2
+    exit 1
+fi
+
+printf 'Pinned toolchain: JDK %s, %s, Build Tools %s, NDK %s, AGP %s\n' \
+    "$ACTUAL_JAVA_VERSION" \
+    "$ANDROID_PLATFORM" \
+    "$ANDROID_BUILD_TOOLS_VERSION" \
+    "$ACTUAL_NDK_VERSION" \
+    "$ACTUAL_AGP_VERSION"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,12 +33,14 @@ android {
                 r8 {
                     runInSeparateProcess = true
                     jvmOptions.addAll(
-                        "-Xmx2048m",
-                        "-XX:ActiveProcessorCount=1",
-                        "-Dfile.encoding=UTF-8",
-                        "-Duser.language=en",
-                        "-Duser.country=US",
-                        "-Duser.timezone=UTC"
+                        listOf(
+                            "-Xmx2048m",
+                            "-XX:ActiveProcessorCount=1",
+                            "-Dfile.encoding=UTF-8",
+                            "-Duser.language=en",
+                            "-Duser.country=US",
+                            "-Duser.timezone=UTC"
+                        )
                     )
                 }
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,16 +2,51 @@
  * SPDX-FileCopyrightText: 2025 NewPipe e.V. <https://newpipe-ev.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-rootProject.name = "WizeStream"
-
 pluginManagement {
+    val reproducibleBuildProperties = java.util.Properties().apply {
+        file("gradle/reproducible-build.properties").inputStream().use { load(it) }
+    }
+
+    plugins {
+        id("com.android.settings") version
+            reproducibleBuildProperties.getProperty("androidGradlePluginVersion")
+    }
+
     repositories {
         gradlePluginPortal()
         google()
         mavenCentral()
     }
 }
+
+plugins {
+    id("com.android.settings")
+}
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+rootProject.name = "WizeStream"
+
+android {
+    execution {
+        profiles {
+            create("reproducibleRelease") {
+                r8 {
+                    runInSeparateProcess = true
+                    jvmOptions.addAll(
+                        "-Xmx2048m",
+                        "-XX:ActiveProcessorCount=1",
+                        "-Dfile.encoding=UTF-8",
+                        "-Duser.language=en",
+                        "-Duser.country=US",
+                        "-Duser.timezone=UTC"
+                    )
+                }
+            }
+        }
+        defaultProfile = "reproducibleRelease"
+    }
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
- Run R8 in a dedicated JVM with one active processor while preserving normal Gradle parallelism for all other work.
- Pin Temurin 21.0.12+8, Android platform 36.1, Build Tools 36.1.0, NDK 28.2.13676358, AGP 9.2.1, and the existing checksum-verified Gradle wrapper.
- Add `scripts/reproducible-build.sh` as the shared local and CI release entry point with fixed locale, timezone, commit-derived `SOURCE_DATE_EPOCH`, and disabled build/configuration caches.
- Build clean release APKs twice and compare SHA-256 in pull-request CI.
- Apply the same two-build SHA-256 gate to both signed ARM and x86_64 APKs before publishing a release.
- Document the exact toolchain and independent verification command for downstream builders.
- Reference #243 without closing it; the issue remains open until Izzy confirms the next APK reproduces independently.