### PR TITLE
Fix BiliBili empty POST requests

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
@@ -196,10 +196,7 @@ public final class DownloaderImpl extends Downloader {
         final Map<String, List<String>> headers = request.headers();
         final byte[] dataToSend = request.dataToSend();
 
-        RequestBody requestBody = null;
-        if (dataToSend != null) {
-            requestBody = RequestBody.create(dataToSend);
-        }
+        final RequestBody requestBody = buildRequestBody(httpMethod, dataToSend);
 
         final okhttp3.Request.Builder requestBuilder = new okhttp3.Request.Builder()
                 .method(httpMethod, requestBody)
@@ -217,6 +214,18 @@ public final class DownloaderImpl extends Downloader {
                     requestBuilder.addHeader(headerName, headerValue));
         });
         return requestBuilder.build();
+    }
+
+    @Nullable
+    static RequestBody buildRequestBody(@NonNull final String httpMethod,
+                                        @Nullable final byte[] dataToSend) {
+        if (dataToSend != null) {
+            return RequestBody.create(dataToSend);
+        }
+
+        // OkHttp requires POST requests to have a body, while the extractor downloader contract
+        // permits callers to represent an empty body with null.
+        return "POST".equals(httpMethod) ? RequestBody.create(new byte[0]) : null;
     }
 
     @NonNull

--- a/app/src/test/java/org/schabi/newpipe/DownloaderImplTest.java
+++ b/app/src/test/java/org/schabi/newpipe/DownloaderImplTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+public class DownloaderImplTest {
+    @Test
+    public void postWithoutDataUsesEmptyRequestBody() throws IOException {
+        final RequestBody requestBody = DownloaderImpl.buildRequestBody("POST", null);
+
+        assertNotNull(requestBody);
+        assertEquals(0, requestBody.contentLength());
+        final Buffer buffer = new Buffer();
+        requestBody.writeTo(buffer);
+        assertEquals(0, buffer.size());
+    }
+
+    @Test
+    public void postWithDataPreservesRequestBody() throws IOException {
+        final byte[] payload = "ticket-request".getBytes(StandardCharsets.UTF_8);
+        final RequestBody requestBody = DownloaderImpl.buildRequestBody("POST", payload);
+
+        assertNotNull(requestBody);
+        assertEquals(payload.length, requestBody.contentLength());
+        final Buffer buffer = new Buffer();
+        requestBody.writeTo(buffer);
+        assertArrayEquals(payload, buffer.readByteArray());
+    }
+
+    @Test
+    public void methodsWithoutDataRemainBodyless() {
+        assertNull(DownloaderImpl.buildRequestBody("GET", null));
+        assertNull(DownloaderImpl.buildRequestBody("HEAD", null));
+        assertNull(DownloaderImpl.buildRequestBody("OPTIONS", null));
+    }
+}


### PR DESCRIPTION
- Send a zero-length OkHttp request body when the extractor represents an empty `POST` body as `null`
- Preserve existing payloads and keep `GET`, `HEAD`, and `OPTIONS` bodyless
- Add regression coverage for empty, populated, and bodyless requests
- Restore BiliBili ticket acquisition before kiosk loading