### PR TITLE
Prevent FCast crashes on null manifest URLs

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/cast/FCastManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/cast/FCastManager.kt
@@ -358,8 +358,9 @@ object FCastManager {
         .isPresent
 
     private fun selectSource(context: Context, info: StreamInfo): CastSource? {
-        if (info.hlsUrl.isNotBlank()) {
-            return CastSource(info.hlsUrl, "application/vnd.apple.mpegurl")
+        val hlsUrl: String? = info.hlsUrl
+        if (!hlsUrl.isNullOrBlank()) {
+            return CastSource(hlsUrl, "application/vnd.apple.mpegurl")
         }
 
         val videoStreams = info.videoStreams
@@ -372,8 +373,9 @@ object FCastManager {
             return sourceFrom(videoStreams[index])
         }
 
-        if (info.dashMpdUrl.isNotBlank()) {
-            return CastSource(info.dashMpdUrl, "application/dash+xml")
+        val dashMpdUrl: String? = info.dashMpdUrl
+        if (!dashMpdUrl.isNullOrBlank()) {
+            return CastSource(dashMpdUrl, "application/dash+xml")
         }
 
         return info.audioStreams.firstOrNull { it.isUrl }?.let(::sourceFrom)

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/niconico/extractors/NiconicoStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/niconico/extractors/NiconicoStreamExtractor.java
@@ -498,6 +498,6 @@ public class NiconicoStreamExtractor extends StreamExtractor {
         if (getStreamType() == StreamType.LIVE_STREAM) {
             return getUrl();
         }
-        return null;
+        return "";
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/stream/StreamInfo.java
@@ -765,7 +765,7 @@ public class StreamInfo extends Info {
     }
 
     public void setDashMpdUrl(final String dashMpdUrl) {
-        this.dashMpdUrl = dashMpdUrl;
+        this.dashMpdUrl = dashMpdUrl == null ? "" : dashMpdUrl;
     }
 
     public String getHlsUrl() {
@@ -773,7 +773,7 @@ public class StreamInfo extends Info {
     }
 
     public void setHlsUrl(final String hlsUrl) {
-        this.hlsUrl = hlsUrl;
+        this.hlsUrl = hlsUrl == null ? "" : hlsUrl;
     }
 
     public List<InfoItem> getRelatedItems() {

--- a/app/src/test/java/org/schabi/newpipe/extractor/stream/StreamInfoTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/stream/StreamInfoTest.java
@@ -13,6 +13,17 @@ import static org.mockito.Mockito.when;
 class StreamInfoTest {
 
     @Test
+    void normalizesNullManifestUrls() {
+        final StreamInfo streamInfo = new StreamInfo();
+
+        streamInfo.setHlsUrl(null);
+        streamInfo.setDashMpdUrl(null);
+
+        assertEquals("", streamInfo.getHlsUrl());
+        assertEquals("", streamInfo.getDashMpdUrl());
+    }
+
+    @Test
     void acceptsHlsOnlyLiveStream() throws Exception {
         final StreamExtractor extractor = createExtractor();
         final String hlsUrl = "https://example.com/live.m3u8";


### PR DESCRIPTION
- Return an empty HLS URL for NicoNico non-live streams instead of violating the extractor contract with `null`
- Normalize null HLS and DASH manifest URLs when constructing `StreamInfo`
- Make FCast source selection defensively tolerate null or blank manifests
- Add regression coverage for the non-null manifest invariant