### PR TITLE
Handle BiliBili risk-control blocks gracefully

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/error/ErrorInfoTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/error/ErrorInfoTest.java
@@ -10,11 +10,13 @@ import org.junit.runner.RunWith;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.exceptions.ServiceTemporaryBlockedException;
 
 import java.util.Arrays;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -58,5 +60,20 @@ public class ErrorInfoTest {
         assertEquals(R.string.parsing_error, getMessageFromErrorInfo(infoFromParcel));
 
         parcel.recycle();
+    }
+
+    @Test
+    public void temporaryServiceBlockIsRetryableButNotReportable()
+            throws NoSuchFieldException, IllegalAccessException {
+        final ErrorInfo info = new ErrorInfo(
+                new ServiceTemporaryBlockedException("temporarily blocked"),
+                UserAction.REQUESTED_CHANNEL,
+                "https://space.bilibili.com/1",
+                ServiceList.BiliBili.getServiceId()
+        );
+
+        assertEquals(R.string.service_temporary_block, getMessageFromErrorInfo(info));
+        assertFalse(info.isReportable());
+        assertTrue(info.isRetryable());
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
@@ -22,6 +22,7 @@ import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException
 import org.schabi.newpipe.extractor.exceptions.PaidContentException
 import org.schabi.newpipe.extractor.exceptions.PrivateContentException
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import org.schabi.newpipe.extractor.exceptions.ServiceTemporaryBlockedException
 import org.schabi.newpipe.extractor.exceptions.SoundCloudGoPlusContentException
 import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException
 import org.schabi.newpipe.ktx.isNetworkRelated
@@ -255,6 +256,12 @@ class ErrorInfo private constructor(
                         YOUTUBE_IP_BAN_FAQ_URL
                     )
 
+                throwable is ServiceTemporaryBlockedException ->
+                    ErrorMessage(
+                        R.string.service_temporary_block,
+                        getServiceName(serviceId)
+                    )
+
                 throwable is ContentNotAvailableException ->
                     ErrorMessage(R.string.content_not_available)
 
@@ -311,6 +318,9 @@ class ErrorInfo private constructor(
 
                 // we know the content is not supported, no need to let the user report it
                 is ContentNotSupportedException -> false
+
+                // Temporary anti-bot blocks are service/network conditions, not app defects.
+                is ServiceTemporaryBlockedException -> false
 
                 // happens often when there is no internet connection; we don't use
                 // `throwable.isNetworkRelated` since any `IOException` would make that function

--- a/app/src/main/java/org/schabi/newpipe/extractor/exceptions/ServiceTemporaryBlockedException.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/exceptions/ServiceTemporaryBlockedException.java
@@ -1,0 +1,19 @@
+package org.schabi.newpipe.extractor.exceptions;
+
+/**
+ * Indicates that a service temporarily rejected otherwise valid requests through its anti-bot or
+ * risk-control system.
+ *
+ * <p>This is an expected, retryable service condition rather than evidence that the extractor no
+ * longer understands the response format.</p>
+ */
+public class ServiceTemporaryBlockedException extends AntiBotException {
+
+    public ServiceTemporaryBlockedException(final String message) {
+        super(message);
+    }
+
+    public ServiceTemporaryBlockedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliService.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliService.java
@@ -505,11 +505,18 @@ public class BilibiliService extends StreamingService {
 
     private static int userVideoApiMode = USER_VIDEO_API_MODE_WEB;
 
-    public static int getCurrentVideoApiMode() {
+    public static synchronized int getCurrentVideoApiMode() {
         return userVideoApiMode;
     }
 
-    public static void rotateVideoApiMode() {
+    public static synchronized void rotateVideoApiMode() {
         userVideoApiMode = (userVideoApiMode + 1) % SIZE_USER_VIDEO_API_MODE;
+    }
+
+    public static synchronized void setCurrentVideoApiMode(final int mode) {
+        if (mode < 0 || mode >= SIZE_USER_VIDEO_API_MODE) {
+            throw new IllegalArgumentException("Unknown user video API mode: " + mode);
+        }
+        userVideoApiMode = mode;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractor.java
@@ -13,9 +13,11 @@ import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.exceptions.ServiceTemporaryBlockedException;
 import org.schabi.newpipe.extractor.linkhandler.ChannelTabs;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.search.filter.Filter;
@@ -45,10 +47,9 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
     private final ClientUserVideoImpl clientUserVideoImpl = new ClientUserVideoImpl();
     private final SearchUserVideoImpl searchUserVideoImpl = new SearchUserVideoImpl();
     private final WebUserVideoImpl webUserVideoImpl = new WebUserVideoImpl();
+    private UserVideoImpl activeUserVideoImpl;
 
-
-    private UserVideoImpl getVideoImpl() {
-        int mode = getCurrentVideoApiMode();
+    private UserVideoImpl getVideoImpl(final int mode) {
         switch (mode) {
             case USER_VIDEO_API_MODE_WEB:
                 return webUserVideoImpl;
@@ -57,8 +58,82 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
             case USER_VIDEO_API_MODE_CLIENT:
                 return clientUserVideoImpl;
             default:
-                rotateVideoApiMode();
                 return webUserVideoImpl;
+        }
+    }
+
+    private UserVideoImpl getActiveVideoImpl() {
+        if (activeUserVideoImpl == null) {
+            activeUserVideoImpl = getVideoImpl(getCurrentVideoApiMode());
+        }
+        return activeUserVideoImpl;
+    }
+
+    @FunctionalInterface
+    interface VideoApiAttempt {
+        void fetch(int mode) throws IOException, ExtractionException;
+    }
+
+    static int runVideoApiFallback(final int preferredMode, final VideoApiAttempt attempt)
+            throws IOException, ExtractionException {
+        ServiceTemporaryBlockedException lastBlock = null;
+
+        for (int offset = 0; offset < SIZE_USER_VIDEO_API_MODE; offset++) {
+            final int mode = (preferredMode + offset) % SIZE_USER_VIDEO_API_MODE;
+            try {
+                attempt.fetch(mode);
+                setCurrentVideoApiMode(mode);
+                return mode;
+            } catch (final ServiceTemporaryBlockedException block) {
+                lastBlock = block;
+                if (offset + 1 < SIZE_USER_VIDEO_API_MODE) {
+                    DeviceForger.regenerateRandomDevice();
+                }
+            }
+        }
+
+        // Avoid starting the next manual retry with the same endpoint that was attempted first.
+        setCurrentVideoApiMode((preferredMode + 1) % SIZE_USER_VIDEO_API_MODE);
+        throw lastBlock;
+    }
+
+    private UserVideoImpl fetchInitialVideoPageWithFallback(
+            @Nonnull final Downloader downloader,
+            final String id,
+            final String url
+    ) throws IOException, ExtractionException {
+        final int mode = runVideoApiFallback(
+                getCurrentVideoApiMode(),
+                candidateMode -> getVideoImpl(candidateMode).onFetchPage(downloader, id, url)
+        );
+        activeUserVideoImpl = getVideoImpl(mode);
+        return activeUserVideoImpl;
+    }
+
+    private NextVideoPageResult fetchNextVideoPageWithFallback(
+            @Nonnull final Page page,
+            @Nonnull final StreamInfoItemsCollector collector,
+            @Nonnull final Downloader downloader,
+            @Nonnull final ChannelExtractor extractor,
+            @Nonnull final String id
+    ) throws IOException, ExtractionException {
+        final boolean[] hasVideos = {false};
+        final int mode = runVideoApiFallback(
+                getCurrentVideoApiMode(),
+                candidateMode -> hasVideos[0] = getVideoImpl(candidateMode)
+                        .getPage(page, collector, downloader, extractor, id)
+        );
+        activeUserVideoImpl = getVideoImpl(mode);
+        return new NextVideoPageResult(activeUserVideoImpl, hasVideos[0]);
+    }
+
+    private static final class NextVideoPageResult {
+        private final UserVideoImpl videoImpl;
+        private final boolean hasVideos;
+
+        private NextVideoPageResult(final UserVideoImpl videoImpl, final boolean hasVideos) {
+            this.videoImpl = videoImpl;
+            this.hasVideos = hasVideos;
         }
     }
     //endregion
@@ -72,7 +147,7 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
         Map<String, List<String>> headers = getHeaders(getOriginalUrl());
         String id = getId();
 
-        getVideoImpl().onFetchPage(downloader, id, getUrl());
+        fetchInitialVideoPageWithFallback(downloader, id, getUrl());
 
         userInfoData = requestUserSpaceResponse(downloader, QUERY_USER_INFO_URL + id, headers);
 
@@ -93,7 +168,7 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
         if (userLiveData.getObject("data").getObject(getId()).getInt("live_status") != 0) {
             collector.commit(new BilibiliLiveInfoItemExtractor(userLiveData.getObject("data").getObject(getId()), 1));
         }
-        UserVideoImpl videoImpl = getVideoImpl();
+        UserVideoImpl videoImpl = getActiveVideoImpl();
         boolean hasVideos = videoImpl.getInitialPage(collector, this);
         Page nextPage = null;
         if (hasVideos) nextPage = new Page(getNextPageFromCurrentUrl(
@@ -114,8 +189,10 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
         userInfoData = requestUserSpaceResponse(downloader, QUERY_USER_INFO_URL + id, headers);
 
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        UserVideoImpl videoImpl = getVideoImpl();
-        boolean hasVideos = videoImpl.getPage(page, collector, getDownloader(), this, getId());
+        NextVideoPageResult result = fetchNextVideoPageWithFallback(
+                page, collector, downloader, this, id);
+        UserVideoImpl videoImpl = result.videoImpl;
+        boolean hasVideos = result.hasVideos;
         Page nextPage = null;
         if (hasVideos) nextPage = new Page(
                 getNextPageFromCurrentUrl(page.getUrl(), "pn", 1), String.valueOf(videoImpl.lastVideo()), null, BilibiliService.getDefaultCookies(), null
@@ -544,45 +621,68 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
             String url,
             Map<String, List<String>> headers
     ) throws ParsingException, IOException, ReCaptchaException {
-        int maxTry = 2;
-        int currentTry = maxTry;
+        final Response response = downloader.get(url, headers);
+        final String responseBody = stripLeadingBomAndWhitespace(response.responseBody());
 
-        String responseBody = "";
-
-        while (currentTry > 0) {
-            responseBody = downloader.get(url, headers).responseBody();
-            if (responseBody.startsWith("<!DOCTYPE html>")) {
-                // returns HTML, due to risk control
-                DeviceForger.regenerateRandomDevice(); // try to regenerate a new one
-                currentTry -= 1;
-                continue;
-            }
-            try {
-                JsonObject responseJson = JsonParser.object().from(responseBody);
-                long code = responseJson.getLong("code");
-                if (code != 0) {
-                    if (code == -352) {
-                        // blocked risk control
-                        DeviceForger.regenerateRandomDevice(); // try to regenerate a new one
-                    }
-                    currentTry -= 1;
-                } else {
-                    return responseJson;
-                }
-            } catch (JsonParserException e) {
-                e.printStackTrace();
-                throw new ParsingException("Failed parse response body: " + responseBody);
-            }
+        if (isRiskControlResponse(response.responseCode(), responseBody)) {
+            throw temporaryBlock();
         }
 
-        DeviceForger.Device device = DeviceForger.requireRandomDevice();
-        String msg = "BiliBili blocked us, we retried " + maxTry + " times, the last forged device is:\n"
-                + device.info()
-                + "\nTry to refresh, or report this!\n"
-                + responseBody;
-        rotateVideoApiMode();
-        DeviceForger.regenerateRandomDevice(); // try to regenerate a new one
-        throw new ParsingException(msg);
+        final JsonObject responseJson;
+        try {
+            responseJson = JsonParser.object().from(responseBody);
+        } catch (final JsonParserException error) {
+            throw new ParsingException(
+                    "BiliBili returned an invalid response (HTTP "
+                            + response.responseCode() + ")",
+                    error
+            );
+        }
+
+        final long code = responseJson.getLong("code");
+        if (code == -352) {
+            throw temporaryBlock();
+        }
+        if (code != 0) {
+            throw new ParsingException("BiliBili API returned error code " + code);
+        }
+        return responseJson;
+    }
+
+    static boolean isRiskControlResponse(final int responseCode, final String responseBody) {
+        if (responseCode == 412) {
+            return true;
+        }
+
+        final String normalizedBody = stripLeadingBomAndWhitespace(responseBody);
+        if (!normalizedBody.regionMatches(true, 0, "<!doctype html", 0, 14)
+                && !normalizedBody.regionMatches(true, 0, "<html", 0, 5)) {
+            return false;
+        }
+
+        final String lowerBody = normalizedBody.toLowerCase(java.util.Locale.ROOT);
+        return lowerBody.contains("security.bilibili.com")
+                || lowerBody.contains("security control policy")
+                || normalizedBody.contains("错误号: 412")
+                || normalizedBody.contains("风控策略");
+    }
+
+    static String stripLeadingBomAndWhitespace(final String responseBody) {
+        int offset = 0;
+        while (offset < responseBody.length()) {
+            final char character = responseBody.charAt(offset);
+            if (character != '\uFEFF' && !Character.isWhitespace(character)) {
+                break;
+            }
+            offset++;
+        }
+        return responseBody.substring(offset);
+    }
+
+    private static ServiceTemporaryBlockedException temporaryBlock() {
+        return new ServiceTemporaryBlockedException(
+                "BiliBili temporarily blocked requests from this network"
+        );
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1325,6 +1325,7 @@
     <string name="player_http_invalid_status">HTTP error %1$s received from server while playing</string>
     <string name="youtube_player_http_403">HTTP error 403 received from server while playing, likely caused by an IP ban or streaming URL deobfuscation issues</string>
     <string name="sign_in_confirm_not_bot_error">%1$s refused to provide data, asking for a login to confirm the requester is not a bot.\n\nYour IP might have been temporarily banned by %1$s, you can wait some time or switch to a different IP (for example by turning on/off a VPN, or by switching from WiFi to mobile data).\n\nPlease see <a href="%2$s">this FAQ entry</a> for more information.</string>
+    <string name="service_temporary_block">%1$s temporarily blocked requests from this network. Wait and try again, or switch to another network.</string>
     <string name="unsupported_content_in_country">This content is not available for the currently selected content country.\n\nChange your selection from \"Settings > Content > Default content country\".</string>
     <string name="kao_dialog_warning">In August 2025, Google announced that as of September 2026, installing apps will require developer verification for all Android apps on certified devices, including those installed outside of the Play Store. Since the developers of WizeStream do not agree to this requirement, WizeStream will no longer work on certified Android devices after that time.</string>
     <string name="kao_dialog_more_info">Details</string>

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractorRiskControlTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractorRiskControlTest.java
@@ -4,9 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.USER_VIDEO_API_MODE_CLIENT;
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.USER_VIDEO_API_MODE_SEARCH;
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.USER_VIDEO_API_MODE_WEB;
@@ -17,7 +14,9 @@ import com.grack.nanojson.JsonObject;
 
 import org.junit.After;
 import org.junit.Test;
+import org.schabi.newpipe.extractor.downloader.CancellableCall;
 import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Request;
 import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ServiceTemporaryBlockedException;
@@ -172,15 +171,27 @@ public class BilibiliChannelExtractorRiskControlTest {
 
     private static Downloader downloaderReturning(final int responseCode, final String body)
             throws Exception {
-        final Downloader downloader = mock(Downloader.class);
-        when(downloader.execute(any())).thenReturn(new Response(
+        final Response response = new Response(
                 responseCode,
                 "response",
                 Collections.emptyMap(),
                 body,
                 body.getBytes(StandardCharsets.UTF_8),
                 URL
-        ));
-        return downloader;
+        );
+        return new Downloader() {
+            @Override
+            public Response execute(final Request request) {
+                return response;
+            }
+
+            @Override
+            public CancellableCall executeAsync(
+                    final Request request,
+                    final AsyncCallback callback
+            ) {
+                throw new UnsupportedOperationException("Async requests are not used in this test");
+            }
+        };
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractorRiskControlTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractorRiskControlTest.java
@@ -1,0 +1,186 @@
+package org.schabi.newpipe.extractor.services.bilibili.extractors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.USER_VIDEO_API_MODE_CLIENT;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.USER_VIDEO_API_MODE_SEARCH;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.USER_VIDEO_API_MODE_WEB;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getCurrentVideoApiMode;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.setCurrentVideoApiMode;
+
+import com.grack.nanojson.JsonObject;
+
+import org.junit.After;
+import org.junit.Test;
+import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.exceptions.ServiceTemporaryBlockedException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BilibiliChannelExtractorRiskControlTest {
+
+    private static final String URL = "https://api.bilibili.com/test";
+
+    @After
+    public void resetPreferredMode() {
+        setCurrentVideoApiMode(USER_VIDEO_API_MODE_WEB);
+    }
+
+    @Test
+    public void recognizesHttp412WithLeadingBomAndWhitespace() throws Exception {
+        final String body = "\uFEFF  \n<!DOCTYPE html><html>ordinary response</html>";
+        final ServiceTemporaryBlockedException exception = assertThrows(
+                ServiceTemporaryBlockedException.class,
+                () -> BilibiliChannelExtractor.requestUserSpaceResponse(
+                        downloaderReturning(412, body), URL, Collections.emptyMap())
+        );
+
+        assertEquals("BiliBili temporarily blocked requests from this network",
+                exception.getMessage());
+        assertFalse(exception.getMessage().contains("<!DOCTYPE"));
+    }
+
+    @Test
+    public void recognizesSecurityHtmlReturnedWithSuccessStatus() throws Exception {
+        final String body = "\uFEFF \n<!DOCTYPE html><html>"
+                + "<script src=\"//security.bilibili.com/static/js/412.js\"></script>"
+                + "</html>";
+
+        assertThrows(
+                ServiceTemporaryBlockedException.class,
+                () -> BilibiliChannelExtractor.requestUserSpaceResponse(
+                        downloaderReturning(200, body), URL, Collections.emptyMap())
+        );
+    }
+
+    @Test
+    public void recognizesJsonRiskControlCode() throws Exception {
+        final String body = "{\"code\":-352,\"message\":\"risk control\","
+                + "\"data\":{\"v_voucher\":\"private-value\"}}";
+        setCurrentVideoApiMode(USER_VIDEO_API_MODE_SEARCH);
+        final ServiceTemporaryBlockedException exception = assertThrows(
+                ServiceTemporaryBlockedException.class,
+                () -> BilibiliChannelExtractor.requestUserSpaceResponse(
+                        downloaderReturning(200, body), URL, Collections.emptyMap())
+        );
+
+        assertFalse(exception.getMessage().contains("private-value"));
+        assertEquals(USER_VIDEO_API_MODE_SEARCH, getCurrentVideoApiMode());
+    }
+
+    @Test
+    public void returnsSuccessfulJsonResponse() throws Exception {
+        final JsonObject response = BilibiliChannelExtractor.requestUserSpaceResponse(
+                downloaderReturning(200, "{\"code\":0,\"data\":{\"name\":\"ok\"}}"),
+                URL,
+                Collections.emptyMap()
+        );
+
+        assertEquals("ok", response.getObject("data").getString("name"));
+    }
+
+    @Test
+    public void sanitizesUnexpectedNonJsonResponse() throws Exception {
+        final String body = "<html>not a BiliBili security response</html>";
+        final ParsingException exception = assertThrows(
+                ParsingException.class,
+                () -> BilibiliChannelExtractor.requestUserSpaceResponse(
+                        downloaderReturning(500, body), URL, Collections.emptyMap())
+        );
+
+        assertTrue(exception.getMessage().contains("HTTP 500"));
+        assertFalse(exception.getMessage().contains(body));
+    }
+
+    @Test
+    public void fallsBackAcrossEachVideoApiOnceAndKeepsSuccessfulMode() throws Exception {
+        final List<Integer> attemptedModes = new ArrayList<>();
+
+        final int selectedMode = BilibiliChannelExtractor.runVideoApiFallback(
+                USER_VIDEO_API_MODE_WEB,
+                mode -> {
+                    attemptedModes.add(mode);
+                    if (mode != USER_VIDEO_API_MODE_CLIENT) {
+                        throw blocked();
+                    }
+                }
+        );
+
+        assertEquals(List.of(
+                USER_VIDEO_API_MODE_WEB,
+                USER_VIDEO_API_MODE_SEARCH,
+                USER_VIDEO_API_MODE_CLIENT
+        ), attemptedModes);
+        assertEquals(USER_VIDEO_API_MODE_CLIENT, selectedMode);
+        assertEquals(USER_VIDEO_API_MODE_CLIENT, getCurrentVideoApiMode());
+    }
+
+    @Test
+    public void stopsAfterAllVideoApisAreBlocked() {
+        final List<Integer> attemptedModes = new ArrayList<>();
+
+        assertThrows(
+                ServiceTemporaryBlockedException.class,
+                () -> BilibiliChannelExtractor.runVideoApiFallback(
+                        USER_VIDEO_API_MODE_SEARCH,
+                        mode -> {
+                            attemptedModes.add(mode);
+                            throw blocked();
+                        }
+                )
+        );
+
+        assertEquals(List.of(
+                USER_VIDEO_API_MODE_SEARCH,
+                USER_VIDEO_API_MODE_CLIENT,
+                USER_VIDEO_API_MODE_WEB
+        ), attemptedModes);
+        assertEquals(USER_VIDEO_API_MODE_CLIENT, getCurrentVideoApiMode());
+    }
+
+    @Test
+    public void doesNotFallbackForOrdinaryParsingFailures() {
+        final List<Integer> attemptedModes = new ArrayList<>();
+
+        assertThrows(
+                ParsingException.class,
+                () -> BilibiliChannelExtractor.runVideoApiFallback(
+                        USER_VIDEO_API_MODE_WEB,
+                        mode -> {
+                            attemptedModes.add(mode);
+                            throw new ParsingException("unexpected schema");
+                        }
+                )
+        );
+
+        assertEquals(List.of(USER_VIDEO_API_MODE_WEB), attemptedModes);
+    }
+
+    private static ServiceTemporaryBlockedException blocked() {
+        return new ServiceTemporaryBlockedException("temporarily blocked");
+    }
+
+    private static Downloader downloaderReturning(final int responseCode, final String body)
+            throws Exception {
+        final Downloader downloader = mock(Downloader.class);
+        when(downloader.execute(any())).thenReturn(new Response(
+                responseCode,
+                "response",
+                Collections.emptyMap(),
+                body,
+                body.getBytes(StandardCharsets.UTF_8),
+                URL
+        ));
+        return downloader;
+    }
+}


### PR DESCRIPTION
- Detect HTTP 412 responses, BiliBili security HTML, and API code `-352` as temporary service blocks without exposing response bodies or forged-device details.
- Try the Web, Search, and Client channel APIs at most once each, retain the successful mode, and stop cleanly when every mode is blocked.
- Keep profile and live-status failures from rotating the video API mode.
- Present temporary blocks as retryable, non-reportable service conditions with concise network guidance.
- Add JVM and Android regression coverage for risk-control detection, response sanitization, fallback ordering, exhaustion, and error classification.