### PR TITLE
Refresh service-scoped feeds without restart

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/feed/FeedScopeTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/feed/FeedScopeTest.kt
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.feed
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
+import org.schabi.newpipe.util.ServiceHelper
+
+@RunWith(AndroidJUnit4::class)
+class FeedScopeTest {
+    @Test
+    fun changesFollowServiceAndYoutubeModeWithoutRecreatingSubscriber() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        ServiceHelper.setSelectedServiceId(context, SubscriptionEntity.YOUTUBE_SERVICE_ID)
+
+        val observer = FeedScope.changes(context).test()
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ServiceHelper.setSelectedServiceId(context, 1)
+            ServiceHelper.setSelectedServiceId(context, SubscriptionEntity.YOUTUBE_SERVICE_ID)
+            ServiceHelper.setYoutubeMusicMode(context)
+        }
+
+        observer.awaitCount(4)
+            .assertValueCount(4)
+            .assertValueAt(
+                0,
+                FeedScope(
+                    SubscriptionEntity.YOUTUBE_SERVICE_ID,
+                    SubscriptionEntity.YOUTUBE_MODE_REGULAR
+                )
+            )
+            .assertValueAt(
+                1,
+                FeedScope(1, SubscriptionEntity.YOUTUBE_MODE_REGULAR)
+            )
+            .assertValueAt(
+                2,
+                FeedScope(
+                    SubscriptionEntity.YOUTUBE_SERVICE_ID,
+                    SubscriptionEntity.YOUTUBE_MODE_REGULAR
+                )
+            )
+            .assertValueAt(
+                3,
+                FeedScope(
+                    SubscriptionEntity.YOUTUBE_SERVICE_ID,
+                    SubscriptionEntity.YOUTUBE_MODE_MUSIC
+                )
+            )
+            .assertNoErrors()
+
+        observer.cancel()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            ServiceHelper.setSelectedServiceId(context, SubscriptionEntity.YOUTUBE_SERVICE_ID)
+        }
+        observer.assertValueCount(4)
+    }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.schabi.newpipe.database.AppDatabase;
 import org.schabi.newpipe.database.feed.model.FeedGroupEntity;
 import org.schabi.newpipe.database.subscription.SubscriptionEntity;
+import org.schabi.newpipe.local.feed.FeedScope;
 import org.schabi.newpipe.testUtil.TestDatabase;
 import org.schabi.newpipe.testUtil.TrampolineSchedulerRule;
 import org.schabi.newpipe.util.ServiceHelper;
@@ -142,5 +143,32 @@ public class SubscriptionManagerTest {
         assertEquals(1, manager.getSubscriptions(
                 FeedGroupEntity.GROUP_ALL_ID, "", false)
                 .blockingFirst().get(0).getServiceId());
+    }
+
+    @Test
+    public void subscriptionsCanSwitchServiceAndYoutubeModeWithoutRecreatingManager() {
+        manager.insertSubscription(createSubscriptionEntity());
+
+        final SubscriptionEntity otherServiceSubscription = createSubscriptionEntity();
+        otherServiceSubscription.setServiceId(1);
+        otherServiceSubscription.setUrl("https://example.com/other-service/channel");
+        database.subscriptionDAO().insert(otherServiceSubscription);
+
+        assertEquals(0, manager.getSubscriptionsForScope(
+                new FeedScope(SERVICE_ID, SubscriptionEntity.YOUTUBE_MODE_MUSIC),
+                FeedGroupEntity.GROUP_ALL_ID,
+                "",
+                false).blockingFirst().size());
+
+        final List<SubscriptionEntity> otherServiceSubscriptions = manager
+                .getSubscriptionsForScope(
+                        new FeedScope(1, SubscriptionEntity.YOUTUBE_MODE_REGULAR),
+                        FeedGroupEntity.GROUP_ALL_ID,
+                        "",
+                        false)
+                .blockingFirst();
+
+        assertEquals(1, otherServiceSubscriptions.size());
+        assertEquals(1, otherServiceSubscriptions.get(0).getServiceId());
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedScope.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedScope.kt
@@ -6,6 +6,11 @@
 package org.schabi.newpipe.local.feed
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import io.reactivex.rxjava3.core.BackpressureStrategy
+import io.reactivex.rxjava3.core.Flowable
+import org.schabi.newpipe.R
 import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.util.ServiceHelper
 
@@ -38,6 +43,39 @@ data class FeedScope(
                     SubscriptionEntity.YOUTUBE_MODE_REGULAR
                 }
             )
+        }
+
+        /**
+         * Emits the current scope and every subsequent service or YouTube mode selection.
+         *
+         * The stream owns its preference listener, so disposing the subscription also unregisters
+         * the listener. Distinct scope values prevent an unchanged preference value from
+         * rebuilding service-scoped database subscriptions.
+         */
+        @JvmStatic
+        fun changes(context: Context): Flowable<FeedScope> {
+            val applicationContext = context.applicationContext
+            val preferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+            val servicePreferenceKey = applicationContext.getString(R.string.current_service_key)
+
+            return Flowable
+                .create(
+                    { emitter ->
+                        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+                            if (key == servicePreferenceKey) {
+                                emitter.onNext(from(applicationContext))
+                            }
+                        }
+
+                        preferences.registerOnSharedPreferenceChangeListener(listener)
+                        emitter.setCancellable {
+                            preferences.unregisterOnSharedPreferenceChangeListener(listener)
+                        }
+                        emitter.onNext(from(applicationContext))
+                    },
+                    BackpressureStrategy.LATEST
+                )
+                .distinctUntilChanged()
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedViewModel.kt
@@ -36,7 +36,6 @@ class FeedViewModel(
     initialShowFutureItems: Boolean
 ) : ViewModel() {
     private val feedDatabaseManager = FeedDatabaseManager(application)
-    private val feedScope = FeedScope.from(application)
 
     private val showPlayedItems = BehaviorProcessor.create<Boolean>()
     private val showPlayedItemsFlowable = showPlayedItems
@@ -56,54 +55,69 @@ class FeedViewModel(
     private val mutableStateLiveData = MutableLiveData<FeedState>()
     val stateLiveData: LiveData<FeedState> = mutableStateLiveData
 
-    private var combineDisposable = Flowable
-        .combineLatest(
-            FeedEventManager.events(feedScope),
-            showPlayedItemsFlowable,
-            showPartiallyPlayedItemsFlowable,
-            showFutureItemsFlowable,
-            feedDatabaseManager.notLoadedCount(
-                groupId,
-                feedScope
-            ),
-            feedDatabaseManager.oldestSubscriptionUpdate(
-                groupId,
-                feedScope
-            ),
+    private var combineDisposable = FeedScope.changes(application)
+        .switchMap { feedScope ->
+            Flowable.combineLatest(
+                FeedEventManager.events(feedScope),
+                showPlayedItemsFlowable,
+                showPartiallyPlayedItemsFlowable,
+                showFutureItemsFlowable,
+                feedDatabaseManager.notLoadedCount(
+                    groupId,
+                    feedScope
+                ),
+                feedDatabaseManager.oldestSubscriptionUpdate(
+                    groupId,
+                    feedScope
+                ),
 
-            Function6 {
-                    t1: FeedEventManager.Event,
-                    t2: Boolean,
-                    t3: Boolean,
-                    t4: Boolean,
-                    t5: Long,
-                    t6: List<OffsetDateTime?>
-                ->
-                return@Function6 CombineResultEventHolder(t1, t2, t3, t4, t5, t6.firstOrNull())
-            }
-        )
-        .throttleLatest(DEFAULT_THROTTLE_TIMEOUT, TimeUnit.MILLISECONDS)
-        .subscribeOn(Schedulers.io())
-        .observeOn(Schedulers.io())
-        .map { (event, showPlayedItems, showPartiallyPlayedItems, showFutureItems, notLoadedCount, oldestUpdate) ->
-            val streamItems = if (event is SuccessResultEvent || event is IdleEvent) {
-                feedDatabaseManager
-                    .getStreams(
-                        groupId,
-                        showPlayedItems,
-                        showPartiallyPlayedItems,
-                        showFutureItems,
-                        feedScope
+                Function6 {
+                        t1: FeedEventManager.Event,
+                        t2: Boolean,
+                        t3: Boolean,
+                        t4: Boolean,
+                        t5: Long,
+                        t6: List<OffsetDateTime?>
+                    ->
+                    return@Function6 CombineResultEventHolder(
+                        t1,
+                        t2,
+                        t3,
+                        t4,
+                        t5,
+                        t6.firstOrNull()
                     )
-                    .blockingGet(arrayListOf())
-            } else {
-                arrayListOf()
-            }
+                }
+            )
+                .throttleLatest(DEFAULT_THROTTLE_TIMEOUT, TimeUnit.MILLISECONDS)
+                .observeOn(Schedulers.io())
+                .map { (event, showPlayedItems, showPartiallyPlayedItems, showFutureItems, notLoadedCount, oldestUpdate) ->
+                    val streamItems = if (event is SuccessResultEvent || event is IdleEvent) {
+                        feedDatabaseManager
+                            .getStreams(
+                                groupId,
+                                showPlayedItems,
+                                showPartiallyPlayedItems,
+                                showFutureItems,
+                                feedScope
+                            )
+                            .blockingGet(arrayListOf())
+                    } else {
+                        arrayListOf()
+                    }
 
-            CombineResultDataHolder(event, streamItems, notLoadedCount, oldestUpdate)
+                    CombineResultDataHolder(
+                        feedScope,
+                        event,
+                        streamItems,
+                        notLoadedCount,
+                        oldestUpdate
+                    )
+                }
         }
+        .subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
-        .subscribe { (event, listFromDB, notLoadedCount, oldestUpdate) ->
+        .subscribe { (feedScope, event, listFromDB, notLoadedCount, oldestUpdate) ->
             mutableStateLiveData.postValue(
                 when (event) {
                     is IdleEvent -> FeedState.LoadedState(listFromDB.map { e -> StreamItem(e) }, oldestUpdate, notLoadedCount, listOf())
@@ -133,6 +147,7 @@ class FeedViewModel(
     )
 
     private data class CombineResultDataHolder(
+        val scope: FeedScope,
         val t1: FeedEventManager.Event,
         val t2: List<StreamWithState>,
         val t3: Long,

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -40,6 +40,18 @@ class SubscriptionManager(context: Context) {
         currentGroupId: Long = FeedGroupEntity.GROUP_ALL_ID,
         filterQuery: String = "",
         showOnlyUngrouped: Boolean = false
+    ): Flowable<List<SubscriptionEntity>> = getSubscriptionsForScope(
+        currentScope,
+        currentGroupId,
+        filterQuery,
+        showOnlyUngrouped
+    )
+
+    fun getSubscriptionsForScope(
+        scope: FeedScope,
+        currentGroupId: Long = FeedGroupEntity.GROUP_ALL_ID,
+        filterQuery: String = "",
+        showOnlyUngrouped: Boolean = false
     ): Flowable<List<SubscriptionEntity>> {
         return when {
             filterQuery.isNotEmpty() -> {
@@ -56,7 +68,7 @@ class SubscriptionManager(context: Context) {
             showOnlyUngrouped -> subscriptionTable.getSubscriptionsOnlyUngrouped(currentGroupId)
 
             else -> subscriptionTable.getAll()
-        }.map { subscriptions -> subscriptions.filter(currentScope::includes) }
+        }.map { subscriptions -> subscriptions.filter(scope::includes) }
     }
 
     fun upsertAll(infoList: List<Pair<ChannelInfo, ChannelTabInfo?>>) {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt
@@ -12,6 +12,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 import org.schabi.newpipe.info_list.ItemViewMode
 import org.schabi.newpipe.local.feed.FeedDatabaseManager
+import org.schabi.newpipe.local.feed.FeedScope
 import org.schabi.newpipe.local.search.ContextualSearchHelper
 import org.schabi.newpipe.local.subscription.item.ChannelItem
 import org.schabi.newpipe.local.subscription.item.FeedGroupCardGridItem
@@ -55,13 +56,19 @@ class SubscriptionViewModel(application: Application) : AndroidViewModel(applica
 
     private val filterQuery = BehaviorProcessor.createDefault("")
 
-    private var stateItemsDisposable = filterQuery
-        .distinctUntilChanged()
-        .switchMap {
-            subscriptionManager.getSubscriptions(filterQuery = it)
+    private var stateItemsDisposable = Flowable.combineLatest(
+        FeedScope.changes(application),
+        filterQuery.distinctUntilChanged(),
+        ::Pair
+    )
+        .switchMap { (feedScope, query) ->
+            subscriptionManager.getSubscriptionsForScope(
+                scope = feedScope,
+                filterQuery = query
+            )
                 .subscribeOn(Schedulers.io())
+                .throttleLatest(DEFAULT_THROTTLE_TIMEOUT, TimeUnit.MILLISECONDS)
         }
-        .throttleLatest(DEFAULT_THROTTLE_TIMEOUT, TimeUnit.MILLISECONDS)
         .map { it.map { entity -> ChannelItem(entity.toChannelInfoItem(), entity.uid, ChannelItem.ItemVersion.MINI) } }
         .subscribeOn(Schedulers.io())
         .subscribe(

--- a/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
@@ -27,7 +27,9 @@ public class ContextualSearchIntegrationTest {
         assertSourceContains("org/schabi/newpipe/download/DownloadsTabFragment.java",
                 "implements ContextualSearchable");
         assertSourceContains("org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt",
-                "getSubscriptions(filterQuery = it)");
+                "getSubscriptionsForScope(");
+        assertSourceContains("org/schabi/newpipe/local/subscription/SubscriptionViewModel.kt",
+                "filterQuery = query");
         assertSourceContains("org/schabi/newpipe/MainActivity.java",
                 "fragment instanceof MainFragment");
     }


### PR DESCRIPTION
- Observe service and YouTube mode preference changes through a disposable reactive feed scope.
- Switch What’s New database queries and feed-event subscriptions to the newly selected scope.
- Rebind Subscriptions queries to the active scope without recreating its retained ViewModel or manager.
- Prevent throttled results from the previous service from appearing after a scope switch.
- Add Android regression coverage for live service and YouTube mode changes.