### PR TITLE
Restore YouTube quality options after 1.10.2

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1385,7 +1385,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         }
         boolean playableResponseSelected = selectPlayablePlayerResponse(videoId);
 
-        if (!playableResponseSelected) {
+        if (!playableResponseSelected || needsDirectStreamFallback()) {
             tryFetchVisionOsJsonPlayer(contentCountry, localization, videoId);
             playableResponseSelected = selectPlayablePlayerResponse(videoId);
         }
@@ -1394,7 +1394,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 localization, contentCountry, videoId, this);
 
         CancellableCall primaryCall = null;
-        if (!playableResponseSelected) {
+        if (!playableResponseSelected || needsDirectStreamFallback()) {
             if (StringUtils.isBlank(ServiceList.YouTube.getTokens())) {
                 primaryCall = fetchAndroidVRJsonPlayer(contentCountry, localization, videoId);
             } else {
@@ -1440,21 +1440,22 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
             playableResponseSelected = selectPlayablePlayerResponse(videoId);
 
-            if (!playableResponseSelected) {
+            if (!playableResponseSelected || needsDirectStreamFallback()) {
                 final CancellableCall iosCall = fetchIosMobileJsonPlayer(contentCountry,
                         localization, videoId);
                 waitForCallsToFinish(iosCall);
                 playableResponseSelected = selectPlayablePlayerResponse(videoId);
             }
 
-            if (StringUtils.isBlank(ServiceList.YouTube.getTokens()) && !playableResponseSelected) {
+            if (StringUtils.isBlank(ServiceList.YouTube.getTokens())
+                    && (!playableResponseSelected || needsDirectStreamFallback())) {
                 final CancellableCall safariCall = tryFetchSafariJsonPlayer(
                         contentCountry, localization, videoId);
                 waitForCallsToFinish(safariCall);
                 playableResponseSelected = selectPlayablePlayerResponse(videoId);
             }
 
-            if (!playableResponseSelected) {
+            if (!playableResponseSelected || needsDirectStreamFallback()) {
                 final CancellableCall tvHtml5Call = tryFetchTvHtml5EmbedJsonPlayer(
                         contentCountry, localization, videoId);
                 waitForCallsToFinish(tvHtml5Call);
@@ -1539,17 +1540,32 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 .anyMatch(this::hasUsableStreamingData);
     }
 
+    private boolean needsDirectStreamFallback() {
+        return Arrays.asList(visionOsStreamingData, safariStreamingData, iosStreamingData,
+                        tvHtml5SimplyEmbedStreamingData, androidStreamingData, webStreamingData)
+                .stream()
+                .noneMatch(YoutubeStreamExtractor::hasUsableAdaptiveOrManifestData);
+    }
+
+    static boolean hasUsableAdaptiveOrManifestData(
+            @Nullable final JsonObject streamingData) {
+        if (streamingData == null || streamingData.isEmpty()) {
+            return false;
+        }
+        return hasUsableFormats(streamingData.getArray(ADAPTIVE_FORMATS))
+                || !isNullOrEmpty(streamingData.getString("hlsManifestUrl"))
+                || !isNullOrEmpty(streamingData.getString("dashManifestUrl"));
+    }
+
     private boolean hasUsableStreamingData(@Nullable final JsonObject streamingData) {
         if (streamingData == null || streamingData.isEmpty()) {
             return false;
         }
         return hasUsableFormats(streamingData.getArray(FORMATS))
-                || hasUsableFormats(streamingData.getArray(ADAPTIVE_FORMATS))
-                || !isNullOrEmpty(streamingData.getString("hlsManifestUrl"))
-                || !isNullOrEmpty(streamingData.getString("dashManifestUrl"));
+                || hasUsableAdaptiveOrManifestData(streamingData);
     }
 
-    private boolean hasUsableFormats(@Nullable final JsonArray formats) {
+    private static boolean hasUsableFormats(@Nullable final JsonArray formats) {
         if (formats == null || formats.isEmpty()) {
             return false;
         }

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractorTest.java
@@ -1,8 +1,12 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -93,6 +97,44 @@ public class YoutubeStreamExtractorTest {
         assertTrue(source.contains("&$fields=playerResponse"));
         assertTrue(source.contains("prepareAndroidMobileJsonBuilder("));
         assertTrue(source.contains("getJsonAndroidPostResponse("));
+    }
+
+    @Test
+    public void muxed360pOnlyStillNeedsDirectStreamFallback() throws JsonParserException {
+        final JsonObject reelStreamingData = JsonParser.object().from(
+                "{\"formats\":[{\"itag\":18,\"url\":\"https://example.com/360p\"}],"
+                        + "\"adaptiveFormats\":[{\"itag\":137}],"
+                        + "\"serverAbrStreamingUrl\":\"https://example.com/sabr\"}");
+        assertFalse(YoutubeStreamExtractor.hasUsableAdaptiveOrManifestData(
+                reelStreamingData));
+
+        final JsonObject adaptiveStreamingData = JsonParser.object().from(
+                "{\"adaptiveFormats\":[{\"itag\":137,"
+                        + "\"url\":\"https://example.com/1080p\"}]}");
+        assertTrue(YoutubeStreamExtractor.hasUsableAdaptiveOrManifestData(
+                adaptiveStreamingData));
+
+        final JsonObject liveStreamingData = JsonParser.object().from(
+                "{\"hlsManifestUrl\":\"https://example.com/live.m3u8\"}");
+        assertTrue(YoutubeStreamExtractor.hasUsableAdaptiveOrManifestData(
+                liveStreamingData));
+    }
+
+    @Test
+    public void muxedPlaybackDoesNotSuppressQualityFallbacks() throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/extractor/services/youtube/extractors/"
+                        + "YoutubeStreamExtractor.java"));
+        final int fetchStart = source.indexOf("public void onFetchPage(");
+        final int fetchEnd = source.indexOf(
+                "private void waitForCallsToFinish", fetchStart);
+
+        assertTrue(fetchStart >= 0);
+        assertTrue(fetchEnd > fetchStart);
+        assertEquals(5, countOccurrences(source.substring(fetchStart, fetchEnd),
+                "needsDirectStreamFallback()"));
     }
 
     @Test


### PR DESCRIPTION
- Keep Android Reel as the primary anonymous playback response while treating muxed-only streaming data as incomplete.
- Continue through VisionOS and existing direct-stream fallbacks when adaptive URLs or manifests are missing.
- Add regression coverage for a playable MPEG-4 360p response with SABR-only higher formats.