### PR TITLE
Show a dialog when a live stream has not started

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -79,6 +79,7 @@ import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.exceptions.LiveNotStartException;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
@@ -237,6 +238,8 @@ public final class VideoDetailFragment
     private boolean forceFullscreen = false;
 
     private Disposable currentWorker;
+    @Nullable
+    private AlertDialog liveNotStartedDialog;
     @NonNull
     private final CompositeDisposable disposables = new CompositeDisposable();
     @Nullable
@@ -483,6 +486,10 @@ public final class VideoDetailFragment
 
     @Override
     public void onDestroyView() {
+        if (liveNotStartedDialog != null) {
+            liveNotStartedDialog.dismiss();
+            liveNotStartedDialog = null;
+        }
         super.onDestroyView();
         binding = null;
     }
@@ -1110,8 +1117,33 @@ public final class VideoDetailFragment
                             openVideoPlayerAutoFullscreen();
                         }
                     }
-                }, throwable -> showError(new ErrorInfo(throwable, UserAction.REQUESTED_STREAM,
-                        url == null ? "no url" : url, serviceId, url)));
+                }, throwable -> {
+                    if (throwable instanceof LiveNotStartException) {
+                        showLiveNotStartedDialog();
+                    } else {
+                        showError(new ErrorInfo(throwable, UserAction.REQUESTED_STREAM,
+                                url == null ? "no url" : url, serviceId, url));
+                    }
+                });
+    }
+
+    private void showLiveNotStartedDialog() {
+        handleError();
+        if (!isAdded() || activity == null) {
+            return;
+        }
+        if (liveNotStartedDialog != null && liveNotStartedDialog.isShowing()) {
+            return;
+        }
+
+        liveNotStartedDialog = new AlertDialog.Builder(activity)
+                .setTitle(R.string.live_stream_not_started_title)
+                .setMessage(R.string.live_stream_not_started_message)
+                .setNegativeButton(R.string.close, null)
+                .setPositiveButton(R.string.retry, (dialog, which) -> reloadContent())
+                .create();
+        liveNotStartedDialog.setOnDismissListener(dialog -> liveNotStartedDialog = null);
+        liveNotStartedDialog.show();
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,6 +624,8 @@
     <string name="comments_are_disabled">Comments are disabled</string>
     <string name="no_streams">No streams</string>
     <string name="no_live_streams">No live streams</string>
+    <string name="live_stream_not_started_title">Live stream has not started</string>
+    <string name="live_stream_not_started_message">This live stream has not started yet. Please try again when it begins.</string>
     <plurals name="new_streams">
         <item quantity="one">%s new stream</item>
         <item quantity="other">%s new streams</item>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLiveStreamErrorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLiveStreamErrorTest.java
@@ -1,0 +1,76 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class VideoDetailLiveStreamErrorTest {
+    @Test
+    public void liveNotStartedUsesDialogInsteadOfGenericErrorReporting() throws IOException {
+        final String source = readMainSource();
+        final int workerStart = source.indexOf("private void runWorker(");
+        final int dialogStart = source.indexOf(
+                "private void showLiveNotStartedDialog()", workerStart);
+
+        assertTrue(workerStart >= 0);
+        assertTrue(dialogStart > workerStart);
+
+        final String workerFlow = source.substring(workerStart, dialogStart);
+        final int liveCheck = workerFlow.indexOf(
+                "if (throwable instanceof LiveNotStartException)");
+        final int liveDialog = workerFlow.indexOf("showLiveNotStartedDialog()", liveCheck);
+        final int genericError = workerFlow.indexOf("showError(new ErrorInfo(", liveDialog);
+
+        assertTrue(liveCheck >= 0);
+        assertTrue(liveDialog > liveCheck);
+        assertTrue(genericError > liveDialog);
+    }
+
+    @Test
+    public void liveNotStartedDialogStopsLoadingAndOffersRetry() throws IOException {
+        final String source = readMainSource();
+        final int dialogStart = source.indexOf("private void showLiveNotStartedDialog()");
+        final int dialogEnd = source.indexOf(
+                "//////////////////////////////////////////////////////////////////////////\n"
+                        + "    // Tabs", dialogStart);
+
+        assertTrue(dialogStart >= 0);
+        assertTrue(dialogEnd > dialogStart);
+
+        final String dialog = source.substring(dialogStart, dialogEnd);
+        assertTrue(dialog.contains("handleError();"));
+        assertTrue(dialog.contains(
+                ".setTitle(R.string.live_stream_not_started_title)"));
+        assertTrue(dialog.contains(
+                ".setMessage(R.string.live_stream_not_started_message)"));
+        assertTrue(dialog.contains(".setNegativeButton(R.string.close, null)"));
+        assertTrue(dialog.contains(
+                ".setPositiveButton(R.string.retry, (dialog, which) -> reloadContent())"));
+    }
+
+    @Test
+    public void liveNotStartedDialogStringsAreDefined() throws IOException {
+        final Path resourceDirectory = Files.exists(Path.of("src/main/res"))
+                ? Path.of("src/main/res") : Path.of("app/src/main/res");
+        final String strings = Files.readString(resourceDirectory.resolve("values/strings.xml"));
+
+        assertTrue(strings.contains(
+                "<string name=\"live_stream_not_started_title\">"
+                        + "Live stream has not started</string>"));
+        assertTrue(strings.contains(
+                "<string name=\"live_stream_not_started_message\">"
+                        + "This live stream has not started yet. "
+                        + "Please try again when it begins.</string>"));
+    }
+
+    private static String readMainSource() throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        return Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));
+    }
+}


### PR DESCRIPTION
- Handle scheduled YouTube livestreams as an expected availability state instead of a generic reportable error.
- Show a dedicated dialog with Retry and Close actions when the livestream has not started.
- Dismiss the dialog safely with the fragment lifecycle and add JVM regression coverage.