### PR TITLE
Keep portrait video details above navigation

### DIFF
--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -616,7 +616,7 @@
                 android:id="@+id/view_pager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingBottom="@dimen/video_detail_navigation_height"
+                android:layout_marginBottom="@dimen/video_detail_navigation_height"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
             <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -622,7 +622,7 @@
             android:id="@+id/view_pager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingBottom="@dimen/video_detail_navigation_height"
+            android:layout_marginBottom="@dimen/video_detail_navigation_height"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
@@ -77,8 +77,10 @@ public class VideoDetailNavigationResourcesTest {
         final var viewPagers = document.getElementsByTagName(
                 "androidx.viewpager.widget.ViewPager");
         assertEquals(1, viewPagers.getLength());
+        final var viewPager = (Element) viewPagers.item(0);
         assertEquals("@dimen/video_detail_navigation_height",
-                ((Element) viewPagers.item(0)).getAttribute("android:paddingBottom"));
+                viewPager.getAttribute("android:layout_marginBottom"));
+        assertEquals("", viewPager.getAttribute("android:paddingBottom"));
     }
 
     private void assertMenuItem(final Element item,

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,11 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Fixes
+
+- Prevented portrait videos from leaving Related items underneath the video-detail navigation by
+  reserving the navigation's full height in the content layout.
+
 ## WizeStream 1.10.4 (`1010004`)
 
 ### New features


### PR DESCRIPTION
- Reserve the full video-detail navigation height instead of drawing tab content underneath it.
- Apply the layout correction to phone and large-landscape video-detail layouts without changing portrait player sizing.
- Strengthen the navigation resource regression test and document the fix for the next patch release.