### PR TITLE
Add channel notification keyword controls

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -48,6 +48,7 @@ import org.schabi.newpipe.local.feed.notifications.NotificationHelper;
 import org.schabi.newpipe.local.search.ContextualSearchHelper;
 import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.local.subscription.SubscriptionManager;
+import org.schabi.newpipe.settings.notifications.NotificationConfigDialog;
 import org.schabi.newpipe.util.ChannelTabHelper;
 import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.ExtractorApiCompat;
@@ -111,6 +112,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
 
     private MenuItem menuRssButton;
     private MenuItem menuNotifyButton;
+    private MenuItem menuNotificationKeywordsButton;
     private SubscriptionEntity channelSubscription;
 
     public static ChannelFragment getInstance(final int serviceId, final String url,
@@ -185,6 +187,8 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                 }
                 menuRssButton = menu.findItem(R.id.menu_item_rss);
                 menuNotifyButton = menu.findItem(R.id.menu_item_notify);
+                menuNotificationKeywordsButton =
+                        menu.findItem(R.id.menu_item_notification_keywords);
                 updateRssButton();
                 updateNotifyButton(channelSubscription);
             }
@@ -196,6 +200,8 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                     final boolean value = !item.isChecked();
                     item.setEnabled(false);
                     setNotify(value);
+                } else if (itemId == R.id.menu_item_notification_keywords) {
+                    showNotificationConfigDialog();
                 } else if (itemId == R.id.action_settings) {
                     NavigationHelper.openSettings(requireContext());
                 } else if (itemId == R.id.menu_item_rss) {
@@ -483,7 +489,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
     }
 
     private void updateNotifyButton(@Nullable final SubscriptionEntity subscription) {
-        if (menuNotifyButton == null) {
+        if (menuNotifyButton == null || menuNotificationKeywordsButton == null) {
             return;
         }
         if (subscription != null) {
@@ -491,11 +497,46 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                     NotificationHelper.areNewStreamsNotificationsEnabled(requireContext())
             );
             menuNotifyButton.setChecked(
-                    subscription.getNotificationMode() == NotificationMode.ENABLED
+                    subscription.getNotificationMode() != NotificationMode.DISABLED
             );
         }
 
         menuNotifyButton.setVisible(subscription != null);
+        menuNotificationKeywordsButton.setVisible(subscription != null);
+    }
+
+    private void showNotificationConfigDialog() {
+        final SubscriptionEntity subscription = channelSubscription;
+        if (subscription == null) {
+            return;
+        }
+
+        final String title = currentInfo == null ? name : currentInfo.getName();
+        NotificationConfigDialog.show(
+                this,
+                title,
+                subscription.getNotificationMode(),
+                subscription.getNotificationKeywords(),
+                (mode, keywords) -> updateNotificationSettings(
+                        subscription, mode, keywords)
+        );
+    }
+
+    private void updateNotificationSettings(
+            @NonNull final SubscriptionEntity subscription,
+            final int mode,
+            @NonNull final String keywords) {
+        disposables.add(
+                subscriptionManager
+                        .updateNotificationSettings(
+                                subscription.getServiceId(),
+                                subscription.getUrl(),
+                                mode,
+                                keywords)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe()
+        );
     }
 
     private void setNotify(final boolean isEnabled) {

--- a/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationConfigDialog.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationConfigDialog.kt
@@ -20,7 +20,7 @@ object NotificationConfigDialog {
         title: CharSequence,
         @NotificationMode currentMode: Int,
         currentKeywords: String?,
-        saveListener: SaveListener,
+        saveListener: SaveListener
     ) {
         val binding = DialogNotificationFilterBinding.inflate(fragment.layoutInflater)
         binding.keywords.setText(currentKeywords.orEmpty())
@@ -57,7 +57,7 @@ object NotificationConfigDialog {
                     else -> NotificationMode.DISABLED
                 }
                 val normalizedKeywords = NotificationKeywordFilter.normalize(
-                    binding.keywords.text?.toString().orEmpty(),
+                    binding.keywords.text?.toString().orEmpty()
                 )
                 if (
                     mode == NotificationMode.KEYWORDS_ONLY &&

--- a/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationConfigDialog.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationConfigDialog.kt
@@ -1,0 +1,76 @@
+package org.schabi.newpipe.settings.notifications
+
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.schabi.newpipe.R
+import org.schabi.newpipe.database.subscription.NotificationMode
+import org.schabi.newpipe.databinding.DialogNotificationFilterBinding
+import org.schabi.newpipe.local.feed.notifications.NotificationKeywordFilter
+
+object NotificationConfigDialog {
+    fun interface SaveListener {
+        fun onSave(@NotificationMode mode: Int, keywords: String)
+    }
+
+    @JvmStatic
+    fun show(
+        fragment: Fragment,
+        title: CharSequence,
+        @NotificationMode currentMode: Int,
+        currentKeywords: String?,
+        saveListener: SaveListener,
+    ) {
+        val binding = DialogNotificationFilterBinding.inflate(fragment.layoutInflater)
+        binding.keywords.setText(currentKeywords.orEmpty())
+        when (currentMode) {
+            NotificationMode.ENABLED -> binding.modeAll.isChecked = true
+            NotificationMode.KEYWORDS_ONLY -> binding.modeKeywords.isChecked = true
+            else -> binding.modeDisabled.isChecked = true
+        }
+
+        fun updateKeywordVisibility() {
+            binding.keywordsLayout.visibility = if (binding.modeKeywords.isChecked) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
+        }
+        binding.modeGroup.setOnCheckedChangeListener { _, _ ->
+            binding.keywordsLayout.error = null
+            updateKeywordVisibility()
+        }
+        updateKeywordVisibility()
+
+        val dialog = MaterialAlertDialogBuilder(fragment.requireContext())
+            .setTitle(title)
+            .setView(binding.root)
+            .setNegativeButton(R.string.cancel, null)
+            .setPositiveButton(R.string.save, null)
+            .create()
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                val mode = when (binding.modeGroup.checkedRadioButtonId) {
+                    R.id.mode_all -> NotificationMode.ENABLED
+                    R.id.mode_keywords -> NotificationMode.KEYWORDS_ONLY
+                    else -> NotificationMode.DISABLED
+                }
+                val normalizedKeywords = NotificationKeywordFilter.normalize(
+                    binding.keywords.text?.toString().orEmpty(),
+                )
+                if (
+                    mode == NotificationMode.KEYWORDS_ONLY &&
+                    !NotificationKeywordFilter.isValid(normalizedKeywords)
+                ) {
+                    binding.keywordsLayout.error =
+                        fragment.getString(R.string.notification_keywords_invalid)
+                    return@setOnClickListener
+                }
+                saveListener.onSave(mode, normalizedKeywords)
+                dialog.dismiss()
+            }
+        }
+        dialog.show()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigFragment.kt
@@ -8,18 +8,14 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.subscription.NotificationMode
-import org.schabi.newpipe.databinding.DialogNotificationFilterBinding
 import org.schabi.newpipe.databinding.FragmentChannelsNotificationsBinding
-import org.schabi.newpipe.local.feed.notifications.NotificationKeywordFilter
 import org.schabi.newpipe.local.subscription.SubscriptionManager
 
 /**
@@ -111,58 +107,15 @@ class NotificationModeConfigFragment : Fragment() {
     }
 
     private fun showNotificationConfigDialog(item: SubscriptionItem) {
-        val dialogBinding = DialogNotificationFilterBinding.inflate(layoutInflater)
-        dialogBinding.keywords.setText(item.notificationKeywords)
-        when (item.notificationMode) {
-            NotificationMode.ENABLED -> dialogBinding.modeAll.isChecked = true
-            NotificationMode.KEYWORDS_ONLY -> dialogBinding.modeKeywords.isChecked = true
-            else -> dialogBinding.modeDisabled.isChecked = true
+        NotificationConfigDialog.show(
+            this,
+            item.title,
+            item.notificationMode,
+            item.notificationKeywords,
+        ) { mode, keywords ->
+            updateNotificationSettings(item, mode, keywords)
         }
-
-        fun updateKeywordVisibility() {
-            dialogBinding.keywordsLayout.visibility = if (dialogBinding.modeKeywords.isChecked) {
-                View.VISIBLE
-            } else {
-                View.GONE
-            }
-        }
-        dialogBinding.modeGroup.setOnCheckedChangeListener { _, _ ->
-            dialogBinding.keywordsLayout.error = null
-            updateKeywordVisibility()
-        }
-        updateKeywordVisibility()
-
-        val dialog = MaterialAlertDialogBuilder(requireContext())
-            .setTitle(item.title)
-            .setView(dialogBinding.root)
-            .setNegativeButton(R.string.cancel, null)
-            .setPositiveButton(R.string.save, null)
-            .create()
-        dialog.setOnShowListener {
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
-                val mode = when (dialogBinding.modeGroup.checkedRadioButtonId) {
-                    R.id.mode_all -> NotificationMode.ENABLED
-                    R.id.mode_keywords -> NotificationMode.KEYWORDS_ONLY
-                    else -> NotificationMode.DISABLED
-                }
-                val normalizedKeywords = NotificationKeywordFilter.normalize(
-                    dialogBinding.keywords.text?.toString().orEmpty()
-                )
-                if (
-                    mode == NotificationMode.KEYWORDS_ONLY &&
-                    !NotificationKeywordFilter.isValid(normalizedKeywords)
-                ) {
-                    dialogBinding.keywordsLayout.error =
-                        getString(R.string.notification_keywords_invalid)
-                    return@setOnClickListener
-                }
-                updateNotificationSettings(item, mode, normalizedKeywords)
-                dialog.dismiss()
-            }
-        }
-        dialog.show()
     }
-
     private fun updateNotificationSettings(
         item: SubscriptionItem,
         @NotificationMode mode: Int,

--- a/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/notifications/NotificationModeConfigFragment.kt
@@ -111,7 +111,7 @@ class NotificationModeConfigFragment : Fragment() {
             this,
             item.title,
             item.notificationMode,
-            item.notificationKeywords,
+            item.notificationKeywords
         ) { mode, keywords ->
             updateNotificationSettings(item, mode, keywords)
         }

--- a/app/src/main/res/menu/menu_channel.xml
+++ b/app/src/main/res/menu/menu_channel.xml
@@ -35,14 +35,22 @@
         tools:visible="true" />
 
     <item
-        android:id="@+id/action_settings"
+        android:id="@+id/menu_item_notification_keywords"
         android:orderInCategory="2"
+        android:title="@string/notification_keywords_title"
+        android:visible="false"
+        app:showAsAction="never"
+        tools:visible="true" />
+
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="3"
         android:title="@string/settings"
         app:showAsAction="never" />
 
     <item
         android:id="@+id/menu_item_openInBrowser"
-        android:orderInCategory="3"
+        android:orderInCategory="4"
         android:title="@string/open_in_browser"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -914,6 +914,7 @@
     <string name="enable_streams_notifications_title">New streams notifications</string>
     <string name="enable_streams_notifications_summary">Notify about new streams from subscriptions</string>
     <string name="edit_notification_filter">Edit notification filter</string>
+    <string name="notification_keywords_title">Notification keywords</string>
     <string name="notification_mode_disabled">Notifications disabled</string>
     <string name="notification_mode_all_uploads">All uploads</string>
     <string name="notification_mode_keywords_only">Matching keywords only</string>

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/channel/ChannelNotificationKeywordsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/channel/ChannelNotificationKeywordsTest.java
@@ -1,0 +1,96 @@
+package org.schabi.newpipe.fragments.list.channel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class ChannelNotificationKeywordsTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+    private static final String APP_NAMESPACE =
+            "http://schemas.android.com/apk/res-auto";
+
+    private final Path projectDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("") : Path.of("app");
+
+    @Test
+    public void subscribedChannelMenuExposesNotificationKeywords() throws Exception {
+        final Document menu = parse("src/main/res/menu/menu_channel.xml");
+        final Element item = findByAndroidId(
+                menu, "@+id/menu_item_notification_keywords");
+
+        assertNotNull(item);
+        assertEquals("@string/notification_keywords_title",
+                item.getAttributeNS(ANDROID_NAMESPACE, "title"));
+        assertEquals("false", item.getAttributeNS(ANDROID_NAMESPACE, "visible"));
+        assertEquals("never", item.getAttributeNS(APP_NAMESPACE, "showAsAction"));
+    }
+
+    @Test
+    public void channelUsesSharedNotificationDialogAndTracksKeywordMode() throws Exception {
+        final String source = read(
+                "src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java");
+
+        assertTrue(source.contains(
+                "menu.findItem(R.id.menu_item_notification_keywords)"));
+        assertTrue(source.contains(
+                "menuNotificationKeywordsButton.setVisible(subscription != null)"));
+        assertTrue(source.contains(
+                "subscription.getNotificationMode() != NotificationMode.DISABLED"));
+        assertTrue(source.contains("NotificationConfigDialog.show("));
+        assertTrue(source.contains(
+                "subscriptionManager\n                        .updateNotificationSettings("));
+    }
+
+    @Test
+    public void settingsAndChannelShareValidationAndPersistence() throws Exception {
+        final String settingsSource = read(
+                "src/main/java/org/schabi/newpipe/settings/notifications/"
+                        + "NotificationModeConfigFragment.kt");
+        final String dialogSource = read(
+                "src/main/java/org/schabi/newpipe/settings/notifications/"
+                        + "NotificationConfigDialog.kt");
+
+        assertTrue(settingsSource.contains("NotificationConfigDialog.show("));
+        assertTrue(dialogSource.contains("NotificationKeywordFilter.normalize("));
+        assertTrue(dialogSource.contains("NotificationKeywordFilter.isValid("));
+        assertTrue(dialogSource.contains("saveListener.onSave(mode, normalizedKeywords)"));
+    }
+
+    private Element findByAndroidId(final Document document, final String id) {
+        final NodeList elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            if (id.equals(element.getAttributeNS(ANDROID_NAMESPACE, "id"))) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private Document parse(final String relativePath) throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-parameter-entities", false);
+        return factory.newDocumentBuilder()
+                .parse(projectDirectory.resolve(relativePath).toFile());
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(projectDirectory.resolve(relativePath));
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,10 @@ Release history is listed newest first. The number beside each release is its An
 
 ## Unreleased
 
+### Improvements
+
+- Added direct notification keyword management to subscribed channel menus.
+
 ## WizeStream 1.10.4 (`1010004`)
 
 ### New features


### PR DESCRIPTION
- Adds a Notification keywords action to subscribed channel menus.
- Reuses the existing three-mode notification dialog and validation for direct channel configuration.
- Keeps Settings as the centralized notification-management screen.
- Treats keyword-only mode as enabled in the channel notification quick toggle.
- Adds regression coverage for menu wiring, shared validation, and persistence.
- Fixes #257.