### PR TITLE
Polish and cancel feed refresh progress

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -230,6 +230,10 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         super.initListeners()
         feedBinding.refreshRootView.setOnClickListener { reloadContent() }
         feedBinding.swipeRefreshLayout.setOnRefreshListener { reloadContent() }
+        feedBinding.cancelRefreshButton.setOnClickListener {
+            it.isEnabled = false
+            FeedLoadService.cancel(requireContext())
+        }
         feedBinding.swipeRefreshLayout.setOnChildScrollUpCallback { _, _ ->
             !feedHeaderExpanded || feedBinding.itemsList.canScrollVertically(-1)
         }
@@ -360,10 +364,10 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
 
     override fun showLoading() {
         super.showLoading()
-        feedBinding.itemsList.animateHideRecyclerViewAllowingScrolling()
+        feedBinding.itemsList.animate(true, 0)
         feedBinding.refreshRootView.animate(false, 0)
         feedBinding.streamFilterChips.root.animate(false, 0)
-        feedBinding.loadingProgressText.animate(true, 200)
+        showRefreshOverlay()
         feedBinding.swipeRefreshLayout.isRefreshing = true
         isRefreshing = true
     }
@@ -373,7 +377,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         feedBinding.itemsList.animate(true, 0)
         feedBinding.refreshRootView.animate(true, 200)
         feedBinding.streamFilterChips.root.animate(true, 200)
-        feedBinding.loadingProgressText.animate(false, 0)
+        hideRefreshOverlay()
         feedBinding.swipeRefreshLayout.isRefreshing = false
         isRefreshing = false
     }
@@ -383,8 +387,9 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         feedBinding.itemsList.animateHideRecyclerViewAllowingScrolling()
         feedBinding.refreshRootView.animate(true, 200)
         feedBinding.streamFilterChips.root.animate(true, 200)
-        feedBinding.loadingProgressText.animate(false, 0)
+        hideRefreshOverlay()
         feedBinding.swipeRefreshLayout.isRefreshing = false
+        isRefreshing = false
     }
 
     override fun handleResult(result: FeedState) {
@@ -402,7 +407,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         feedBinding.itemsList.animateHideRecyclerViewAllowingScrolling()
         feedBinding.refreshRootView.animate(false, 0)
         feedBinding.streamFilterChips.root.animate(true, 200)
-        feedBinding.loadingProgressText.animate(false, 0)
+        hideRefreshOverlay()
         feedBinding.swipeRefreshLayout.isRefreshing = false
         isRefreshing = false
     }
@@ -410,22 +415,39 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     private fun handleProgressState(progressState: FeedState.ProgressState) {
         showLoading()
 
-        val isIndeterminate = progressState.currentProgress == -1 &&
-            progressState.maxProgress == -1
+        val isIndeterminate = progressState.currentProgress < 0 ||
+            progressState.maxProgress < 0
+        feedBinding.loadingProgressBar.isVisible = !isIndeterminate
+        feedBinding.loadingIndeterminateProgressBar.isVisible = isIndeterminate
+        feedBinding.loadingProgressText.isVisible = !isIndeterminate
+        feedBinding.loadingProgressStatusText.isVisible = isIndeterminate
 
-        feedBinding.loadingProgressText.text = if (!isIndeterminate) {
-            "${progressState.currentProgress}/${progressState.maxProgress}"
-        } else if (progressState.progressMessage > 0) {
-            getString(progressState.progressMessage)
+        if (isIndeterminate) {
+            feedBinding.loadingProgressStatusText.text =
+                if (progressState.progressMessage > 0) {
+                    getString(progressState.progressMessage)
+                } else {
+                    getString(R.string.feed_notification_loading)
+                }
         } else {
-            "∞/∞"
+            val maxProgress = progressState.maxProgress.coerceAtLeast(1)
+            val currentProgress = progressState.currentProgress.coerceIn(0, maxProgress)
+            feedBinding.loadingProgressText.text = "$currentProgress/$maxProgress"
+            feedBinding.loadingProgressBar.max = maxProgress
+            feedBinding.loadingProgressBar.setProgressCompat(currentProgress, true)
         }
+    }
 
-        feedBinding.loadingProgressBar.isIndeterminate = isIndeterminate ||
-            (progressState.maxProgress > 0 && progressState.currentProgress == 0)
-        feedBinding.loadingProgressBar.progress = progressState.currentProgress
+    private fun showRefreshOverlay() {
+        if (!feedBinding.refreshLoadingOverlay.isVisible) {
+            feedBinding.refreshLoadingOverlay.animate(true, 200)
+        }
+        feedBinding.cancelRefreshButton.isEnabled = true
+    }
 
-        feedBinding.loadingProgressBar.max = progressState.maxProgress
+    private fun hideRefreshOverlay() {
+        feedBinding.cancelRefreshButton.isEnabled = false
+        feedBinding.refreshLoadingOverlay.animate(false, 200)
     }
 
     private fun showInfoItemDialog(item: StreamInfoItem) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadService.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadService.kt
@@ -48,7 +48,17 @@ class FeedLoadService : Service() {
     companion object {
         private val TAG = FeedLoadService::class.java.simpleName
         const val NOTIFICATION_ID = 7293450
-        private const val ACTION_CANCEL = App.PACKAGE_NAME + ".local.feed.service.FeedLoadService.CANCEL"
+        private const val ACTION_CANCEL =
+            App.PACKAGE_NAME + ".local.feed.service.FeedLoadService.CANCEL"
+
+        @JvmStatic
+        fun cancel(context: Context) {
+            context.sendBroadcast(cancelIntent(context))
+        }
+
+        private fun cancelIntent(context: Context): Intent {
+            return Intent(ACTION_CANCEL).setPackage(context.packageName)
+        }
 
         /**
          * How often the notification will be updated.
@@ -119,9 +129,23 @@ class FeedLoadService : Service() {
     }
 
     private fun disposeAll() {
-        unregisterReceiver(broadcastReceiver)
+        broadcastReceiver?.let {
+            unregisterReceiver(it)
+            broadcastReceiver = null
+        }
         loadingDisposable?.dispose()
+        loadingDisposable = null
         notificationDisposable?.dispose()
+        notificationDisposable = null
+    }
+
+    private fun cancelLoading() {
+        feedLoadManager.cancel()
+        loadingDisposable?.dispose()
+        if (::feedScope.isInitialized) {
+            FeedEventManager.reset(feedScope)
+        }
+        stopService()
     }
 
     private fun stopService() {
@@ -149,7 +173,7 @@ class FeedLoadService : Service() {
 
     private fun createNotification(): NotificationCompat.Builder {
         val cancelActionIntent = PendingIntentCompat
-            .getBroadcast(this, NOTIFICATION_ID, Intent(ACTION_CANCEL), 0, false)
+            .getBroadcast(this, NOTIFICATION_ID, cancelIntent(this), 0, false)
 
         return NotificationCompat.Builder(this, getString(R.string.notification_channel_id))
             .setOngoing(true)
@@ -206,17 +230,23 @@ class FeedLoadService : Service() {
     // Notification Actions
     // /////////////////////////////////////////////////////////////////////////
 
-    private lateinit var broadcastReceiver: BroadcastReceiver
+    private var broadcastReceiver: BroadcastReceiver? = null
 
     private fun setupBroadcastReceiver() {
-        broadcastReceiver = object : BroadcastReceiver() {
+        val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {
                 if (intent?.action == ACTION_CANCEL) {
-                    feedLoadManager.cancel()
+                    cancelLoading()
                 }
             }
         }
-        ContextCompat.registerReceiver(this, broadcastReceiver, IntentFilter(ACTION_CANCEL), ContextCompat.RECEIVER_NOT_EXPORTED)
+        broadcastReceiver = receiver
+        ContextCompat.registerReceiver(
+            this,
+            receiver,
+            IntentFilter(ACTION_CANCEL),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
     }
 
     // /////////////////////////////////////////////////////////////////////////

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -102,15 +102,116 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/items_list"
+        <FrameLayout
+            android:id="@+id/feed_content_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scrollbars="vertical"
-            android:visibility="gone"
-            tools:listitem="@layout/list_stream_item"
-            tools:visibility="visible" />
+            android:layout_height="match_parent">
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/items_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical"
+                android:visibility="gone"
+                tools:listitem="@layout/list_stream_item"
+                tools:visibility="visible" />
+
+            <FrameLayout
+                android:id="@+id/refresh_loading_overlay"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clickable="true"
+                android:focusable="true"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <View
+                    android:id="@+id/refresh_loading_scrim"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:alpha="0.78"
+                    android:background="?attr/colorSurface" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <FrameLayout
+                        android:layout_width="88dp"
+                        android:layout_height="88dp">
+
+                        <com.google.android.material.progressindicator.CircularProgressIndicator
+                            android:id="@+id/loading_progress_bar"
+                            android:layout_width="88dp"
+                            android:layout_height="88dp"
+                            android:indeterminate="false"
+                            android:max="1"
+                            android:progress="0"
+                            app:indicatorColor="?attr/colorPrimary"
+                            app:indicatorDirectionCircular="clockwise"
+                            app:indicatorSize="88dp"
+                            app:trackColor="?attr/colorSurfaceVariant"
+                            app:trackCornerRadius="3dp"
+                            app:trackThickness="6dp" />
+
+                        <com.google.android.material.progressindicator.CircularProgressIndicator
+                            android:id="@+id/loading_indeterminate_progress_bar"
+                            android:layout_width="88dp"
+                            android:layout_height="88dp"
+                            android:indeterminate="true"
+                            android:visibility="gone"
+                            app:indicatorColor="?attr/colorPrimary"
+                            app:indicatorDirectionCircular="clockwise"
+                            app:indicatorSize="88dp"
+                            app:trackColor="?attr/colorSurfaceVariant"
+                            app:trackCornerRadius="3dp"
+                            app:trackThickness="6dp" />
+
+                        <org.schabi.newpipe.views.NewPipeTextView
+                            android:id="@+id/loading_progress_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:accessibilityLiveRegion="polite"
+                            android:text="0/0"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                            android:textColor="?attr/colorOnSurface"
+                            android:textSize="14sp"
+                            android:textStyle="bold"
+                            tools:text="16/47" />
+                    </FrameLayout>
+
+                    <org.schabi.newpipe.views.NewPipeTextView
+                        android:id="@+id/loading_progress_status_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:accessibilityLiveRegion="polite"
+                        android:gravity="center"
+                        android:maxWidth="240dp"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                        android:textColor="?attr/colorOnSurfaceVariant"
+                        android:visibility="gone"
+                        tools:text="@string/feed_processing_message" />
+                </LinearLayout>
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/cancel_refresh_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginBottom="56dp"
+                    android:contentDescription="@string/cancel_refresh"
+                    app:backgroundTint="?attr/colorSurface"
+                    app:elevation="6dp"
+                    app:fabCustomSize="48dp"
+                    app:srcCompat="@drawable/ic_close"
+                    app:tint="?attr/colorOnSurface" />
+            </FrameLayout>
+        </FrameLayout>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <Button
@@ -125,37 +226,6 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <ProgressBar
-            android:id="@+id/loading_progress_bar"
-            style="@style/MaterialStateHorizontalProgressIndicator"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:indeterminate="true"
-            android:minWidth="128dp"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
-        <org.schabi.newpipe.views.NewPipeTextView
-            android:id="@+id/loading_progress_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:text="∞/∞"
-            android:textColor="?attr/colorOnSurfaceVariant"
-            android:textAppearance="@style/TextAppearance.AppCompat.Title"
-            android:textSize="16sp"
-            android:visibility="gone"
-            tools:text="1/120"
-            tools:visibility="visible" />
-    </LinearLayout>
 
     <!--ERROR PANEL-->
     <include

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1112,6 +1112,7 @@
     <string name="feed_oldest_subscription_update">Feed last updated: %s</string>
     <string name="feed_subscription_not_loaded_count">Not loaded: %d</string>
     <string name="feed_notification_loading">Loading feed…</string>
+    <string name="cancel_refresh">Cancel refresh</string>
     <string name="feed_processing_message">Processing feed…</string>
     <string name="feed_new_items">New feed items</string>
     <string name="feed_group_dialog_select_subscriptions">Select subscriptions</string>

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
@@ -1,20 +1,34 @@
 package org.schabi.newpipe.local.feed;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+
 public class FeedRefreshControlsTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+    private static final String APP_NAMESPACE =
+            "http://schemas.android.com/apk/res-auto";
+
     private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
             ? Path.of("src/main/java") : Path.of("app/src/main/java");
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
 
     @Test
     public void filtersFollowTheFeedLoadingLifecycle() throws Exception {
-        final String source = Files.readString(sourceDirectory.resolve(
-                "org/schabi/newpipe/local/feed/FeedFragment.kt"));
+        final String source = readSource(
+                "org/schabi/newpipe/local/feed/FeedFragment.kt");
 
         assertTrue(methodBody(source, "override fun showLoading()", "override fun hideLoading()")
                 .contains("streamFilterChips.root.animate(false, 0)"));
@@ -27,6 +41,110 @@ public class FeedRefreshControlsTest {
                 "override fun handleError()",
                 "private fun handleProgressState"
         ).contains("streamFilterChips.root.animate(true, 200)"));
+    }
+
+    @Test
+    public void refreshOverlayKeepsFeedVisibleBehindAThemeAwareScrim() throws Exception {
+        final Document document = parseLayout();
+        final Element overlay = findByAndroidId(
+                document, "@+id/refresh_loading_overlay");
+        final Element scrim = findByAndroidId(
+                document, "@+id/refresh_loading_scrim");
+
+        assertNotNull(overlay);
+        assertEquals("gone", overlay.getAttributeNS(ANDROID_NAMESPACE, "visibility"));
+        assertNotNull(scrim);
+        assertEquals("0.78", scrim.getAttributeNS(ANDROID_NAMESPACE, "alpha"));
+        assertEquals("?attr/colorSurface",
+                scrim.getAttributeNS(ANDROID_NAMESPACE, "background"));
+
+        final String source = readSource(
+                "org/schabi/newpipe/local/feed/FeedFragment.kt");
+        assertTrue(methodBody(source, "override fun showLoading()", "override fun hideLoading()")
+                .contains("itemsList.animate(true, 0)"));
+        assertTrue(source.contains("refreshLoadingOverlay.animate(true, 200)"));
+        assertTrue(source.contains("refreshLoadingOverlay.animate(false, 200)"));
+    }
+
+    @Test
+    public void progressAndCancelControlsUsePolishedCircularSurfaces() throws Exception {
+        final Document document = parseLayout();
+        final Element progress = findByAndroidId(
+                document, "@+id/loading_progress_bar");
+        final Element cancel = findByAndroidId(
+                document, "@+id/cancel_refresh_button");
+
+        assertNotNull(progress);
+        assertEquals(
+                "com.google.android.material.progressindicator.CircularProgressIndicator",
+                progress.getTagName());
+        assertEquals("88dp", progress.getAttributeNS(APP_NAMESPACE, "indicatorSize"));
+        assertEquals("6dp", progress.getAttributeNS(APP_NAMESPACE, "trackThickness"));
+        assertEquals("3dp", progress.getAttributeNS(APP_NAMESPACE, "trackCornerRadius"));
+
+        assertNotNull(cancel);
+        assertEquals(
+                "com.google.android.material.floatingactionbutton.FloatingActionButton",
+                cancel.getTagName());
+        assertEquals("bottom|center_horizontal",
+                cancel.getAttributeNS(ANDROID_NAMESPACE, "layout_gravity"));
+        assertEquals("56dp",
+                cancel.getAttributeNS(ANDROID_NAMESPACE, "layout_marginBottom"));
+        assertEquals("@string/cancel_refresh",
+                cancel.getAttributeNS(ANDROID_NAMESPACE, "contentDescription"));
+        assertEquals("@drawable/ic_close",
+                cancel.getAttributeNS(APP_NAMESPACE, "srcCompat"));
+    }
+
+    @Test
+    public void cancelButtonStopsTheSharedRefreshServicePath() throws Exception {
+        final String fragment = readSource(
+                "org/schabi/newpipe/local/feed/FeedFragment.kt");
+        final String service = readSource(
+                "org/schabi/newpipe/local/feed/service/FeedLoadService.kt");
+
+        assertTrue(fragment.contains("cancelRefreshButton.setOnClickListener"));
+        assertTrue(fragment.contains("FeedLoadService.cancel(requireContext())"));
+        assertTrue(service.contains("fun cancel(context: Context)"));
+        assertTrue(service.contains("getBroadcast(this, NOTIFICATION_ID, cancelIntent(this)"));
+        assertTrue(methodBody(service, "private fun cancelLoading()", "private fun stopService()")
+                .contains("feedLoadManager.cancel()"));
+        assertTrue(methodBody(service, "private fun cancelLoading()", "private fun stopService()")
+                .contains("FeedEventManager.reset(feedScope)"));
+        assertTrue(methodBody(service, "private fun cancelLoading()", "private fun stopService()")
+                .contains("stopService()"));
+        assertTrue(methodBody(
+                service,
+                "private fun setupBroadcastReceiver()",
+                "// Error handling"
+        ).contains("cancelLoading()"));
+    }
+
+    private String readSource(final String relativePath) throws Exception {
+        return Files.readString(sourceDirectory.resolve(relativePath));
+    }
+
+    private Document parseLayout() throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-parameter-entities", false);
+        return factory.newDocumentBuilder()
+                .parse(resourcesDirectory.resolve("layout/fragment_feed.xml").toFile());
+    }
+
+    private Element findByAndroidId(final Document document, final String id) {
+        final NodeList elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            if (id.equals(element.getAttributeNS(ANDROID_NAMESPACE, "id"))) {
+                return element;
+            }
+        }
+        return null;
     }
 
     private String methodBody(final String source, final String signature,

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -7,6 +7,7 @@ Release history is listed newest first. The number beside each release is its An
 ### Improvements
 
 - Added direct notification keyword management to subscribed channel menus.
+- Polished feed refreshing with a translucent overlay, circular progress, and immediate cancellation.
 
 ## WizeStream 1.10.4 (`1010004`)
 


### PR DESCRIPTION
- Keeps existing feed content visible behind a theme-aware translucent refresh scrim while blocking accidental interaction.
- Replaces the horizontal progress bar with polished determinate and indeterminate circular indicators and a centered item count.
- Adds a symmetric circular X button near the bottom with an accessible Cancel refresh label.
- Routes both in-app and notification cancellation through one immediate service shutdown path while preserving committed feed batches.
- Adds regression coverage for overlay opacity, circular controls, lifecycle visibility, and shared cancellation.