### PR TITLE
Prevent empty feed highlight ranges

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -758,13 +758,17 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             }
         }
 
-        // Force updates all items so that the highlighting is correct
-        // If this isn't done visible items that are already highlighted will stay in a highlighted
-        // state until the user scrolls them out of the visible area which causes a update/bind-call
-        groupAdapter.notifyItemRangeChanged(
-            0,
-            highlightCount.coerceIn(lastNewItemsCount, groupAdapter.itemCount)
+        // Rebind enough remaining items to both apply new highlights and clear stale ones.
+        // The displayed list can shrink below lastNewItemsCount after filtering or refreshing,
+        // including all the way to zero, so cap the range to the current adapter size.
+        val rebindCount = calculateFeedHighlightRebindCount(
+            lastNewItemsCount,
+            highlightCount,
+            groupAdapter.itemCount
         )
+        if (rebindCount > 0) {
+            groupAdapter.notifyItemRangeChanged(0, rebindCount)
+        }
 
         if (highlightCount > 0) {
             showNewItemsLoaded()

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedHighlightRange.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedHighlightRange.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 WizeStream contributors
+ * FeedHighlightRange.kt is part of WizeStream
+ *
+ * License: GPL-3.0+
+ */
+
+package org.schabi.newpipe.local.feed
+
+internal fun calculateFeedHighlightRebindCount(
+    previousHighlightCount: Int,
+    currentHighlightCount: Int,
+    itemCount: Int
+): Int = maxOf(previousHighlightCount, currentHighlightCount).coerceAtMost(itemCount)

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedHighlightRangeTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedHighlightRangeTest.kt
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.local.feed
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FeedHighlightRangeTest {
+    @Test
+    fun emptyFeedDoesNotProduceAnInvalidRange() {
+        assertEquals(0, calculateFeedHighlightRebindCount(1, 0, 0))
+    }
+
+    @Test
+    fun rebindCountClearsStaleHighlightsAfterTheListShrinks() {
+        assertEquals(3, calculateFeedHighlightRebindCount(5, 2, 3))
+    }
+
+    @Test
+    fun rebindCountIncludesAllNewHighlights() {
+        assertEquals(5, calculateFeedHighlightRebindCount(2, 5, 8))
+    }
+
+    @Test
+    fun unchangedUnhighlightedFeedNeedsNoRebind() {
+        assertEquals(0, calculateFeedHighlightRebindCount(0, 0, 8))
+    }
+}

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -9,6 +9,10 @@ Release history is listed newest first. The number beside each release is its An
 - Added direct notification keyword management to subscribed channel menus.
 - Polished feed refreshing with a translucent overlay, circular progress, and immediate cancellation.
 
+### Fixes
+
+- Prevented feed refreshes and filters from crashing when the displayed list shrinks to zero items.
+
 ## WizeStream 1.10.4 (`1010004`)
 
 ### New features


### PR DESCRIPTION
- Prevent feed highlighting from constructing an invalid range when filtering or refreshing leaves no displayed items.
- Rebind the larger of the previous and current highlighted regions while capping it to the adapter’s current item count.
- Add regression coverage for empty feeds, shrinking lists, new highlights, and unchanged unhighlighted feeds.
- Document the crash fix in the Unreleased changelog.