### PR TITLE
Prevent feed progress indicator clipping

### DIFF
--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -140,13 +140,13 @@
                     android:orientation="vertical">
 
                     <FrameLayout
-                        android:layout_width="88dp"
-                        android:layout_height="88dp">
+                        android:layout_width="104dp"
+                        android:layout_height="104dp">
 
                         <com.google.android.material.progressindicator.CircularProgressIndicator
                             android:id="@+id/loading_progress_bar"
-                            android:layout_width="88dp"
-                            android:layout_height="88dp"
+                            android:layout_width="104dp"
+                            android:layout_height="104dp"
                             android:indeterminate="false"
                             android:max="1"
                             android:progress="0"
@@ -159,8 +159,8 @@
 
                         <com.google.android.material.progressindicator.CircularProgressIndicator
                             android:id="@+id/loading_indeterminate_progress_bar"
-                            android:layout_width="88dp"
-                            android:layout_height="88dp"
+                            android:layout_width="104dp"
+                            android:layout_height="104dp"
                             android:indeterminate="true"
                             android:visibility="gone"
                             app:indicatorColor="?attr/colorPrimary"

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
@@ -71,14 +71,28 @@ public class FeedRefreshControlsTest {
         final Document document = parseLayout();
         final Element progress = findByAndroidId(
                 document, "@+id/loading_progress_bar");
+        final Element indeterminateProgress = findByAndroidId(
+                document, "@+id/loading_indeterminate_progress_bar");
         final Element cancel = findByAndroidId(
                 document, "@+id/cancel_refresh_button");
 
         assertNotNull(progress);
+        assertNotNull(indeterminateProgress);
         assertEquals(
                 "com.google.android.material.progressindicator.CircularProgressIndicator",
                 progress.getTagName());
+        assertEquals("104dp", progress.getAttributeNS(ANDROID_NAMESPACE, "layout_width"));
+        assertEquals("104dp", progress.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
         assertEquals("88dp", progress.getAttributeNS(APP_NAMESPACE, "indicatorSize"));
+        assertEquals(
+                "104dp",
+                indeterminateProgress.getAttributeNS(ANDROID_NAMESPACE, "layout_width"));
+        assertEquals(
+                "104dp",
+                indeterminateProgress.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
+        assertEquals(
+                "88dp",
+                indeterminateProgress.getAttributeNS(APP_NAMESPACE, "indicatorSize"));
         assertEquals("6dp", progress.getAttributeNS(APP_NAMESPACE, "trackThickness"));
         assertEquals("3dp", progress.getAttributeNS(APP_NAMESPACE, "trackCornerRadius"));
 

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -12,6 +12,7 @@ Release history is listed newest first. The number beside each release is its An
 ### Fixes
 
 - Prevented feed refreshes and filters from crashing when the displayed list shrinks to zero items.
+- Prevented the circular feed refresh indicator from being clipped along its edges.
 
 ## WizeStream 1.10.4 (`1010004`)
 


### PR DESCRIPTION
- Preserve the visible 88dp circular feed progress ring while enlarging its drawing surface to 104dp.
- Add an 8dp safety inset on every edge for both determinate and indeterminate progress states.
- Extend layout regression coverage to verify both indicators retain the inset drawing surface.
- Document the clipping fix in the Unreleased changelog.