### PR TITLE
Handle Rumble videos without related items

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/rumble/extractors/RumbleStreamExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/rumble/extractors/RumbleStreamExtractor.java
@@ -69,7 +69,7 @@ public class RumbleStreamExtractor extends StreamExtractor {
 
     private final String videoViewerCountHtmlKey =
             "div.media-engage div.video-counters--item.video-item--views";
-    private final String relatedStreamHtmlKey = "ul.mediaList-list";
+    private static final String RELATED_STREAM_HTML_KEY = "ul.mediaList-list";
 
     private Document doc;
     JsonObject embedJsonStreamInfoObj;
@@ -565,12 +565,19 @@ public class RumbleStreamExtractor extends StreamExtractor {
         return isLiveStream ? StreamType.LIVE_STREAM : StreamType.VIDEO_STREAM;
     }
 
+    static List<Node> getRelatedItemNodes(final Document document) {
+        final Element relatedItems = document.selectFirst(RELATED_STREAM_HTML_KEY);
+        if (relatedItems == null) {
+            return Collections.emptyList();
+        }
+        return relatedItems.childNodes();
+    }
+
     @Nullable
     @Override
     public StreamInfoItemsCollector getRelatedItems() throws ExtractionException {
-        final List<Node> nodes = doc.select(relatedStreamHtmlKey).first().childNodes();
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
-        for (final Node node : nodes) {
+        for (final Node node : getRelatedItemNodes(doc)) {
             // we only want Element(s) as they might bear useful content
             if ((node instanceof Element)
                     && (null != ((Element) node).closest(".mediaList-item"))) {

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/rumble/extractors/RumbleStreamExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/rumble/extractors/RumbleStreamExtractorTest.java
@@ -1,0 +1,35 @@
+package org.schabi.newpipe.extractor.services.rumble.extractors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class RumbleStreamExtractorTest {
+
+    @Test
+    void returnsNoRelatedNodesWhenTheOptionalSectionIsMissing() {
+        final Document document = Jsoup.parse(
+                "<html><body><main>Video metadata only</main></body></html>",
+                "https://rumble.com/v7epypu");
+
+        assertTrue(RumbleStreamExtractor.getRelatedItemNodes(document).isEmpty());
+    }
+
+    @Test
+    void retainsRelatedNodesWhenTheOptionalSectionExists() {
+        final Document document = Jsoup.parse(
+                "<ul class=\"mediaList-list\"><li class=\"mediaList-item\"></li></ul>",
+                "https://rumble.com/example");
+        final List<Node> nodes = RumbleStreamExtractor.getRelatedItemNodes(document);
+
+        assertEquals(1, nodes.size());
+        assertTrue(nodes.get(0) instanceof Element);
+    }
+}


### PR DESCRIPTION
- Treat a missing Rumble related-items section as an empty optional result
- Preserve the primary stream metadata and playback path for pages such as `https://rumble.com/v7epypu`
- Add regression coverage for pages with and without the related-items container