### PR TITLE
Use Material theme colors for seekbars

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -16,6 +16,7 @@ import static org.schabi.newpipe.player.helper.PlayerHelper.getTimeString;
 import static org.schabi.newpipe.player.helper.PlayerHelper.nextResizeModeAndSaveToPrefs;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
@@ -204,10 +205,10 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
                         seekBarContext, R.attr.colorPrimaryFixedDim));
         final ColorStateList bufferedColor = ColorStateList.valueOf(
                 ThemeHelper.resolveColorFromAttr(
-                        seekBarContext, R.attr.colorPrimaryContainer));
+                        seekBarContext, com.google.android.material.R.attr.colorPrimaryContainer));
         final ColorStateList inactiveColor = ColorStateList.valueOf(
                 ThemeHelper.resolveColorFromAttr(
-                        seekBarContext, R.attr.colorSurfaceVariant));
+                        seekBarContext, com.google.android.material.R.attr.colorSurfaceVariant));
 
         binding.playbackSeekBar.setProgressTintList(activeColor);
         binding.playbackSeekBar.setProgressTintMode(PorterDuff.Mode.SRC_IN);

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -198,14 +198,24 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     }
 
     private void applyPlayerSeekBarColor() {
-        final int playerSeekBarColor = ThemeHelper.resolveColorFromAttr(
-                binding.playbackSeekBar.getContext(), R.attr.colorPrimaryFixedDim);
-        final ColorStateList playerSeekBarColorStateList =
-                ColorStateList.valueOf(playerSeekBarColor);
+        final Context seekBarContext = binding.playbackSeekBar.getContext();
+        final ColorStateList activeColor = ColorStateList.valueOf(
+                ThemeHelper.resolveColorFromAttr(
+                        seekBarContext, R.attr.colorPrimaryFixedDim));
+        final ColorStateList bufferedColor = ColorStateList.valueOf(
+                ThemeHelper.resolveColorFromAttr(
+                        seekBarContext, R.attr.colorPrimaryContainer));
+        final ColorStateList inactiveColor = ColorStateList.valueOf(
+                ThemeHelper.resolveColorFromAttr(
+                        seekBarContext, R.attr.colorSurfaceVariant));
 
-        binding.playbackSeekBar.setProgressTintList(playerSeekBarColorStateList);
+        binding.playbackSeekBar.setProgressTintList(activeColor);
         binding.playbackSeekBar.setProgressTintMode(PorterDuff.Mode.SRC_IN);
-        binding.playbackSeekBar.setThumbTintList(playerSeekBarColorStateList);
+        binding.playbackSeekBar.setSecondaryProgressTintList(bufferedColor);
+        binding.playbackSeekBar.setSecondaryProgressTintMode(PorterDuff.Mode.SRC_IN);
+        binding.playbackSeekBar.setProgressBackgroundTintList(inactiveColor);
+        binding.playbackSeekBar.setProgressBackgroundTintMode(PorterDuff.Mode.SRC_IN);
+        binding.playbackSeekBar.setThumbTintList(activeColor);
         binding.playbackSeekBar.setThumbTintMode(PorterDuff.Mode.SRC_IN);
     }
 

--- a/app/src/main/res/layout-land/activity_player_queue_control.xml
+++ b/app/src/main/res/layout-land/activity_player_queue_control.xml
@@ -282,7 +282,7 @@
 
         <androidx.appcompat.widget.AppCompatSeekBar
             android:id="@+id/seek_bar"
-            style="@style/Widget.AppCompat.SeekBar"
+            style="@style/Widget.WizeStream.SeekBar"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"

--- a/app/src/main/res/layout/activity_player_queue_control.xml
+++ b/app/src/main/res/layout/activity_player_queue_control.xml
@@ -118,7 +118,7 @@
 
         <androidx.appcompat.widget.AppCompatSeekBar
             android:id="@+id/seek_bar"
-            style="@style/Widget.AppCompat.SeekBar"
+            style="@style/Widget.WizeStream.SeekBar"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"

--- a/app/src/main/res/layout/dialog_sponsor_block_color_picker.xml
+++ b/app/src/main/res/layout/dialog_sponsor_block_color_picker.xml
@@ -19,6 +19,7 @@
 
     <SeekBar
         android:id="@+id/red"
+        style="@style/Widget.WizeStream.SeekBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:contentDescription="@string/sponsor_block_color_red"
@@ -32,6 +33,7 @@
 
     <SeekBar
         android:id="@+id/green"
+        style="@style/Widget.WizeStream.SeekBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:contentDescription="@string/sponsor_block_color_green"
@@ -45,6 +47,7 @@
 
     <SeekBar
         android:id="@+id/blue"
+        style="@style/Widget.WizeStream.SeekBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:contentDescription="@string/sponsor_block_color_blue"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -567,7 +567,7 @@
 
                     <org.schabi.newpipe.views.FocusAwareSeekBar
                         android:id="@+id/playbackSeekBar"
-                        style="@style/Widget.AppCompat.SeekBar"
+                        style="@style/Widget.WizeStream.SeekBar"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:nextFocusDown="@id/screenRotationButton"

--- a/app/src/main/res/values/styles_misc.xml
+++ b/app/src/main/res/values/styles_misc.xml
@@ -56,12 +56,14 @@
         <item name="cornerSize">@dimen/stream_thumbnail_corner_radius</item>
     </style>
 
-    <style name="PlaybackParameterSeekBar" parent="Widget.AppCompat.SeekBar">
+    <style name="Widget.WizeStream.SeekBar" parent="Widget.AppCompat.SeekBar">
         <item name="android:thumbTint">?attr/colorPrimary</item>
         <item name="android:progressTint">?attr/colorPrimary</item>
         <item name="android:progressBackgroundTint">?attr/colorSurfaceVariant</item>
         <item name="android:secondaryProgressTint">?attr/colorPrimaryContainer</item>
     </style>
+
+    <style name="PlaybackParameterSeekBar" parent="Widget.WizeStream.SeekBar" />
 
 
     <!--File picker styles-->

--- a/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
@@ -40,8 +40,10 @@ public class ThemeColorIntegrationTest {
         assertTrue(playerUi.contains(
                 "final Context seekBarContext = binding.playbackSeekBar.getContext();"));
         assertTrue(playerUi.contains("seekBarContext, R.attr.colorPrimaryFixedDim"));
-        assertTrue(playerUi.contains("seekBarContext, R.attr.colorPrimaryContainer"));
-        assertTrue(playerUi.contains("seekBarContext, R.attr.colorSurfaceVariant"));
+        assertTrue(playerUi.contains("seekBarContext, "
+                + "com.google.android.material.R.attr.colorPrimaryContainer"));
+        assertTrue(playerUi.contains("seekBarContext, "
+                + "com.google.android.material.R.attr.colorSurfaceVariant"));
         assertTrue(playerUi.contains("setSecondaryProgressTintList(bufferedColor)"));
         assertTrue(playerUi.contains("setProgressBackgroundTintList(inactiveColor)"));
         assertFalse(playerUi.contains("context, R.attr.colorPrimaryFixedDim"));

--- a/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
@@ -33,17 +33,50 @@ public class ThemeColorIntegrationTest {
     }
 
     @Test
-    public void playerSeekBarUsesItsThemedViewContext() throws Exception {
+    public void playerSeekBarUsesMaterialColorsFromItsThemedViewContext() throws Exception {
         final String playerUi = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/player/ui/VideoPlayerUi.java"));
 
         assertTrue(playerUi.contains(
-                "binding.playbackSeekBar.getContext(), R.attr.colorPrimaryFixedDim"));
+                "final Context seekBarContext = binding.playbackSeekBar.getContext();"));
+        assertTrue(playerUi.contains("seekBarContext, R.attr.colorPrimaryFixedDim"));
+        assertTrue(playerUi.contains("seekBarContext, R.attr.colorPrimaryContainer"));
+        assertTrue(playerUi.contains("seekBarContext, R.attr.colorSurfaceVariant"));
+        assertTrue(playerUi.contains("setSecondaryProgressTintList(bufferedColor)"));
+        assertTrue(playerUi.contains("setProgressBackgroundTintList(inactiveColor)"));
         assertFalse(playerUi.contains("context, R.attr.colorPrimaryFixedDim"));
     }
 
+    @Test
+    public void xmlSeekBarsShareTheMaterialColorStyle() throws Exception {
+        final String styles = Files.readString(
+                resourceDirectory.resolve("values/styles_misc.xml"));
+        final String materialSeekBar = styleBody(styles, "Widget.WizeStream.SeekBar");
+
+        assertTrue(materialSeekBar.contains(
+                "<item name=\"android:thumbTint\">?attr/colorPrimary</item>"));
+        assertTrue(materialSeekBar.contains(
+                "<item name=\"android:progressTint\">?attr/colorPrimary</item>"));
+        assertTrue(materialSeekBar.contains(
+                "<item name=\"android:progressBackgroundTint\">"
+                        + "?attr/colorSurfaceVariant</item>"));
+        assertTrue(materialSeekBar.contains(
+                "<item name=\"android:secondaryProgressTint\">"
+                        + "?attr/colorPrimaryContainer</item>"));
+
+        assertLayoutUsesMaterialSeekBar("layout/player.xml");
+        assertLayoutUsesMaterialSeekBar("layout/activity_player_queue_control.xml");
+        assertLayoutUsesMaterialSeekBar("layout-land/activity_player_queue_control.xml");
+        assertLayoutUsesMaterialSeekBar("layout/dialog_sponsor_block_color_picker.xml");
+    }
+
+    private void assertLayoutUsesMaterialSeekBar(final String layout) throws Exception {
+        final String source = Files.readString(resourceDirectory.resolve(layout));
+        assertTrue(source.contains("style=\"@style/Widget.WizeStream.SeekBar\""));
+    }
+
     private String styleBody(final String styles, final String styleName) {
-        final String openingTag = "<style name=\"" + styleName + "\">";
+        final String openingTag = "<style name=\"" + styleName + "\"";
         final int start = styles.indexOf(openingTag);
         if (start < 0) {
             throw new AssertionError("Missing style: " + styleName);


### PR DESCRIPTION
- Apply the selected Material primary color to seekbar progress and thumbs
- Use `colorPrimaryContainer` for buffered progress and `colorSurfaceVariant` for inactive tracks
- Share the style across player, queue, playback-parameter, and SponsorBlock color seekbars
- Resolve player colors from the seekbar’s themed context in every playback state
- Add theme integration regression coverage

Part of #266