### PR TITLE
Improve player control accessibility

### DIFF
--- a/app/src/main/res/layout-land/activity_player_queue_control.xml
+++ b/app/src/main/res/layout-land/activity_player_queue_control.xml
@@ -112,8 +112,8 @@
 
             <ImageButton
                 android:id="@+id/control_fast_rewind"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_toLeftOf="@+id/control_play_pause"
@@ -162,8 +162,8 @@
 
             <ImageButton
                 android:id="@+id/control_fast_forward"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginRight="5dp"
                 android:layout_toRightOf="@+id/control_play_pause"
@@ -188,7 +188,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/control_backward"
                 android:layout_width="wrap_content"
-                android:layout_height="35dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_marginRight="5dp"
@@ -205,8 +205,8 @@
 
             <ImageButton
                 android:id="@+id/control_repeat"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_toLeftOf="@+id/anchor"
@@ -226,8 +226,8 @@
 
             <ImageButton
                 android:id="@+id/control_shuffle"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginRight="5dp"
                 android:layout_toRightOf="@+id/anchor"
@@ -242,7 +242,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/control_forward"
                 android:layout_width="wrap_content"
-                android:layout_height="35dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_marginRight="5dp"

--- a/app/src/main/res/layout/activity_player_queue_control.xml
+++ b/app/src/main/res/layout/activity_player_queue_control.xml
@@ -164,26 +164,27 @@
 
         <ImageButton
             android:id="@+id/control_repeat"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:layout_toLeftOf="@+id/control_backward"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitXY"
             android:src="@drawable/ic_repeat"
+            android:contentDescription="@string/notification_action_repeat"
             app:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/control_backward"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
+            android:layout_marginLeft="0dp"
             android:layout_toLeftOf="@+id/control_fast_rewind"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
@@ -191,48 +192,50 @@
             android:scaleType="fitCenter"
             android:src="@drawable/ic_previous"
             android:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            android:contentDescription="@string/previous_stream" />
 
         <ImageButton
             android:id="@+id/control_fast_rewind"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
+            android:layout_marginLeft="0dp"
             android:layout_toLeftOf="@id/control_play_pause"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             android:src="@drawable/exo_controls_rewind"
+            android:contentDescription="@string/rewind"
             app:tint="?attr/colorAccent" />
 
         <ImageButton
             android:id="@+id/control_play_pause"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_pause"
+            android:contentDescription="@string/pause"
             app:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            />
 
         <ProgressBar
             android:id="@+id/control_progress_bar"
             style="?android:attr/progressBarStyleLargeInverse"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
             android:layout_centerInParent="true"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:background="#00000000"
             android:clickable="false"
             android:indeterminate="true"
@@ -245,24 +248,25 @@
 
         <ImageButton
             android:id="@+id/control_fast_forward"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginRight="5dp"
+            android:layout_marginRight="0dp"
             android:layout_toRightOf="@id/control_play_pause"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             android:src="@drawable/exo_controls_fastforward"
+            android:contentDescription="@string/forward"
             app:tint="?attr/colorAccent" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/control_forward"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginRight="5dp"
+            android:layout_marginRight="0dp"
             android:layout_toRightOf="@+id/control_fast_forward"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
@@ -270,23 +274,24 @@
             android:scaleType="fitCenter"
             android:src="@drawable/ic_next"
             android:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            android:contentDescription="@string/next_stream" />
 
         <ImageButton
             android:id="@+id/control_shuffle"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:layout_toRightOf="@+id/control_forward"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitXY"
             android:src="@drawable/ic_shuffle"
+            android:contentDescription="@string/notification_action_shuffle"
             app:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            />
 
     </RelativeLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/item_learning_note.xml
+++ b/app/src/main/res/layout/item_learning_note.xml
@@ -27,8 +27,8 @@
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/learning_note_edit"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/learning_note_edit"
         android:padding="8dp"
@@ -37,8 +37,8 @@
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/learning_note_delete"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/delete"
         android:padding="8dp"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -109,13 +109,13 @@
                     android:baselineAligned="false"
                     android:descendantFocusability="afterDescendants"
                     android:gravity="top"
-                    android:minHeight="45dp"
+                    android:minHeight="48dp"
                     tools:ignore="RtlHardcoded">
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/playerCloseButton"
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
@@ -183,13 +183,13 @@
                             <org.schabi.newpipe.views.NewPipeTextView
                                 android:id="@+id/audioTrackTextView"
                                 android:layout_width="wrap_content"
-                                android:layout_height="35dp"
+                                android:layout_height="48dp"
                                 android:layout_gravity="right"
                                 android:layout_marginEnd="8dp"
                                 android:background="?attr/selectableItemBackground"
                                 android:ellipsize="end"
                                 android:gravity="center"
-                                android:minWidth="0dp"
+                                android:minWidth="48dp"
                                 android:padding="@dimen/player_main_buttons_padding"
                                 android:singleLine="true"
                                 android:textColor="@android:color/white"
@@ -205,11 +205,11 @@
                     <org.schabi.newpipe.views.NewPipeTextView
                         android:id="@+id/qualityTextView"
                         android:layout_width="wrap_content"
-                        android:layout_height="35dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackground"
                         android:gravity="center"
-                        android:minWidth="0dp"
+                        android:minWidth="48dp"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:textColor="@android:color/white"
                         android:textStyle="bold"
@@ -219,11 +219,11 @@
                     <org.schabi.newpipe.views.NewPipeTextView
                         android:id="@+id/playbackSpeed"
                         android:layout_width="wrap_content"
-                        android:layout_height="35dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:gravity="center"
-                        android:minWidth="0dp"
+                        android:minWidth="48dp"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:textColor="@android:color/white"
                         android:textStyle="bold"
@@ -232,8 +232,8 @@
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/queueButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
@@ -251,8 +251,8 @@
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/segmentsButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
@@ -270,8 +270,8 @@
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/moreOptionsButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
                         android:contentDescription="@string/more_options"
@@ -304,7 +304,7 @@
                         <org.schabi.newpipe.views.NewPipeTextView
                             android:id="@+id/resizeTextView"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackground"
                             android:gravity="center"
@@ -329,7 +329,7 @@
                                 android:gravity="center|left"
                                 android:lines="1"
                                 android:minWidth="50dp"
-                                android:minHeight="35dp"
+                                android:minHeight="48dp"
                                 android:padding="@dimen/player_main_buttons_padding"
                                 android:textColor="@android:color/white"
                                 android:textStyle="bold"
@@ -341,12 +341,13 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/playWithKodi"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/play_with_kodi_title"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_cast"
@@ -356,12 +357,13 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/openInBrowser"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/open_in_browser"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_language"
@@ -371,12 +373,13 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/share"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/share"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_share"
@@ -385,8 +388,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/learningNoteButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -400,8 +403,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/sleepTimerButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -414,8 +417,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/equalizerButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -428,8 +431,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/listenModeButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -443,11 +446,12 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/switchMute"
                             android:layout_width="wrap_content"
-                            android:layout_height="37dp"
+                            android:layout_height="48dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/mute"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_volume_off"
@@ -456,8 +460,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/fullScreenButton"
-                            android:layout_width="40dp"
-                            android:layout_height="40dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/toggle_fullscreen"
@@ -613,8 +617,8 @@
 
                 <androidx.appcompat.widget.AppCompatImageButton
                     android:id="@+id/screenRotationButton"
-                    android:layout_width="40dp"
-                    android:layout_height="40dp"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
                     android:layout_marginStart="4dp"
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:clickable="true"
@@ -641,7 +645,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/playPreviousButton"
                 android:layout_width="0dp"
-                android:layout_height="40dp"
+                android:layout_height="48dp"
                 android:layout_marginEnd="10dp"
                 android:layout_weight="1"
                 android:background="?attr/selectableItemBackgroundBorderless"
@@ -667,7 +671,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/playNextButton"
                 android:layout_width="0dp"
-                android:layout_height="40dp"
+                android:layout_height="48dp"
                 android:layout_marginStart="10dp"
                 android:layout_weight="1"
                 android:background="?attr/selectableItemBackgroundBorderless"

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerControlAccessibilityResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerControlAccessibilityResourcesTest.java
@@ -1,0 +1,126 @@
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class PlayerControlAccessibilityResourcesTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void queueControlsHaveAccessibleTargetsAndLabels() throws Exception {
+        assertControls(
+                "layout/activity_player_queue_control.xml",
+                "control_repeat",
+                "control_backward",
+                "control_fast_rewind",
+                "control_play_pause",
+                "control_fast_forward",
+                "control_forward",
+                "control_shuffle");
+        assertControls(
+                "layout-land/activity_player_queue_control.xml",
+                "control_repeat",
+                "control_backward",
+                "control_fast_rewind",
+                "control_play_pause",
+                "control_fast_forward",
+                "control_forward",
+                "control_shuffle");
+    }
+
+    @Test
+    public void playerIconControlsHaveAccessibleTargetsAndLabels() throws Exception {
+        assertControls(
+                "layout/player.xml",
+                "playerCloseButton",
+                "queueButton",
+                "segmentsButton",
+                "moreOptionsButton",
+                "learningNoteButton",
+                "sleepTimerButton",
+                "equalizerButton",
+                "listenModeButton",
+                "fullScreenButton",
+                "screenRotationButton");
+    }
+
+    @Test
+    public void learningNoteActionsHaveAccessibleTargetsAndLabels() throws Exception {
+        assertControls(
+                "layout/item_learning_note.xml",
+                "learning_note_edit",
+                "learning_note_delete");
+    }
+
+    private void assertControls(final String layout, final String... ids) throws Exception {
+        final Document document = parse(layout);
+        for (final String id : ids) {
+            final Element element = findById(document, id);
+            assertNotNull(layout + ": " + id, element);
+            assertAtLeast48Dp(layout, id, element, "layout_width");
+            assertAtLeast48Dp(layout, id, element, "layout_height");
+            assertFalse(layout + ": " + id,
+                    element.getAttributeNS(ANDROID_NAMESPACE, "contentDescription").isBlank());
+        }
+    }
+
+    private void assertAtLeast48Dp(final String layout,
+                                   final String id,
+                                   final Element element,
+                                   final String attribute) {
+        final String value = element.getAttributeNS(ANDROID_NAMESPACE, attribute);
+        if ("wrap_content".equals(value) || "0dp".equals(value)) {
+            final String minimumAttribute = "layout_width".equals(attribute)
+                    ? "minWidth" : "minHeight";
+            final String minimum = element.getAttributeNS(ANDROID_NAMESPACE, minimumAttribute);
+            assertTrue(layout + ": " + id + " " + minimumAttribute,
+                    parseDp(minimum) >= 48);
+        } else {
+            assertTrue(layout + ": " + id + " " + attribute,
+                    parseDp(value) >= 48);
+        }
+    }
+
+    private int parseDp(final String value) {
+        assertTrue(value, value.endsWith("dp"));
+        return Integer.parseInt(value.substring(0, value.length() - 2));
+    }
+
+    private Element findById(final Document document, final String id) {
+        final var elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            final String androidId = element.getAttributeNS(ANDROID_NAMESPACE, "id");
+            if (("@+id/" + id).equals(androidId) || ("@id/" + id).equals(androidId)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private Document parse(final String relativePath) throws Exception {
+        final var factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder()
+                .parse(resourcesDirectory.resolve(relativePath).toFile());
+    }
+}


### PR DESCRIPTION
- Expand player, queue, and learning-note controls to at least 48dp touch targets
- Add missing accessible labels to portrait play-queue actions
- Preserve compact visual icons through internal padding and scrollable player controls
- Add source-level regression coverage for target sizes and labels
- Verified with the complete remediation stack: https://github.com/wizdom13/WizeStream/actions/runs/33172531465