### PR TITLE
Use Material 3 components and surface roles

### DIFF
--- a/app/src/main/res/layout-land/activity_player_queue_control.xml
+++ b/app/src/main/res/layout-land/activity_player_queue_control.xml
@@ -12,17 +12,21 @@
         android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.DayNight.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight.ActionBar">
+        android:background="?attr/colorSurfaceContainer"
+        android:theme="@style/ToolbarTheme"
+        app:popupTheme="@style/ToolbarTheme">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:layout_weight="1"
-            android:background="?attr/colorPrimaryContainer"
+            android:background="?attr/colorSurfaceContainer"
             android:theme="@style/ToolbarTheme"
             app:layout_scrollFlags="scroll|enterAlways"
+            app:navigationIconTint="?attr/colorOnSurface"
+            app:subtitleTextColor="?attr/colorOnSurfaceVariant"
+            app:titleTextColor="?attr/colorOnSurface"
             app:title="@string/app_name" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout-land/activity_player_queue_control.xml
+++ b/app/src/main/res/layout-land/activity_player_queue_control.xml
@@ -112,8 +112,8 @@
 
             <ImageButton
                 android:id="@+id/control_fast_rewind"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_toLeftOf="@+id/control_play_pause"
@@ -162,8 +162,8 @@
 
             <ImageButton
                 android:id="@+id/control_fast_forward"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginRight="5dp"
                 android:layout_toRightOf="@+id/control_play_pause"
@@ -188,7 +188,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/control_backward"
                 android:layout_width="wrap_content"
-                android:layout_height="35dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_marginRight="5dp"
@@ -205,8 +205,8 @@
 
             <ImageButton
                 android:id="@+id/control_repeat"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_toLeftOf="@+id/anchor"
@@ -226,8 +226,8 @@
 
             <ImageButton
                 android:id="@+id/control_shuffle"
-                android:layout_width="30dp"
-                android:layout_height="30dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginRight="5dp"
                 android:layout_toRightOf="@+id/anchor"
@@ -242,7 +242,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/control_forward"
                 android:layout_width="wrap_content"
-                android:layout_height="35dp"
+                android:layout_height="48dp"
                 android:layout_centerVertical="true"
                 android:layout_marginLeft="5dp"
                 android:layout_marginRight="5dp"

--- a/app/src/main/res/layout/activity_player_queue_control.xml
+++ b/app/src/main/res/layout/activity_player_queue_control.xml
@@ -12,17 +12,21 @@
         android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.DayNight.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight.ActionBar">
+        android:background="?attr/colorSurfaceContainer"
+        android:theme="@style/ToolbarTheme"
+        app:popupTheme="@style/ToolbarTheme">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:layout_weight="1"
-            android:background="?attr/colorPrimary"
+            android:background="?attr/colorSurfaceContainer"
             android:theme="@style/ToolbarTheme"
             app:layout_scrollFlags="scroll|enterAlways"
+            app:navigationIconTint="?attr/colorOnSurface"
+            app:subtitleTextColor="?attr/colorOnSurfaceVariant"
+            app:titleTextColor="?attr/colorOnSurface"
             app:title="@string/app_name" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_player_queue_control.xml
+++ b/app/src/main/res/layout/activity_player_queue_control.xml
@@ -164,26 +164,27 @@
 
         <ImageButton
             android:id="@+id/control_repeat"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:layout_toLeftOf="@+id/control_backward"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitXY"
             android:src="@drawable/ic_repeat"
+            android:contentDescription="@string/notification_action_repeat"
             app:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/control_backward"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
+            android:layout_marginLeft="0dp"
             android:layout_toLeftOf="@+id/control_fast_rewind"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
@@ -191,48 +192,50 @@
             android:scaleType="fitCenter"
             android:src="@drawable/ic_previous"
             android:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            android:contentDescription="@string/previous_stream" />
 
         <ImageButton
             android:id="@+id/control_fast_rewind"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
+            android:layout_marginLeft="0dp"
             android:layout_toLeftOf="@id/control_play_pause"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             android:src="@drawable/exo_controls_rewind"
+            android:contentDescription="@string/rewind"
             app:tint="?attr/colorAccent" />
 
         <ImageButton
             android:id="@+id/control_play_pause"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_pause"
+            android:contentDescription="@string/pause"
             app:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            />
 
         <ProgressBar
             android:id="@+id/control_progress_bar"
             style="?android:attr/progressBarStyleLargeInverse"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
             android:layout_centerInParent="true"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:background="#00000000"
             android:clickable="false"
             android:indeterminate="true"
@@ -245,24 +248,25 @@
 
         <ImageButton
             android:id="@+id/control_fast_forward"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginRight="5dp"
+            android:layout_marginRight="0dp"
             android:layout_toRightOf="@id/control_play_pause"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitCenter"
             android:src="@drawable/exo_controls_fastforward"
+            android:contentDescription="@string/forward"
             app:tint="?attr/colorAccent" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/control_forward"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginRight="5dp"
+            android:layout_marginRight="0dp"
             android:layout_toRightOf="@+id/control_fast_forward"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
@@ -270,23 +274,24 @@
             android:scaleType="fitCenter"
             android:src="@drawable/ic_next"
             android:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            android:contentDescription="@string/next_stream" />
 
         <ImageButton
             android:id="@+id/control_shuffle"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_marginRight="5dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
             android:layout_toRightOf="@+id/control_forward"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:clickable="true"
             android:focusable="true"
             android:scaleType="fitXY"
             android:src="@drawable/ic_shuffle"
+            android:contentDescription="@string/notification_action_shuffle"
             app:tint="?attr/colorAccent"
-            tools:ignore="ContentDescription" />
+            />
 
     </RelativeLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/dialog_feed_group_create.xml
+++ b/app/src/main/res/layout/dialog_feed_group_create.xml
@@ -137,14 +137,15 @@
                 android:orientation="vertical"
                 android:visibility="gone">
 
-                <androidx.appcompat.widget.Toolbar
+                <com.google.android.material.appbar.MaterialToolbar
                     android:id="@+id/subscriptions_header_toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
+                    android:background="?attr/colorSurfaceContainer"
                     android:gravity="center_vertical"
                     android:paddingStart="8dp"
                     android:paddingEnd="8dp"
-                    android:theme="@style/ContrastToolbarTheme">
+                    android:theme="@style/ToolbarTheme">
 
                     <LinearLayout
                         android:id="@+id/subscriptions_header_info_container"
@@ -176,7 +177,7 @@
                         android:id="@+id/subscriptions_header_search_container"
                         layout="@layout/toolbar_search_layout"
                         android:visibility="gone" />
-                </androidx.appcompat.widget.Toolbar>
+                </com.google.android.material.appbar.MaterialToolbar>
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/subscriptions_selector_list"

--- a/app/src/main/res/layout/dialog_sponsor_block_color_picker.xml
+++ b/app/src/main/res/layout/dialog_sponsor_block_color_picker.xml
@@ -53,11 +53,18 @@
         android:contentDescription="@string/sponsor_block_color_blue"
         android:max="255" />
 
-    <EditText
-        android:id="@+id/hex"
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/sponsor_block_color_hex_label"
-        android:inputType="textNoSuggestions|textCapCharacters"
-        android:singleLine="true" />
+        android:hint="@string/sponsor_block_color_hex_label">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/hex"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textNoSuggestions|textCapCharacters"
+            android:singleLine="true" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/item_learning_note.xml
+++ b/app/src/main/res/layout/item_learning_note.xml
@@ -27,8 +27,8 @@
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/learning_note_edit"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/learning_note_edit"
         android:padding="8dp"
@@ -37,8 +37,8 @@
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/learning_note_delete"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/delete"
         android:padding="8dp"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -109,13 +109,13 @@
                     android:baselineAligned="false"
                     android:descendantFocusability="afterDescendants"
                     android:gravity="top"
-                    android:minHeight="45dp"
+                    android:minHeight="48dp"
                     tools:ignore="RtlHardcoded">
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/playerCloseButton"
-                        android:layout_width="36dp"
-                        android:layout_height="36dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
@@ -183,13 +183,13 @@
                             <org.schabi.newpipe.views.NewPipeTextView
                                 android:id="@+id/audioTrackTextView"
                                 android:layout_width="wrap_content"
-                                android:layout_height="35dp"
+                                android:layout_height="48dp"
                                 android:layout_gravity="right"
                                 android:layout_marginEnd="8dp"
                                 android:background="?attr/selectableItemBackground"
                                 android:ellipsize="end"
                                 android:gravity="center"
-                                android:minWidth="0dp"
+                                android:minWidth="48dp"
                                 android:padding="@dimen/player_main_buttons_padding"
                                 android:singleLine="true"
                                 android:textColor="@android:color/white"
@@ -205,11 +205,11 @@
                     <org.schabi.newpipe.views.NewPipeTextView
                         android:id="@+id/qualityTextView"
                         android:layout_width="wrap_content"
-                        android:layout_height="35dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackground"
                         android:gravity="center"
-                        android:minWidth="0dp"
+                        android:minWidth="48dp"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:textColor="@android:color/white"
                         android:textStyle="bold"
@@ -219,11 +219,11 @@
                     <org.schabi.newpipe.views.NewPipeTextView
                         android:id="@+id/playbackSpeed"
                         android:layout_width="wrap_content"
-                        android:layout_height="35dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:gravity="center"
-                        android:minWidth="0dp"
+                        android:minWidth="48dp"
                         android:padding="@dimen/player_main_buttons_padding"
                         android:textColor="@android:color/white"
                         android:textStyle="bold"
@@ -232,8 +232,8 @@
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/queueButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
@@ -251,8 +251,8 @@
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/segmentsButton"
-                        android:layout_width="35dp"
-                        android:layout_height="35dp"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:layout_marginEnd="8dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
@@ -270,8 +270,8 @@
 
                     <androidx.appcompat.widget.AppCompatImageButton
                         android:id="@+id/moreOptionsButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:clickable="true"
                         android:contentDescription="@string/more_options"
@@ -304,7 +304,7 @@
                         <org.schabi.newpipe.views.NewPipeTextView
                             android:id="@+id/resizeTextView"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackground"
                             android:gravity="center"
@@ -329,7 +329,7 @@
                                 android:gravity="center|left"
                                 android:lines="1"
                                 android:minWidth="50dp"
-                                android:minHeight="35dp"
+                                android:minHeight="48dp"
                                 android:padding="@dimen/player_main_buttons_padding"
                                 android:textColor="@android:color/white"
                                 android:textStyle="bold"
@@ -341,12 +341,13 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/playWithKodi"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/play_with_kodi_title"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_cast"
@@ -356,12 +357,13 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/openInBrowser"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/open_in_browser"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_language"
@@ -371,12 +373,13 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/share"
                             android:layout_width="wrap_content"
-                            android:layout_height="35dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/share"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_share"
@@ -385,8 +388,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/learningNoteButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -400,8 +403,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/sleepTimerButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -414,8 +417,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/equalizerButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -428,8 +431,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/listenModeButton"
-                            android:layout_width="35dp"
-                            android:layout_height="35dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:layout_marginEnd="8dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
@@ -443,11 +446,12 @@
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/switchMute"
                             android:layout_width="wrap_content"
-                            android:layout_height="37dp"
+                            android:layout_height="48dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/mute"
                             android:focusable="true"
+                            android:minWidth="48dp"
                             android:padding="@dimen/player_main_buttons_padding"
                             android:scaleType="fitXY"
                             android:src="@drawable/ic_volume_off"
@@ -456,8 +460,8 @@
 
                         <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/fullScreenButton"
-                            android:layout_width="40dp"
-                            android:layout_height="40dp"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
                             android:background="?attr/selectableItemBackgroundBorderless"
                             android:clickable="true"
                             android:contentDescription="@string/toggle_fullscreen"
@@ -613,8 +617,8 @@
 
                 <androidx.appcompat.widget.AppCompatImageButton
                     android:id="@+id/screenRotationButton"
-                    android:layout_width="40dp"
-                    android:layout_height="40dp"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
                     android:layout_marginStart="4dp"
                     android:background="?attr/selectableItemBackgroundBorderless"
                     android:clickable="true"
@@ -641,7 +645,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/playPreviousButton"
                 android:layout_width="0dp"
-                android:layout_height="40dp"
+                android:layout_height="48dp"
                 android:layout_marginEnd="10dp"
                 android:layout_weight="1"
                 android:background="?attr/selectableItemBackgroundBorderless"
@@ -667,7 +671,7 @@
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/playNextButton"
                 android:layout_width="0dp"
-                android:layout_height="40dp"
+                android:layout_height="48dp"
                 android:layout_marginStart="10dp"
                 android:layout_weight="1"
                 android:background="?attr/selectableItemBackgroundBorderless"

--- a/app/src/main/res/layout/related_items_header.xml
+++ b/app/src/main/res/layout/related_items_header.xml
@@ -18,13 +18,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.appcompat.widget.SwitchCompat
+    <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/autoplay_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:text="@string/auto_queue_toggle"
-        android:textColor="@android:color/tab_indicator_text"
+        android:textColor="?attr/colorOnSurface"
         android:textSize="13sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,6 +26,13 @@
     <color name="light_m3_inverse_surface_color">#30332F</color>
     <color name="light_m3_inverse_on_surface_color">#F0F1EC</color>
     <color name="light_m3_inverse_primary_color">#AED4AF</color>
+    <color name="light_m3_surface_container_lowest_color">#FFFFFF</color>
+    <color name="light_m3_surface_container_low_color">#F8F8F8</color>
+    <color name="light_m3_surface_container_color">#F2F2F2</color>
+    <color name="light_m3_surface_container_high_color">#E9E9E9</color>
+    <color name="light_m3_surface_container_highest_color">#E3E3E3</color>
+    <color name="light_m3_outline_color">#747873</color>
+    <color name="light_m3_outline_variant_color">#C4C8C2</color>
 
     <color name="dark_m3_primary_color">#AED4AF</color>
     <color name="dark_m3_on_primary_color">#19361E</color>
@@ -40,6 +47,13 @@
     <color name="dark_m3_inverse_surface_color">#E2E3DD</color>
     <color name="dark_m3_inverse_on_surface_color">#2F312D</color>
     <color name="dark_m3_inverse_primary_color">#46674F</color>
+    <color name="dark_m3_surface_container_lowest_color">#1A1A1A</color>
+    <color name="dark_m3_surface_container_low_color">#242424</color>
+    <color name="dark_m3_surface_container_color">#292929</color>
+    <color name="dark_m3_surface_container_high_color">#313131</color>
+    <color name="dark_m3_surface_container_highest_color">#3A3A3A</color>
+    <color name="dark_m3_outline_color">#8D918B</color>
+    <color name="dark_m3_outline_variant_color">#454A45</color>
 
     <!-- Light Theme -->
     <color name="light_background_color">#EEEEEE</color>
@@ -80,6 +94,11 @@
     <color name="black_card_item_background_color">#0F0F0F</color>
     <color name="black_card_item_contrast_color">#202020</color>
     <color name="black_border_color">#25FFFFFF</color>
+    <color name="black_m3_surface_container_lowest_color">#000000</color>
+    <color name="black_m3_surface_container_low_color">#0F0F0F</color>
+    <color name="black_m3_surface_container_color">#171717</color>
+    <color name="black_m3_surface_container_high_color">#202020</color>
+    <color name="black_m3_surface_container_highest_color">#2A2A2A</color>
 
     <!-- Miscellaneous -->
     <color name="queue_background_color">@color/dark_queue_background_color</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
         <item name="snackbarButtonStyle">@style/Widget.wizestream.Button.TextButton.Snackbar</item>
         <item name="snackbarTextViewStyle">@style/Widget.wizestream.Snackbar.TextView</item>
         <item name="toolbarSearchColor">?attr/colorOnSurface</item>
-        <item name="colorControlActivated">?attr/colorSecondary</item>
+        <item name="colorControlActivated">?attr/colorPrimary</item>
     </style>
     <style name="Base" parent="Base.V21"/>
 
@@ -44,27 +44,33 @@
         <item name="colorSurfaceInverse">@color/light_m3_inverse_surface_color</item>
         <item name="colorOnSurfaceInverse">@color/light_m3_inverse_on_surface_color</item>
         <item name="colorPrimaryInverse">@color/light_m3_inverse_primary_color</item>
+        <item name="colorSurfaceContainerLowest">@color/light_m3_surface_container_lowest_color</item>
+        <item name="colorSurfaceContainerLow">@color/light_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/light_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/light_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/light_m3_surface_container_highest_color</item>
         <item name="actionColor">?attr/colorOnSurface</item>
         <item name="toolbarSearchColor">?attr/colorOnSurface</item>
         <item name="colorPrimaryContainer">@color/light_m3_primary_container_color</item>
         <item name="colorOnPrimaryContainer">@color/light_m3_on_primary_container_color</item>
-        <item name="colorOutline">@color/light_border_color</item>
+        <item name="colorOutline">@color/light_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/light_m3_outline_variant_color</item>
         <item name="android:windowBackground">@color/light_background_color</item>
         <item name="windowBackground">@color/light_background_color</item>
         <item name="android:statusBarColor">?attr/colorSurface</item>
         <item name="android:navigationBarColor">?attr/colorSurface</item>
 
-        <item name="separator_color">@color/light_separator_color</item>
-        <item name="contrast_background_color">@color/light_contrast_background_color</item>
+        <item name="separator_color">?attr/colorOutlineVariant</item>
+        <item name="contrast_background_color">?attr/colorSurfaceContainerHigh</item>
         <item name="checked_selector">@drawable/selector_checked_light</item>
         <item name="focused_selector">@drawable/selector_focused_light</item>
         <item name="toolbar_shadow">@drawable/toolbar_shadow_light</item>
         <item name="selector">@drawable/selector_light</item>
         <item name="colorControlHighlight">@color/light_ripple_color</item>
         <item name="progress_horizontal_drawable">@drawable/progress_youtube_horizontal_light</item>
-        <item name="card_item_background_color">@color/light_card_item_background_color</item>
-        <item name="card_item_contrast_color">@color/light_card_item_contrast_color</item>
-        <item name="border_color">@color/light_border_color</item>
+        <item name="card_item_background_color">?attr/colorSurfaceContainerLow</item>
+        <item name="card_item_contrast_color">?attr/colorSurfaceContainerHigh</item>
+        <item name="border_color">?attr/colorOutlineVariant</item>
         <item name="dashed_border">@drawable/dashed_border_light</item>
     </style>
     <style name="Base.LightTheme" parent="Base.V21.LightTheme" />
@@ -88,27 +94,33 @@
         <item name="colorSurfaceInverse">@color/dark_m3_inverse_surface_color</item>
         <item name="colorOnSurfaceInverse">@color/dark_m3_inverse_on_surface_color</item>
         <item name="colorPrimaryInverse">@color/dark_m3_inverse_primary_color</item>
+        <item name="colorSurfaceContainerLowest">@color/dark_m3_surface_container_lowest_color</item>
+        <item name="colorSurfaceContainerLow">@color/dark_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/dark_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/dark_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/dark_m3_surface_container_highest_color</item>
         <item name="actionColor">?attr/colorOnSurface</item>
         <item name="toolbarSearchColor">?attr/colorOnSurface</item>
         <item name="colorPrimaryContainer">@color/dark_m3_primary_container_color</item>
         <item name="colorOnPrimaryContainer">@color/dark_m3_on_primary_container_color</item>
-        <item name="colorOutline">@color/dark_border_color</item>
+        <item name="colorOutline">@color/dark_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/dark_m3_outline_variant_color</item>
         <item name="android:windowBackground">@color/dark_background_color</item>
         <item name="windowBackground">@color/dark_background_color</item>
         <item name="android:statusBarColor">?attr/colorSurface</item>
         <item name="android:navigationBarColor">?attr/colorSurface</item>
 
-        <item name="separator_color">@color/dark_separator_color</item>
-        <item name="contrast_background_color">@color/dark_contrast_background_color</item>
+        <item name="separator_color">?attr/colorOutlineVariant</item>
+        <item name="contrast_background_color">?attr/colorSurfaceContainerHigh</item>
         <item name="checked_selector">@drawable/selector_checked_dark</item>
         <item name="focused_selector">@drawable/selector_focused_dark</item>
         <item name="toolbar_shadow">@drawable/toolbar_shadow_dark</item>
         <item name="selector">@drawable/selector_dark</item>
         <item name="colorControlHighlight">@color/dark_ripple_color</item>
         <item name="progress_horizontal_drawable">@drawable/progress_youtube_horizontal_dark</item>
-        <item name="card_item_background_color">@color/dark_card_item_background_color</item>
-        <item name="card_item_contrast_color">@color/dark_card_item_contrast_color</item>
-        <item name="border_color">@color/dark_border_color</item>
+        <item name="card_item_background_color">?attr/colorSurfaceContainerLow</item>
+        <item name="card_item_contrast_color">?attr/colorSurfaceContainerHigh</item>
+        <item name="border_color">?attr/colorOutlineVariant</item>
         <item name="dashed_border">@drawable/dashed_border_dark</item>
     </style>
     <style name="Base.DarkTheme" parent="Base.V21.DarkTheme" />
@@ -132,14 +144,20 @@
         <item name="colorSurfaceInverse">@color/dark_m3_inverse_surface_color</item>
         <item name="colorOnSurfaceInverse">@color/dark_m3_inverse_on_surface_color</item>
         <item name="colorPrimaryInverse">@color/dark_m3_inverse_primary_color</item>
-        <item name="colorOutline">@color/black_border_color</item>
+        <item name="colorSurfaceContainerLowest">@color/black_m3_surface_container_lowest_color</item>
+        <item name="colorSurfaceContainerLow">@color/black_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/black_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/black_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/black_m3_surface_container_highest_color</item>
+        <item name="colorOutline">@color/dark_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/dark_m3_outline_variant_color</item>
 
-        <item name="separator_color">@color/black_separator_color</item>
-        <item name="contrast_background_color">@color/black_contrast_background_color</item>
+        <item name="separator_color">?attr/colorOutlineVariant</item>
+        <item name="contrast_background_color">?attr/colorSurfaceContainerHigh</item>
 
-        <item name="card_item_background_color">@color/black_card_item_background_color</item>
-        <item name="card_item_contrast_color">@color/black_card_item_contrast_color</item>
-        <item name="border_color">@color/black_border_color</item>
+        <item name="card_item_background_color">?attr/colorSurfaceContainerLow</item>
+        <item name="card_item_contrast_color">?attr/colorSurfaceContainerHigh</item>
+        <item name="border_color">?attr/colorOutlineVariant</item>
         <item name="dashed_border">@drawable/dashed_border_black</item>
     </style>
     <style name="Base.BlackTheme" parent="Base.V21.BlackTheme" />
@@ -152,6 +170,11 @@
         <item name="android:statusBarColor">@color/black_background_color</item>
         <item name="android:navigationBarColor">@color/black_background_color</item>
         <item name="colorSurface">@color/black_background_color</item>
+        <item name="colorSurfaceContainerLowest">@color/black_m3_surface_container_lowest_color</item>
+        <item name="colorSurfaceContainerLow">@color/black_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/black_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/black_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/black_m3_surface_container_highest_color</item>
     </style>
 
 
@@ -166,7 +189,7 @@
         <item name="colorSecondary">#52634F</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#52634F</item>
-        <item name="colorControlActivated">#52634F</item>
+        <item name="colorControlActivated">#46674F</item>
         <item name="colorSecondaryContainer">#D5E8CF</item>
         <item name="colorOnSecondaryContainer">#10200F</item>
     </style>
@@ -181,7 +204,7 @@
         <item name="colorSecondary">#5E5E5E</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#5E5E5E</item>
-        <item name="colorControlActivated">#5E5E5E</item>
+        <item name="colorControlActivated">#5F5F5F</item>
         <item name="colorSecondaryContainer">#E5E5E5</item>
         <item name="colorOnSecondaryContainer">#1B1B1B</item>
     </style>
@@ -196,7 +219,7 @@
         <item name="colorSecondary">#55624C</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#55624C</item>
-        <item name="colorControlActivated">#55624C</item>
+        <item name="colorControlActivated">#386A20</item>
         <item name="colorSecondaryContainer">#D9E7CB</item>
         <item name="colorOnSecondaryContainer">#131F0D</item>
     </style>
@@ -211,7 +234,7 @@
         <item name="colorSecondary">#535F70</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#535F70</item>
-        <item name="colorControlActivated">#535F70</item>
+        <item name="colorControlActivated">#0061A4</item>
         <item name="colorSecondaryContainer">#D7E3F7</item>
         <item name="colorOnSecondaryContainer">#101C2B</item>
     </style>
@@ -226,7 +249,7 @@
         <item name="colorSecondary">#625B71</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#625B71</item>
-        <item name="colorControlActivated">#625B71</item>
+        <item name="colorControlActivated">#6750A4</item>
         <item name="colorSecondaryContainer">#E8DEF8</item>
         <item name="colorOnSecondaryContainer">#1D192B</item>
     </style>
@@ -241,7 +264,7 @@
         <item name="colorSecondary">#77574A</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#77574A</item>
-        <item name="colorControlActivated">#77574A</item>
+        <item name="colorControlActivated">#9B4300</item>
         <item name="colorSecondaryContainer">#FFDBCE</item>
         <item name="colorOnSecondaryContainer">#2C160D</item>
     </style>
@@ -256,7 +279,7 @@
         <item name="colorSecondary">#74565F</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#74565F</item>
-        <item name="colorControlActivated">#74565F</item>
+        <item name="colorControlActivated">#984061</item>
         <item name="colorSecondaryContainer">#FFD8E7</item>
         <item name="colorOnSecondaryContainer">#2B151D</item>
     </style>
@@ -271,7 +294,7 @@
         <item name="colorSecondary">#775651</item>
         <item name="colorOnSecondary">#FFFFFF</item>
         <item name="colorAccent">#775651</item>
-        <item name="colorControlActivated">#775651</item>
+        <item name="colorControlActivated">#BA1A1A</item>
         <item name="colorSecondaryContainer">#FFDAD6</item>
         <item name="colorOnSecondaryContainer">#2C1512</item>
     </style>
@@ -283,9 +306,14 @@
         <item name="colorSecondary">@color/light_m3_secondary_color</item>
         <item name="colorAccent">@color/light_m3_secondary_color</item>
         <item name="colorSurface">@color/light_dialog_background_color</item>
+        <item name="colorSurfaceContainerLow">@color/light_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/light_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/light_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/light_m3_surface_container_highest_color</item>
         <item name="colorOnSurface">#1B1C18</item>
         <item name="colorOnSurfaceVariant">@color/light_m3_on_surface_variant_color</item>
-        <item name="colorOutline">@color/light_border_color</item>
+        <item name="colorOutline">@color/light_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/light_m3_outline_variant_color</item>
         <item name="android:windowBackground">@color/light_dialog_background_color</item>
         <item name="windowBackground">@color/light_dialog_background_color</item>
 
@@ -299,9 +327,14 @@
         <item name="colorSecondary">@color/dark_m3_secondary_color</item>
         <item name="colorAccent">@color/dark_m3_secondary_color</item>
         <item name="colorSurface">@color/dark_dialog_background_color</item>
+        <item name="colorSurfaceContainerLow">@color/dark_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/dark_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/dark_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/dark_m3_surface_container_highest_color</item>
         <item name="colorOnSurface">@color/white</item>
         <item name="colorOnSurfaceVariant">@color/dark_m3_on_surface_variant_color</item>
-        <item name="colorOutline">@color/dark_border_color</item>
+        <item name="colorOutline">@color/dark_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/dark_m3_outline_variant_color</item>
         <item name="android:windowBackground">@color/dark_dialog_background_color</item>
         <item name="windowBackground">@color/dark_dialog_background_color</item>
 
@@ -317,9 +350,14 @@
         <item name="colorSecondary">@color/light_m3_secondary_color</item>
         <item name="colorAccent">@color/light_m3_secondary_color</item>
         <item name="colorSurface">@color/light_dialog_background_color</item>
+        <item name="colorSurfaceContainerLow">@color/light_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/light_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/light_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/light_m3_surface_container_highest_color</item>
         <item name="colorOnSurface">#1B1C18</item>
         <item name="colorOnSurfaceVariant">@color/light_m3_on_surface_variant_color</item>
-        <item name="colorOutline">@color/light_border_color</item>
+        <item name="colorOutline">@color/light_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/light_m3_outline_variant_color</item>
         <item name="android:windowBackground">@color/light_dialog_background_color</item>
         <item name="windowBackground">@color/light_dialog_background_color</item>
 
@@ -335,9 +373,14 @@
         <item name="colorSecondary">@color/dark_m3_secondary_color</item>
         <item name="colorAccent">@color/dark_m3_secondary_color</item>
         <item name="colorSurface">@color/dark_dialog_background_color</item>
+        <item name="colorSurfaceContainerLow">@color/dark_m3_surface_container_low_color</item>
+        <item name="colorSurfaceContainer">@color/dark_m3_surface_container_color</item>
+        <item name="colorSurfaceContainerHigh">@color/dark_m3_surface_container_high_color</item>
+        <item name="colorSurfaceContainerHighest">@color/dark_m3_surface_container_highest_color</item>
         <item name="colorOnSurface">@color/white</item>
         <item name="colorOnSurfaceVariant">@color/dark_m3_on_surface_variant_color</item>
-        <item name="colorOutline">@color/dark_border_color</item>
+        <item name="colorOutline">@color/dark_m3_outline_color</item>
+        <item name="colorOutlineVariant">@color/dark_m3_outline_variant_color</item>
         <item name="android:windowBackground">@color/dark_dialog_background_color</item>
         <item name="windowBackground">@color/dark_dialog_background_color</item>
 

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerControlAccessibilityResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerControlAccessibilityResourcesTest.java
@@ -1,0 +1,126 @@
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class PlayerControlAccessibilityResourcesTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void queueControlsHaveAccessibleTargetsAndLabels() throws Exception {
+        assertControls(
+                "layout/activity_player_queue_control.xml",
+                "control_repeat",
+                "control_backward",
+                "control_fast_rewind",
+                "control_play_pause",
+                "control_fast_forward",
+                "control_forward",
+                "control_shuffle");
+        assertControls(
+                "layout-land/activity_player_queue_control.xml",
+                "control_repeat",
+                "control_backward",
+                "control_fast_rewind",
+                "control_play_pause",
+                "control_fast_forward",
+                "control_forward",
+                "control_shuffle");
+    }
+
+    @Test
+    public void playerIconControlsHaveAccessibleTargetsAndLabels() throws Exception {
+        assertControls(
+                "layout/player.xml",
+                "playerCloseButton",
+                "queueButton",
+                "segmentsButton",
+                "moreOptionsButton",
+                "learningNoteButton",
+                "sleepTimerButton",
+                "equalizerButton",
+                "listenModeButton",
+                "fullScreenButton",
+                "screenRotationButton");
+    }
+
+    @Test
+    public void learningNoteActionsHaveAccessibleTargetsAndLabels() throws Exception {
+        assertControls(
+                "layout/item_learning_note.xml",
+                "learning_note_edit",
+                "learning_note_delete");
+    }
+
+    private void assertControls(final String layout, final String... ids) throws Exception {
+        final Document document = parse(layout);
+        for (final String id : ids) {
+            final Element element = findById(document, id);
+            assertNotNull(layout + ": " + id, element);
+            assertAtLeast48Dp(layout, id, element, "layout_width");
+            assertAtLeast48Dp(layout, id, element, "layout_height");
+            assertFalse(layout + ": " + id,
+                    element.getAttributeNS(ANDROID_NAMESPACE, "contentDescription").isBlank());
+        }
+    }
+
+    private void assertAtLeast48Dp(final String layout,
+                                   final String id,
+                                   final Element element,
+                                   final String attribute) {
+        final String value = element.getAttributeNS(ANDROID_NAMESPACE, attribute);
+        if ("wrap_content".equals(value) || "0dp".equals(value)) {
+            final String minimumAttribute = "layout_width".equals(attribute)
+                    ? "minWidth" : "minHeight";
+            final String minimum = element.getAttributeNS(ANDROID_NAMESPACE, minimumAttribute);
+            assertTrue(layout + ": " + id + " " + minimumAttribute,
+                    parseDp(minimum) >= 48);
+        } else {
+            assertTrue(layout + ": " + id + " " + attribute,
+                    parseDp(value) >= 48);
+        }
+    }
+
+    private int parseDp(final String value) {
+        assertTrue(value, value.endsWith("dp"));
+        return Integer.parseInt(value.substring(0, value.length() - 2));
+    }
+
+    private Element findById(final Document document, final String id) {
+        final var elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            final String androidId = element.getAttributeNS(ANDROID_NAMESPACE, "id");
+            if (("@+id/" + id).equals(androidId) || ("@id/" + id).equals(androidId)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private Document parse(final String relativePath) throws Exception {
+        final var factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder()
+                .parse(resourcesDirectory.resolve(relativePath).toFile());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
@@ -28,8 +28,68 @@ public class ThemeColorIntegrationTest {
                 < helper.indexOf("applyBlackSurfaceOverlay(context);"));
         assertTrue(blackOverlay.contains(
                 "<item name=\"colorSurface\">@color/black_background_color</item>"));
+        assertTrue(blackOverlay.contains(
+                "<item name=\"colorSurfaceContainer\">"
+                        + "@color/black_m3_surface_container_color</item>"));
+        assertTrue(blackOverlay.contains(
+                "<item name=\"colorSurfaceContainerHigh\">"
+                        + "@color/black_m3_surface_container_high_color</item>"));
         assertFalse(blackOverlay.contains("colorPrimary"));
         assertFalse(blackOverlay.contains("colorSecondary"));
+    }
+
+    @Test
+    public void themesExposeMaterialSurfaceAndOutlineRoles() throws Exception {
+        final String styles = Files.readString(resourceDirectory.resolve("values/styles.xml"));
+
+        for (final String theme : new String[]{
+                "Base.V21.LightTheme",
+                "Base.V21.DarkTheme",
+                "Base.V21.BlackTheme"
+        }) {
+            final String body = styleBody(styles, theme);
+            assertTrue(theme, body.contains("<item name=\"colorSurfaceContainerLow\">"));
+            assertTrue(theme, body.contains("<item name=\"colorSurfaceContainer\">"));
+            assertTrue(theme, body.contains("<item name=\"colorSurfaceContainerHigh\">"));
+            assertTrue(theme, body.contains("<item name=\"colorOutlineVariant\">"));
+            assertTrue(theme, body.contains(
+                    "<item name=\"separator_color\">?attr/colorOutlineVariant</item>"));
+            assertTrue(theme, body.contains(
+                    "<item name=\"card_item_background_color\">"
+                            + "?attr/colorSurfaceContainerLow</item>"));
+        }
+
+        final String baseTheme = styleBody(styles, "Base.V21");
+        assertTrue(baseTheme.contains(
+                "<item name=\"colorControlActivated\">?attr/colorPrimary</item>"));
+        assertFalse(baseTheme.contains(
+                "<item name=\"colorControlActivated\">?attr/colorSecondary</item>"));
+    }
+
+    @Test
+    public void explicitLegacyWidgetsUseMaterial3Components() throws Exception {
+        final String relatedItems = Files.readString(
+                resourceDirectory.resolve("layout/related_items_header.xml"));
+        final String colorPicker = Files.readString(
+                resourceDirectory.resolve("layout/dialog_sponsor_block_color_picker.xml"));
+        final String queue = Files.readString(
+                resourceDirectory.resolve("layout/activity_player_queue_control.xml"));
+        final String queueLandscape = Files.readString(
+                resourceDirectory.resolve("layout-land/activity_player_queue_control.xml"));
+        final String feedGroupDialog = Files.readString(
+                resourceDirectory.resolve("layout/dialog_feed_group_create.xml"));
+
+        assertTrue(relatedItems.contains(
+                "com.google.android.material.materialswitch.MaterialSwitch"));
+        assertFalse(relatedItems.contains("androidx.appcompat.widget.SwitchCompat"));
+        assertTrue(colorPicker.contains(
+                "com.google.android.material.textfield.TextInputLayout"));
+        assertTrue(colorPicker.contains(
+                "com.google.android.material.textfield.TextInputEditText"));
+        assertFalse(colorPicker.contains("<EditText"));
+        assertMaterialToolbar(queue);
+        assertMaterialToolbar(queueLandscape);
+        assertMaterialToolbar(feedGroupDialog);
     }
 
     @Test
@@ -75,6 +135,12 @@ public class ThemeColorIntegrationTest {
     private void assertLayoutUsesMaterialSeekBar(final String layout) throws Exception {
         final String source = Files.readString(resourceDirectory.resolve(layout));
         assertTrue(source.contains("style=\"@style/Widget.WizeStream.SeekBar\""));
+    }
+
+    private void assertMaterialToolbar(final String layout) {
+        assertTrue(layout.contains("com.google.android.material.appbar.MaterialToolbar"));
+        assertTrue(layout.contains("android:background=\"?attr/colorSurfaceContainer\""));
+        assertFalse(layout.contains("androidx.appcompat.widget.Toolbar"));
     }
 
     private String styleBody(final String styles, final String styleName) {


### PR DESCRIPTION
- Define complete light, dark, and AMOLED surface-container and outline roles
- Map legacy card, separator, contrast, border, and activated-control colors to semantic Material roles
- Replace explicit AppCompat switches, toolbars, and the plain color-field editor with Material 3 components
- Preserve dynamic accent colors and AMOLED surface behavior
- Extend theme and component regression coverage
- Verified with the complete remediation stack: https://github.com/wizdom13/WizeStream/actions/runs/33172531465