### PR TITLE
Fix edge-to-edge navigation insets

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
@@ -10,6 +10,7 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SdkSuppress;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
@@ -33,14 +34,8 @@ public class EdgeToEdgeHelperTest {
         final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
                 source,
                 new WindowInsetsCompat.Builder()
-                        .setInsets(WindowInsetsCompat.Type.statusBars(),
-                                Insets.of(0, 24, 0, 0))
-                        .setInsets(WindowInsetsCompat.Type.navigationBars(),
-                                Insets.of(0, 0, 0, 48))
-                        .setInsets(WindowInsetsCompat.Type.displayCutout(),
-                                Insets.of(2, 30, 3, 0))
-                        .setInsets(WindowInsetsCompat.Type.ime(),
-                                Insets.of(0, 0, 0, 220))
+                        .setInsets(WindowInsetsCompat.Type.systemBars(),
+                                Insets.of(2, 30, 3, 48))
                         .build());
 
         assertPadding(content, 3, 32, 6, 52);
@@ -48,15 +43,60 @@ public class EdgeToEdgeHelperTest {
         assertPadding(header, 9, 40, 11, 12);
         assertEquals(Insets.NONE,
                 result.getInsets(WindowInsetsCompat.Type.systemBars()));
-        assertEquals(Insets.NONE,
-                result.getInsets(WindowInsetsCompat.Type.displayCutout()));
-        assertEquals(Insets.of(0, 0, 0, 220),
-                result.getInsets(WindowInsetsCompat.Type.ime()));
 
         ViewCompat.dispatchApplyWindowInsets(source, new WindowInsetsCompat.Builder().build());
         assertPadding(content, 1, 2, 3, 4);
         assertPadding(drawer, 5, 6, 7, 8);
         assertPadding(header, 9, 10, 11, 12);
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 28)
+    public void displayCutoutExpandsTheSafeSystemBarInsets() {
+        final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        final View source = new FrameLayout(context);
+        final View content = new FrameLayout(context);
+        final View drawer = new FrameLayout(context);
+        final View header = new FrameLayout(context);
+
+        EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding(
+                source, content, drawer, header);
+        final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
+                source,
+                new WindowInsetsCompat.Builder()
+                        .setInsets(WindowInsetsCompat.Type.systemBars(),
+                                Insets.of(1, 10, 1, 20))
+                        .setInsets(WindowInsetsCompat.Type.displayCutout(),
+                                Insets.of(2, 30, 3, 0))
+                        .build());
+
+        assertPadding(content, 2, 30, 3, 20);
+        assertPadding(drawer, 2, 0, 3, 20);
+        assertPadding(header, 0, 30, 0, 0);
+        assertEquals(Insets.NONE,
+                result.getInsets(WindowInsetsCompat.Type.displayCutout()));
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30)
+    public void consumingSystemBarsPreservesImeInsets() {
+        final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        final View source = new FrameLayout(context);
+
+        EdgeToEdgeHelper.applySystemBarPadding(source);
+        final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
+                source,
+                new WindowInsetsCompat.Builder()
+                        .setInsets(WindowInsetsCompat.Type.systemBars(),
+                                Insets.of(0, 24, 0, 48))
+                        .setInsets(WindowInsetsCompat.Type.ime(),
+                                Insets.of(0, 0, 0, 220))
+                        .build());
+
+        assertEquals(Insets.NONE,
+                result.getInsets(WindowInsetsCompat.Type.systemBars()));
+        assertEquals(Insets.of(0, 0, 0, 220),
+                result.getInsets(WindowInsetsCompat.Type.ime()));
     }
 
     private static void assertPadding(final View view,

--- a/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
@@ -1,0 +1,72 @@
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class EdgeToEdgeHelperTest {
+    @Test
+    public void drawerLayoutInsetsAreDistributedToSafeContentEdges() {
+        final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        final View source = new FrameLayout(context);
+        final View content = new FrameLayout(context);
+        final View drawer = new FrameLayout(context);
+        final View header = new FrameLayout(context);
+        content.setPadding(1, 2, 3, 4);
+        drawer.setPadding(5, 6, 7, 8);
+        header.setPadding(9, 10, 11, 12);
+
+        EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding(
+                source, content, drawer, header);
+        final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
+                source,
+                new WindowInsetsCompat.Builder()
+                        .setInsets(WindowInsetsCompat.Type.statusBars(),
+                                Insets.of(0, 24, 0, 0))
+                        .setInsets(WindowInsetsCompat.Type.navigationBars(),
+                                Insets.of(0, 0, 0, 48))
+                        .setInsets(WindowInsetsCompat.Type.displayCutout(),
+                                Insets.of(2, 30, 3, 0))
+                        .setInsets(WindowInsetsCompat.Type.ime(),
+                                Insets.of(0, 0, 0, 220))
+                        .build());
+
+        assertPadding(content, 3, 32, 6, 52);
+        assertPadding(drawer, 7, 6, 10, 56);
+        assertPadding(header, 9, 40, 11, 12);
+        assertEquals(Insets.NONE,
+                result.getInsets(WindowInsetsCompat.Type.systemBars()));
+        assertEquals(Insets.NONE,
+                result.getInsets(WindowInsetsCompat.Type.displayCutout()));
+        assertEquals(Insets.of(0, 0, 0, 220),
+                result.getInsets(WindowInsetsCompat.Type.ime()));
+
+        ViewCompat.dispatchApplyWindowInsets(source, new WindowInsetsCompat.Builder().build());
+        assertPadding(content, 1, 2, 3, 4);
+        assertPadding(drawer, 5, 6, 7, 8);
+        assertPadding(header, 9, 10, 11, 12);
+    }
+
+    private static void assertPadding(final View view,
+                                      final int left,
+                                      final int top,
+                                      final int right,
+                                      final int bottom) {
+        assertEquals(left, view.getPaddingLeft());
+        assertEquals(top, view.getPaddingTop());
+        assertEquals(right, view.getPaddingRight());
+        assertEquals(bottom, view.getPaddingBottom());
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -192,7 +192,11 @@ public class MainActivity extends AppCompatActivity {
                 .getHeaderView(0));
         toolbarLayoutBinding = mainBinding.toolbarLayout;
         setContentView(mainBinding.getRoot());
-        EdgeToEdgeHelper.applySystemBarPadding(mainBinding.getRoot());
+        EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding(
+                mainBinding.getRoot(),
+                mainBinding.mainContent,
+                drawerLayoutBinding.navigation,
+                drawerHeaderBinding.getRoot());
         nativePipController = new NativePipController(this);
         mainBinding.fragmentPlayerHolder.addOnLayoutChangeListener(
                 (view, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->

--- a/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
@@ -56,6 +56,11 @@ public final class EdgeToEdgeHelper {
      * <p>The drawer keeps drawing its background edge-to-edge. Only its header content receives
      * the top inset, while the drawer container receives horizontal cutout protection and the
      * bottom system-bar inset.</p>
+     *
+     * @param insetSource view that receives the window inset dispatch
+     * @param content main activity content constrained inside all safe edges
+     * @param drawer navigation drawer protected on its horizontal and bottom edges
+     * @param drawerHeader drawer header whose content is protected below the status bar
      */
     public static void applyDrawerLayoutSystemBarPadding(
             @NonNull final View insetSource,

--- a/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
@@ -35,23 +35,86 @@ public final class EdgeToEdgeHelper {
         final int initialBottom = view.getPaddingBottom();
 
         ViewCompat.setOnApplyWindowInsetsListener(view, (target, windowInsets) -> {
-            final Insets systemBars = windowInsets.getInsets(
-                    WindowInsetsCompat.Type.systemBars());
-            final Insets displayCutout = windowInsets.getInsets(
-                    WindowInsetsCompat.Type.displayCutout());
-            final Insets safeInsets = Insets.max(systemBars, displayCutout);
+            final Insets safeInsets = getSafeSystemBarInsets(windowInsets);
             target.setPadding(
                     initialLeft + safeInsets.left,
                     initialTop + safeInsets.top,
                     initialRight + safeInsets.right,
                     initialBottom + safeInsets.bottom);
 
-            return new WindowInsetsCompat.Builder(windowInsets)
-                    .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.NONE)
-                    .setInsets(WindowInsetsCompat.Type.displayCutout(), Insets.NONE)
-                    .build();
+            return consumeAppliedInsets(windowInsets);
         });
         ViewCompat.requestApplyInsets(view);
+    }
+
+    /**
+     * Applies insets to the independently laid-out content and drawer children of a
+     * {@link androidx.drawerlayout.widget.DrawerLayout}. Padding the drawer layout itself does
+     * not constrain those children, which can leave bottom navigation behind the system
+     * navigation bar and drawer header content behind the status bar.
+     *
+     * <p>The drawer keeps drawing its background edge-to-edge. Only its header content receives
+     * the top inset, while the drawer container receives horizontal cutout protection and the
+     * bottom system-bar inset.</p>
+     */
+    public static void applyDrawerLayoutSystemBarPadding(
+            @NonNull final View insetSource,
+            @NonNull final View content,
+            @NonNull final View drawer,
+            @NonNull final View drawerHeader) {
+        final int contentLeft = content.getPaddingLeft();
+        final int contentTop = content.getPaddingTop();
+        final int contentRight = content.getPaddingRight();
+        final int contentBottom = content.getPaddingBottom();
+        final int drawerLeft = drawer.getPaddingLeft();
+        final int drawerTop = drawer.getPaddingTop();
+        final int drawerRight = drawer.getPaddingRight();
+        final int drawerBottom = drawer.getPaddingBottom();
+        final int headerLeft = drawerHeader.getPaddingLeft();
+        final int headerTop = drawerHeader.getPaddingTop();
+        final int headerRight = drawerHeader.getPaddingRight();
+        final int headerBottom = drawerHeader.getPaddingBottom();
+
+        ViewCompat.setOnApplyWindowInsetsListener(insetSource, (target, windowInsets) -> {
+            final Insets safeInsets = getSafeSystemBarInsets(windowInsets);
+            content.setPadding(
+                    contentLeft + safeInsets.left,
+                    contentTop + safeInsets.top,
+                    contentRight + safeInsets.right,
+                    contentBottom + safeInsets.bottom);
+            drawer.setPadding(
+                    drawerLeft + safeInsets.left,
+                    drawerTop,
+                    drawerRight + safeInsets.right,
+                    drawerBottom + safeInsets.bottom);
+            drawerHeader.setPadding(
+                    headerLeft,
+                    headerTop + safeInsets.top,
+                    headerRight,
+                    headerBottom);
+
+            return consumeAppliedInsets(windowInsets);
+        });
+        ViewCompat.requestApplyInsets(insetSource);
+    }
+
+    @NonNull
+    private static Insets getSafeSystemBarInsets(
+            @NonNull final WindowInsetsCompat windowInsets) {
+        final Insets systemBars = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars());
+        final Insets displayCutout = windowInsets.getInsets(
+                WindowInsetsCompat.Type.displayCutout());
+        return Insets.max(systemBars, displayCutout);
+    }
+
+    @NonNull
+    private static WindowInsetsCompat consumeAppliedInsets(
+            @NonNull final WindowInsetsCompat windowInsets) {
+        return new WindowInsetsCompat.Builder(windowInsets)
+                .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.NONE)
+                .setInsets(WindowInsetsCompat.Type.displayCutout(), Insets.NONE)
+                .build();
     }
 
     public static void showSystemBars(@NonNull final Activity activity) {

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent">
 
     <org.schabi.newpipe.views.FocusAwareCoordinator
+        android:id="@+id/main_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent">
 
     <org.schabi.newpipe.views.FocusAwareCoordinator
+        android:id="@+id/main_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
@@ -36,7 +36,6 @@ public class EdgeToEdgeIntegrationTest {
     @Test
     public void coreActivitiesApplySystemBarPadding() throws Exception {
         final List<String> activitySources = List.of(
-                "java/org/schabi/newpipe/MainActivity.java",
                 "java/org/schabi/newpipe/about/AboutActivity.kt",
                 "java/org/schabi/newpipe/download/DownloadActivity.java",
                 "java/org/schabi/newpipe/error/ErrorActivity.kt",
@@ -50,6 +49,22 @@ public class EdgeToEdgeIntegrationTest {
             assertTrue(sourcePath,
                     source.contains("EdgeToEdgeHelper.applySystemBarPadding("));
         }
+    }
+
+    @Test
+    public void mainActivityDistributesInsetsInsideDrawerLayout() throws Exception {
+        final String activity = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/MainActivity.java"));
+        final String phoneLayout = Files.readString(mainDirectory.resolve(
+                "res/layout/activity_main.xml"));
+        final String tabletLayout = Files.readString(mainDirectory.resolve(
+                "res/layout-sw600dp/activity_main.xml"));
+
+        assertTrue(activity.contains("EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding("));
+        assertFalse(activity.contains(
+                "EdgeToEdgeHelper.applySystemBarPadding(mainBinding.getRoot())"));
+        assertTrue(phoneLayout.contains("android:id=\"@+id/main_content\""));
+        assertTrue(tabletLayout.contains("android:id=\"@+id/main_content\""));
     }
 
     @Test


### PR DESCRIPTION
- Apply system-bar insets to the main content coordinator instead of the outer drawer container
- Keep the drawer background edge-to-edge while protecting its header and menu content
- Position main and video-detail navigation above gesture and three-button system navigation
- Preserve dynamic inset updates when fullscreen playback hides or restores system bars
- Add source and instrumented regression coverage for inset distribution and IME preservation