### PR TITLE
Fix unanswered exception reports

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/App.kt
+++ b/app/src/main/java/org/schabi/newpipe/App.kt
@@ -10,6 +10,7 @@ import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.memory.MemoryCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowRgb565
 import coil3.request.crossfade
@@ -164,14 +165,22 @@ open class App :
         DynamicColors.applyToActivitiesIfAvailable(this, dynamicColorsOptions)
     }
 
-    override fun newImageLoader(context: Context): ImageLoader = ImageLoader
-        .Builder(this)
-        .logger(if (BuildConfig.DEBUG) DebugLogger() else null)
-        .allowRgb565(getSystemService<ActivityManager>()!!.isLowRamDevice)
-        .crossfade(true)
-        .components {
-            add(OkHttpNetworkFetcherFactory(callFactory = DownloaderImpl.getInstance().client))
-        }.build()
+    override fun newImageLoader(context: Context): ImageLoader {
+        val isLowRamDevice = getSystemService<ActivityManager>()!!.isLowRamDevice
+        return ImageLoader
+            .Builder(this)
+            .logger(if (BuildConfig.DEBUG) DebugLogger() else null)
+            .allowRgb565(isLowRamDevice)
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(this, imageMemoryCachePercent(isLowRamDevice))
+                    .build()
+            }
+            .crossfade(true)
+            .components {
+                add(OkHttpNetworkFetcherFactory(callFactory = DownloaderImpl.getInstance().client))
+            }.build()
+    }
 
     protected open fun getDownloader(): Downloader {
         val proxySelector = AppProxySelector.install(this)
@@ -344,6 +353,10 @@ open class App :
 
         const val PACKAGE_NAME: String = BuildConfig.APPLICATION_ID
         private val TAG = App::class.java.toString()
+
+        internal fun imageMemoryCachePercent(isLowRamDevice: Boolean): Double {
+            return if (isLowRamDevice) 0.10 else 0.20
+        }
 
         @JvmStatic
         lateinit var instance: App

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -17,6 +17,8 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getThumbnailUrlFromInfoItem;
@@ -42,6 +44,7 @@ import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
  */
 
 public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
+    private static final Pattern VIEW_LABEL_PATTERN = Pattern.compile("\\bviews?\\b");
     private final JsonObject videoInfo;
     private final TimeAgoParser timeAgoParser;
     private StreamType cachedStreamType;
@@ -459,7 +462,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
                 if (isNullOrEmpty(text) || text.equals(" • ")) {
                     continue;
                 }
-                if (text.contains("ukubukwa") || text.toLowerCase().contains("view")) {
+                if (hasViewCountLabel(text)) {
                     continue;
                 }
                 if (timeAgoParser != null) {
@@ -570,20 +573,9 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
                     final JsonArray runs = videoInfo.getObject("videoInfo").getArray("runs");
                     for (final Object runObj : runs) {
                         final String text = ((JsonObject) runObj).getString("text");
-                        if (text != null
-                                && (text.toLowerCase().contains("view")
-                                || text.toLowerCase().contains("ukubukwa")
-                                || text.toLowerCase().contains("no views")
-                                || text.toLowerCase().contains("akukho"))) {
-                            if (text.toLowerCase().contains("no views")
-                                    || text.toLowerCase().contains("akukho ukubukwa")
-                                    || text.toLowerCase().contains("akukho kubukwa")) {
-                                return 0;
-                            } else if (text.toLowerCase().contains("recommended")
-                                    || text.toLowerCase().contains("okutusiwe")) {
-                                return -1;
-                            }
-                            return Utils.mixedNumberWordToLong(text);
+                        final Long parsedViewCount = parseFallbackViewCount(text);
+                        if (parsedViewCount != null) {
+                            return parsedViewCount;
                         }
                     }
                 } catch (final Exception ignored) {
@@ -601,19 +593,9 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
                         final String content = ((JsonObject) part)
                                 .getObject("text")
                                 .getString("content");
-                        if (content != null && (content.toLowerCase().contains("view")
-                                || content.toLowerCase().contains("ukubukwa")
-                                || content.toLowerCase().contains("no views")
-                                || content.toLowerCase().contains("akukho"))) {
-                            if (content.toLowerCase().contains("no views")
-                                    || content.toLowerCase().contains("akukho ukubukwa")
-                                    || content.toLowerCase().contains("akukho kubukwa")) {
-                                return 0;
-                            } else if (content.toLowerCase().contains("recommended")
-                                    || content.toLowerCase().contains("okutusiwe")) {
-                                return -1;
-                            }
-                            return Utils.mixedNumberWordToLong(content);
+                        final Long parsedViewCount = parseFallbackViewCount(content);
+                        if (parsedViewCount != null) {
+                            return parsedViewCount;
                         }
                     }
                 }
@@ -632,10 +614,46 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
                 return -1;
             }
 
-            return Long.parseLong(Utils.removeNonDigitCharacters(viewCount));
+            final String digits = Utils.removeNonDigitCharacters(viewCount);
+            return isNullOrEmpty(digits) ? -1 : Long.parseLong(digits);
         } catch (final Exception e) {
             throw new ParsingException("Could not get view count", e);
         }
+    }
+
+    @Nullable
+    private static Long parseFallbackViewCount(@Nullable final String text) {
+        if (isNullOrEmpty(text)) {
+            return null;
+        }
+
+        final String lowercaseText = text.toLowerCase(Locale.ROOT);
+        if (lowercaseText.contains("no views")
+                || lowercaseText.contains("akukho ukubukwa")
+                || lowercaseText.contains("akukho kubukwa")) {
+            return 0L;
+        }
+        if (lowercaseText.contains("recommended") || lowercaseText.contains("okutusiwe")) {
+            return -1L;
+        }
+
+        final boolean hasViewLabel = hasViewCountLabel(lowercaseText);
+        final boolean hasDigit = text.codePoints().anyMatch(Character::isDigit);
+        if (!hasViewLabel || !hasDigit) {
+            return null;
+        }
+
+        try {
+            return Utils.mixedNumberWordToLong(text);
+        } catch (final Exception ignored) {
+            return null;
+        }
+    }
+
+    private static boolean hasViewCountLabel(final String text) {
+        final String lowercaseText = text.toLowerCase(Locale.ROOT);
+        return VIEW_LABEL_PATTERN.matcher(lowercaseText).find()
+                || lowercaseText.contains("ukubukwa");
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSuggestionExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSuggestionExtractor.java
@@ -1,7 +1,7 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
-import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.addCookieHeader;
-import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
+import static org.schabi.newpipe.extractor.utils.Utils.isBlank;
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 import com.grack.nanojson.JsonArray;
 import com.grack.nanojson.JsonParser;
@@ -9,17 +9,18 @@ import com.grack.nanojson.JsonParserException;
 
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.StreamingService;
-import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
+import org.schabi.newpipe.extractor.utils.Utils;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /*
  * Created by Christian Schabesberger on 28.09.16.
@@ -49,38 +50,46 @@ public class YoutubeSuggestionExtractor extends SuggestionExtractor {
 
     @Override
     public List<String> suggestionList(final String query) throws IOException, ExtractionException {
-        final Downloader dl = NewPipe.getDownloader();
-        final List<String> suggestions = new ArrayList<>();
-
-        final String url = "https://suggestqueries.google.com/complete/search"
-                + "?client=" + "youtube" //"firefox" for JSON, 'toolbar' for xml
-                + "&jsonp=" + "JP"
+        final String url = "https://suggestqueries-clients6.youtube.com/complete/search"
+                + "?client=" + "youtube"
                 + "&ds=" + "yt"
-                + "&gl=" + URLEncoder.encode(getExtractorContentCountry().getCountryCode(), UTF_8)
-                + "&q=" + URLEncoder.encode(query, UTF_8);
+                + "&gl=" + Utils.encodeUrlUtf8(getExtractorContentCountry().getCountryCode())
+                + "&q=" + Utils.encodeUrlUtf8(query)
+                + "&xhr=t";
 
         final Map<String, List<String>> headers = new HashMap<>();
-        addCookieHeader(headers);
+        headers.put("Origin", Collections.singletonList("https://www.youtube.com"));
+        headers.put("Referer", Collections.singletonList("https://www.youtube.com"));
 
-        String response = dl.get(url, headers, getExtractorLocalization()).responseBody();
-        // trim JSONP part "JP(...)"
-        response = response.substring(3, response.length() - 1);
+        final Response response = NewPipe.getDownloader()
+                .get(url, headers, getExtractorLocalization());
+
+        final String contentTypeHeader = response.getHeader("Content-Type");
+        if (isNullOrEmpty(contentTypeHeader) || !contentTypeHeader.contains("application/json")) {
+            throw new ExtractionException("Invalid response type (got \"" + contentTypeHeader
+                    + "\", expected a JSON response) (response code "
+                    + response.responseCode() + ")");
+        }
+
+        return parseSuggestions(response.responseBody());
+    }
+
+    static List<String> parseSuggestions(final String responseBody) throws ExtractionException {
+        if (responseBody.isEmpty()) {
+            throw new ExtractionException("Empty response received");
+        }
         try {
-            final JsonArray collection = JsonParser.array().from(response).getArray(1);
-            for (final Object suggestion : collection) {
-                if (!(suggestion instanceof JsonArray)) {
-                    continue;
-                }
-                final String suggestionStr = ((JsonArray) suggestion).getString(0);
-                if (suggestionStr == null) {
-                    continue;
-                }
-                suggestions.add(suggestionStr);
-            }
-
-            return suggestions;
+            return JsonParser.array()
+                    .from(responseBody)
+                    .getArray(1)
+                    .stream()
+                    .filter(JsonArray.class::isInstance)
+                    .map(JsonArray.class::cast)
+                    .map(suggestion -> suggestion.getString(0))
+                    .filter(suggestion -> !isBlank(suggestion))
+                    .collect(Collectors.toUnmodifiableList());
         } catch (final JsonParserException e) {
-            throw new ParsingException("Could not parse json response", e);
+            throw new ParsingException("Could not parse JSON response", e);
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -68,6 +68,7 @@ import org.schabi.newpipe.error.UserAction
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem
 import org.schabi.newpipe.extractor.exceptions.AccountTerminatedException
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException
+import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty
 import org.schabi.newpipe.fragments.BaseStateFragment
@@ -122,7 +123,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
 
     private lateinit var groupAdapter: GroupieAdapter
 
-    private var onSettingsChangeListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
+    private lateinit var onSettingsChangeListener: SharedPreferences.OnSharedPreferenceChangeListener
     private var updateListViewModeOnResume = false
     private var isRefreshing = false
 
@@ -150,8 +151,6 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
                 latestLoadedState?.let { showFilteredFeedItems(it, false) }
             }
         }
-        PreferenceManager.getDefaultSharedPreferences(activity)
-            .registerOnSharedPreferenceChangeListener(onSettingsChangeListener)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -162,6 +161,8 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         // super.onViewCreated() calls initListeners() which require the binding to be initialized
         _feedBinding = FragmentFeedBinding.bind(rootView)
         super.onViewCreated(rootView, savedInstanceState)
+        PreferenceManager.getDefaultSharedPreferences(requireContext())
+            .registerOnSharedPreferenceChangeListener(onSettingsChangeListener)
 
         val factory = FeedViewModel.getFactory(requireContext(), groupId)
         viewModel = ViewModelProvider(this, factory)[FeedViewModel::class.java]
@@ -332,12 +333,6 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
 
     override fun onDestroy() {
         disposables.dispose()
-        if (onSettingsChangeListener != null) {
-            PreferenceManager.getDefaultSharedPreferences(activity)
-                .unregisterOnSharedPreferenceChangeListener(onSettingsChangeListener)
-            onSettingsChangeListener = null
-        }
-
         super.onDestroy()
 
         if (
@@ -349,6 +344,9 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     }
 
     override fun onDestroyView() {
+        PreferenceManager.getDefaultSharedPreferences(requireContext())
+            .unregisterOnSharedPreferenceChangeListener(onSettingsChangeListener)
+
         // Ensure that all animations are canceled
         tryGetNewItemsLoadedButton()?.clearAnimation()
 
@@ -538,6 +536,10 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         loadedState: FeedState.LoadedState,
         restoreListState: Boolean
     ) {
+        if (_feedBinding == null) {
+            return
+        }
+
         val itemVersion = when (getItemViewMode(requireContext())) {
             ItemViewMode.GRID -> StreamItem.ItemVersion.GRID
             ItemViewMode.CARD -> StreamItem.ItemVersion.CARD
@@ -624,7 +626,8 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     private fun handleItemsErrors(errors: List<Throwable>) {
         errors.forEachIndexed { i, t ->
             if (t is FeedLoadService.RequestException &&
-                t.cause is ContentNotAvailableException
+                (t.cause is ContentNotAvailableException ||
+                    t.cause is ContentNotSupportedException)
             ) {
                 disposables.add(
                     Single.fromCallable {
@@ -690,6 +693,8 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             } else if (!isNullOrEmpty(cause.message)) {
                 message += "\n" + cause.message
             }
+        } else if (!isNullOrEmpty(cause?.message)) {
+            message += "\n" + cause.message
         }
         builder.setMessage(message)
             .show()

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -625,10 +625,9 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
 
     private fun handleItemsErrors(errors: List<Throwable>) {
         errors.forEachIndexed { i, t ->
-            if (t is FeedLoadService.RequestException &&
-                (t.cause is ContentNotAvailableException ||
-                    t.cause is ContentNotSupportedException)
-            ) {
+            val isUnavailableFeed = t.cause is ContentNotAvailableException ||
+                t.cause is ContentNotSupportedException
+            if (t is FeedLoadService.RequestException && isUnavailableFeed) {
                 disposables.add(
                     Single.fromCallable {
                         NewPipeDatabase.getInstance(requireContext()).subscriptionDAO()

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -693,7 +693,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
                 message += "\n" + cause.message
             }
         } else if (!isNullOrEmpty(cause?.message)) {
-            message += "\n" + cause.message
+            message += "\n" + cause?.message
         }
         builder.setMessage(message)
             .show()

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -121,6 +121,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     private final Handler controlsVisibilityHandler = new Handler(Looper.getMainLooper());
     @Nullable
     private SurfaceHolderCallback surfaceHolderCallback;
+    @Nullable
+    private Bitmap scaledEndScreenThumbnail;
     boolean surfaceIsSetup = false;
 
 
@@ -442,7 +444,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @Override
     public void destroy() {
         super.destroy();
-        binding.endScreen.setImageDrawable(null);
+        clearScaledEndScreenThumbnail();
         deinitPlayerSeekOverlay();
         deinitListeners();
     }
@@ -509,18 +511,28 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
     private void updateEndScreenThumbnail(@Nullable final Bitmap thumbnail) {
         if (thumbnail == null) {
-            // remove end screen thumbnail
-            binding.endScreen.setImageDrawable(null);
+            clearScaledEndScreenThumbnail();
             return;
         }
 
         final float endScreenHeight = calculateMaxEndScreenThumbnailHeight(thumbnail);
-        final Bitmap endScreenBitmap = BitmapCompat.createScaledBitmap(
-                thumbnail,
-                (int) (thumbnail.getWidth() / (thumbnail.getHeight() / endScreenHeight)),
-                (int) endScreenHeight,
-                null,
-                true);
+        final Bitmap endScreenBitmap;
+        if (needsThumbnailScaling(thumbnail.getHeight(), endScreenHeight)) {
+            final int targetHeight = Math.max(1, Math.round(endScreenHeight));
+            final int targetWidth = Math.max(
+                    1,
+                    Math.round(thumbnail.getWidth()
+                            * (targetHeight / (float) thumbnail.getHeight()))
+            );
+            endScreenBitmap = BitmapCompat.createScaledBitmap(
+                    thumbnail,
+                    targetWidth,
+                    targetHeight,
+                    null,
+                    true);
+        } else {
+            endScreenBitmap = thumbnail;
+        }
 
         if (DEBUG) {
             Log.d(TAG, "Thumbnail - onThumbnailLoaded() called with: "
@@ -530,7 +542,23 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
                     + ", scaled end screen width = " + endScreenBitmap.getWidth());
         }
 
+        clearScaledEndScreenThumbnail();
+        if (endScreenBitmap != thumbnail) {
+            scaledEndScreenThumbnail = endScreenBitmap;
+        }
         binding.endScreen.setImageBitmap(endScreenBitmap);
+    }
+
+    static boolean needsThumbnailScaling(final int sourceHeight, final float targetHeight) {
+        return targetHeight > 0 && targetHeight < sourceHeight;
+    }
+
+    private void clearScaledEndScreenThumbnail() {
+        binding.endScreen.setImageDrawable(null);
+        if (scaledEndScreenThumbnail != null && !scaledEndScreenThumbnail.isRecycled()) {
+            scaledEndScreenThumbnail.recycle();
+        }
+        scaledEndScreenThumbnail = null;
     }
 
     protected abstract float calculateMaxEndScreenThumbnailHeight(@NonNull Bitmap bitmap);

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -239,6 +239,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                 Toast.makeText(requireContext(), R.string.could_not_import_all_files,
                                 Toast.LENGTH_LONG)
                         .show();
+                return;
             }
 
             // if settings file exist, ask if it should be imported.

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
@@ -5,12 +5,16 @@ import com.grack.nanojson.JsonArray
 import com.grack.nanojson.JsonParser
 import com.grack.nanojson.JsonParserException
 import com.grack.nanojson.JsonWriter
+import java.io.DataInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.deleteIfExists
+import org.schabi.newpipe.database.Migrations
 import org.schabi.newpipe.streams.io.SharpInputStream
 import org.schabi.newpipe.streams.io.SharpOutputStream
 import org.schabi.newpipe.streams.io.StoredFileHelper
@@ -20,6 +24,11 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
     companion object {
         const val TAG = "ImportExportManager"
         private const val MANIFEST_FORMAT_VERSION = 1
+        private const val SQLITE_HEADER_LENGTH = 16
+        private const val SQLITE_USER_VERSION_OFFSET = 60
+        private const val SQLITE_HEADER_TO_VERSION_LENGTH =
+            SQLITE_USER_VERSION_OFFSET - SQLITE_HEADER_LENGTH
+        private const val SQLITE_MAGIC = "SQLite format 3\u0000"
     }
 
     data class BackupContents(
@@ -100,15 +109,46 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
      */
     fun extractDb(file: StoredFileHelper): Boolean {
         val name = BackupFileLocator.FILE_NAME_DB
-        val success = ZipHelper.extractFileFromZip(file, name, fileLocator.db)
+        val importedDb = fileLocator.db.resolveSibling("${fileLocator.db.fileName}.import")
+        importedDb.deleteIfExists()
 
-        if (success) {
+        try {
+            if (!ZipHelper.extractFileFromZip(file, name, importedDb)) {
+                return false
+            }
+            val databaseVersion = readSqliteUserVersion(importedDb)
+            if (databaseVersion !in Migrations.DB_VER_1..Migrations.DB_VER_23) {
+                return false
+            }
+
+            Files.move(importedDb, fileLocator.db, StandardCopyOption.REPLACE_EXISTING)
             fileLocator.dbJournal.deleteIfExists()
             fileLocator.dbWal.deleteIfExists()
             fileLocator.dbShm.deleteIfExists()
+            return true
+        } finally {
+            importedDb.deleteIfExists()
         }
+    }
 
-        return success
+    private fun readSqliteUserVersion(database: java.nio.file.Path): Int? {
+        return try {
+            DataInputStream(Files.newInputStream(database).buffered()).use { input ->
+                val header = ByteArray(SQLITE_HEADER_LENGTH)
+                input.readFully(header)
+                if (header.toString(Charsets.US_ASCII) != SQLITE_MAGIC) {
+                    return null
+                }
+                if (input.skipBytes(SQLITE_HEADER_TO_VERSION_LENGTH)
+                    != SQLITE_HEADER_TO_VERSION_LENGTH
+                ) {
+                    return null
+                }
+                input.readInt()
+            }
+        } catch (error: IOException) {
+            null
+        }
     }
 
     @Deprecated(

--- a/app/src/main/java/org/schabi/newpipe/sync/DeviceSyncManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/DeviceSyncManager.kt
@@ -82,24 +82,24 @@ class DeviceSyncManager private constructor(context: Context) {
 
     @Synchronized
     fun createPairingCode(): String {
-        node.start(allowEphemeralFallback = true)
+        startNode()
         return node.createPairingCode()
     }
 
     @Synchronized
     fun pair(pairingCode: String): TrustedPeer {
-        node.start(allowEphemeralFallback = true)
+        startNode()
         return node.pair(pairingCode)
     }
 
     @Synchronized
     fun startListening() {
-        node.start(allowEphemeralFallback = true)
+        startNode()
     }
 
     @Synchronized
     fun syncSubscriptions(): DeviceSyncSummary {
-        node.start(allowEphemeralFallback = true)
+        startNode()
         val peers = trustedPeers
         if (peers.isEmpty()) {
             throw SubscriptionSyncException("Pair a trusted device before synchronizing")
@@ -162,7 +162,7 @@ class DeviceSyncManager private constructor(context: Context) {
     }
 
     private fun syncInternal(background: Boolean): DeviceSyncSummary {
-        node.start(allowEphemeralFallback = true)
+        startNode()
         val peers = trustedPeers
         if (peers.isEmpty()) {
             throw SubscriptionSyncException("Pair a trusted device before synchronizing")
@@ -341,6 +341,20 @@ class DeviceSyncManager private constructor(context: Context) {
         }
     }
 
+    private fun startNode() {
+        try {
+            node.start(allowEphemeralFallback = true)
+        } catch (error: LinkageError) {
+            if (isUnsupportedCompletableFutureError(Build.VERSION.SDK_INT, error)) {
+                throw IllegalStateException(
+                    applicationContext.getString(R.string.device_sync_android_version_unsupported),
+                    error
+                )
+            }
+            throw error
+        }
+    }
+
     companion object {
         private const val DYNAMIC_LISTEN_PORT = 0
         private const val LEGACY_LISTEN_PORT = 48_243
@@ -360,6 +374,22 @@ class DeviceSyncManager private constructor(context: Context) {
 
         fun hasTrustedPeers(context: Context): Boolean {
             return AndroidSyncStateRepository(context.applicationContext).hasTrustedPeers()
+        }
+
+        internal fun isUnsupportedCompletableFutureError(
+            sdkInt: Int,
+            error: Throwable
+        ): Boolean {
+            if (sdkInt >= Build.VERSION_CODES.N) {
+                return false
+            }
+            return generateSequence(error) { it.cause }
+                .take(MAX_LOG_CAUSE_DEPTH)
+                .mapNotNull(Throwable::message)
+                .any { message ->
+                    message.contains("java/util/concurrent/CompletableFuture") ||
+                        message.contains("java.util.concurrent.CompletableFuture")
+                }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -378,6 +378,7 @@
     <string name="device_sync_search_history_title">Synchronize search history</string>
     <string name="device_sync_search_history_summary">Private by default. Enable to exchange search history with trusted devices; the other device must also enable it.</string>
     <string name="device_sync_sync_failed">Synchronization failed</string>
+    <string name="device_sync_android_version_unsupported">Secure device synchronization requires Android 7.0 or newer on this device</string>
     <string name="device_sync_identity_title">This device PeerID</string>
     <string name="device_sync_show_code_title">Show pairing code</string>
     <string name="device_sync_show_code_summary">Let another WizeStream device scan this one-time QR code</string>

--- a/app/src/test/java/org/schabi/newpipe/AppImageCacheTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/AppImageCacheTest.kt
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppImageCacheTest {
+    @Test
+    fun `low-memory devices use a smaller bounded image cache`() {
+        val lowMemoryPercent = App.imageMemoryCachePercent(true)
+        val regularPercent = App.imageMemoryCachePercent(false)
+
+        assertEquals(0.10, lowMemoryPercent, 0.0)
+        assertEquals(0.20, regularPercent, 0.0)
+        assertTrue(lowMemoryPercent < regularPercent)
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractorTest.java
@@ -1,0 +1,38 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import static org.junit.Assert.assertEquals;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+
+import org.junit.Test;
+
+public class YoutubeStreamInfoItemExtractorTest {
+
+    @Test
+    public void uploaderNamesContainingViewAreNotParsedAsViewCounts() throws Exception {
+        final JsonObject videoInfo = JsonParser.object().from(
+                "{\"videoInfo\":{\"runs\":["
+                        + "{\"text\":\"I-Genso - One Piece Analytiker ne-SerienReviewer\"},"
+                        + "{\"text\":\"2 days ago\"}]}}"
+        );
+
+        assertEquals(-1L, new YoutubeStreamInfoItemExtractor(videoInfo, null).getViewCount());
+    }
+
+    @Test
+    public void numericFallbackViewCountsAreStillParsed() throws Exception {
+        final JsonObject videoInfo = JsonParser.object().from(
+                "{\"videoInfo\":{\"runs\":[{\"text\":\"1.2K views\"}]}}"
+        );
+
+        assertEquals(1_200L, new YoutubeStreamInfoItemExtractor(videoInfo, null).getViewCount());
+    }
+
+    @Test
+    public void hiddenViewCountsReturnUnknown() throws Exception {
+        assertEquals(
+                -1L,
+                new YoutubeStreamInfoItemExtractor(new JsonObject(), null).getViewCount());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSuggestionExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeSuggestionExtractorTest.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class YoutubeSuggestionExtractorTest {
+
+    @Test
+    public void parsesJsonSuggestionsWithoutJsonpTrimming() throws Exception {
+        final String response = "[\"query\",[[\"first result\"],[\"second result\"],[\"\"]]]";
+
+        assertEquals(
+                Arrays.asList("first result", "second result"),
+                YoutubeSuggestionExtractor.parseSuggestions(response));
+    }
+
+    @Test
+    public void ignoresEntriesThatAreNotSuggestionArrays() throws Exception {
+        final String response = "[\"query\",[\"tracking\",[\"valid result\"]]]";
+
+        assertEquals(
+                Collections.singletonList("valid result"),
+                YoutubeSuggestionExtractor.parseSuggestions(response));
+    }
+
+    @Test
+    public void rejectsMalformedResponses() {
+        assertThrows(
+                ExtractionException.class,
+                () -> YoutubeSuggestionExtractor.parseSuggestions("ml-not-json"));
+    }
+
+    @Test
+    public void rejectsEmptyResponses() {
+        assertThrows(
+                ExtractionException.class,
+                () -> YoutubeSuggestionExtractor.parseSuggestions(""));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
@@ -134,6 +134,28 @@ public class FeedRefreshControlsTest {
         ).contains("cancelLoading()"));
     }
 
+    @Test
+    public void preferenceChangesCannotOutliveTheFeedViewBinding() throws Exception {
+        final String source = readSource(
+                "org/schabi/newpipe/local/feed/FeedFragment.kt");
+
+        assertTrue(methodBody(
+                source,
+                "override fun onViewCreated",
+                "override fun onResume"
+        ).contains("registerOnSharedPreferenceChangeListener(onSettingsChangeListener)"));
+        assertTrue(methodBody(
+                source,
+                "override fun onDestroyView()",
+                "// Handling"
+        ).contains("unregisterOnSharedPreferenceChangeListener(onSettingsChangeListener)"));
+        assertTrue(methodBody(
+                source,
+                "private fun showFilteredFeedItems",
+                "override fun setContextualSearchQuery"
+        ).contains("if (_feedBinding == null)"));
+    }
+
     private String readSource(final String relativePath) throws Exception {
         return Files.readString(sourceDirectory.resolve(relativePath));
     }

--- a/app/src/test/java/org/schabi/newpipe/player/ui/VideoPlayerUiThumbnailTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/ui/VideoPlayerUiThumbnailTest.java
@@ -1,0 +1,21 @@
+package org.schabi.newpipe.player.ui;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class VideoPlayerUiThumbnailTest {
+
+    @Test
+    public void avoidsAllocatingAnotherBitmapWhenTheThumbnailAlreadyFits() {
+        assertFalse(VideoPlayerUi.needsThumbnailScaling(720, 720));
+        assertFalse(VideoPlayerUi.needsThumbnailScaling(720, 1080));
+    }
+
+    @Test
+    public void scalesOnlyOversizedThumbnails() {
+        assertTrue(VideoPlayerUi.needsThumbnailScaling(2160, 1080));
+        assertFalse(VideoPlayerUi.needsThumbnailScaling(2160, 0));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/settings/ImportExportManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/ImportExportManagerTest.kt
@@ -3,8 +3,11 @@ package org.schabi.newpipe.settings
 import android.content.SharedPreferences
 import com.grack.nanojson.JsonParser
 import java.io.File
+import java.nio.ByteBuffer
 import java.nio.file.Paths
+import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.createTempFile
 import kotlin.io.path.deleteIfExists
@@ -12,6 +15,9 @@ import kotlin.io.path.div
 import kotlin.io.path.exists
 import kotlin.io.path.fileSize
 import kotlin.io.path.inputStream
+import kotlin.io.path.outputStream
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
@@ -165,6 +171,29 @@ class ImportExportManagerTest {
         assertTrue(dbWal.exists())
         assertTrue(dbShm.exists())
         assertEquals(0, db.fileSize())
+    }
+
+    @Test
+    fun `An incompatible foreign database must not replace the current database`() {
+        val db = createTempFile("newpipe_", "")
+        db.writeText("current WizeStream database")
+        `when`(fileLocator.db).thenReturn(db)
+
+        val foreignDatabase = ByteArray(100)
+        "SQLite format 3\u0000".toByteArray(Charsets.US_ASCII)
+            .copyInto(foreignDatabase)
+        ByteBuffer.wrap(foreignDatabase, 60, Int.SIZE_BYTES).putInt(901)
+
+        val zip = createTempFile("pipepipe_", ".zip")
+        ZipOutputStream(zip.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(BackupFileLocator.FILE_NAME_DB))
+            output.write(foreignDatabase)
+            output.closeEntry()
+        }
+        `when`(storedFileHelper.stream).thenReturn(FileStream(zip.toFile()))
+
+        assertFalse(ImportExportManager(fileLocator).extractDb(storedFileHelper))
+        assertEquals("current WizeStream database", db.readText())
     }
 
     @Suppress("DEPRECATION")

--- a/app/src/test/java/org/schabi/newpipe/sync/Libp2pSyncNodeTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/sync/Libp2pSyncNodeTest.kt
@@ -10,12 +10,27 @@ import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import java.net.ServerSocket
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class Libp2pSyncNodeTest {
+    @Test
+    fun `device sync recognizes Android 6 CompletableFuture linkage failures`() {
+        val missingCompletableFuture = NoClassDefFoundError(
+            "Failed resolution of: Ljava/util/concurrent/CompletableFuture;"
+        )
+
+        assertTrue(
+            DeviceSyncManager.isUnsupportedCompletableFutureError(23, missingCompletableFuture)
+        )
+        assertFalse(
+            DeviceSyncManager.isUnsupportedCompletableFutureError(24, missingCompletableFuture)
+        )
+    }
+
     @Test
     fun `default listener advertises and reports its selected dynamic port`() {
         val state = InMemorySyncStateRepository()

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -25,6 +25,10 @@ Release history is listed newest first. The number beside each release is its An
 - Handled Rumble videos that do not provide related items.
 - Kept navigation and drawer content clear of status bars, display cutouts, gesture navigation,
   and three-button navigation while preserving fullscreen playback.
+- Hardened YouTube search suggestions and feed view-count parsing against malformed metadata.
+- Prevented preference updates from reaching a destroyed feed view and handled unsupported channels.
+- Prevented Android 6 device-sync linkage failures and repeated player-thumbnail allocations.
+- Rejected incompatible foreign databases before they could replace WizeStream data.
 
 [View the complete changes since v1.10.4](https://github.com/wizdom13/WizeStream/compare/v1.10.4...v1.11.0)
 

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -27,7 +27,8 @@ Release history is listed newest first. The number beside each release is its An
   and three-button navigation while preserving fullscreen playback.
 - Hardened YouTube search suggestions and feed view-count parsing against malformed metadata.
 - Prevented preference updates from reaching a destroyed feed view and handled unsupported channels.
-- Prevented Android 6 device-sync linkage failures and repeated player-thumbnail allocations.
+- Prevented Android 6 device-sync linkage failures, bounded the image cache, and reused player
+  thumbnails to reduce memory pressure.
 - Rejected incompatible foreign databases before they could replace WizeStream data.
 
 [View the complete changes since v1.10.4](https://github.com/wizdom13/WizeStream/compare/v1.10.4...v1.11.0)

--- a/fastlane/metadata/android/en-US/changelogs/1011000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1011000.txt
@@ -1,6 +1,5 @@
 • Added BitChute and Rumble browsing, search, channels, comments, live streams and playback.
-• Refreshed the interface with Material 3 colors, typography, components and adaptive navigation.
-• Improved player controls, seekbars, navigation indicators and accessibility.
-• Added channel notification keyword controls.
-• Polished feed refresh and made it cancellable.
-• Fixed empty-feed crashes, clipped progress, missing Rumble related items and system-bar overlaps.
+• Refreshed the interface with Material 3 styling, adaptive navigation and improved player controls.
+• Added channel notification keyword controls and cancellable feed refresh.
+• Fixed system-bar overlaps, empty-feed crashes, YouTube suggestions/view counts and unsupported channels.
+• Prevented Android 6 sync crashes, player-thumbnail memory spikes and unsafe foreign database imports.


### PR DESCRIPTION
- Replace YouTube’s brittle JSONP suggestion endpoint with the validated JSON endpoint and reject malformed response types.
- Ignore nonnumeric metadata containing words such as “Reviewer” instead of treating it as a view count.
- Scope feed preference listeners to the view lifecycle and handle unsupported subscribed channels without a generic exception report.
- Convert Android 6 `CompletableFuture` linkage failures into a recoverable device-sync error instead of crashing.
- Bound Coil’s image memory cache, avoid duplicate player-thumbnail allocations, and recycle only scaled bitmaps owned by the player UI.
- Stage and validate imported SQLite databases before replacing WizeStream data, rejecting incompatible version `901` backups safely.
- Add regression coverage for extractor parsing, feed lifecycle, Android 6 linkage detection, memory bounds, thumbnail scaling, and foreign database imports.
- Document the fixes in the WizeStream 1.11.0 release and store changelogs.