### PR TITLE
Fix video detail loading transition

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import android.content.Context;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import androidx.core.graphics.Insets;
@@ -23,14 +24,20 @@ public class EdgeToEdgeHelperTest {
         final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final View source = new FrameLayout(context);
         final View content = new FrameLayout(context);
+        final View toolbar = new FrameLayout(context);
+        final View navigation = new FrameLayout(context);
+        final View player = new FrameLayout(context);
         final View drawer = new FrameLayout(context);
         final View header = new FrameLayout(context);
         content.setPadding(1, 2, 3, 4);
+        toolbar.setPadding(13, 14, 15, 16);
+        navigation.setLayoutParams(new FrameLayout.LayoutParams(100, 100));
+        player.setPadding(17, 18, 19, 20);
         drawer.setPadding(5, 6, 7, 8);
         header.setPadding(9, 10, 11, 12);
 
-        EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding(
-                source, content, drawer, header);
+        EdgeToEdgeHelper.applyMainActivitySystemBarInsets(
+                source, content, toolbar, navigation, player, drawer, header);
         final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
                 source,
                 new WindowInsetsCompat.Builder()
@@ -39,6 +46,9 @@ public class EdgeToEdgeHelperTest {
                         .build());
 
         assertPadding(content, 3, 32, 6, 52);
+        assertPadding(toolbar, 15, 44, 18, 16);
+        assertMargins(navigation, 2, 30, 3, 48);
+        assertPadding(player, 19, 18, 22, 68);
         assertPadding(drawer, 7, 6, 10, 56);
         assertPadding(header, 9, 40, 11, 12);
         assertEquals(Insets.NONE,
@@ -46,6 +56,9 @@ public class EdgeToEdgeHelperTest {
 
         ViewCompat.dispatchApplyWindowInsets(source, new WindowInsetsCompat.Builder().build());
         assertPadding(content, 1, 2, 3, 4);
+        assertPadding(toolbar, 13, 14, 15, 16);
+        assertMargins(navigation, 0, 0, 0, 0);
+        assertPadding(player, 17, 18, 19, 20);
         assertPadding(drawer, 5, 6, 7, 8);
         assertPadding(header, 9, 10, 11, 12);
     }
@@ -56,11 +69,15 @@ public class EdgeToEdgeHelperTest {
         final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         final View source = new FrameLayout(context);
         final View content = new FrameLayout(context);
+        final View toolbar = new FrameLayout(context);
+        final View navigation = new FrameLayout(context);
+        final View player = new FrameLayout(context);
         final View drawer = new FrameLayout(context);
         final View header = new FrameLayout(context);
+        navigation.setLayoutParams(new FrameLayout.LayoutParams(100, 100));
 
-        EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding(
-                source, content, drawer, header);
+        EdgeToEdgeHelper.applyMainActivitySystemBarInsets(
+                source, content, toolbar, navigation, player, drawer, header);
         final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
                 source,
                 new WindowInsetsCompat.Builder()
@@ -71,6 +88,9 @@ public class EdgeToEdgeHelperTest {
                         .build());
 
         assertPadding(content, 2, 30, 3, 20);
+        assertPadding(toolbar, 2, 30, 3, 0);
+        assertMargins(navigation, 2, 30, 3, 20);
+        assertPadding(player, 2, 0, 3, 20);
         assertPadding(drawer, 2, 0, 3, 20);
         assertPadding(header, 0, 30, 0, 0);
         assertEquals(Insets.NONE,
@@ -108,5 +128,18 @@ public class EdgeToEdgeHelperTest {
         assertEquals(top, view.getPaddingTop());
         assertEquals(right, view.getPaddingRight());
         assertEquals(bottom, view.getPaddingBottom());
+    }
+
+    private static void assertMargins(final View view,
+                                      final int left,
+                                      final int top,
+                                      final int right,
+                                      final int bottom) {
+        final ViewGroup.MarginLayoutParams params =
+                (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        assertEquals(left, params.leftMargin);
+        assertEquals(top, params.topMargin);
+        assertEquals(right, params.rightMargin);
+        assertEquals(bottom, params.bottomMargin);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -192,9 +192,12 @@ public class MainActivity extends AppCompatActivity {
                 .getHeaderView(0));
         toolbarLayoutBinding = mainBinding.toolbarLayout;
         setContentView(mainBinding.getRoot());
-        EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding(
+        EdgeToEdgeHelper.applyMainActivitySystemBarInsets(
                 mainBinding.getRoot(),
-                mainBinding.mainContent,
+                mainBinding.mainSafeContent,
+                mainBinding.toolbarLayout.getRoot(),
+                mainBinding.mainBottomNavigation,
+                mainBinding.fragmentPlayerHolder,
                 drawerLayoutBinding.navigation,
                 drawerHeaderBinding.getRoot());
         nativePipController = new NativePipController(this);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -898,6 +898,7 @@ public final class VideoDetailFragment
             player.disablePreloadingOfCurrentTrack();
         }
 
+        hideMainPlayerOnLoadingNewStream();
         setInitialData(newServiceId, newUrl, newTitle, newQueue);
         if (currentLocalItem != null) {
             prepareAndHandleLocalMedia(currentLocalItem, true);
@@ -1709,6 +1710,15 @@ public final class VideoDetailFragment
                 && !tabletLayout;
     }
 
+    static boolean shouldHidePreviousStreamContent(final boolean streamInfoCached) {
+        return !streamInfoCached;
+    }
+
+    static boolean shouldShowQueueItemLoadingPreview(final boolean hasQueueItem,
+                                                     final boolean localMedia) {
+        return hasQueueItem && !localMedia;
+    }
+
     private void updatePinnedPlayerLayout() {
         updatePinnedPlayerLayout(0);
     }
@@ -1887,9 +1897,13 @@ public final class VideoDetailFragment
 
         super.showLoading();
 
-        //if data is already cached, transition from VISIBLE -> INVISIBLE -> VISIBLE is not required
-        if (!ExtractorHelper.isCached(serviceId, url, InfoCache.Type.STREAM)) {
+        // If data is already cached, the transition from visible to hidden and back is unnecessary.
+        final boolean streamInfoCached =
+                ExtractorHelper.isCached(serviceId, url, InfoCache.Type.STREAM);
+        if (shouldHidePreviousStreamContent(streamInfoCached)) {
             binding.detailContentRootHiding.setVisibility(View.INVISIBLE);
+            binding.viewPager.setVisibility(View.GONE);
+            detailNavigation.setVisibility(View.GONE);
         }
 
         animate(binding.detailThumbnailPlayButton, false, 50);
@@ -1920,6 +1934,32 @@ public final class VideoDetailFragment
         CoilUtils.dispose(binding.detailUploaderThumbnailView);
         binding.detailThumbnailImageView.setImageBitmap(null);
         binding.detailSubChannelThumbnailView.setImageBitmap(null);
+        showQueueItemLoadingPreview();
+    }
+
+    private void showQueueItemLoadingPreview() {
+        final PlayQueueItem queueItem = playQueue == null ? null : playQueue.getItem();
+        if (!shouldShowQueueItemLoadingPreview(
+                queueItem != null, queueItem != null && queueItem.isLocalMedia())) {
+            return;
+        }
+
+        CoilHelper.INSTANCE.loadDetailsThumbnail(
+                binding.detailThumbnailImageView,
+                ExtractorImageCompat.thumbnailImages(queueItem));
+        if (queueItem.getDuration() > 0) {
+            binding.detailDurationView.setText(
+                    Localization.getDurationString(queueItem.getDuration()));
+            binding.detailDurationView.setBackgroundColor(
+                    ContextCompat.getColor(activity, R.color.duration_background_color));
+            animate(binding.detailDurationView, true, 100);
+        } else if (queueItem.getStreamType() == StreamType.LIVE_STREAM
+                || queueItem.getStreamType() == StreamType.AUDIO_LIVE_STREAM) {
+            binding.detailDurationView.setText(R.string.duration_live);
+            binding.detailDurationView.setBackgroundColor(
+                    ContextCompat.getColor(activity, R.color.live_duration_background_color));
+            animate(binding.detailDurationView, true, 100);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -256,6 +256,9 @@ public final class VideoDetailFragment
     //////////////////////////////////////////////////////////////////////////*/
 
     private TabAdapter pageAdapter;
+    private View activityToolbarLayout;
+    private View.OnLayoutChangeListener toolbarLayoutChangeListener;
+    private int activityToolbarHeight;
 
     private ContentObserver settingsContentObserver;
     @Nullable
@@ -492,6 +495,12 @@ public final class VideoDetailFragment
             liveNotStartedDialog.dismiss();
             liveNotStartedDialog = null;
         }
+        if (activityToolbarLayout != null && toolbarLayoutChangeListener != null) {
+            activityToolbarLayout.removeOnLayoutChangeListener(toolbarLayoutChangeListener);
+        }
+        activityToolbarLayout = null;
+        toolbarLayoutChangeListener = null;
+        activityToolbarHeight = 0;
         super.onDestroyView();
         detailNavigation = null;
         binding = null;
@@ -703,6 +712,17 @@ public final class VideoDetailFragment
         super.initViews(rootView, savedInstanceState);
 
         detailNavigation = rootView.findViewById(R.id.detail_navigation);
+        activityToolbarLayout = requireActivity().findViewById(R.id.toolbar_layout);
+        activityToolbarHeight = Math.max(activityToolbarLayout.getHeight(), 0);
+        toolbarLayoutChangeListener = (view, left, top, right, bottom,
+                                       oldLeft, oldTop, oldRight, oldBottom) -> {
+            if (bottom > top) {
+                activityToolbarHeight = bottom - top;
+            }
+            updateDetailContentTopMargin(isFullscreen());
+        };
+        activityToolbarLayout.addOnLayoutChangeListener(toolbarLayoutChangeListener);
+        binding.getRoot().post(() -> updateDetailContentTopMargin(isFullscreen()));
         pageAdapter = new TabAdapter(getChildFragmentManager());
         binding.viewPager.setAdapter(pageAdapter);
         binding.viewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
@@ -1719,6 +1739,25 @@ public final class VideoDetailFragment
         return hasQueueItem && !localMedia;
     }
 
+    static int getDetailContentTopMargin(final boolean fullscreen,
+                                         final int toolbarHeight) {
+        return fullscreen ? 0 : Math.max(toolbarHeight, 0);
+    }
+
+    private void updateDetailContentTopMargin(final boolean fullscreen) {
+        if (binding == null || activityToolbarLayout == null) {
+            return;
+        }
+        final int desiredTopMargin = getDetailContentTopMargin(
+                fullscreen, activityToolbarHeight);
+        final ViewGroup.MarginLayoutParams params =
+                (ViewGroup.MarginLayoutParams) binding.detailMainContent.getLayoutParams();
+        if (params.topMargin != desiredTopMargin) {
+            params.topMargin = desiredTopMargin;
+            binding.detailMainContent.setLayoutParams(params);
+        }
+    }
+
     private void updatePinnedPlayerLayout() {
         updatePinnedPlayerLayout(0);
     }
@@ -2408,8 +2447,8 @@ public final class VideoDetailFragment
         } else {
             showSystemUi();
         }
-        requireActivity().findViewById(R.id.toolbar_layout)
-                .setVisibility(fullscreen ? View.GONE : View.VISIBLE);
+        activityToolbarLayout.setVisibility(fullscreen ? View.GONE : View.VISIBLE);
+        updateDetailContentTopMargin(fullscreen);
 
         if (binding.relatedItemsLayout != null) {
             if (showRelatedItems) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2408,6 +2408,8 @@ public final class VideoDetailFragment
         } else {
             showSystemUi();
         }
+        requireActivity().findViewById(R.id.toolbar_layout)
+                .setVisibility(fullscreen ? View.GONE : View.VISIBLE);
 
         if (binding.relatedItemsLayout != null) {
             if (showRelatedItems) {

--- a/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 
 import androidx.annotation.NonNull;
@@ -48,29 +49,48 @@ public final class EdgeToEdgeHelper {
     }
 
     /**
-     * Applies insets to the independently laid-out content and drawer children of a
-     * {@link androidx.drawerlayout.widget.DrawerLayout}. Padding the drawer layout itself does
-     * not constrain those children, which can leave bottom navigation behind the system
-     * navigation bar and drawer header content behind the status bar.
+     * Applies insets to the independently laid-out main activity and drawer children.
      *
-     * <p>The drawer keeps drawing its background edge-to-edge. Only its header content receives
-     * the top inset, while the drawer container receives horizontal cutout protection and the
-     * bottom system-bar inset.</p>
+     * <p>The player bottom sheet deliberately remains outside {@code safeContent}. Padding the
+     * sheet's {@link androidx.coordinatorlayout.widget.CoordinatorLayout} parent changes the
+     * height used by {@code BottomSheetBehavior} and shifts its expanded position downward. The
+     * regular fragment content, toolbar, and adaptive navigation receive their insets directly
+     * instead.</p>
      *
      * @param insetSource view that receives the window inset dispatch
-     * @param content main activity content constrained inside all safe edges
+     * @param safeContent regular fragment content constrained inside all safe edges
+     * @param toolbar toolbar protected below the status bar and display cutouts
+     * @param navigation bottom navigation or navigation rail protected inside all safe edges
+     * @param playerSheet player sheet whose children avoid horizontal and bottom system bars
      * @param drawer navigation drawer protected on its horizontal and bottom edges
      * @param drawerHeader drawer header whose content is protected below the status bar
      */
-    public static void applyDrawerLayoutSystemBarPadding(
+    public static void applyMainActivitySystemBarInsets(
             @NonNull final View insetSource,
-            @NonNull final View content,
+            @NonNull final View safeContent,
+            @NonNull final View toolbar,
+            @NonNull final View navigation,
+            @NonNull final View playerSheet,
             @NonNull final View drawer,
             @NonNull final View drawerHeader) {
-        final int contentLeft = content.getPaddingLeft();
-        final int contentTop = content.getPaddingTop();
-        final int contentRight = content.getPaddingRight();
-        final int contentBottom = content.getPaddingBottom();
+        final int contentLeft = safeContent.getPaddingLeft();
+        final int contentTop = safeContent.getPaddingTop();
+        final int contentRight = safeContent.getPaddingRight();
+        final int contentBottom = safeContent.getPaddingBottom();
+        final int toolbarLeft = toolbar.getPaddingLeft();
+        final int toolbarTop = toolbar.getPaddingTop();
+        final int toolbarRight = toolbar.getPaddingRight();
+        final int toolbarBottom = toolbar.getPaddingBottom();
+        final ViewGroup.MarginLayoutParams navigationParams =
+                (ViewGroup.MarginLayoutParams) navigation.getLayoutParams();
+        final int navigationLeft = navigationParams.leftMargin;
+        final int navigationTop = navigationParams.topMargin;
+        final int navigationRight = navigationParams.rightMargin;
+        final int navigationBottom = navigationParams.bottomMargin;
+        final int playerLeft = playerSheet.getPaddingLeft();
+        final int playerTop = playerSheet.getPaddingTop();
+        final int playerRight = playerSheet.getPaddingRight();
+        final int playerBottom = playerSheet.getPaddingBottom();
         final int drawerLeft = drawer.getPaddingLeft();
         final int drawerTop = drawer.getPaddingTop();
         final int drawerRight = drawer.getPaddingRight();
@@ -82,11 +102,29 @@ public final class EdgeToEdgeHelper {
 
         ViewCompat.setOnApplyWindowInsetsListener(insetSource, (target, windowInsets) -> {
             final Insets safeInsets = getSafeSystemBarInsets(windowInsets);
-            content.setPadding(
+            safeContent.setPadding(
                     contentLeft + safeInsets.left,
                     contentTop + safeInsets.top,
                     contentRight + safeInsets.right,
                     contentBottom + safeInsets.bottom);
+            toolbar.setPadding(
+                    toolbarLeft + safeInsets.left,
+                    toolbarTop + safeInsets.top,
+                    toolbarRight + safeInsets.right,
+                    toolbarBottom);
+            final ViewGroup.MarginLayoutParams updatedNavigationParams =
+                    (ViewGroup.MarginLayoutParams) navigation.getLayoutParams();
+            updatedNavigationParams.setMargins(
+                    navigationLeft + safeInsets.left,
+                    navigationTop + safeInsets.top,
+                    navigationRight + safeInsets.right,
+                    navigationBottom + safeInsets.bottom);
+            navigation.setLayoutParams(updatedNavigationParams);
+            playerSheet.setPadding(
+                    playerLeft + safeInsets.left,
+                    playerTop,
+                    playerRight + safeInsets.right,
+                    playerBottom + safeInsets.bottom);
             drawer.setPadding(
                     drawerLeft + safeInsets.left,
                     drawerTop,

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -9,17 +9,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/fragment_holder"
+        <FrameLayout
+            android:id="@+id/main_safe_content"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginStart="@dimen/main_navigation_rail_width"
-            android:layout_marginTop="?attr/actionBarSize" />
+            android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/toolbar_layout"
-            layout="@layout/toolbar_layout"
-            android:layout_marginStart="@dimen/main_navigation_rail_width" />
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/fragment_holder"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/main_navigation_rail_width"
+                android:layout_marginTop="?attr/actionBarSize" />
+
+        </FrameLayout>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"
@@ -30,6 +32,11 @@
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
             app:layout_behavior="org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior" />
+
+        <include
+            android:id="@+id/toolbar_layout"
+            layout="@layout/toolbar_layout"
+            android:layout_marginStart="@dimen/main_navigation_rail_width" />
 
         <com.google.android.material.navigationrail.NavigationRailView
             android:id="@+id/main_bottom_navigation"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,15 +9,18 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/fragment_holder"
+        <FrameLayout
+            android:id="@+id/main_safe_content"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="?attr/actionBarSize" />
+            android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/toolbar_layout"
-            layout="@layout/toolbar_layout" />
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/fragment_holder"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="?attr/actionBarSize" />
+
+        </FrameLayout>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"
@@ -27,6 +30,10 @@
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
             app:layout_behavior="org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior" />
+
+        <include
+            android:id="@+id/toolbar_layout"
+            layout="@layout/toolbar_layout" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/main_bottom_navigation"

--- a/app/src/main/res/layout/toolbar_layout.xml
+++ b/app/src/main/res/layout/toolbar_layout.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/colorSurface"
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
@@ -1,0 +1,22 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class VideoDetailLayoutStateTest {
+    @Test
+    public void normalDetailContentStartsBelowTheCompleteToolbar() {
+        assertEquals(86, VideoDetailFragment.getDetailContentTopMargin(false, 86));
+    }
+
+    @Test
+    public void fullscreenDetailContentStartsAtTheTopOfTheWindow() {
+        assertEquals(0, VideoDetailFragment.getDetailContentTopMargin(true, 86));
+    }
+
+    @Test
+    public void unmeasuredToolbarDoesNotCreateANegativeOffset() {
+        assertEquals(0, VideoDetailFragment.getDetailContentTopMargin(false, -1));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLoadingStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLoadingStateTest.java
@@ -1,0 +1,29 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class VideoDetailLoadingStateTest {
+    @Test
+    public void uncachedStreamHidesPreviousDetailsAndTabs() {
+        assertTrue(VideoDetailFragment.shouldHidePreviousStreamContent(false));
+    }
+
+    @Test
+    public void cachedStreamAvoidsUnnecessaryContentFlicker() {
+        assertFalse(VideoDetailFragment.shouldHidePreviousStreamContent(true));
+    }
+
+    @Test
+    public void remoteQueueItemProvidesLoadingPreview() {
+        assertTrue(VideoDetailFragment.shouldShowQueueItemLoadingPreview(true, false));
+    }
+
+    @Test
+    public void missingOrLocalQueueItemDoesNotProvideRemotePreview() {
+        assertFalse(VideoDetailFragment.shouldShowQueueItemLoadingPreview(false, false));
+        assertFalse(VideoDetailFragment.shouldShowQueueItemLoadingPreview(true, true));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
@@ -60,11 +60,33 @@ public class EdgeToEdgeIntegrationTest {
         final String tabletLayout = Files.readString(mainDirectory.resolve(
                 "res/layout-sw600dp/activity_main.xml"));
 
-        assertTrue(activity.contains("EdgeToEdgeHelper.applyDrawerLayoutSystemBarPadding("));
+        assertTrue(activity.contains("EdgeToEdgeHelper.applyMainActivitySystemBarInsets("));
         assertFalse(activity.contains(
                 "EdgeToEdgeHelper.applySystemBarPadding(mainBinding.getRoot())"));
         assertTrue(phoneLayout.contains("android:id=\"@+id/main_content\""));
         assertTrue(tabletLayout.contains("android:id=\"@+id/main_content\""));
+        assertTrue(phoneLayout.contains("android:id=\"@+id/main_safe_content\""));
+        assertTrue(tabletLayout.contains("android:id=\"@+id/main_safe_content\""));
+    }
+
+    @Test
+    public void playerSheetStaysOutsideInsetContentContainer() throws Exception {
+        final List<String> layouts = List.of(
+                "res/layout/activity_main.xml",
+                "res/layout-sw600dp/activity_main.xml");
+
+        for (final String layoutPath : layouts) {
+            final String layout = Files.readString(mainDirectory.resolve(layoutPath));
+            final int safeContentStart = layout.indexOf(
+                    "android:id=\"@+id/main_safe_content\"");
+            final int safeContentEnd = layout.indexOf("</FrameLayout>", safeContentStart);
+            final int playerSheetStart = layout.indexOf(
+                    "android:id=\"@+id/fragment_player_holder\"");
+
+            assertTrue(layoutPath, safeContentStart >= 0);
+            assertTrue(layoutPath, safeContentEnd > safeContentStart);
+            assertTrue(layoutPath, playerSheetStart > safeContentEnd);
+        }
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
@@ -90,6 +90,22 @@ public class EdgeToEdgeIntegrationTest {
     }
 
     @Test
+    public void miniPlayerOverlayStaysOutsideToolbarInsetDetailContent() throws Exception {
+        final String detailLayout = Files.readString(mainDirectory.resolve(
+                "res/layout/fragment_video_detail.xml"));
+        final int detailContentStart = detailLayout.indexOf(
+                "android:id=\"@+id/detail_main_content\"");
+        final int detailContentEnd = detailLayout.indexOf(
+                "</androidx.coordinatorlayout.widget.CoordinatorLayout>", detailContentStart);
+        final int miniPlayerOverlayStart = detailLayout.indexOf(
+                "android:id=\"@+id/overlay_layout\"");
+
+        assertTrue(detailContentStart >= 0);
+        assertTrue(detailContentEnd > detailContentStart);
+        assertTrue(miniPlayerOverlayStart > detailContentEnd);
+    }
+
+    @Test
     public void playerDoesNotUseDeprecatedSystemUiVisibilityFlags() throws Exception {
         final String detailSource = Files.readString(mainDirectory.resolve(
                 "java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));


### PR DESCRIPTION
- Show the selected queue item’s thumbnail and duration while its stream information loads.
- Remove the previous player immediately when switching videos so it cannot cover the new preview.
- Hide the previous video’s comments, tabs, and navigation during uncached loads.
- Restore the matching detail content and tabs only after the new stream information is ready.
- Keep the Material player sheet outside the padded safe-content container so its bottom-sheet geometry remains stable.
- Position only the expanded detail content below the complete measured toolbar so the parent screen cannot cover the video.
- Keep the collapsed mini-player overlay at the sheet origin and restore the toolbar offset immediately after fullscreen.
- Apply system-bar protection separately to screen content, the toolbar, adaptive navigation, the player’s children, and the drawer.
- Preserve fullscreen edge-to-edge playback and cache-hit transitions without unnecessary flicker.
- Add regression coverage for loading states, toolbar offsets, collapsed-overlay containment, insets, and display cutouts.