### PR TITLE
Show expanded player below status bar

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -258,7 +258,7 @@ public final class VideoDetailFragment
     private TabAdapter pageAdapter;
     private View activityToolbarLayout;
     private View.OnLayoutChangeListener toolbarLayoutChangeListener;
-    private int activityToolbarHeight;
+    private int activityStatusBarInset;
 
     private ContentObserver settingsContentObserver;
     @Nullable
@@ -500,7 +500,7 @@ public final class VideoDetailFragment
         }
         activityToolbarLayout = null;
         toolbarLayoutChangeListener = null;
-        activityToolbarHeight = 0;
+        activityStatusBarInset = 0;
         super.onDestroyView();
         detailNavigation = null;
         binding = null;
@@ -713,11 +713,12 @@ public final class VideoDetailFragment
 
         detailNavigation = rootView.findViewById(R.id.detail_navigation);
         activityToolbarLayout = requireActivity().findViewById(R.id.toolbar_layout);
-        activityToolbarHeight = Math.max(activityToolbarLayout.getHeight(), 0);
+        activityStatusBarInset = Math.max(activityToolbarLayout.getPaddingTop(), 0);
         toolbarLayoutChangeListener = (view, left, top, right, bottom,
                                        oldLeft, oldTop, oldRight, oldBottom) -> {
-            if (bottom > top) {
-                activityToolbarHeight = bottom - top;
+            final int currentTopInset = Math.max(view.getPaddingTop(), 0);
+            if (currentTopInset > 0 || activityStatusBarInset == 0) {
+                activityStatusBarInset = currentTopInset;
             }
             updateDetailContentTopMargin(isFullscreen());
         };
@@ -1740,8 +1741,8 @@ public final class VideoDetailFragment
     }
 
     static int getDetailContentTopMargin(final boolean fullscreen,
-                                         final int toolbarHeight) {
-        return fullscreen ? 0 : Math.max(toolbarHeight, 0);
+                                         final int statusBarInset) {
+        return fullscreen ? 0 : Math.max(statusBarInset, 0);
     }
 
     private void updateDetailContentTopMargin(final boolean fullscreen) {
@@ -1749,7 +1750,7 @@ public final class VideoDetailFragment
             return;
         }
         final int desiredTopMargin = getDetailContentTopMargin(
-                fullscreen, activityToolbarHeight);
+                fullscreen, activityStatusBarInset);
         final ViewGroup.MarginLayoutParams params =
                 (ViewGroup.MarginLayoutParams) binding.detailMainContent.getLayoutParams();
         if (params.topMargin != desiredTopMargin) {
@@ -2447,7 +2448,6 @@ public final class VideoDetailFragment
         } else {
             showSystemUi();
         }
-        activityToolbarLayout.setVisibility(fullscreen ? View.GONE : View.VISIBLE);
         updateDetailContentTopMargin(fullscreen);
 
         if (binding.relatedItemsLayout != null) {

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -23,6 +23,11 @@
 
         </FrameLayout>
 
+        <include
+            android:id="@+id/toolbar_layout"
+            layout="@layout/toolbar_layout"
+            android:layout_marginStart="@dimen/main_navigation_rail_width" />
+
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"
             android:layout_width="match_parent"
@@ -32,11 +37,6 @@
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
             app:layout_behavior="org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior" />
-
-        <include
-            android:id="@+id/toolbar_layout"
-            layout="@layout/toolbar_layout"
-            android:layout_marginStart="@dimen/main_navigation_rail_width" />
 
         <com.google.android.material.navigationrail.NavigationRailView
             android:id="@+id/main_bottom_navigation"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,6 +22,10 @@
 
         </FrameLayout>
 
+        <include
+            android:id="@+id/toolbar_layout"
+            layout="@layout/toolbar_layout" />
+
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"
             android:layout_width="match_parent"
@@ -30,10 +34,6 @@
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
             app:layout_behavior="org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior" />
-
-        <include
-            android:id="@+id/toolbar_layout"
-            layout="@layout/toolbar_layout" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/main_bottom_navigation"

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
@@ -6,13 +6,13 @@ import org.junit.Test;
 
 public class VideoDetailLayoutStateTest {
     @Test
-    public void normalDetailContentStartsBelowTheCompleteToolbar() {
-        assertEquals(86, VideoDetailFragment.getDetailContentTopMargin(false, 86));
+    public void normalDetailContentStartsBelowTheStatusBar() {
+        assertEquals(30, VideoDetailFragment.getDetailContentTopMargin(false, 30));
     }
 
     @Test
     public void fullscreenDetailContentStartsAtTheTopOfTheWindow() {
-        assertEquals(0, VideoDetailFragment.getDetailContentTopMargin(true, 86));
+        assertEquals(0, VideoDetailFragment.getDetailContentTopMargin(true, 30));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
@@ -90,6 +90,24 @@ public class EdgeToEdgeIntegrationTest {
     }
 
     @Test
+    public void expandedPlayerIsDrawnAboveTheParentToolbar() throws Exception {
+        final List<String> layouts = List.of(
+                "res/layout/activity_main.xml",
+                "res/layout-sw600dp/activity_main.xml");
+
+        for (final String layoutPath : layouts) {
+            final String layout = Files.readString(mainDirectory.resolve(layoutPath));
+            final int toolbarStart = layout.indexOf(
+                    "android:id=\"@+id/toolbar_layout\"");
+            final int playerSheetStart = layout.indexOf(
+                    "android:id=\"@+id/fragment_player_holder\"");
+
+            assertTrue(layoutPath, toolbarStart >= 0);
+            assertTrue(layoutPath, playerSheetStart > toolbarStart);
+        }
+    }
+
+    @Test
     public void miniPlayerOverlayStaysOutsideToolbarInsetDetailContent() throws Exception {
         final String detailLayout = Files.readString(mainDirectory.resolve(
                 "res/layout/fragment_video_detail.xml"));


### PR DESCRIPTION
- Draw the expanded video-detail sheet above the parent toolbar so it replaces the parent screen.
- Offset expanded player content by only the status-bar safe inset.
- Keep the collapsed mini-player outside the expanded-content inset.
- Remove the top inset in fullscreen playback.
- Apply the corrected stacking order to phone and tablet layouts.
- Add regression coverage for player z-order, status-bar spacing, fullscreen spacing, and mini-player placement.