### PR TITLE
Fix fullscreen metadata and restored video sizing

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayerSecondaryControlsLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayerSecondaryControlsLayoutTest.kt
@@ -1,11 +1,13 @@
 package org.schabi.newpipe.player.ui
 
 import android.content.Context
+import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
+import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
@@ -16,6 +18,38 @@ import org.schabi.newpipe.R
 
 @RunWith(AndroidJUnit4::class)
 class PlayerSecondaryControlsLayoutTest {
+    @Test
+    fun metadataExpandsBeforeSecondaryControlsAtLargeTextSize() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val context = ContextThemeWrapper(instrumentation.targetContext, R.style.LightTheme)
+            val root = LayoutInflater.from(context)
+                .inflate(R.layout.player, FrameLayout(context), false)
+
+            val playbackControlRoot = root.findViewById<View>(R.id.playbackControlRoot)
+            val primaryControls = root.findViewById<View>(R.id.primaryControls)
+            val metadataControls = root.findViewById<View>(R.id.metadataControls)
+            val metadata = root.findViewById<View>(R.id.metadataView)
+            val secondaryControls = root.findViewById<View>(R.id.secondaryControls)
+            val title = root.findViewById<TextView>(R.id.titleTextView)
+            val channel = root.findViewById<TextView>(R.id.channelTextView)
+
+            playbackControlRoot.visibility = View.VISIBLE
+            metadata.visibility = View.VISIBLE
+            secondaryControls.visibility = View.VISIBLE
+            title.text = "A long fullscreen title that needs the complete metadata row"
+            channel.text = "A channel name that must remain fully visible"
+            title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 24f)
+            channel.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20f)
+
+            measureAndLayout(root, dp(context, 640), dp(context, 288))
+
+            assertTrue(channel.bottom <= metadata.height)
+            assertTrue(metadataControls.top + metadata.bottom <= primaryControls.height)
+            assertTrue(primaryControls.bottom <= secondaryControls.top)
+        }
+    }
+
     @Test
     fun captionControlStaysVisibleAtNarrowPhoneWidth() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/org/schabi/newpipe/views/ExpandableSurfaceViewTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/views/ExpandableSurfaceViewTest.kt
@@ -1,0 +1,38 @@
+package org.schabi.newpipe.views
+
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExpandableSurfaceViewTest {
+    @Test
+    fun clearingPreviousAspectRatioFillsTheNewVideoContainer() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val surface = ExpandableSurfaceView(instrumentation.targetContext, null)
+            surface.setHeights(180, 180)
+            surface.setAspectRatio(4f / 3f)
+
+            measure(surface, 320, 180)
+            assertEquals(240, surface.measuredWidth)
+
+            surface.clearAspectRatio()
+            measure(surface, 320, 180)
+
+            assertEquals(0f, surface.videoAspectRatio, 0f)
+            assertEquals(320, surface.measuredWidth)
+            assertEquals(180, surface.measuredHeight)
+        }
+    }
+
+    private fun measure(view: View, width: Int, height: Int) {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        )
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2244,6 +2244,7 @@ public final class Player implements PlaybackListener, Listener {
         // Refresh the playback if there is a transition to the next video
         final int newIndex = newPosition.mediaItemIndex;
         if (newIndex != oldPosition.mediaItemIndex) {
+            UIs.call(PlayerUi::onMediaItemTransition);
             cancelPendingMediaUrlRecovery();
             mediaUrlRecoveryGuard.reset();
         }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -371,7 +371,8 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         binding.metadataView.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
 
         // Reset workaround changes from popup player
-        binding.audioTrackTextView.setMaxWidth(Integer.MAX_VALUE);
+        binding.audioTrackTextView.setMaxWidth(context.getResources().getDimensionPixelSize(
+                R.dimen.player_audio_track_max_width));
         updateSleepTimerButton(player.getSleepTimerMode(),
                 player.getSleepTimerRemainingMillis());
     }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/PlayerUi.java
@@ -176,6 +176,9 @@ public abstract class PlayerUi {
     public void onBlocked() {
     }
 
+    public void onMediaItemTransition() {
+    }
+
     public void onPlaying() {
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -916,6 +916,8 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     public void onBlocked() {
         super.onBlocked();
 
+        binding.surfaceView.clearAspectRatio();
+
         // if we are e.g. switching players, hide controls
         hideControls(DEFAULT_CONTROLS_DURATION, 0);
 
@@ -929,6 +931,12 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
         updatePlayPauseButton(PlayButtonAction.PLAY);
         animatePlayButtons(false, 100);
         binding.getRoot().setKeepScreenOn(false);
+    }
+
+    @Override
+    public void onMediaItemTransition() {
+        super.onMediaItemTransition();
+        binding.surfaceView.clearAspectRatio();
     }
 
     @Override
@@ -1687,12 +1695,32 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @Override
     public void onVideoSizeChanged(@NonNull final VideoSize videoSize) {
         super.onVideoSizeChanged(videoSize);
-        // Starting with ExoPlayer 2.19.0, the VideoSize will report a width and height of 0
-        // if the renderer is disabled. In that case, we skip updating the aspect ratio.
-        if (videoSize.width == 0 || videoSize.height == 0) {
+        final float displayAspectRatio = calculateDisplayAspectRatio(
+                videoSize.width, videoSize.height, videoSize.unappliedRotationDegrees,
+                videoSize.pixelWidthHeightRatio);
+        if (displayAspectRatio == 0.0f) {
             return;
         }
-        binding.surfaceView.setAspectRatio(((float) videoSize.width) / videoSize.height);
+        binding.surfaceView.setAspectRatio(displayAspectRatio);
+    }
+
+    static float calculateDisplayAspectRatio(final int width,
+                                             final int height,
+                                             final int unappliedRotationDegrees,
+                                             final float pixelWidthHeightRatio) {
+        if (width <= 0 || height <= 0) {
+            return 0.0f;
+        }
+
+        final float safePixelRatio = Float.isFinite(pixelWidthHeightRatio)
+                && pixelWidthHeightRatio > 0.0f ? pixelWidthHeightRatio : 1.0f;
+        float displayAspectRatio = width * safePixelRatio / height;
+        final int normalizedRotation = Math.floorMod(unappliedRotationDegrees, 360);
+        if (normalizedRotation == 90 || normalizedRotation == 270) {
+            displayAspectRatio = 1.0f / displayAspectRatio;
+        }
+        return Float.isFinite(displayAspectRatio) && displayAspectRatio > 0.0f
+                ? displayAspectRatio : 0.0f;
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
@@ -153,6 +153,19 @@ public class ExpandableSurfaceView extends SurfaceView {
         return videoAspectRatio;
     }
 
+    /**
+     * Clears geometry left by the previous video while a new video size is not available yet.
+     * The surface temporarily fills its parent until {@link #setAspectRatio(float)} receives the
+     * new stream dimensions.
+     */
+    public void clearAspectRatio() {
+        videoAspectRatio = 0.0f;
+        scaleX = 1.0f;
+        scaleY = 1.0f;
+        resetUserTransform();
+        requestLayout();
+    }
+
     public void setAspectRatio(final float aspectRatio) {
         if (videoAspectRatio == aspectRatio || aspectRatio == 0 || !Float.isFinite(aspectRatio)) {
             return;

--- a/app/src/main/res/layout-large-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-large-land/fragment_video_detail.xml
@@ -56,7 +56,7 @@
                             android:layout_height="wrap_content"
                             android:background="?windowBackground"
                             android:contentDescription="@string/detail_thumbnail_view_description"
-                            android:scaleType="fitCenter"
+                            android:scaleType="centerCrop"
                             tools:ignore="RtlHardcoded"
                             tools:layout_height="200dp"
                             tools:src="@drawable/placeholder_thumbnail_video" />

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -46,7 +46,7 @@
                         android:background="?windowBackground"
                         android:contentDescription="@string/detail_thumbnail_view_description"
                         android:minHeight="200dp"
-                        android:scaleType="fitCenter"
+                        android:scaleType="centerCrop"
                         tools:ignore="RtlHardcoded"
                         tools:layout_height="200dp"
                         tools:src="@drawable/placeholder_thumbnail_video" />

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -128,14 +128,16 @@
                         tools:ignore="RtlHardcoded" />
 
                     <LinearLayout
+                        android:id="@+id/metadataControls"
                         android:layout_width="0dp"
-                        android:layout_height="match_parent"
+                        android:layout_height="wrap_content"
                         android:layout_weight="1"
+                        android:minHeight="48dp"
                         android:orientation="horizontal">
 
                         <LinearLayout
                             android:id="@+id/metadataView"
-                            android:layout_width="wrap_content"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="6dp"
                             android:layout_marginEnd="8dp"
@@ -175,9 +177,9 @@
                         </LinearLayout>
 
                         <FrameLayout
+                            android:id="@+id/audioTrackContainer"
                             android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1">
+                            android:layout_height="wrap_content">
 
                             <org.schabi.newpipe.views.NewPipeTextView
                                 android:id="@+id/audioTrackTextView"
@@ -188,6 +190,7 @@
                                 android:background="?attr/selectableItemBackground"
                                 android:ellipsize="end"
                                 android:gravity="center"
+                                android:maxWidth="@dimen/player_audio_track_max_width"
                                 android:minWidth="48dp"
                                 android:padding="@dimen/player_main_buttons_padding"
                                 android:singleLine="true"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -73,6 +73,7 @@
     <dimen name="player_main_buttons_padding">6dp</dimen>
     <dimen name="player_main_icon_buttons_padding">12dp</dimen>
     <dimen name="player_main_controls_text_size">14sp</dimen>
+    <dimen name="player_audio_track_max_width">160dp</dimen>
     <dimen name="player_seek_gesture_horizontal_padding">14dp</dimen>
     <dimen name="player_seek_gesture_vertical_padding">8dp</dimen>
     <dimen name="player_seek_gesture_text_size">16sp</dimen>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailThumbnailLayoutTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailThumbnailLayoutTest.java
@@ -1,0 +1,58 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class VideoDetailThumbnailLayoutTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void returnedVideoPreviewFillsThePlayerFrame() throws Exception {
+        assertThumbnailFillsFrame("layout/fragment_video_detail.xml");
+        assertThumbnailFillsFrame("layout-large-land/fragment_video_detail.xml");
+    }
+
+    private void assertThumbnailFillsFrame(final String layout) throws Exception {
+        final Element thumbnail = findById(parse(layout), "detail_thumbnail_image_view");
+        assertNotNull(layout, thumbnail);
+        assertEquals(layout, "centerCrop",
+                thumbnail.getAttributeNS(ANDROID_NAMESPACE, "scaleType"));
+    }
+
+    private Element findById(final Document document, final String id) {
+        final var elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            final String androidId = element.getAttributeNS(ANDROID_NAMESPACE, "id");
+            if (("@+id/" + id).equals(androidId) || ("@id/" + id).equals(androidId)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private Document parse(final String relativePath) throws Exception {
+        final var factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder()
+                .parse(resourcesDirectory.resolve(relativePath).toFile());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerControlAccessibilityResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerControlAccessibilityResourcesTest.java
@@ -88,6 +88,19 @@ public class PlayerControlAccessibilityResourcesTest {
     }
 
     @Test
+    public void fullscreenMetadataOwnsSpaceBeforeTheCappedAudioSelector() throws Exception {
+        final Document player = parse("layout/player.xml");
+        assertAttribute(player, "metadataView", "layout_width", "0dp");
+        assertAttribute(player, "metadataView", "layout_weight", "1");
+        assertAttribute(player, "metadataControls", "layout_height", "wrap_content");
+        assertAttribute(player, "metadataControls", "minHeight", "48dp");
+        assertAttribute(player, "audioTrackContainer", "layout_width", "wrap_content");
+        assertAttribute(player, "audioTrackContainer", "layout_weight", "");
+        assertAttribute(player, "audioTrackTextView", "maxWidth",
+                "@dimen/player_audio_track_max_width");
+    }
+
+    @Test
     public void seekGestureUsesCompactRoundedScrim() throws Exception {
         final Document player = parse("layout/player.xml");
         assertAttribute(player, "swipeSeekDisplay", "background",

--- a/app/src/test/java/org/schabi/newpipe/player/ui/VideoPlayerUiAspectRatioTransitionTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/ui/VideoPlayerUiAspectRatioTransitionTest.java
@@ -1,0 +1,79 @@
+package org.schabi.newpipe.player.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class VideoPlayerUiAspectRatioTransitionTest {
+    private final Path mainDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main") : Path.of("app/src/main");
+
+    @Test
+    public void playbackBlockClearsThePreviousVideoAspectRatio() throws Exception {
+        final String source = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/player/ui/VideoPlayerUi.java"));
+        final int blockedMethodStart = source.indexOf("public void onBlocked()");
+        final int playingMethodStart = source.indexOf(
+                "public void onPlaying()", blockedMethodStart);
+
+        assertTrue(blockedMethodStart >= 0);
+        assertTrue(playingMethodStart > blockedMethodStart);
+        assertTrue(source.substring(blockedMethodStart, playingMethodStart)
+                .contains("binding.surfaceView.clearAspectRatio()"));
+    }
+
+    @Test
+    public void cachedPreviousQueueItemAlsoClearsThePreviousVideoAspectRatio() throws Exception {
+        final String playerSource = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/player/Player.java"));
+        final String uiSource = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/player/ui/VideoPlayerUi.java"));
+
+        final int itemChangeStart = playerSource.indexOf(
+                "if (newIndex != oldPosition.mediaItemIndex)");
+        final int discontinuitySwitchStart = playerSource.indexOf(
+                "switch (discontinuityReason)", itemChangeStart);
+        assertTrue(itemChangeStart >= 0);
+        assertTrue(discontinuitySwitchStart > itemChangeStart);
+        assertTrue(playerSource.substring(itemChangeStart, discontinuitySwitchStart)
+                .contains("UIs.call(PlayerUi::onMediaItemTransition)"));
+        final int transitionMethodStart = uiSource.indexOf(
+                "public void onMediaItemTransition()");
+        final int playingMethodStart = uiSource.indexOf(
+                "public void onPlaying()", transitionMethodStart);
+        assertTrue(transitionMethodStart >= 0);
+        assertTrue(playingMethodStart > transitionMethodStart);
+        assertTrue(uiSource.substring(transitionMethodStart, playingMethodStart)
+                .contains("binding.surfaceView.clearAspectRatio()"));
+    }
+
+    @Test
+    public void anamorphicVideoUsesItsDisplayPixelRatio() {
+        assertEquals(16.0f / 9.0f,
+                VideoPlayerUi.calculateDisplayAspectRatio(1440, 1080, 0, 4.0f / 3.0f),
+                0.0001f);
+    }
+
+    @Test
+    public void unappliedQuarterTurnInvertsTheDisplayAspectRatio() {
+        assertEquals(9.0f / 16.0f,
+                VideoPlayerUi.calculateDisplayAspectRatio(1440, 1080, 90, 4.0f / 3.0f),
+                0.0001f);
+        assertEquals(9.0f / 16.0f,
+                VideoPlayerUi.calculateDisplayAspectRatio(1440, 1080, -90, 4.0f / 3.0f),
+                0.0001f);
+    }
+
+    @Test
+    public void invalidDimensionsAreIgnoredAndInvalidPixelRatioFallsBackToSquarePixels() {
+        assertEquals(0.0f,
+                VideoPlayerUi.calculateDisplayAspectRatio(0, 1080, 0, 1.0f), 0.0f);
+        assertEquals(16.0f / 9.0f,
+                VideoPlayerUi.calculateDisplayAspectRatio(1920, 1080, 0, Float.NaN),
+                0.0001f);
+    }
+}


### PR DESCRIPTION
- Give fullscreen video metadata the remaining horizontal space before optional controls.
- Let the title and channel row grow to its full two-line height before secondary controls.
- Cap long audio-track labels while preserving accessible 48dp touch targets.
- Clear outgoing surface geometry for blocked loads and every previous/next queue transition.
- Calculate display ratio from encoded size, pixel ratio, and unapplied rotation.
- Crop cached 4:3 return thumbnails into the 16:9 player frame instead of exposing side gaps.
- Add resource, large-text layout, cached-return, thumbnail-fill, anamorphic-video, and Android measurement regression tests for #283.