### PR TITLE
Serialize complete reproducible release builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,10 +60,16 @@ scripts/build.sh release -PreleaseAbi=x86_64
 The `releaseAbi` property accepts `arm` (the default) or `x86_64`. Published releases build
 both targets from the same tagged source and sign them with the same release key.
 
-The release build runs R8 in a dedicated JVM with one active processor. Other Gradle work keeps
-its normal parallelism. Build and configuration caches are disabled by the reproducible entry
-point, the locale and timezone are fixed, and `SOURCE_DATE_EPOCH` comes from the checked-out
-commit. A verified APK and its `SHA256SUMS` file are written to `dist/reproducible/`.
+The reproducible entry point runs the complete release pipeline with one visible processor and one
+Gradle worker. `JAVA_TOOL_OPTIONS` propagates the processor limit to Gradle, D8/L8, R8, and child
+JVMs, while the existing R8 execution profile provides an additional dedicated-process safeguard.
+Normal debug and test builds keep their parallelism. Build and configuration caches are disabled,
+the locale and timezone are fixed, and `SOURCE_DATE_EPOCH` comes from the checked-out commit. A
+verified APK and its `SHA256SUMS` file are written to `dist/reproducible/`.
+
+Independent rebuilders must use `scripts/reproducible-build.sh` rather than invoking
+`./gradlew assembleRelease` directly. The script validates the pinned toolchain and fails before
+assembly if the Gradle JVM does not observe exactly one active processor.
 
 Run Android instrumented tests:
 

--- a/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class ReproducibleBuildConfigurationTest {
+    private final Path repositoryRoot = Files.exists(Path.of("scripts/reproducible-build.sh"))
+            ? Path.of(".") : Path.of("..");
+
+    @Test
+    public void releaseScriptSerializesTheCompleteJavaAndGradlePipeline() throws Exception {
+        final String script = read("scripts/reproducible-build.sh");
+
+        assertTrue(script.contains("export JAVA_TOOL_OPTIONS="));
+        assertTrue(script.contains("-XX:ActiveProcessorCount=1"));
+        assertTrue(script.contains("--max-workers=1"));
+        assertTrue(script.contains("verifyReproducibleEnvironment"));
+    }
+
+    @Test
+    public void releaseBuildFailsWhenTheGradleJvmSeesMultipleProcessors() throws Exception {
+        final String buildScript = read("build.gradle.kts");
+
+        assertTrue(buildScript.contains("tasks.register(\"verifyReproducibleEnvironment\")"));
+        assertTrue(buildScript.contains("Runtime.getRuntime().availableProcessors()"));
+        assertTrue(buildScript.contains("check(activeProcessors == 1)"));
+    }
+
+    @Test
+    public void ciAndPublishingUseTheSharedReproducibleEntryPoint() throws Exception {
+        final String ciWorkflow = read(".github/workflows/ci.yml");
+        final String releaseWorkflow = read(".github/workflows/release.yml");
+
+        assertEquals(1, occurrences(ciWorkflow, "scripts/reproducible-build.sh"));
+        assertEquals(2, occurrences(releaseWorkflow, "scripts/reproducible-build.sh"));
+    }
+
+    @Test
+    public void downstreamInstructionsRequireTheSharedEntryPoint() throws Exception {
+        final String building = read("BUILDING.md");
+
+        assertTrue(building.contains("Independent rebuilders must use "
+                + "`scripts/reproducible-build.sh`"));
+        assertTrue(building.contains("rather than invoking\n`./gradlew assembleRelease` directly"));
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(repositoryRoot.resolve(relativePath));
+    }
+
+    private int occurrences(final String text, final String value) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(value, index)) >= 0) {
+            count++;
+            index += value.length();
+        }
+        return count;
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,3 +18,17 @@ plugins {
     alias(libs.plugins.jetbrains.kotlinx.serialization) apply false
     alias(libs.plugins.squareup.wire) apply false
 }
+
+tasks.register("verifyReproducibleEnvironment") {
+    group = "verification"
+    description = "Checks the JVM constraints required for reproducible release builds"
+
+    doLast {
+        val activeProcessors = Runtime.getRuntime().availableProcessors()
+        check(activeProcessors == 1) {
+            "Reproducible release builds require exactly one active processor, " +
+                "but the Gradle JVM detected $activeProcessors"
+        }
+        logger.lifecycle("Reproducible release JVM active processors: $activeProcessors")
+    }
+}

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -37,6 +37,8 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:+$JAVA_TOOL_OPTIONS }-XX:ActiveProcessorCount=1"
+
 "$ROOT_DIR/scripts/validate-reproducible-toolchain.sh"
 
 SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
@@ -54,9 +56,10 @@ build_once() {
 
     ./gradlew \
         --no-daemon \
+        --max-workers=1 \
         --no-build-cache \
         --no-configuration-cache \
-        clean assembleRelease \
+        clean verifyReproducibleEnvironment assembleRelease \
         --stacktrace \
         -DskipFormatKtlint \
         "${GRADLE_ARGS[@]}"


### PR DESCRIPTION
- Limit the complete release pipeline to one visible processor through inherited `JAVA_TOOL_OPTIONS`.
- Run release builds with one Gradle worker so D8/L8 and Android Gradle Plugin work are serialized alongside R8.
- Fail before assembly when the Gradle JVM detects more than one active processor.
- Keep normal debug and Android test builds parallel.
- Require downstream reproducible builders to use the shared release script.
- Add regression coverage for script constraints, workflow routing, environment checks, and documentation.
- Keep #243 open until an independently rebuilt release APK matches.