### PR TITLE
Support signed pre-release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ on:
           - release
           - all
   push:
+    branches:
+      - "release-pre-*"
     tags:
       - "v*.*.*"
 
@@ -95,7 +97,7 @@ jobs:
             exit 1
           fi
 
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_NAME" != "$RELEASE_TAG" ]; then
+          if [ "$GITHUB_REF_TYPE" = "tag" ] && [ "$GITHUB_REF_NAME" != "$RELEASE_TAG" ]; then
             echo "Tag mismatch: pushed tag is '$GITHUB_REF_NAME' but Gradle versionName is '$VERSION_NAME' and expects tag '$RELEASE_TAG'"
             exit 1
           fi
@@ -184,7 +186,7 @@ jobs:
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.event_name == 'push' && github.ref_name || steps.release_info.outputs.release_tag }}
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || steps.release_info.outputs.release_tag }}
           target_commitish: pipe
           name: WizeStream ${{ steps.release_info.outputs.version_name }}
           body_path: ${{ steps.release_info.outputs.changelog_path }}
@@ -192,4 +194,5 @@ jobs:
             ${{ steps.release_info.outputs.apk_path }}
             ${{ steps.x86_release_info.outputs.apk_path }}
           fail_on_unmatched_files: true
-          make_latest: true
+          prerelease: ${{ github.ref_type == 'branch' }}
+          make_latest: ${{ github.ref_type == 'tag' }}

--- a/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
@@ -46,6 +46,17 @@ public class ReproducibleBuildConfigurationTest {
     }
 
     @Test
+    public void preReleasePublishingUsesAnExplicitNonLatestBranchTrigger() throws Exception {
+        final String releaseWorkflow = read(".github/workflows/release.yml");
+
+        assertTrue(releaseWorkflow.contains("- \"release-pre-*\""));
+        assertTrue(releaseWorkflow.contains("if [ \"$GITHUB_REF_TYPE\" = \"tag\" ]"));
+        assertTrue(releaseWorkflow.contains("github.ref_type == 'tag' && github.ref_name"));
+        assertTrue(releaseWorkflow.contains("prerelease: ${{ github.ref_type == 'branch' }}"));
+        assertTrue(releaseWorkflow.contains("make_latest: ${{ github.ref_type == 'tag' }}"));
+    }
+
+    @Test
     public void downstreamInstructionsRequireTheSharedEntryPoint() throws Exception {
         final String building = read("BUILDING.md");
 


### PR DESCRIPTION
- Add an explicit `release-pre-*` branch trigger for signed pre-release builds.
- Create the semantic-version tag from the current `pipe` commit when publishing a pre-release.
- Keep stable tag pushes subject to strict tag/version matching.
- Mark branch-triggered releases as pre-release and non-latest.
- Preserve stable tags as latest releases.
- Add regression coverage for the release-mode selection rules.