### PR TITLE
Support PR-triggered pre-release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
           - artifacts
           - release
           - all
+  pull_request:
+    branches:
+      - pipe
+    types:
+      - opened
   push:
     branches:
       - "release-pre-*"
@@ -23,6 +28,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-pre-') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
 
@@ -178,12 +184,12 @@ jobs:
           path: ${{ steps.x86_release_info.outputs.apk_path }}
 
       - name: "Validate changelog"
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
         run: |
           test -s "${{ steps.release_info.outputs.changelog_path }}"
 
       - name: "Create release"
-        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || steps.release_info.outputs.release_tag }}

--- a/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
@@ -54,6 +54,10 @@ public class ReproducibleBuildConfigurationTest {
         assertTrue(releaseWorkflow.contains("github.ref_type == 'tag' && github.ref_name"));
         assertTrue(releaseWorkflow.contains("prerelease: ${{ github.ref_type == 'branch' }}"));
         assertTrue(releaseWorkflow.contains("make_latest: ${{ github.ref_type == 'tag' }}"));
+        assertTrue(releaseWorkflow.contains("github.event_name != 'pull_request' ||"));
+        assertTrue(releaseWorkflow.contains("startsWith(github.head_ref, 'release-pre-')"));
+        assertEquals(2, occurrences(releaseWorkflow,
+                "github.event_name == 'pull_request'"));
     }
 
     @Test


### PR DESCRIPTION
- Add a pull-request event path for environments where Git ref writes do not emit workflow runs.
- Restrict the release job to PRs whose head branch begins with `release-pre-`.
- Require release PRs to target `pipe` and run only when opened.
- Validate the changelog and publish signed assets through the existing release job.
- Preserve the semantic-version tag target as the merged `pipe` commit.
- Extend regression coverage for the guarded PR trigger.