### PR TITLE
Publish WizeStream 1.11.3 pre-release

### DIFF
--- a/.github/release-trigger-1.11.3
+++ b/.github/release-trigger-1.11.3
@@ -1,0 +1,1 @@
+v1.11.3 pre-release


### PR DESCRIPTION
- Trigger the guarded signed pre-release workflow for WizeStream `1.11.3` / `1011003`.
- Build ARM and x86_64 APKs twice under the serialized release environment and compare checksums.
- Create tag `v1.11.3` from the current merged `pipe` commit.
- Attach both signed APKs and mark the GitHub release as pre-release and non-latest.
- Keep issue #243 open for Izzy’s independent reproducibility result.