### PR TITLE
Fix Android 6 feed filtering errors

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractor.java
@@ -638,7 +638,7 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
         }
 
         final boolean hasViewLabel = hasViewCountLabel(lowercaseText);
-        final boolean hasDigit = text.codePoints().anyMatch(Character::isDigit);
+        final boolean hasDigit = containsDigit(text);
         if (!hasViewLabel || !hasDigit) {
             return null;
         }
@@ -648,6 +648,17 @@ public class YoutubeStreamInfoItemExtractor implements StreamInfoItemExtractor {
         } catch (final Exception ignored) {
             return null;
         }
+    }
+
+    static boolean containsDigit(final String text) {
+        for (int index = 0; index < text.length();) {
+            final int codePoint = Character.codePointAt(text, index);
+            if (Character.isDigit(codePoint)) {
+                return true;
+            }
+            index += Character.charCount(codePoint);
+        }
+        return false;
     }
 
     private static boolean hasViewCountLabel(final String text) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -361,32 +361,35 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     // //////////////////////////////////////////////////////////////////////////
 
     override fun showLoading() {
+        val binding = _feedBinding ?: return
         super.showLoading()
-        feedBinding.itemsList.animate(true, 0)
-        feedBinding.refreshRootView.animate(false, 0)
-        feedBinding.streamFilterChips.root.animate(false, 0)
-        showRefreshOverlay()
-        feedBinding.swipeRefreshLayout.isRefreshing = true
+        binding.itemsList.animate(true, 0)
+        binding.refreshRootView.animate(false, 0)
+        binding.streamFilterChips.root.animate(false, 0)
+        showRefreshOverlay(binding)
+        binding.swipeRefreshLayout.isRefreshing = true
         isRefreshing = true
     }
 
     override fun hideLoading() {
+        val binding = _feedBinding ?: return
         super.hideLoading()
-        feedBinding.itemsList.animate(true, 0)
-        feedBinding.refreshRootView.animate(true, 200)
-        feedBinding.streamFilterChips.root.animate(true, 200)
-        hideRefreshOverlay()
-        feedBinding.swipeRefreshLayout.isRefreshing = false
+        binding.itemsList.animate(true, 0)
+        binding.refreshRootView.animate(true, 200)
+        binding.streamFilterChips.root.animate(true, 200)
+        hideRefreshOverlay(binding)
+        binding.swipeRefreshLayout.isRefreshing = false
         isRefreshing = false
     }
 
     override fun showEmptyState() {
+        val binding = _feedBinding ?: return
         super.showEmptyState()
-        feedBinding.itemsList.animateHideRecyclerViewAllowingScrolling()
-        feedBinding.refreshRootView.animate(true, 200)
-        feedBinding.streamFilterChips.root.animate(true, 200)
-        hideRefreshOverlay()
-        feedBinding.swipeRefreshLayout.isRefreshing = false
+        binding.itemsList.animateHideRecyclerViewAllowingScrolling()
+        binding.refreshRootView.animate(true, 200)
+        binding.streamFilterChips.root.animate(true, 200)
+        hideRefreshOverlay(binding)
+        binding.swipeRefreshLayout.isRefreshing = false
         isRefreshing = false
     }
 
@@ -401,12 +404,13 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     }
 
     override fun handleError() {
+        val binding = _feedBinding ?: return
         super.handleError()
-        feedBinding.itemsList.animateHideRecyclerViewAllowingScrolling()
-        feedBinding.refreshRootView.animate(false, 0)
-        feedBinding.streamFilterChips.root.animate(true, 200)
-        hideRefreshOverlay()
-        feedBinding.swipeRefreshLayout.isRefreshing = false
+        binding.itemsList.animateHideRecyclerViewAllowingScrolling()
+        binding.refreshRootView.animate(false, 0)
+        binding.streamFilterChips.root.animate(true, 200)
+        hideRefreshOverlay(binding)
+        binding.swipeRefreshLayout.isRefreshing = false
         isRefreshing = false
     }
 
@@ -436,16 +440,16 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         }
     }
 
-    private fun showRefreshOverlay() {
-        if (!feedBinding.refreshLoadingOverlay.isVisible) {
-            feedBinding.refreshLoadingOverlay.animate(true, 200)
+    private fun showRefreshOverlay(binding: FragmentFeedBinding) {
+        if (!binding.refreshLoadingOverlay.isVisible) {
+            binding.refreshLoadingOverlay.animate(true, 200)
         }
-        feedBinding.cancelRefreshButton.isEnabled = true
+        binding.cancelRefreshButton.isEnabled = true
     }
 
-    private fun hideRefreshOverlay() {
-        feedBinding.cancelRefreshButton.isEnabled = false
-        feedBinding.refreshLoadingOverlay.animate(false, 200)
+    private fun hideRefreshOverlay(binding: FragmentFeedBinding) {
+        binding.cancelRefreshButton.isEnabled = false
+        binding.refreshLoadingOverlay.animate(false, 200)
     }
 
     private fun showInfoItemDialog(item: StreamInfoItem) {

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamInfoItemExtractorTest.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
@@ -27,6 +29,13 @@ public class YoutubeStreamInfoItemExtractorTest {
         );
 
         assertEquals(1_200L, new YoutubeStreamInfoItemExtractor(videoInfo, null).getViewCount());
+    }
+
+    @Test
+    public void digitDetectionDoesNotRequireJavaStreamApis() {
+        assertTrue(YoutubeStreamInfoItemExtractor.containsDigit("1.2K views"));
+        assertTrue(YoutubeStreamInfoItemExtractor.containsDigit("١٢٣ مشاهدة"));
+        assertFalse(YoutubeStreamInfoItemExtractor.containsDigit("no views"));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedFragmentLifecycleTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedFragmentLifecycleTest.kt
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.local.feed
+
+import org.junit.Test
+
+class FeedFragmentLifecycleTest {
+    @Test
+    fun `state rendering before view creation is ignored`() {
+        val fragment = FeedFragment()
+
+        fragment.showLoading()
+        fragment.hideLoading()
+        fragment.showEmptyState()
+        fragment.handleError()
+    }
+}


### PR DESCRIPTION
- Guard feed loading-state rendering when the fragment view binding is unavailable
- Snapshot the binding for each loading-state transition to avoid lifecycle-time null dereferences
- Replace `String.codePoints()` with API 23-compatible Unicode code-point iteration
- Add regression coverage for pre-view feed state rendering and Unicode digit detection