### PR TITLE
Add tablet navigation position settings

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/util/EdgeToEdgeHelperTest.java
@@ -26,6 +26,7 @@ public class EdgeToEdgeHelperTest {
         final View content = new FrameLayout(context);
         final View toolbar = new FrameLayout(context);
         final View navigation = new FrameLayout(context);
+        final View navigationRail = new FrameLayout(context);
         final View navigationScrim = new FrameLayout(context);
         final View player = new FrameLayout(context);
         final View drawer = new FrameLayout(context);
@@ -33,13 +34,15 @@ public class EdgeToEdgeHelperTest {
         content.setPadding(1, 2, 3, 4);
         toolbar.setPadding(13, 14, 15, 16);
         navigation.setLayoutParams(new FrameLayout.LayoutParams(100, 100));
+        navigationRail.setLayoutParams(new FrameLayout.LayoutParams(100, 100));
         navigationScrim.setLayoutParams(new FrameLayout.LayoutParams(100, 5));
         player.setPadding(17, 18, 19, 20);
         drawer.setPadding(5, 6, 7, 8);
         header.setPadding(9, 10, 11, 12);
 
         EdgeToEdgeHelper.applyMainActivitySystemBarInsets(
-                source, content, toolbar, navigation, navigationScrim, player, drawer, header);
+                source, content, toolbar, navigation, navigationRail,
+                navigationScrim, player, drawer, header);
         final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
                 source,
                 new WindowInsetsCompat.Builder()
@@ -50,6 +53,7 @@ public class EdgeToEdgeHelperTest {
         assertPadding(content, 3, 32, 6, 52);
         assertPadding(toolbar, 15, 44, 18, 16);
         assertMargins(navigation, 2, 30, 3, 48);
+        assertMargins(navigationRail, 2, 30, 3, 48);
         assertHeight(navigationScrim, 53);
         assertPadding(player, 17, 18, 19, 20);
         assertPadding(drawer, 7, 6, 10, 56);
@@ -61,6 +65,7 @@ public class EdgeToEdgeHelperTest {
         assertPadding(content, 1, 2, 3, 4);
         assertPadding(toolbar, 13, 14, 15, 16);
         assertMargins(navigation, 0, 0, 0, 0);
+        assertMargins(navigationRail, 0, 0, 0, 0);
         assertHeight(navigationScrim, 5);
         assertPadding(player, 17, 18, 19, 20);
         assertPadding(drawer, 5, 6, 7, 8);
@@ -75,15 +80,18 @@ public class EdgeToEdgeHelperTest {
         final View content = new FrameLayout(context);
         final View toolbar = new FrameLayout(context);
         final View navigation = new FrameLayout(context);
+        final View navigationRail = new FrameLayout(context);
         final View navigationScrim = new FrameLayout(context);
         final View player = new FrameLayout(context);
         final View drawer = new FrameLayout(context);
         final View header = new FrameLayout(context);
         navigation.setLayoutParams(new FrameLayout.LayoutParams(100, 100));
+        navigationRail.setLayoutParams(new FrameLayout.LayoutParams(100, 100));
         navigationScrim.setLayoutParams(new FrameLayout.LayoutParams(100, 0));
 
         EdgeToEdgeHelper.applyMainActivitySystemBarInsets(
-                source, content, toolbar, navigation, navigationScrim, player, drawer, header);
+                source, content, toolbar, navigation, navigationRail,
+                navigationScrim, player, drawer, header);
         final WindowInsetsCompat result = ViewCompat.dispatchApplyWindowInsets(
                 source,
                 new WindowInsetsCompat.Builder()
@@ -96,6 +104,7 @@ public class EdgeToEdgeHelperTest {
         assertPadding(content, 2, 30, 3, 20);
         assertPadding(toolbar, 2, 30, 3, 0);
         assertMargins(navigation, 2, 30, 3, 20);
+        assertMargins(navigationRail, 2, 30, 3, 20);
         assertHeight(navigationScrim, 20);
         assertPadding(player, 0, 0, 0, 0);
         assertPadding(drawer, 2, 0, 3, 20);

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -197,6 +197,7 @@ public class MainActivity extends AppCompatActivity {
                 mainBinding.mainSafeContent,
                 mainBinding.toolbarLayout.getRoot(),
                 mainBinding.mainBottomNavigation,
+                mainBinding.mainNavigationRail,
                 mainBinding.mainBottomSystemBarScrim,
                 mainBinding.fragmentPlayerHolder,
                 drawerLayoutBinding.navigation,

--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -9,6 +9,7 @@ import static com.google.android.material.tabs.TabLayout.INDICATOR_GRAVITY_TOP;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -36,6 +37,7 @@ import androidx.preference.PreferenceManager;
 import androidx.viewpager.widget.ViewPager;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationBarView;
 import com.google.android.material.navigationrail.NavigationRailView;
 import com.google.android.material.tabs.TabLayout;
@@ -54,7 +56,9 @@ import org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior;
 import org.schabi.newpipe.settings.tabs.HomeNavigationMode;
 import org.schabi.newpipe.settings.tabs.HomeNavigationModeResolver;
 import org.schabi.newpipe.settings.tabs.Tab;
+import org.schabi.newpipe.settings.tabs.TabletNavigationPositionResolver;
 import org.schabi.newpipe.settings.tabs.TabsManager;
+import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.KeyboardUtil;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.ServiceHelper;
@@ -75,6 +79,8 @@ public class MainFragment extends BaseFragment
 
     private FragmentMainBinding binding;
     private NavigationBarView bottomNavigation;
+    private BottomNavigationView bottomNavigationView;
+    private NavigationRailView navigationRailView;
     private SelectedTabsPagerAdapter pagerAdapter;
 
     private View contextualSearchContainer;
@@ -100,6 +106,7 @@ public class MainFragment extends BaseFragment
     private String mainTabsPositionKey;
     private String bottomNavigationLabelsKey;
     private String bottomNavigationLabelsValue;
+    private boolean tabletNavigation;
 
     /*//////////////////////////////////////////////////////////////////////////
     // Fragment's LifeCycle
@@ -151,7 +158,9 @@ public class MainFragment extends BaseFragment
         super.initViews(rootView, savedInstanceState);
 
         binding = FragmentMainBinding.bind(rootView);
-        bottomNavigation = requireActivity().findViewById(R.id.main_bottom_navigation);
+        bottomNavigationView = requireActivity().findViewById(R.id.main_bottom_navigation);
+        navigationRailView = requireActivity().findViewById(R.id.main_navigation_rail);
+        selectMainNavigation();
         updateBottomNavigationLabelVisibility();
 
         binding.mainTabLayout.setupWithViewPager(binding.pager);
@@ -168,24 +177,6 @@ public class MainFragment extends BaseFragment
                 requireActivity().invalidateOptionsMenu();
             }
         });
-        bottomNavigation.setOnItemSelectedListener(item -> {
-            final int position = getBottomNavigationItemPosition(item.getItemId());
-            if (position < 0 || position >= tabsList.size()) {
-                return false;
-            }
-            if (binding.pager.getCurrentItem() != position) {
-                binding.pager.setCurrentItem(position);
-            }
-            updateTitleForTab(position);
-            return true;
-        });
-        bottomNavigation.setOnItemReselectedListener(item -> {
-            final int position = getBottomNavigationItemPosition(item.getItemId());
-            if (position >= 0 && position < tabsList.size()) {
-                updateTitleForTab(position);
-            }
-        });
-
         setupTabs();
         initContextualSearchToolbar();
         if (contextualSearchOpen) {
@@ -196,6 +187,8 @@ public class MainFragment extends BaseFragment
     @Override
     public void onResume() {
         super.onResume();
+
+        final boolean navigationChanged = selectMainNavigation();
 
         final boolean newYoutubeRestrictedModeEnabled =
                 prefs.getBoolean(youtubeRestrictedModeEnabledKey, false);
@@ -212,6 +205,9 @@ public class MainFragment extends BaseFragment
         if (!bottomNavigationLabelsValue.equals(newBottomNavigationLabelsValue)) {
             bottomNavigationLabelsValue = newBottomNavigationLabelsValue;
             updateBottomNavigationLabelVisibility();
+        }
+        if (navigationChanged) {
+            updateBottomNavigationItems();
         }
         updateMainNavigationMode();
         scheduleBottomNavigationRemeasure();
@@ -259,15 +255,11 @@ public class MainFragment extends BaseFragment
         contextualSearchClose = null;
         contextualSearchTextWatcher = null;
         contextualSearchTarget = null;
-        if (bottomNavigation != null) {
-            bottomNavigation.setOnItemSelectedListener(null);
-            bottomNavigation.setOnItemReselectedListener(null);
-            bottomNavigation.getMenu().clear();
-            bottomNavigation.setTag(Boolean.FALSE);
-            bottomNavigation.setAlpha(1.0f);
-            bottomNavigation.setVisibility(View.GONE);
-            bottomNavigation = null;
-        }
+        clearMainNavigation(bottomNavigationView);
+        clearMainNavigation(navigationRailView);
+        bottomNavigation = null;
+        bottomNavigationView = null;
+        navigationRailView = null;
         super.onDestroyView();
         binding = null;
     }
@@ -369,6 +361,74 @@ public class MainFragment extends BaseFragment
     private int getSafeTabIconRes(final Tab tab) {
         final int iconRes = tab.getTabIconRes(requireContext());
         return iconRes > 0 ? iconRes : R.drawable.ic_asterisk;
+    }
+
+    private boolean selectMainNavigation() {
+        if (bottomNavigationView == null || navigationRailView == null) {
+            return false;
+        }
+
+        final int orientation = getResources().getConfiguration().orientation;
+        final int positionKey = orientation == Configuration.ORIENTATION_LANDSCAPE
+                ? R.string.tablet_navigation_landscape_position_key
+                : R.string.tablet_navigation_portrait_position_key;
+        final String defaultPosition = getString(
+                R.string.tablet_navigation_position_default_value);
+        final String position = prefs.getString(getString(positionKey), defaultPosition);
+        tabletNavigation = DeviceUtils.isTablet(requireContext());
+        final boolean useNavigationRail = TabletNavigationPositionResolver.useNavigationRail(
+                tabletNavigation, orientation, position);
+        final NavigationBarView selectedNavigation = useNavigationRail
+                ? navigationRailView : bottomNavigationView;
+        if (bottomNavigation == selectedNavigation) {
+            return false;
+        }
+
+        if (bottomNavigation != null) {
+            setNavigationRailContentInset(false);
+            clearMainNavigation(bottomNavigation);
+        }
+        bottomNavigation = selectedNavigation;
+        setBottomNavigationListeners();
+        updateBottomNavigationLabelVisibility();
+        return true;
+    }
+
+    private void setBottomNavigationListeners() {
+        if (bottomNavigation == null) {
+            return;
+        }
+        bottomNavigation.setOnItemSelectedListener(item -> {
+            final int position = getBottomNavigationItemPosition(item.getItemId());
+            if (position < 0 || position >= tabsList.size()) {
+                return false;
+            }
+            if (binding.pager.getCurrentItem() != position) {
+                binding.pager.setCurrentItem(position);
+            }
+            updateTitleForTab(position);
+            return true;
+        });
+        bottomNavigation.setOnItemReselectedListener(item -> {
+            final int position = getBottomNavigationItemPosition(item.getItemId());
+            if (position >= 0 && position < tabsList.size()) {
+                updateTitleForTab(position);
+            }
+        });
+    }
+
+    private static void clearMainNavigation(@Nullable final NavigationBarView navigation) {
+        if (navigation == null) {
+            return;
+        }
+        navigation.setOnItemSelectedListener(null);
+        navigation.setOnItemReselectedListener(null);
+        navigation.getMenu().clear();
+        navigation.setTag(Boolean.FALSE);
+        navigation.setAlpha(1.0f);
+        navigation.setTranslationX(0.0f);
+        navigation.setTranslationY(0.0f);
+        navigation.setVisibility(View.GONE);
     }
 
     private void updateTitleForTab(final int tabPosition) {
@@ -704,7 +764,7 @@ public class MainFragment extends BaseFragment
         final boolean navigationRail = isNavigationRail();
         final HomeNavigationMode navigationMode = HomeNavigationModeResolver
                 .resolveNavigationMode(tabsList.size(), bottom);
-        final boolean showBottomNavigation = navigationRail
+        final boolean showBottomNavigation = tabletNavigation
                 ? tabsList.size() <= getNavigationItemLimit()
                 : navigationMode == HomeNavigationMode.BOTTOM_NAVIGATION;
         final boolean showTabLayout = !showBottomNavigation

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
@@ -146,9 +146,8 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
     private void updateBottomNavigation(@NonNull final FrameLayout bottomSheet,
                                         final int state,
                                         @Nullable final Float slideOffset) {
-        final View bottomNavigation = bottomSheet.getRootView()
-                .findViewById(R.id.main_bottom_navigation);
-        if (bottomNavigation == null || !Boolean.TRUE.equals(bottomNavigation.getTag())) {
+        final View bottomNavigation = findRequestedNavigation(bottomSheet);
+        if (bottomNavigation == null) {
             applyPlayerPeekHeight(bottomSheet, false);
             return;
         }
@@ -168,8 +167,7 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
 
     private void applyPlayerPeekHeight(@NonNull final FrameLayout bottomSheet,
                                        final boolean bottomNavigationVisible) {
-        final View bottomNavigation = bottomSheet.getRootView()
-                .findViewById(R.id.main_bottom_navigation);
+        final View bottomNavigation = findRequestedNavigation(bottomSheet);
         final int navigationHeight = bottomNavigation == null
                 ? bottomSheet.getResources()
                 .getDimensionPixelSize(R.dimen.main_bottom_navigation_height)
@@ -228,8 +226,18 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
     }
 
     private static boolean isBottomNavigationRequested(@NonNull final View bottomSheet) {
-        final View bottomNavigation = bottomSheet.getRootView()
-                .findViewById(R.id.main_bottom_navigation);
-        return bottomNavigation != null && Boolean.TRUE.equals(bottomNavigation.getTag());
+        return findRequestedNavigation(bottomSheet) != null;
+    }
+
+    @Nullable
+    private static View findRequestedNavigation(@NonNull final View bottomSheet) {
+        final View root = bottomSheet.getRootView();
+        final View navigationRail = root.findViewById(R.id.main_navigation_rail);
+        if (navigationRail != null && Boolean.TRUE.equals(navigationRail.getTag())) {
+            return navigationRail;
+        }
+        final View bottomNavigation = root.findViewById(R.id.main_bottom_navigation);
+        return bottomNavigation != null && Boolean.TRUE.equals(bottomNavigation.getTag())
+                ? bottomNavigation : null;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
@@ -15,6 +15,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ThemeHelper;
 
 public class AppearanceSettingsFragment extends BasePreferenceFragment {
@@ -64,6 +65,19 @@ public class AppearanceSettingsFragment extends BasePreferenceFragment {
             applyThemeColorChange(startThemeColorKey, themeColorKey, preference, newValue);
             return false;
         });
+
+        final boolean showTabletNavigationPreferences = DeviceUtils.isTablet(requireContext());
+        setPreferenceVisible(R.string.tablet_navigation_portrait_position_key,
+                showTabletNavigationPreferences);
+        setPreferenceVisible(R.string.tablet_navigation_landscape_position_key,
+                showTabletNavigationPreferences);
+    }
+
+    private void setPreferenceVisible(final int key, final boolean visible) {
+        final Preference preference = findPreference(getString(key));
+        if (preference != null) {
+            preference.setVisible(visible);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/settings/tabs/TabletNavigationPositionResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/tabs/TabletNavigationPositionResolver.java
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.settings.tabs;
+
+import android.content.res.Configuration;
+
+import androidx.annotation.Nullable;
+
+/** Resolves the adaptive navigation component used on the main tablet screen. */
+public final class TabletNavigationPositionResolver {
+    public static final String AUTOMATIC = "automatic";
+    public static final String BOTTOM = "bottom";
+    public static final String LEFT = "left";
+
+    private TabletNavigationPositionResolver() { }
+
+    public static boolean useNavigationRail(final boolean tablet,
+                                            final int orientation,
+                                            @Nullable final String position) {
+        if (!tablet || BOTTOM.equals(position)) {
+            return false;
+        }
+        if (LEFT.equals(position)) {
+            return true;
+        }
+        return orientation == Configuration.ORIENTATION_LANDSCAPE;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/EdgeToEdgeHelper.java
@@ -63,7 +63,8 @@ public final class EdgeToEdgeHelper {
      * @param insetSource view that receives the window inset dispatch
      * @param safeContent regular fragment content constrained inside all safe edges
      * @param toolbar toolbar protected below the status bar and display cutouts
-     * @param navigation bottom navigation or navigation rail protected inside all safe edges
+     * @param bottomNavigation bottom navigation protected inside all safe edges
+     * @param navigationRail navigation rail protected inside all safe edges
      * @param navigationScrim opaque surface drawn behind the bottom system navigation bar
      * @param playerSheet edge-to-edge player sheet; only its collapsed peek height avoids the
      *                    bottom system bar
@@ -74,7 +75,8 @@ public final class EdgeToEdgeHelper {
             @NonNull final View insetSource,
             @NonNull final View safeContent,
             @NonNull final View toolbar,
-            @NonNull final View navigation,
+            @NonNull final View bottomNavigation,
+            @NonNull final View navigationRail,
             @NonNull final View navigationScrim,
             @NonNull final View playerSheet,
             @NonNull final View drawer,
@@ -87,12 +89,18 @@ public final class EdgeToEdgeHelper {
         final int toolbarTop = toolbar.getPaddingTop();
         final int toolbarRight = toolbar.getPaddingRight();
         final int toolbarBottom = toolbar.getPaddingBottom();
-        final ViewGroup.MarginLayoutParams navigationParams =
-                (ViewGroup.MarginLayoutParams) navigation.getLayoutParams();
-        final int navigationLeft = navigationParams.leftMargin;
-        final int navigationTop = navigationParams.topMargin;
-        final int navigationRight = navigationParams.rightMargin;
-        final int navigationBottom = navigationParams.bottomMargin;
+        final ViewGroup.MarginLayoutParams bottomNavigationParams =
+                (ViewGroup.MarginLayoutParams) bottomNavigation.getLayoutParams();
+        final int bottomNavigationLeft = bottomNavigationParams.leftMargin;
+        final int bottomNavigationTop = bottomNavigationParams.topMargin;
+        final int bottomNavigationRight = bottomNavigationParams.rightMargin;
+        final int bottomNavigationBottom = bottomNavigationParams.bottomMargin;
+        final ViewGroup.MarginLayoutParams navigationRailParams =
+                (ViewGroup.MarginLayoutParams) navigationRail.getLayoutParams();
+        final int navigationRailLeft = navigationRailParams.leftMargin;
+        final int navigationRailTop = navigationRailParams.topMargin;
+        final int navigationRailRight = navigationRailParams.rightMargin;
+        final int navigationRailBottom = navigationRailParams.bottomMargin;
         final int navigationScrimHeight = navigationScrim.getLayoutParams().height;
         final int playerLeft = playerSheet.getPaddingLeft();
         final int playerTop = playerSheet.getPaddingTop();
@@ -119,14 +127,12 @@ public final class EdgeToEdgeHelper {
                     toolbarTop + safeInsets.top,
                     toolbarRight + safeInsets.right,
                     toolbarBottom);
-            final ViewGroup.MarginLayoutParams updatedNavigationParams =
-                    (ViewGroup.MarginLayoutParams) navigation.getLayoutParams();
-            updatedNavigationParams.setMargins(
-                    navigationLeft + safeInsets.left,
-                    navigationTop + safeInsets.top,
-                    navigationRight + safeInsets.right,
-                    navigationBottom + safeInsets.bottom);
-            navigation.setLayoutParams(updatedNavigationParams);
+            applyNavigationMargins(bottomNavigation,
+                    bottomNavigationLeft, bottomNavigationTop,
+                    bottomNavigationRight, bottomNavigationBottom, safeInsets);
+            applyNavigationMargins(navigationRail,
+                    navigationRailLeft, navigationRailTop,
+                    navigationRailRight, navigationRailBottom, safeInsets);
             final ViewGroup.LayoutParams updatedScrimParams =
                     navigationScrim.getLayoutParams();
             updatedScrimParams.height = navigationScrimHeight + safeInsets.bottom;
@@ -151,6 +157,22 @@ public final class EdgeToEdgeHelper {
             return consumeAppliedInsets(windowInsets);
         });
         ViewCompat.requestApplyInsets(insetSource);
+    }
+
+    private static void applyNavigationMargins(@NonNull final View navigation,
+                                               final int initialLeft,
+                                               final int initialTop,
+                                               final int initialRight,
+                                               final int initialBottom,
+                                               @NonNull final Insets safeInsets) {
+        final ViewGroup.MarginLayoutParams params =
+                (ViewGroup.MarginLayoutParams) navigation.getLayoutParams();
+        params.setMargins(
+                initialLeft + safeInsets.left,
+                initialTop + safeInsets.top,
+                initialRight + safeInsets.right,
+                initialBottom + safeInsets.bottom);
+        navigation.setLayoutParams(params);
     }
 
     private static void updatePlayerSheetBottomInset(@NonNull final View playerSheet,

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -18,22 +18,19 @@
                 android:id="@+id/fragment_holder"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/main_navigation_rail_width"
                 android:layout_marginTop="?attr/actionBarSize" />
 
         </FrameLayout>
 
         <include
             android:id="@+id/toolbar_layout"
-            layout="@layout/toolbar_layout"
-            android:layout_marginStart="@dimen/main_navigation_rail_width" />
+            layout="@layout/toolbar_layout" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_player_holder"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center_horizontal"
-            android:layout_marginStart="@dimen/main_navigation_rail_width"
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
             app:layout_behavior="org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior" />
@@ -46,8 +43,24 @@
             android:background="?attr/colorSurfaceContainer"
             android:importantForAccessibility="no" />
 
-        <com.google.android.material.navigationrail.NavigationRailView
+        <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/main_bottom_navigation"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/main_bottom_navigation_height"
+            android:layout_gravity="bottom"
+            android:background="?attr/colorSurfaceContainer"
+            android:elevation="0dp"
+            android:visibility="gone"
+            app:itemActiveIndicatorStyle="@style/wizestreamBottomNavigationActiveIndicator"
+            app:itemIconTint="@color/tab_layout_material_item_color"
+            app:itemPaddingBottom="@dimen/main_bottom_navigation_item_padding_bottom"
+            app:itemPaddingTop="@dimen/main_bottom_navigation_item_padding_top"
+            app:itemRippleColor="?attr/colorControlHighlight"
+            app:itemTextColor="@color/tab_layout_material_item_color"
+            app:labelVisibilityMode="labeled" />
+
+        <com.google.android.material.navigationrail.NavigationRailView
+            android:id="@+id/main_navigation_rail"
             android:layout_width="@dimen/main_navigation_rail_width"
             android:layout_height="match_parent"
             android:layout_gravity="start"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -59,6 +59,22 @@
             app:itemTextColor="@color/tab_layout_material_item_color"
             app:labelVisibilityMode="labeled" />
 
+        <com.google.android.material.navigationrail.NavigationRailView
+            android:id="@+id/main_navigation_rail"
+            android:layout_width="@dimen/main_navigation_rail_width"
+            android:layout_height="match_parent"
+            android:layout_gravity="start"
+            android:background="?attr/colorSurfaceContainer"
+            android:elevation="0dp"
+            android:paddingVertical="8dp"
+            android:visibility="gone"
+            app:itemActiveIndicatorStyle="@style/wizestreamBottomNavigationActiveIndicator"
+            app:itemIconTint="@color/tab_layout_material_item_color"
+            app:itemRippleColor="?attr/colorControlHighlight"
+            app:itemTextColor="@color/tab_layout_material_item_color"
+            app:labelVisibilityMode="labeled"
+            app:menuGravity="center" />
+
         <org.schabi.newpipe.views.ThemedSplashOverlay
             android:id="@+id/themed_splash_overlay"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -350,6 +350,25 @@
 
     <!-- Main-Tabs Position -->
     <string name="main_tabs_position_key">main_tabs_position</string>
+    <string name="tablet_navigation_portrait_position_key">tablet_navigation_portrait_position</string>
+    <string name="tablet_navigation_landscape_position_key">tablet_navigation_landscape_position</string>
+    <string name="tablet_navigation_position_automatic_value">automatic</string>
+    <string name="tablet_navigation_position_bottom_value">bottom</string>
+    <string name="tablet_navigation_position_left_value">left</string>
+    <string name="tablet_navigation_position_default_value">@string/tablet_navigation_position_automatic_value</string>
+
+    <string-array name="tablet_navigation_position_description">
+        <item>@string/tablet_navigation_position_automatic</item>
+        <item>@string/tablet_navigation_position_bottom</item>
+        <item>@string/tablet_navigation_position_left</item>
+    </string-array>
+
+    <string-array name="tablet_navigation_position_values">
+        <item>@string/tablet_navigation_position_automatic_value</item>
+        <item>@string/tablet_navigation_position_bottom_value</item>
+        <item>@string/tablet_navigation_position_left_value</item>
+    </string-array>
+
     <string name="bottom_navigation_labels_key">bottom_navigation_labels</string>
     <string name="bottom_navigation_labels_always_value">always</string>
     <string name="bottom_navigation_labels_active_value">active</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -521,6 +521,11 @@
     <string name="fast_mode">Fast mode</string>
     <string name="main_tabs_position_summary">Move main tab selector to the bottom</string>
     <string name="main_tabs_position_title">Main tabs position</string>
+    <string name="tablet_navigation_portrait_position_title">Tablet navigation in portrait</string>
+    <string name="tablet_navigation_landscape_position_title">Tablet navigation in landscape</string>
+    <string name="tablet_navigation_position_automatic">Automatic</string>
+    <string name="tablet_navigation_position_bottom">Bottom</string>
+    <string name="tablet_navigation_position_left">Left</string>
     <string name="bottom_navigation_labels_title">Bottom navigation labels</string>
     <string name="bottom_navigation_labels_always">Always visible</string>
     <string name="bottom_navigation_labels_active">Active only</string>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -86,6 +86,26 @@
         app:iconSpaceReserved="false" />
 
     <ListPreference
+        android:defaultValue="@string/tablet_navigation_position_default_value"
+        android:entries="@array/tablet_navigation_position_description"
+        android:entryValues="@array/tablet_navigation_position_values"
+        android:key="@string/tablet_navigation_portrait_position_key"
+        android:title="@string/tablet_navigation_portrait_position_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="true" />
+
+    <ListPreference
+        android:defaultValue="@string/tablet_navigation_position_default_value"
+        android:entries="@array/tablet_navigation_position_description"
+        android:entryValues="@array/tablet_navigation_position_values"
+        android:key="@string/tablet_navigation_landscape_position_key"
+        android:title="@string/tablet_navigation_landscape_position_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="true" />
+
+    <ListPreference
         android:defaultValue="@string/bottom_navigation_labels_default_value"
         android:entries="@array/bottom_navigation_labels_description"
         android:entryValues="@array/bottom_navigation_labels_values"

--- a/app/src/test/java/org/schabi/newpipe/fragments/MainBottomNavigationLayoutTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/MainBottomNavigationLayoutTest.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.fragments;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -33,23 +34,40 @@ public class MainBottomNavigationLayoutTest {
     }
 
     @Test
-    public void largeScreensUseAStableLabeledNavigationRail() throws Exception {
+    public void tabletsCanSwitchBetweenBottomAndLeftNavigation() throws Exception {
         final String layout = Files.readString(
                 resourcesDirectory.resolve("layout-sw600dp/activity_main.xml"));
         final String settings = Files.readString(
                 resourcesDirectory.resolve("values/settings_keys.xml"));
+        final String appearanceSettings = Files.readString(
+                resourcesDirectory.resolve("xml/appearance_settings.xml"));
         final String source = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/fragments/MainFragment.java"));
 
         assertTrue(layout.contains(
                 "com.google.android.material.navigationrail.NavigationRailView"));
+        assertTrue(layout.contains(
+                "com.google.android.material.bottomnavigation.BottomNavigationView"));
+        assertTrue(layout.contains("android:id=\"@+id/main_navigation_rail\""));
+        assertTrue(layout.contains("android:id=\"@+id/main_bottom_navigation\""));
+        assertFalse(layout.contains(
+                "android:layout_marginStart=\"@dimen/main_navigation_rail_width\""));
         assertTrue(layout.contains("android:background=\"?attr/colorSurfaceContainer\""));
         assertTrue(layout.contains("android:elevation=\"0dp\""));
         assertTrue(layout.contains("app:labelVisibilityMode=\"labeled\""));
         assertTrue(settings.contains(
                 "bottom_navigation_labels_default_value\">"
                         + "@string/bottom_navigation_labels_always_value"));
+        assertTrue(settings.contains("tablet_navigation_portrait_position_key"));
+        assertTrue(settings.contains("tablet_navigation_landscape_position_key"));
+        assertTrue(appearanceSettings.contains(
+                "android:key=\"@string/tablet_navigation_portrait_position_key\""));
+        assertTrue(appearanceSettings.contains(
+                "android:key=\"@string/tablet_navigation_landscape_position_key\""));
         assertTrue(source.contains("private NavigationBarView bottomNavigation;"));
+        assertTrue(source.contains("private BottomNavigationView bottomNavigationView;"));
+        assertTrue(source.contains("private NavigationRailView navigationRailView;"));
+        assertTrue(source.contains("TabletNavigationPositionResolver.useNavigationRail("));
         assertTrue(source.contains("bottomNavigation instanceof NavigationRailView"));
     }
 

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
@@ -81,9 +81,15 @@ public class VideoDetailNavigationResourcesTest {
         final var rails = largeDocument.getElementsByTagName(NAVIGATION_RAIL_VIEW);
         assertEquals(1, rails.getLength());
         final var rail = (Element) rails.item(0);
-        assertEquals("@+id/main_bottom_navigation", rail.getAttribute("android:id"));
+        assertEquals("@+id/main_navigation_rail", rail.getAttribute("android:id"));
         assertEquals("@style/wizestreamBottomNavigationActiveIndicator",
                 rail.getAttribute("app:itemActiveIndicatorStyle"));
+
+        final var largeBottomNavigation =
+                largeDocument.getElementsByTagName(BOTTOM_NAVIGATION_VIEW);
+        assertEquals(1, largeBottomNavigation.getLength());
+        assertEquals("@+id/main_bottom_navigation",
+                ((Element) largeBottomNavigation.item(0)).getAttribute("android:id"));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/settings/tabs/TabletNavigationPositionResolverTest.java
+++ b/app/src/test/java/org/schabi/newpipe/settings/tabs/TabletNavigationPositionResolverTest.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.settings.tabs;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.res.Configuration;
+
+import org.junit.Test;
+
+public class TabletNavigationPositionResolverTest {
+    @Test
+    public void automaticUsesBottomInPortraitAndRailInLandscape() {
+        assertFalse(TabletNavigationPositionResolver.useNavigationRail(true,
+                Configuration.ORIENTATION_PORTRAIT,
+                TabletNavigationPositionResolver.AUTOMATIC));
+        assertTrue(TabletNavigationPositionResolver.useNavigationRail(true,
+                Configuration.ORIENTATION_LANDSCAPE,
+                TabletNavigationPositionResolver.AUTOMATIC));
+    }
+
+    @Test
+    public void explicitPositionOverridesOrientation() {
+        assertTrue(TabletNavigationPositionResolver.useNavigationRail(true,
+                Configuration.ORIENTATION_PORTRAIT,
+                TabletNavigationPositionResolver.LEFT));
+        assertFalse(TabletNavigationPositionResolver.useNavigationRail(true,
+                Configuration.ORIENTATION_LANDSCAPE,
+                TabletNavigationPositionResolver.BOTTOM));
+    }
+
+    @Test
+    public void phonesAlwaysUseBottomNavigation() {
+        assertFalse(TabletNavigationPositionResolver.useNavigationRail(false,
+                Configuration.ORIENTATION_LANDSCAPE,
+                TabletNavigationPositionResolver.LEFT));
+    }
+
+    @Test
+    public void unknownPositionFallsBackToAutomatic() {
+        assertTrue(TabletNavigationPositionResolver.useNavigationRail(true,
+                Configuration.ORIENTATION_LANDSCAPE, "unknown"));
+        assertFalse(TabletNavigationPositionResolver.useNavigationRail(true,
+                Configuration.ORIENTATION_PORTRAIT, null));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
@@ -61,6 +61,7 @@ public class EdgeToEdgeIntegrationTest {
                 "res/layout-sw600dp/activity_main.xml"));
 
         assertTrue(activity.contains("EdgeToEdgeHelper.applyMainActivitySystemBarInsets("));
+        assertTrue(activity.contains("mainBinding.mainNavigationRail"));
         assertTrue(activity.contains("mainBinding.mainBottomSystemBarScrim"));
         assertFalse(activity.contains(
                 "EdgeToEdgeHelper.applySystemBarPadding(mainBinding.getRoot())"));
@@ -72,6 +73,8 @@ public class EdgeToEdgeIntegrationTest {
                 "android:id=\"@+id/main_bottom_system_bar_scrim\""));
         assertTrue(tabletLayout.contains(
                 "android:id=\"@+id/main_bottom_system_bar_scrim\""));
+        assertTrue(phoneLayout.contains("android:id=\"@+id/main_navigation_rail\""));
+        assertTrue(tabletLayout.contains("android:id=\"@+id/main_navigation_rail\""));
     }
 
     @Test
@@ -143,10 +146,13 @@ public class EdgeToEdgeIntegrationTest {
                     "android:id=\"@+id/main_bottom_system_bar_scrim\"");
             final int navigationStart = layout.indexOf(
                     "android:id=\"@+id/main_bottom_navigation\"");
+            final int navigationRailStart = layout.indexOf(
+                    "android:id=\"@+id/main_navigation_rail\"");
 
             assertTrue(layoutPath, playerSheetStart >= 0);
             assertTrue(layoutPath, scrimStart > playerSheetStart);
             assertTrue(layoutPath, navigationStart > scrimStart);
+            assertTrue(layoutPath, navigationRailStart > scrimStart);
             assertTrue(layoutPath,
                     layout.contains("android:background=\"?attr/colorSurfaceContainer\""));
         }


### PR DESCRIPTION
- Add independent tablet navigation position preferences for portrait and landscape
- Support Automatic, Bottom, and Left choices for each orientation
- Default Automatic to bottom navigation in portrait and a left rail in landscape
- Keep phone navigation behavior unchanged
- Update content insets, player-sheet spacing, and navigation animations for the active component
- Add resolver, resource, layout, and edge-to-edge regression coverage
- Closes #295