### PR TITLE
Remove PR-triggered prerelease publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ on:
           - artifacts
           - release
           - all
-  pull_request:
-    branches:
-      - pipe
-    types:
-      - opened
   push:
     branches:
       - "release-pre-*"
@@ -28,7 +23,6 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-pre-') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
 
@@ -184,12 +178,12 @@ jobs:
           path: ${{ steps.x86_release_info.outputs.apk_path }}
 
       - name: "Validate changelog"
-        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
         run: |
           test -s "${{ steps.release_info.outputs.changelog_path }}"
 
       - name: "Create release"
-        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.release_target == 'release' || inputs.release_target == 'all')) }}
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || steps.release_info.outputs.release_tag }}

--- a/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
@@ -6,6 +6,7 @@
 package org.schabi.newpipe.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class ReproducibleBuildConfigurationTest {
     }
 
     @Test
-    public void preReleasePublishingUsesAnExplicitNonLatestBranchTrigger() throws Exception {
+    public void preReleasePublishingUsesOnlyAnExplicitNonLatestBranchTrigger() throws Exception {
         final String releaseWorkflow = read(".github/workflows/release.yml");
 
         assertTrue(releaseWorkflow.contains("- \"release-pre-*\""));
@@ -54,10 +55,9 @@ public class ReproducibleBuildConfigurationTest {
         assertTrue(releaseWorkflow.contains("github.ref_type == 'tag' && github.ref_name"));
         assertTrue(releaseWorkflow.contains("prerelease: ${{ github.ref_type == 'branch' }}"));
         assertTrue(releaseWorkflow.contains("make_latest: ${{ github.ref_type == 'tag' }}"));
-        assertTrue(releaseWorkflow.contains("github.event_name != 'pull_request' ||"));
-        assertTrue(releaseWorkflow.contains("startsWith(github.head_ref, 'release-pre-')"));
-        assertEquals(2, occurrences(releaseWorkflow,
-                "github.event_name == 'pull_request'"));
+        assertFalse(releaseWorkflow.contains("pull_request:"));
+        assertFalse(releaseWorkflow.contains("github.event_name == 'pull_request'"));
+        assertFalse(releaseWorkflow.contains("github.head_ref"));
     }
 
     @Test


### PR DESCRIPTION
- Publish prereleases only from explicit `release-pre-*` branch pushes.
- Remove pull-request event conditions that could build temporary merge commits.
- Preserve stable tag releases and manual release dispatch behavior.
- Add regression coverage preventing PR-triggered publishing from returning.