### PR TITLE
Show full video titles in grid view

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamGridInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamGridInfoItemHolder.java
@@ -3,10 +3,20 @@ package org.schabi.newpipe.info_list.holder;
 import android.view.ViewGroup;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
+import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.GridTitleDisplayPolicy;
 
 public class StreamGridInfoItemHolder extends StreamInfoItemHolder {
     public StreamGridInfoItemHolder(final InfoItemBuilder infoItemBuilder, final ViewGroup parent) {
         super(infoItemBuilder, R.layout.list_stream_grid_item, parent);
+    }
+
+    @Override
+    public void updateFromItem(final InfoItem infoItem,
+                               final HistoryRecordManager historyRecordManager) {
+        GridTitleDisplayPolicy.apply(itemVideoTitleView);
+        super.updateFromItem(infoItem, historyRecordManager);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamGridItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalPlaylistStreamGridItemHolder.java
@@ -3,11 +3,24 @@ package org.schabi.newpipe.local.holder;
 import android.view.ViewGroup;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.local.LocalItemBuilder;
+import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.GridTitleDisplayPolicy;
+
+import java.time.format.DateTimeFormatter;
 
 public class LocalPlaylistStreamGridItemHolder extends LocalPlaylistStreamItemHolder {
     public LocalPlaylistStreamGridItemHolder(final LocalItemBuilder infoItemBuilder,
                                              final ViewGroup parent) {
-        super(infoItemBuilder, R.layout.list_stream_playlist_grid_item, parent); // TODO
+        super(infoItemBuilder, R.layout.list_stream_playlist_grid_item, parent);
+    }
+
+    @Override
+    public void updateFromItem(final LocalItem localItem,
+                               final HistoryRecordManager historyRecordManager,
+                               final DateTimeFormatter dateTimeFormatter) {
+        GridTitleDisplayPolicy.apply(itemVideoTitleView);
+        super.updateFromItem(localItem, historyRecordManager, dateTimeFormatter);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalStatisticStreamGridItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalStatisticStreamGridItemHolder.java
@@ -3,11 +3,24 @@ package org.schabi.newpipe.local.holder;
 import android.view.ViewGroup;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.local.LocalItemBuilder;
+import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.GridTitleDisplayPolicy;
+
+import java.time.format.DateTimeFormatter;
 
 public class LocalStatisticStreamGridItemHolder extends LocalStatisticStreamItemHolder {
     public LocalStatisticStreamGridItemHolder(final LocalItemBuilder infoItemBuilder,
                                               final ViewGroup parent) {
         super(infoItemBuilder, R.layout.list_stream_grid_item, parent);
+    }
+
+    @Override
+    public void updateFromItem(final LocalItem localItem,
+                               final HistoryRecordManager historyRecordManager,
+                               final DateTimeFormatter dateTimeFormatter) {
+        GridTitleDisplayPolicy.apply(itemVideoTitleView);
+        super.updateFromItem(localItem, historyRecordManager, dateTimeFormatter);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/GridTitleDisplayPolicy.java
+++ b/app/src/main/java/org/schabi/newpipe/util/GridTitleDisplayPolicy.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.util;
+
+import android.text.TextUtils;
+import android.widget.TextView;
+
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.R;
+
+public final class GridTitleDisplayPolicy {
+    static final int COMPACT_TITLE_LINES = 2;
+
+    private GridTitleDisplayPolicy() {
+    }
+
+    public static void apply(final TextView titleView) {
+        final boolean showFullTitles = PreferenceManager
+                .getDefaultSharedPreferences(titleView.getContext())
+                .getBoolean(titleView.getContext().getString(
+                        R.string.show_full_grid_titles_key), false);
+
+        titleView.setMaxLines(maxLines(showFullTitles));
+        titleView.setEllipsize(shouldEllipsize(showFullTitles)
+                ? TextUtils.TruncateAt.END : null);
+    }
+
+    static int maxLines(final boolean showFullTitles) {
+        return showFullTitles ? Integer.MAX_VALUE : COMPACT_TITLE_LINES;
+    }
+
+    static boolean shouldEllipsize(final boolean showFullTitles) {
+        return !showFullTitles;
+    }
+}

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1528,6 +1528,7 @@
     </string-array>
 
     <string name="list_view_mode_key">list_view_mode</string>
+    <string name="show_full_grid_titles_key">show_full_grid_titles</string>
     <string name="list_view_mode_value">@string/list_view_mode_auto_key</string>
 
     <!-- TODO: Use these across the app instead of hardcoding it -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -950,6 +950,8 @@
     <string name="wifi_only">Only on Wi-Fi</string>
     <string name="never">Never</string>
     <string name="list_view_mode">List view mode</string>
+    <string name="show_full_grid_titles_title">Show full video titles in grid view</string>
+    <string name="show_full_grid_titles_summary">Allow video titles to wrap instead of limiting them to two lines</string>
     <string name="list">List</string>
     <string name="grid">Grid</string>
     <string name="card">Card</string>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -62,6 +62,14 @@
         app:iconSpaceReserved="false"
         app:useSimpleSummaryProvider="true" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/show_full_grid_titles_key"
+        android:summary="@string/show_full_grid_titles_summary"
+        android:title="@string/show_full_grid_titles_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
     <Preference
         android:key="@string/caption_settings_key"
         android:summary="@string/caption_setting_description"

--- a/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class GridTitleDisplayPolicyTest {
+    private final Path repositoryRoot =
+            Files.exists(Path.of("app/src/main/res/xml/appearance_settings.xml"))
+                    ? Path.of(".") : Path.of("..");
+
+    @Test
+    public void compactModeKeepsTwoLinesAndEllipsizing() {
+        assertEquals(2, GridTitleDisplayPolicy.maxLines(false));
+        assertTrue(GridTitleDisplayPolicy.shouldEllipsize(false));
+    }
+
+    @Test
+    public void fullModeAllowsUnlimitedLinesWithoutEllipsizing() {
+        assertEquals(Integer.MAX_VALUE, GridTitleDisplayPolicy.maxLines(true));
+        assertFalse(GridTitleDisplayPolicy.shouldEllipsize(true));
+    }
+
+    @Test
+    public void settingIsDisabledByDefault() throws Exception {
+        final String appearanceSettings = read(
+                "app/src/main/res/xml/appearance_settings.xml");
+
+        assertTrue(appearanceSettings.contains(
+                "android:key=\"@string/show_full_grid_titles_key\""));
+        assertTrue(appearanceSettings.contains(
+                "android:defaultValue=\"false\""));
+    }
+
+    @Test
+    public void everyStreamGridHolderAppliesTheDisplayPolicy() throws Exception {
+        final List<String> gridHolders = List.of(
+                "app/src/main/java/org/schabi/newpipe/info_list/holder/"
+                        + "StreamGridInfoItemHolder.java",
+                "app/src/main/java/org/schabi/newpipe/local/holder/"
+                        + "LocalPlaylistStreamGridItemHolder.java",
+                "app/src/main/java/org/schabi/newpipe/local/holder/"
+                        + "LocalStatisticStreamGridItemHolder.java");
+
+        for (final String gridHolder : gridHolders) {
+            assertTrue(read(gridHolder).contains(
+                    "GridTitleDisplayPolicy.apply(itemVideoTitleView);"));
+        }
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(repositoryRoot.resolve(relativePath));
+    }
+}


### PR DESCRIPTION
- Add an opt-in Appearance setting for fully wrapped grid video titles.
- Apply the title policy to online streams, local playlists, and history/statistics grids while keeping compact two-line titles as the default.
- Reapply the preference when grid holders bind and add regression coverage for both display modes and holder wiring.
- Fixes #305