### PR TITLE
Add configurable tablet grid columns

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -218,6 +218,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         int width = resources.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width);
         width += (24 * resources.getDisplayMetrics().density);
         return GridLayoutManagerHelper.create(itemsList, width,
+                GridLayoutManagerHelper.getPreferredSpanCount(activity),
                 infoListAdapter::getSpanSizeLookup);
     }
 
@@ -506,7 +507,8 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences,
                                           final String key) {
-        if (getString(R.string.list_view_mode_key).equals(key)) {
+        if (getString(R.string.list_view_mode_key).equals(key)
+                || getString(R.string.grid_columns_key).equals(key)) {
             updateFlags |= LIST_MODE_UPDATE_FLAG;
         } else if (ContentBlockingHelper.isPreferenceKey(requireContext(), key)) {
             reloadContent();

--- a/app/src/main/java/org/schabi/newpipe/local/BaseLocalListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/BaseLocalListFragment.java
@@ -114,6 +114,7 @@ public abstract class BaseLocalListFragment<I, N> extends BaseStateFragment<I>
         int width = resources.getDimensionPixelSize(R.dimen.video_item_grid_thumbnail_image_width);
         width += (24 * resources.getDisplayMetrics().density);
         return GridLayoutManagerHelper.create(itemsList, width,
+                GridLayoutManagerHelper.getPreferredSpanCount(activity),
                 itemListAdapter::getSpanSizeLookup);
     }
 
@@ -253,7 +254,8 @@ public abstract class BaseLocalListFragment<I, N> extends BaseStateFragment<I>
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences,
                                           final String key) {
-        if (getString(R.string.list_view_mode_key).equals(key)) {
+        if (getString(R.string.list_view_mode_key).equals(key)
+                || getString(R.string.grid_columns_key).equals(key)) {
             updateFlags |= LIST_MODE_UPDATE_FLAG;
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
@@ -66,12 +66,12 @@ public class AppearanceSettingsFragment extends BasePreferenceFragment {
             return false;
         });
 
-        final boolean showTabletNavigationPreferences = DeviceUtils.isTablet(requireContext());
-        setPreferenceVisible(R.string.grid_columns_key, showTabletNavigationPreferences);
+        final boolean showTabletPreferences = DeviceUtils.isTablet(requireContext());
+        setPreferenceVisible(R.string.grid_columns_key, showTabletPreferences);
         setPreferenceVisible(R.string.tablet_navigation_portrait_position_key,
-                showTabletNavigationPreferences);
+                showTabletPreferences);
         setPreferenceVisible(R.string.tablet_navigation_landscape_position_key,
-                showTabletNavigationPreferences);
+                showTabletPreferences);
     }
 
     private void setPreferenceVisible(final int key, final boolean visible) {

--- a/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/AppearanceSettingsFragment.java
@@ -67,6 +67,7 @@ public class AppearanceSettingsFragment extends BasePreferenceFragment {
         });
 
         final boolean showTabletNavigationPreferences = DeviceUtils.isTablet(requireContext());
+        setPreferenceVisible(R.string.grid_columns_key, showTabletNavigationPreferences);
         setPreferenceVisible(R.string.tablet_navigation_portrait_position_key,
                 showTabletNavigationPreferences);
         setPreferenceVisible(R.string.tablet_navigation_landscape_position_key,

--- a/app/src/main/java/org/schabi/newpipe/util/GridLayoutManagerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/GridLayoutManagerHelper.java
@@ -1,14 +1,22 @@
 package org.schabi.newpipe.util;
 
+import android.content.Context;
 import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-/** Creates grid layout managers whose span count follows the measured content width. */
+import org.schabi.newpipe.R;
+
+/** Creates grid layout managers whose span count follows the user's preference and content width. */
 public final class GridLayoutManagerHelper {
+    private static final int AUTOMATIC_SPAN_COUNT = 0;
+    private static final int MINIMUM_CONFIGURED_SPAN_COUNT = 2;
+    private static final int MAXIMUM_CONFIGURED_SPAN_COUNT = 4;
+
     private GridLayoutManagerHelper() {
     }
 
@@ -21,7 +29,7 @@ public final class GridLayoutManagerHelper {
     @NonNull
     public static GridLayoutManager create(@NonNull final RecyclerView recyclerView,
                                            final int minimumItemWidth) {
-        return create(recyclerView, minimumItemWidth, null);
+        return create(recyclerView, minimumItemWidth, AUTOMATIC_SPAN_COUNT, null);
     }
 
     @NonNull
@@ -29,8 +37,18 @@ public final class GridLayoutManagerHelper {
             @NonNull final RecyclerView recyclerView,
             final int minimumItemWidth,
             @Nullable final SpanSizeLookupFactory spanSizeLookupFactory) {
+        return create(recyclerView, minimumItemWidth, AUTOMATIC_SPAN_COUNT,
+                spanSizeLookupFactory);
+    }
+
+    @NonNull
+    public static GridLayoutManager create(
+            @NonNull final RecyclerView recyclerView,
+            final int minimumItemWidth,
+            final int preferredSpanCount,
+            @Nullable final SpanSizeLookupFactory spanSizeLookupFactory) {
         final int initialSpanCount = calculateSpanCount(
-                getAvailableWidth(recyclerView), minimumItemWidth);
+                getAvailableWidth(recyclerView), minimumItemWidth, preferredSpanCount);
         final GridLayoutManager layoutManager = new GridLayoutManager(
                 recyclerView.getContext(), initialSpanCount);
         updateSpanSizeLookup(layoutManager, initialSpanCount, spanSizeLookupFactory);
@@ -55,7 +73,7 @@ public final class GridLayoutManagerHelper {
                 }
 
                 final int spanCount = calculateSpanCount(
-                        getAvailableWidth(recyclerView), minimumItemWidth);
+                        getAvailableWidth(recyclerView), minimumItemWidth, preferredSpanCount);
                 if (spanCount != layoutManager.getSpanCount()) {
                     updateSpanSizeLookup(layoutManager, spanCount, spanSizeLookupFactory);
                     layoutManager.setSpanCount(spanCount);
@@ -65,7 +83,41 @@ public final class GridLayoutManagerHelper {
         return layoutManager;
     }
 
+    public static int getPreferredSpanCount(@NonNull final Context context) {
+        final String value = PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(context.getString(R.string.grid_columns_key),
+                        context.getString(R.string.grid_columns_auto_key));
+        return parsePreferredSpanCount(value);
+    }
+
+    static int parsePreferredSpanCount(@Nullable final String value) {
+        if (value == null) {
+            return AUTOMATIC_SPAN_COUNT;
+        }
+
+        try {
+            final int spanCount = Integer.parseInt(value);
+            if (spanCount >= MINIMUM_CONFIGURED_SPAN_COUNT
+                    && spanCount <= MAXIMUM_CONFIGURED_SPAN_COUNT) {
+                return spanCount;
+            }
+        } catch (final NumberFormatException ignored) {
+            // Automatic and unknown values both use responsive sizing.
+        }
+        return AUTOMATIC_SPAN_COUNT;
+    }
+
     static int calculateSpanCount(final int availableWidth, final int minimumItemWidth) {
+        return calculateSpanCount(availableWidth, minimumItemWidth, AUTOMATIC_SPAN_COUNT);
+    }
+
+    static int calculateSpanCount(final int availableWidth,
+                                  final int minimumItemWidth,
+                                  final int preferredSpanCount) {
+        if (preferredSpanCount >= MINIMUM_CONFIGURED_SPAN_COUNT
+                && preferredSpanCount <= MAXIMUM_CONFIGURED_SPAN_COUNT) {
+            return preferredSpanCount;
+        }
         if (availableWidth <= 0 || minimumItemWidth <= 0) {
             return 1;
         }

--- a/app/src/main/java/org/schabi/newpipe/util/GridLayoutManagerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/GridLayoutManagerHelper.java
@@ -11,7 +11,9 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import org.schabi.newpipe.R;
 
-/** Creates grid layout managers whose span count follows the user's preference and content width. */
+/**
+ * Creates grid layout managers whose span count follows the user's preference and content width.
+ */
 public final class GridLayoutManagerHelper {
     private static final int AUTOMATIC_SPAN_COUNT = 0;
     private static final int MINIMUM_CONFIGURED_SPAN_COUNT = 2;

--- a/app/src/main/res/layout/list_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_playlist_grid_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/itemRoot"
     android:layout_width="match_parent"
@@ -11,22 +12,19 @@
 
     <ImageView
         android:id="@+id/itemThumbnailView"
-        android:layout_width="@dimen/video_item_grid_thumbnail_image_width"
-        android:layout_height="@dimen/video_item_grid_thumbnail_image_height"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true"
-        android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="fitStart"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:scaleType="fitCenter"
         android:src="@drawable/placeholder_thumbnail_playlist"
-        tools:ignore="RtlHardcoded" />
+        app:layout_constraintDimensionRatio="H,16:9"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemStreamCountView"
         android:layout_width="@dimen/playlist_item_thumbnail_stream_count_width"
-        android:layout_height="match_parent"
-        android:layout_alignTop="@id/itemThumbnailView"
-        android:layout_alignEnd="@id/itemThumbnailView"
-        android:layout_alignBottom="@id/itemThumbnailView"
+        android:layout_height="0dp"
         android:background="@color/info_list_playlist_stream_count_badge_background_color"
         android:drawableTop="@drawable/ic_playlist_play"
         android:drawableTint="@color/info_list_thumbnail_badge_text_color"
@@ -37,36 +35,38 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
         tools:text="314159" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemTitleView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_below="@id/itemThumbnailView"
-        android:layout_alignLeft="@id/itemThumbnailView"
-        android:layout_alignRight="@id/itemThumbnailView"
         android:layout_marginTop="2dp"
         android:ellipsize="end"
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/video_item_search_title_text_size"
-        tools:ignore="RtlHardcoded"
-        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique vitae sem vitae blanditLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsum" />
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailView"
+        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemUploaderView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/itemTitleView"
-        android:layout_alignLeft="@id/itemThumbnailView"
-        android:layout_alignRight="@id/itemThumbnailView"
         android:lines="1"
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="?attr/colorOnSurfaceVariant"
         android:textSize="@dimen/video_item_search_uploader_text_size"
-        tools:ignore="RtlHardcoded"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
+        app:layout_constraintTop_toBottomOf="@id/itemTitleView"
         tools:text="Uploader" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_grid_item.xml
@@ -12,11 +12,12 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/itemThumbnailView"
-        android:layout_width="@dimen/video_item_grid_thumbnail_image_width"
-        android:layout_height="@dimen/video_item_grid_thumbnail_image_height"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:scaleType="fitCenter"
         android:src="@drawable/placeholder_thumbnail_video"
         app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail"
+        app:layout_constraintDimensionRatio="H,16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/list_stream_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_grid_item.xml
@@ -12,10 +12,11 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/itemThumbnailView"
-        android:layout_width="@dimen/video_item_grid_thumbnail_image_width"
-        android:layout_height="@dimen/video_item_grid_thumbnail_image_height"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:scaleType="fitCenter"
         android:src="@drawable/placeholder_thumbnail_video"
+        app:layout_constraintDimensionRatio="H,16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1528,6 +1528,23 @@
     </string-array>
 
     <string name="list_view_mode_key">list_view_mode</string>
+    <string name="grid_columns_key">grid_columns</string>
+    <string name="grid_columns_auto_key">auto</string>
+    <string name="grid_columns_two_key">2</string>
+    <string name="grid_columns_three_key">3</string>
+    <string name="grid_columns_four_key">4</string>
+    <string-array name="grid_columns_values">
+        <item>@string/grid_columns_auto_key</item>
+        <item>@string/grid_columns_two_key</item>
+        <item>@string/grid_columns_three_key</item>
+        <item>@string/grid_columns_four_key</item>
+    </string-array>
+    <string-array name="grid_columns_description">
+        <item>@string/auto</item>
+        <item>@string/grid_columns_two</item>
+        <item>@string/grid_columns_three</item>
+        <item>@string/grid_columns_four</item>
+    </string-array>
     <string name="show_full_grid_titles_key">show_full_grid_titles</string>
     <string name="list_view_mode_value">@string/list_view_mode_auto_key</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -950,6 +950,10 @@
     <string name="wifi_only">Only on Wi-Fi</string>
     <string name="never">Never</string>
     <string name="list_view_mode">List view mode</string>
+    <string name="grid_columns_title">Grid columns</string>
+    <string name="grid_columns_two">2 columns</string>
+    <string name="grid_columns_three">3 columns</string>
+    <string name="grid_columns_four">4 columns</string>
     <string name="show_full_grid_titles_title">Show full video titles in grid view</string>
     <string name="show_full_grid_titles_summary">Allow video titles to wrap instead of limiting them to two lines</string>
     <string name="list">List</string>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -62,6 +62,16 @@
         app:iconSpaceReserved="false"
         app:useSimpleSummaryProvider="true" />
 
+    <ListPreference
+        android:defaultValue="@string/grid_columns_auto_key"
+        android:entries="@array/grid_columns_description"
+        android:entryValues="@array/grid_columns_values"
+        android:key="@string/grid_columns_key"
+        android:title="@string/grid_columns_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="true" />
+
     <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/show_full_grid_titles_key"

--- a/app/src/test/java/org/schabi/newpipe/util/GridLayoutManagerHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/GridLayoutManagerHelperTest.java
@@ -12,6 +12,32 @@ public class GridLayoutManagerHelperTest {
     }
 
     @Test
+    public void configuredColumnsOverrideAutomaticSizing() {
+        assertEquals(2, GridLayoutManagerHelper.calculateSpanCount(1024, 188, 2));
+        assertEquals(3, GridLayoutManagerHelper.calculateSpanCount(1024, 188, 3));
+        assertEquals(4, GridLayoutManagerHelper.calculateSpanCount(1024, 188, 4));
+    }
+
+    @Test
+    public void invalidConfiguredColumnsFallBackToAutomaticSizing() {
+        assertEquals(5, GridLayoutManagerHelper.calculateSpanCount(1024, 188, 0));
+        assertEquals(5, GridLayoutManagerHelper.calculateSpanCount(1024, 188, 1));
+        assertEquals(5, GridLayoutManagerHelper.calculateSpanCount(1024, 188, 5));
+    }
+
+    @Test
+    public void preferenceValuesAreParsedAndValidated() {
+        assertEquals(0, GridLayoutManagerHelper.parsePreferredSpanCount(null));
+        assertEquals(0, GridLayoutManagerHelper.parsePreferredSpanCount("auto"));
+        assertEquals(0, GridLayoutManagerHelper.parsePreferredSpanCount("invalid"));
+        assertEquals(0, GridLayoutManagerHelper.parsePreferredSpanCount("1"));
+        assertEquals(0, GridLayoutManagerHelper.parsePreferredSpanCount("5"));
+        assertEquals(2, GridLayoutManagerHelper.parsePreferredSpanCount("2"));
+        assertEquals(3, GridLayoutManagerHelper.parsePreferredSpanCount("3"));
+        assertEquals(4, GridLayoutManagerHelper.parsePreferredSpanCount("4"));
+    }
+
+    @Test
     public void narrowAndInvalidMeasurementsKeepOneColumn() {
         assertEquals(1, GridLayoutManagerHelper.calculateSpanCount(180, 240));
         assertEquals(1, GridLayoutManagerHelper.calculateSpanCount(0, 240));

--- a/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
@@ -34,7 +34,7 @@ public class TabletGridConfigurationTest {
                 "android:entryValues=\"@array/grid_columns_values\""));
         assertTrue(appearanceFragment.contains(
                 "setPreferenceVisible(R.string.grid_columns_key, "
-                        + "showTabletNavigationPreferences);"));
+                        + "showTabletPreferences);"));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class TabletGridConfigurationTest {
+    private final Path repositoryRoot =
+            Files.exists(Path.of("app/src/main/res/xml/appearance_settings.xml"))
+                    ? Path.of(".") : Path.of("..");
+
+    @Test
+    public void appearanceSettingsExposeAutomaticAndFixedTabletColumns() throws Exception {
+        final String appearanceSettings = read(
+                "app/src/main/res/xml/appearance_settings.xml");
+        final String appearanceFragment = read(
+                "app/src/main/java/org/schabi/newpipe/settings/"
+                        + "AppearanceSettingsFragment.java");
+
+        assertTrue(appearanceSettings.contains(
+                "android:defaultValue=\"@string/grid_columns_auto_key\""));
+        assertTrue(appearanceSettings.contains(
+                "android:entries=\"@array/grid_columns_description\""));
+        assertTrue(appearanceSettings.contains(
+                "android:entryValues=\"@array/grid_columns_values\""));
+        assertTrue(appearanceFragment.contains(
+                "setPreferenceVisible(R.string.grid_columns_key, "
+                        + "showTabletNavigationPreferences);"));
+    }
+
+    @Test
+    public void remoteAndLocalGridsUseAndObserveTheColumnPreference() throws Exception {
+        for (final String listFragment : List.of(
+                "app/src/main/java/org/schabi/newpipe/fragments/list/"
+                        + "BaseListFragment.java",
+                "app/src/main/java/org/schabi/newpipe/local/"
+                        + "BaseLocalListFragment.java")) {
+            final String source = read(listFragment);
+
+            assertTrue(source.contains(
+                    "GridLayoutManagerHelper.getPreferredSpanCount(activity)"));
+            assertTrue(source.contains(
+                    "getString(R.string.grid_columns_key).equals(key)"));
+        }
+    }
+
+    @Test
+    public void thumbnailCardsFillTheirColumnAtSixteenByNine() throws Exception {
+        for (final String layout : List.of(
+                "app/src/main/res/layout/list_stream_grid_item.xml",
+                "app/src/main/res/layout/list_stream_playlist_grid_item.xml",
+                "app/src/main/res/layout/list_playlist_grid_item.xml")) {
+            final String source = read(layout);
+
+            assertTrue(source.contains(
+                    "android:id=\"@+id/itemThumbnailView\"\n"
+                            + "        android:layout_width=\"0dp\"\n"
+                            + "        android:layout_height=\"0dp\""));
+            assertTrue(source.contains(
+                    "app:layout_constraintDimensionRatio=\"H,16:9\""));
+        }
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(repositoryRoot.resolve(relativePath));
+    }
+}


### PR DESCRIPTION
- Add a tablet-only Appearance preference with Automatic, 2, 3, and 4-column options while preserving responsive automatic sizing by default.
- Apply the selected column count to remote and local grids and refresh layouts when the preference changes.
- Scale video and playlist thumbnails to fill each card at a consistent 16:9 aspect ratio.
- Add regression coverage for span selection, tablet-only settings wiring, and responsive thumbnail layouts.
- Fixes #304