### PR TITLE
Prefer Shorts in automatic queues

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2994,7 +2994,7 @@ public final class Player implements PlaybackListener, Listener {
         // auto queue when starting playback on the last item when not repeating
         final PlayQueueItem currentQueueItem = playQueue.getItem();
         final boolean preferShortFormContent = info.isShortFormContent()
-                || currentQueueItem != null && currentQueueItem.isShortFormContent();
+                || (currentQueueItem != null && currentQueueItem.isShortFormContent());
         final PlayQueue autoQueue = PlayerHelper.autoQueueOf(info,
                 playQueue.getStreams(), preferShortFormContent);
         if (autoQueue != null) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2992,8 +2992,11 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
         // auto queue when starting playback on the last item when not repeating
+        final PlayQueueItem currentQueueItem = playQueue.getItem();
+        final boolean preferShortFormContent = info.isShortFormContent()
+                || currentQueueItem != null && currentQueueItem.isShortFormContent();
         final PlayQueue autoQueue = PlayerHelper.autoQueueOf(info,
-                playQueue.getStreams());
+                playQueue.getStreams(), preferShortFormContent);
         if (autoQueue != null) {
             playQueue.append(autoQueue.getStreams());
         }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -167,13 +167,15 @@ public final class PlayerHelper {
      * from the {@link StreamInfo#getRelatedItems()}. Non-stream items are ignored.
      * </p>
      *
-     * @param info          currently playing stream
-     * @param existingItems existing items in the queue
+     * @param info                   currently playing stream
+     * @param existingItems          existing items in the queue
+     * @param preferShortFormContent whether short-form related streams should be preferred
      * @return {@link SinglePlayQueue} with the next stream to queue
      */
     @Nullable
     public static PlayQueue autoQueueOf(@NonNull final StreamInfo info,
-                                        @NonNull final List<PlayQueueItem> existingItems) {
+                                        @NonNull final List<PlayQueueItem> existingItems,
+                                        final boolean preferShortFormContent) {
         final Set<String> urls = existingItems.stream()
                 .map(PlayQueueItem::getUrl)
                 .collect(Collectors.toUnmodifiableSet());
@@ -181,6 +183,16 @@ public final class PlayerHelper {
         final List<InfoItem> relatedItems = info.getRelatedItems();
         if (Utils.isNullOrEmpty(relatedItems)) {
             return null;
+        }
+
+        if (preferShortFormContent) {
+            for (final InfoItem item : relatedItems) {
+                if (item instanceof StreamInfoItem
+                        && ((StreamInfoItem) item).isShortFormContent()
+                        && !urls.contains(item.getUrl())) {
+                    return getAutoQueuedSinglePlayQueue((StreamInfoItem) item);
+                }
+            }
         }
 
         if (relatedItems.get(0) instanceof StreamInfoItem
@@ -198,6 +210,12 @@ public final class PlayerHelper {
         Collections.shuffle(autoQueueItems);
         return autoQueueItems.isEmpty()
                 ? null : getAutoQueuedSinglePlayQueue(autoQueueItems.get(0));
+    }
+
+    @Nullable
+    public static PlayQueue autoQueueOf(@NonNull final StreamInfo info,
+                                        @NonNull final List<PlayQueueItem> existingItems) {
+        return autoQueueOf(info, existingItems, info.isShortFormContent());
     }
 
     // endregion

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -161,10 +161,10 @@ public final class PlayerHelper {
      * if a candidate next video's url already exists in the existing items.
      * </p>
      * <p>
-     * The first item in {@link StreamInfo#getRelatedItems()} is checked first.
-     * If it is non-null and is not part of the existing items, it will be used as the next stream.
-     * Otherwise, a random stream with non-repeating url will be selected
-     * from the {@link StreamInfo#getRelatedItems()}. Non-stream items are ignored.
+     * For short-form playback, the first non-repeating short-form related stream is preferred.
+     * If none is available, the first related stream is checked. If that stream is unavailable or
+     * already queued, a random stream with a non-repeating URL is selected from
+     * {@link StreamInfo#getRelatedItems()}. Non-stream items are ignored.
      * </p>
      *
      * @param info                   currently playing stream

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
@@ -40,6 +40,7 @@ public class PlayQueueItem implements Serializable {
     private final String uploaderUrl;
     @NonNull
     private final StreamType streamType;
+    private final boolean shortFormContent;
     @NonNull
     private final SourceType sourceType;
     @Nullable
@@ -60,8 +61,8 @@ public class PlayQueueItem implements Serializable {
     public PlayQueueItem(@NonNull final StreamInfo info) {
         this(info.getName(), info.getUrl(), info.getServiceId(), info.getDuration(),
                 ExtractorImageCompat.thumbnailImages(info), info.getUploaderName(),
-                info.getUploaderUrl(), info.getStreamType(), SourceType.REMOTE,
-                null, null, null, -1L, null);
+                info.getUploaderUrl(), info.getStreamType(), info.isShortFormContent(),
+                SourceType.REMOTE, null, null, null, -1L, null);
 
         if (info.getStartPosition() > 0) {
             setRecoveryPosition(info.getStartPosition() * 1000);
@@ -71,8 +72,8 @@ public class PlayQueueItem implements Serializable {
     public PlayQueueItem(@NonNull final StreamInfoItem item) {
         this(item.getName(), item.getUrl(), item.getServiceId(), item.getDuration(),
                 ExtractorImageCompat.thumbnailImages(item), item.getUploaderName(),
-                item.getUploaderUrl(), item.getStreamType(), SourceType.REMOTE,
-                null, null, null, -1L, null);
+                item.getUploaderUrl(), item.getStreamType(), item.isShortFormContent(),
+                SourceType.REMOTE, null, null, null, -1L, null);
     }
 
     @SuppressWarnings("ParameterNumber")
@@ -89,7 +90,7 @@ public class PlayQueueItem implements Serializable {
         return new PlayQueueItem(title, contentUri, LOCAL_SERVICE_ID, duration,
                 Collections.emptyList(), artist, null,
                 video ? StreamType.VIDEO_STREAM : StreamType.AUDIO_STREAM,
-                SourceType.LOCAL, mimeType, album, folder, localMediaId, thumbnailUri);
+                false, SourceType.LOCAL, mimeType, album, folder, localMediaId, thumbnailUri);
     }
 
     @SuppressWarnings("ParameterNumber")
@@ -97,7 +98,8 @@ public class PlayQueueItem implements Serializable {
                           final int serviceId, final long duration,
                           final List<Image> thumbnails, @Nullable final String uploader,
                           final String uploaderUrl, @NonNull final StreamType streamType,
-                          @NonNull final SourceType sourceType, @Nullable final String mimeType,
+                          final boolean shortFormContent, @NonNull final SourceType sourceType,
+                          @Nullable final String mimeType,
                           @Nullable final String album, @Nullable final String folder,
                           final long localMediaId, @Nullable final String localThumbnailUrl) {
         this.title = name != null ? name : EMPTY_STRING;
@@ -108,6 +110,7 @@ public class PlayQueueItem implements Serializable {
         this.uploader = uploader != null ? uploader : EMPTY_STRING;
         this.uploaderUrl = uploaderUrl;
         this.streamType = streamType;
+        this.shortFormContent = shortFormContent;
         this.sourceType = sourceType;
         this.mimeType = mimeType;
         this.album = album;
@@ -170,6 +173,10 @@ public class PlayQueueItem implements Serializable {
     @NonNull
     public StreamType getStreamType() {
         return streamType;
+    }
+
+    public boolean isShortFormContent() {
+        return shortFormContent;
     }
 
     @NonNull

--- a/app/src/test/java/org/schabi/newpipe/player/helper/PlayerHelperAutoQueueTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/PlayerHelperAutoQueueTest.java
@@ -1,0 +1,75 @@
+package org.schabi.newpipe.player.helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.extractor.stream.StreamInfo;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
+import org.schabi.newpipe.player.playqueue.PlayQueue;
+import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+
+import java.util.Collections;
+import java.util.List;
+
+public class PlayerHelperAutoQueueTest {
+    @Test
+    public void shortFormQueueItemPreservesContentType() {
+        assertTrue(new PlayQueueItem(stream("short", true)).isShortFormContent());
+    }
+
+    @Test
+    public void prefersFirstNonRepeatedShortForShortFormPlayback() {
+        final StreamInfoItem longVideo = stream("long", false);
+        final StreamInfoItem repeatedShort = stream("short-1", true);
+        final StreamInfoItem nextShort = stream("short-2", true);
+        final StreamInfo info = infoWithRelated(longVideo, repeatedShort, nextShort);
+
+        final PlayQueue queue = PlayerHelper.autoQueueOf(info,
+                List.of(new PlayQueueItem(repeatedShort)), true);
+
+        assertNotNull(queue);
+        assertEquals(nextShort.getUrl(), queue.getItem().getUrl());
+    }
+
+    @Test
+    public void fallsBackToRegularRelatedVideoWhenNoShortIsAvailable() {
+        final StreamInfoItem longVideo = stream("long", false);
+        final StreamInfo info = infoWithRelated(longVideo);
+
+        final PlayQueue queue = PlayerHelper.autoQueueOf(
+                info, Collections.emptyList(), true);
+
+        assertNotNull(queue);
+        assertEquals(longVideo.getUrl(), queue.getItem().getUrl());
+    }
+
+    @Test
+    public void regularPlaybackKeepsExistingFirstRelatedBehavior() {
+        final StreamInfoItem longVideo = stream("long", false);
+        final StreamInfoItem shortVideo = stream("short", true);
+        final StreamInfo info = infoWithRelated(longVideo, shortVideo);
+
+        final PlayQueue queue = PlayerHelper.autoQueueOf(
+                info, Collections.emptyList(), false);
+
+        assertNotNull(queue);
+        assertEquals(longVideo.getUrl(), queue.getItem().getUrl());
+    }
+
+    private static StreamInfo infoWithRelated(final InfoItem... items) {
+        final StreamInfo info = new StreamInfo();
+        info.setRelatedItems(List.of(items));
+        return info;
+    }
+
+    private static StreamInfoItem stream(final String url, final boolean shortFormContent) {
+        final StreamInfoItem item = new StreamInfoItem(
+                0, url, url, StreamType.VIDEO_STREAM);
+        item.setShortFormContent(shortFormContent);
+        return item;
+    }
+}


### PR DESCRIPTION
- Preserve short-form metadata when streams become play-queue items.
- Prefer the first non-repeated Short when auto-queueing from short-form playback.
- Fall back to the existing related-video selection when no suitable Short is available.
- Keep regular-video and manual queue behavior unchanged.
- Add regression coverage for metadata preservation, Shorts-first selection, fallback, and normal playback.
- Fixes #281