### PR TITLE
Add copy-title action to video menus

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
@@ -120,6 +120,7 @@ public final class InfoItemDialog {
          *     | addEntry() and addAllEntries()             |
          *     + - - - - - - - - - - - - - - - - - - - - - -+
          *     | APPEND_PLAYLIST                            |
+         *     | COPY_TITLE                                 |
          *     | SHARE                                      |
          *     | OPEN_IN_BROWSER                            |
          *     | PLAY_WITH_KODI                             |
@@ -161,6 +162,7 @@ public final class InfoItemDialog {
          *     | addEntry() and addAllEntries()             |
          *     + - - - - - - - - - - - - - - - - - - - - - -+
          *     | APPEND_PLAYLIST                            |
+         *     | COPY_TITLE                                 |
          *     | SHARE                                      |
          *     | OPEN_IN_BROWSER                            |
          *     | PLAY_WITH_KODI                             |
@@ -341,6 +343,7 @@ public final class InfoItemDialog {
             addAllEntries(
                     StreamDialogDefaultEntry.DOWNLOAD,
                     StreamDialogDefaultEntry.APPEND_PLAYLIST,
+                    StreamDialogDefaultEntry.COPY_TITLE,
                     StreamDialogDefaultEntry.SHARE,
                     StreamDialogDefaultEntry.OPEN_IN_BROWSER,
                     StreamDialogDefaultEntry.BLOCK_VIDEO,

--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/StreamDialogDefaultEntry.java
@@ -115,6 +115,9 @@ public enum StreamDialogDefaultEntry {
     PLAY_WITH_KODI(R.string.play_with_kodi_title, (fragment, item) ->
             KoreUtils.playWithKore(fragment.requireContext(), Uri.parse(item.getUrl()))),
 
+    COPY_TITLE(R.string.copy_video_title, (fragment, item) ->
+            ShareUtils.copyToClipboard(fragment.requireContext(), item.getName())),
+
     SHARE(R.string.share, (fragment, item) ->
             ShareUtils.shareText(fragment.requireContext(), item.getName(), item.getUrl(),
                     ExtractorImageCompat.thumbnailImages(item))),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="open_in_popup_mode">Open in popup mode</string>
     <string name="open_with">Open with</string>
     <string name="share">Share</string>
+    <string name="copy_video_title">Copy title</string>
     <string name="download">Download</string>
     <string name="bulk_download_title">Bulk download</string>
     <string name="download_playlist">Download playlist</string>

--- a/app/src/test/java/org/schabi/newpipe/info_list/dialog/InfoItemDialogCopyTitleTest.java
+++ b/app/src/test/java/org/schabi/newpipe/info_list/dialog/InfoItemDialogCopyTitleTest.java
@@ -1,0 +1,52 @@
+package org.schabi.newpipe.info_list.dialog;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class InfoItemDialogCopyTitleTest {
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void defaultMenuPlacesCopyTitleBesideShare() throws Exception {
+        final String dialog = source("InfoItemDialog.java");
+
+        assertTrue(dialog.contains("StreamDialogDefaultEntry.COPY_TITLE,"
+                + System.lineSeparator()
+                + "                    StreamDialogDefaultEntry.SHARE,"));
+    }
+
+    @Test
+    public void copyTitleCopiesOnlyTheDisplayedTitle() throws Exception {
+        final String entries = source("StreamDialogDefaultEntry.java");
+        final int copyTitleStart = entries.indexOf(
+                "COPY_TITLE(R.string.copy_video_title");
+        final int shareStart = entries.indexOf("SHARE(R.string.share", copyTitleStart);
+        final String copyTitleEntry = entries.substring(copyTitleStart, shareStart);
+
+        assertTrue(copyTitleEntry.contains(
+                "ShareUtils.copyToClipboard(fragment.requireContext(), item.getName())"));
+        assertFalse(copyTitleEntry.contains("item.getUrl()"));
+        assertFalse(copyTitleEntry.contains("item.getUploaderName()"));
+    }
+
+    @Test
+    public void copyTitleLabelIsAvailable() throws Exception {
+        final String strings = Files.readString(resourcesDirectory.resolve("values/strings.xml"));
+
+        assertTrue(strings.contains(
+                "<string name=\"copy_video_title\">Copy title</string>"));
+    }
+
+    private String source(final String fileName) throws Exception {
+        return Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/info_list/dialog/" + fileName));
+    }
+}


### PR DESCRIPTION
- Add a Copy title action beside Share in the standard video long-press menu.
- Copy only the displayed video title through the existing clipboard helper.
- Apply the action across every list and grid that uses the shared stream dialog.
- Preserve Android-version-specific clipboard confirmation and failure handling.
- Add regression coverage for menu placement, copied content, and the user-facing label.
- Fixes #309