### PR TITLE
Stabilize tablet detail layout after rotation

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -545,9 +545,12 @@ public final class VideoDetailFragment
         updateDetailNavigationVisibility();
 
         if (binding.relatedItemsLayout != null) {
-            binding.relatedItemsLayout.setVisibility(showRelatedItems
-                    ? fullscreen ? View.GONE : View.VISIBLE
-                    : View.GONE);
+            if (showRelatedItems) {
+                binding.relatedItemsLayout.setVisibility(
+                        fullscreen ? View.GONE : View.VISIBLE);
+            } else {
+                binding.relatedItemsLayout.setVisibility(View.GONE);
+            }
         }
 
         tryAddVideoPlayerView();

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -268,6 +268,7 @@ public final class VideoDetailFragment
     private int viewPagerBaseStartMargin;
     private int viewPagerBaseBottomMargin;
     private boolean detailLayoutRecreationPending;
+    private boolean detailLayoutRecreationRequested;
 
     private ContentObserver settingsContentObserver;
     @Nullable
@@ -412,6 +413,10 @@ public final class VideoDetailFragment
 
         setupBrightness();
 
+        if (detailLayoutRecreationRequested && binding != null) {
+            binding.getRoot().post(this::reconcileDetailLayoutAfterConfigurationChange);
+        }
+
         if (tabSettingsChanged) {
             tabSettingsChanged = false;
             initTabs();
@@ -432,9 +437,9 @@ public final class VideoDetailFragment
         if (binding == null) {
             return;
         }
-        final boolean wideLandscapeLayout = binding.relatedItemsLayout != null;
-        if (wideLandscapeLayout != shouldUseWideLandscapeDetailLayout(
+        if (shouldRecreateDetailLayout(binding.relatedItemsLayout != null,
                 newConfig.orientation, newConfig.screenWidthDp)) {
+            detailLayoutRecreationRequested = true;
             recreateDetailLayoutForConfigurationChange();
             return;
         }
@@ -468,7 +473,15 @@ public final class VideoDetailFragment
                 && screenWidthDp >= EXPANDED_DETAIL_MIN_WIDTH_DP;
     }
 
+    static boolean shouldRecreateDetailLayout(final boolean wideLandscapeLayout,
+                                              final int orientation,
+                                              final int screenWidthDp) {
+        return wideLandscapeLayout
+                != shouldUseWideLandscapeDetailLayout(orientation, screenWidthDp);
+    }
+
     private void recreateDetailLayoutForConfigurationChange() {
+        detailLayoutRecreationRequested = true;
         if (detailLayoutRecreationPending || binding == null) {
             return;
         }
@@ -483,18 +496,65 @@ public final class VideoDetailFragment
                 detailLayoutRecreationPending = false;
                 return;
             }
+            detailLayoutRecreationRequested = false;
             fragmentManager.beginTransaction()
                     .detach(this)
                     .attach(this)
                     .runOnCommit(() -> {
                         detailLayoutRecreationPending = false;
-                        if (binding != null && player != null && isAdded()) {
-                            binding.getRoot().post(() -> syncFullscreenWithOrientation(
-                                    player.UIs().get(MainPlayerUi.class)));
+                        if (binding != null && isAdded()) {
+                            binding.getRoot().post(
+                                    this::reconcileDetailLayoutAfterConfigurationChange);
                         }
                     })
                     .commit();
         });
+    }
+
+    private void reconcileDetailLayoutAfterConfigurationChange() {
+        if (binding == null || !isAdded()) {
+            return;
+        }
+        final Configuration configuration = getResources().getConfiguration();
+        if (shouldRecreateDetailLayout(binding.relatedItemsLayout != null,
+                configuration.orientation, configuration.screenWidthDp)) {
+            detailLayoutRecreationRequested = true;
+            recreateDetailLayoutForConfigurationChange();
+            return;
+        }
+
+        detailLayoutRecreationRequested = false;
+        restoreDetailLayoutAfterConfigurationChange();
+    }
+
+    private void restoreDetailLayoutAfterConfigurationChange() {
+        if (binding == null || !isAdded()) {
+            return;
+        }
+
+        if (currentInfo != null) {
+            prepareAndHandleInfo(currentInfo, false);
+        } else if (currentLocalItem != null) {
+            prepareAndHandleLocalMedia(currentLocalItem, false);
+        }
+
+        final boolean fullscreen = isFullscreen();
+        updateDetailContentTopMargin(fullscreen);
+        updateDetailContentStartMargins(fullscreen);
+        updateDetailNavigationBottomInset();
+        updateDetailNavigationVisibility();
+
+        if (binding.relatedItemsLayout != null) {
+            binding.relatedItemsLayout.setVisibility(showRelatedItems
+                    ? fullscreen ? View.GONE : View.VISIBLE
+                    : View.GONE);
+        }
+
+        tryAddVideoPlayerView();
+        updatePinnedPlayerLayout();
+        if (player != null) {
+            syncFullscreenWithOrientation(player.UIs().get(MainPlayerUi.class));
+        }
     }
 
     @Override

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
@@ -41,6 +41,18 @@ public class VideoDetailLayoutStateTest {
     }
 
     @Test
+    public void layoutRecreationTracksTheCurrentlyInflatedLayout() {
+        assertTrue(VideoDetailFragment.shouldRecreateDetailLayout(
+                false, Configuration.ORIENTATION_LANDSCAPE, 840));
+        assertFalse(VideoDetailFragment.shouldRecreateDetailLayout(
+                true, Configuration.ORIENTATION_LANDSCAPE, 840));
+        assertTrue(VideoDetailFragment.shouldRecreateDetailLayout(
+                true, Configuration.ORIENTATION_PORTRAIT, 1200));
+        assertFalse(VideoDetailFragment.shouldRecreateDetailLayout(
+                false, Configuration.ORIENTATION_PORTRAIT, 1200));
+    }
+
+    @Test
     public void phoneDetailNavigationAvoidsBottomSystemBar() {
         assertEquals(48,
                 VideoDetailFragment.getDetailNavigationBottomInset(

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -23,5 +23,10 @@ public class VideoDetailOrientationHandlingTest {
         assertTrue(fragment.contains("public void onConfigurationChanged("));
         assertTrue(fragment.contains("syncFullscreenWithOrientation("));
         assertTrue(fragment.contains("binding.getRoot().post("));
+        assertTrue(fragment.contains("detailLayoutRecreationRequested"));
+        assertTrue(fragment.contains("reconcileDetailLayoutAfterConfigurationChange"));
+        assertTrue(fragment.contains("restoreDetailLayoutAfterConfigurationChange"));
+        assertTrue(fragment.contains("prepareAndHandleInfo(currentInfo, false)"));
+        assertTrue(fragment.contains("binding.relatedItemsLayout.setVisibility(showRelatedItems"));
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -27,6 +27,6 @@ public class VideoDetailOrientationHandlingTest {
         assertTrue(fragment.contains("reconcileDetailLayoutAfterConfigurationChange"));
         assertTrue(fragment.contains("restoreDetailLayoutAfterConfigurationChange"));
         assertTrue(fragment.contains("prepareAndHandleInfo(currentInfo, false)"));
-        assertTrue(fragment.contains("binding.relatedItemsLayout.setVisibility(showRelatedItems"));
+        assertTrue(fragment.contains("fullscreen ? View.GONE : View.VISIBLE"));
     }
 }


### PR DESCRIPTION
- Coalesce rapid configuration changes instead of dropping rotations while detail-layout recreation is pending.
- Reconcile the inflated detail layout against the device’s latest orientation and width after every recreation.
- Restore the current video metadata, tabs, fullscreen state, player sizing, navigation margins, and pinned-player state after the final layout settles.
- Reattach and show recommendations in non-fullscreen expanded landscape layouts.
- Retry deferred reconciliation safely when FragmentManager state was temporarily saved.
- Add regression coverage for responsive layout mismatches and rotation-state restoration.
- Fixes #294