### PR TITLE
Prevent comment return crash before list initialization

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -112,6 +112,10 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
     }
 
     public boolean scrollToComment(final CommentsInfoItem comment) {
+        if (infoListAdapter == null || itemsList == null) {
+            return false;
+        }
+
         final int position = infoListAdapter.getItemsList().indexOf(comment);
         if (position < 0) {
             return false;

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/comments/CommentsFragmentLifecycleTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/comments/CommentsFragmentLifecycleTest.java
@@ -1,0 +1,28 @@
+package org.schabi.newpipe.fragments.list.comments;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CommentsFragmentLifecycleTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void commentScrollingWaitsForListViewsToBeInitialized() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/fragments/list/comments/CommentsFragment.java"));
+
+        final int lifecycleGuard = source.indexOf(
+                "if (infoListAdapter == null || itemsList == null)");
+        final int adapterAccess = source.indexOf(
+                "infoListAdapter.getItemsList().indexOf(comment)");
+
+        assertTrue("The lifecycle guard must exist", lifecycleGuard >= 0);
+        assertTrue("The lifecycle guard must run before adapter access",
+                lifecycleGuard < adapterAccess);
+    }
+}


### PR DESCRIPTION
- Guard comment scrolling until the comments adapter and RecyclerView are initialized
- Treat an early bottom-sheet expansion callback as a no-op instead of dereferencing lifecycle-bound views
- Add regression coverage that keeps the lifecycle guard ahead of adapter access