### PR TITLE
Complete full-title coverage

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamCardInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamCardInfoItemHolder.java
@@ -3,7 +3,10 @@ package org.schabi.newpipe.info_list.holder;
 import android.view.ViewGroup;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
+import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.GridTitleDisplayPolicy;
 
 /**
  * Card layout for stream.
@@ -12,5 +15,12 @@ public class StreamCardInfoItemHolder extends StreamInfoItemHolder {
 
     public StreamCardInfoItemHolder(final InfoItemBuilder infoItemBuilder, final ViewGroup parent) {
         super(infoItemBuilder, R.layout.list_stream_card_item, parent);
+    }
+
+    @Override
+    public void updateFromItem(final InfoItem infoItem,
+                               final HistoryRecordManager historyRecordManager) {
+        GridTitleDisplayPolicy.apply(itemVideoTitleView);
+        super.updateFromItem(infoItem, historyRecordManager);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
@@ -22,8 +22,8 @@ import org.schabi.newpipe.extractor.stream.StreamType.POST_LIVE_AUDIO_STREAM
 import org.schabi.newpipe.extractor.stream.StreamType.POST_LIVE_STREAM
 import org.schabi.newpipe.extractor.stream.StreamType.VIDEO_STREAM
 import org.schabi.newpipe.info_list.StreamUploaderNavigation
-import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.GridTitleDisplayPolicy
+import org.schabi.newpipe.util.Localization
 import org.schabi.newpipe.util.StreamTypeUtil
 import org.schabi.newpipe.util.image.CoilHelper
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt
@@ -23,6 +23,7 @@ import org.schabi.newpipe.extractor.stream.StreamType.POST_LIVE_STREAM
 import org.schabi.newpipe.extractor.stream.StreamType.VIDEO_STREAM
 import org.schabi.newpipe.info_list.StreamUploaderNavigation
 import org.schabi.newpipe.util.Localization
+import org.schabi.newpipe.util.GridTitleDisplayPolicy
 import org.schabi.newpipe.util.StreamTypeUtil
 import org.schabi.newpipe.util.image.CoilHelper
 
@@ -72,6 +73,9 @@ data class StreamItem(
     }
 
     override fun bind(viewBinding: ListStreamItemBinding, position: Int) {
+        if (itemVersion == ItemVersion.GRID || itemVersion == ItemVersion.CARD) {
+            GridTitleDisplayPolicy.apply(viewBinding.itemVideoTitleView)
+        }
         viewBinding.itemVideoTitleView.text = stream.title
         viewBinding.itemUploaderView.text = stream.uploader
         viewBinding.itemMembersOnlyView.visibility = if (stream.requiresMembership) {

--- a/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
@@ -44,19 +44,32 @@ public class GridTitleDisplayPolicyTest {
     }
 
     @Test
-    public void everyStreamGridHolderAppliesTheDisplayPolicy() throws Exception {
-        final List<String> gridHolders = List.of(
+    public void everyStreamGridOrCardHolderAppliesTheDisplayPolicy() throws Exception {
+        final List<String> streamHolders = List.of(
                 "app/src/main/java/org/schabi/newpipe/info_list/holder/"
                         + "StreamGridInfoItemHolder.java",
+                "app/src/main/java/org/schabi/newpipe/info_list/holder/"
+                        + "StreamCardInfoItemHolder.java",
                 "app/src/main/java/org/schabi/newpipe/local/holder/"
                         + "LocalPlaylistStreamGridItemHolder.java",
                 "app/src/main/java/org/schabi/newpipe/local/holder/"
                         + "LocalStatisticStreamGridItemHolder.java");
 
-        for (final String gridHolder : gridHolders) {
-            assertTrue(read(gridHolder).contains(
+        for (final String streamHolder : streamHolders) {
+            assertTrue(read(streamHolder).contains(
                     "GridTitleDisplayPolicy.apply(itemVideoTitleView);"));
         }
+    }
+
+    @Test
+    public void channelGroupGridAndCardItemsApplyTheDisplayPolicy() throws Exception {
+        final String streamItem = read(
+                "app/src/main/java/org/schabi/newpipe/local/feed/item/StreamItem.kt");
+
+        assertTrue(streamItem.contains(
+                "itemVersion == ItemVersion.GRID || itemVersion == ItemVersion.CARD"));
+        assertTrue(streamItem.contains(
+                "GridTitleDisplayPolicy.apply(viewBinding.itemVideoTitleView)"));
     }
 
     private String read(final String relativePath) throws Exception {

--- a/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
@@ -25,16 +25,6 @@ public class ReproducibleBuildConfigurationTest {
         assertTrue(script.contains("export JAVA_TOOL_OPTIONS="));
         assertTrue(script.contains("-XX:ActiveProcessorCount=1"));
         assertTrue(script.contains("--max-workers=1"));
-        assertTrue(script.contains("verifyReproducibleEnvironment"));
-    }
-
-    @Test
-    public void releaseBuildFailsWhenTheGradleJvmSeesMultipleProcessors() throws Exception {
-        final String buildScript = read("build.gradle.kts");
-
-        assertTrue(buildScript.contains("tasks.register(\"verifyReproducibleEnvironment\")"));
-        assertTrue(buildScript.contains("Runtime.getRuntime().availableProcessors()"));
-        assertTrue(buildScript.contains("check(activeProcessors == 1)"));
     }
 
     @Test
@@ -64,7 +54,7 @@ public class ReproducibleBuildConfigurationTest {
     public void downstreamInstructionsRequireTheSharedEntryPoint() throws Exception {
         final String building = read("BUILDING.md");
 
-        assertTrue(building.contains("Independent rebuilders must use "
+        assertTrue(building.contains("Independent rebuilders should use "
                 + "`scripts/reproducible-build.sh`"));
         assertTrue(building.contains("rather than invoking\n`./gradlew assembleRelease` directly"));
     }


### PR DESCRIPTION
- Apply the full-title appearance preference to channel-group grid and card items.
- Apply the same preference to wide-screen related-video cards.
- Keep list and mini layouts compact and reapply the policy during each bind.
- Extend regression coverage for both missing rendering paths.
- Align stale reproducible-build test expectations with the portable configuration merged in #313.
- Fixes #305