### PR TITLE
Apply grid columns to channel-group feeds

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -145,7 +145,9 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         groupName = arguments?.getString(KEY_GROUP_NAME) ?: ""
 
         onSettingsChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (getString(R.string.list_view_mode_key).equals(key)) {
+            if (getString(R.string.list_view_mode_key).equals(key) ||
+                getString(R.string.grid_columns_key).equals(key)
+            ) {
                 updateListViewModeOnResume = true
             } else if (ContentBlockingHelper.isPreferenceKey(requireContext(), key)) {
                 latestLoadedState?.let { showFilteredFeedItems(it, false) }
@@ -226,7 +228,11 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             R.dimen.video_item_grid_thumbnail_image_width
         ) + resources.getDimensionPixelSize(R.dimen.video_item_search_padding) * 2
         feedBinding.itemsList.layoutManager = if (gridMode) {
-            GridLayoutManagerHelper.create(feedBinding.itemsList, minimumItemWidth) { spanCount ->
+            GridLayoutManagerHelper.create(
+                feedBinding.itemsList,
+                minimumItemWidth,
+                GridLayoutManagerHelper.getPreferredSpanCount(requireContext())
+            ) { spanCount ->
                 groupAdapter.spanCount = spanCount
                 groupAdapter.spanSizeLookup
             }

--- a/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
@@ -54,6 +54,17 @@ public class TabletGridConfigurationTest {
     }
 
     @Test
+    public void channelGroupFeedsUseAndObserveTheColumnPreference() throws Exception {
+        final String feedFragment = read(
+                "app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt");
+
+        assertTrue(feedFragment.contains(
+                "GridLayoutManagerHelper.getPreferredSpanCount(requireContext())"));
+        assertTrue(feedFragment.contains(
+                "getString(R.string.grid_columns_key).equals(key)"));
+    }
+
+    @Test
     public void thumbnailCardsFillTheirColumnAtSixteenByNine() throws Exception {
         for (final String layout : List.of(
                 "app/src/main/res/layout/list_stream_grid_item.xml",


### PR DESCRIPTION
- Apply the tablet grid-column preference to channel-group feeds.
- Rebuild the feed layout when the selected column count changes.
- Preserve Automatic as the default and retain Groupie span-size behavior.
- Add regression coverage for preference use and observation in `FeedFragment`.
- Fixes #304