### PR TITLE
Focus reproducibility checks on build changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,49 +79,6 @@ jobs:
           name: wizestream-debug-apk
           path: app/build/outputs/apk/debug/*.apk
 
-  reproducible-release:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Create and checkout branch
-        if: github.event_name == 'pull_request'
-        env:
-          BRANCH: ${{ github.head_ref }}
-        run: git checkout -B "$BRANCH"
-
-      - name: Set up pinned JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: 21.0.12+8.0.LTS
-          distribution: temurin
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Build release APK twice and compare SHA-256
-        run: scripts/reproducible-build.sh --verify --output-dir "$RUNNER_TEMP/reproducible-release"
-
-      - name: Verify release packaged resources
-        run: |
-          APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
-          test -s "$APK_PATH"
-          BUILD_TOOLS_VERSION="36.1.0"
-          AAPT="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt"
-          "$AAPT" dump resources "$APK_PATH" > "$RUNNER_TEMP/release-resources.txt"
-          grep -q "layout/list_search_no_results" "$RUNNER_TEMP/release-resources.txt"
-          grep -q "layout/list_empty_view_subscriptions" "$RUNNER_TEMP/release-resources.txt"
-          scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
-
-      - name: Upload reproducibility result
-        uses: actions/upload-artifact@v7
-        with:
-          name: wizestream-reproducible-release
-          path: ${{ runner.temp }}/reproducible-release/**
-
   test-android:
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -1,0 +1,92 @@
+name: Reproducibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+  pull_request:
+    branches:
+      - pipe
+    paths:
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/reproducibility.yml"
+      - "scripts/**"
+      - "buildSrc/**"
+      - "gradle/**"
+      - "gradlew"
+      - "gradlew.bat"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle.properties"
+      - "app/build.gradle.kts"
+      - "app/proguard-rules.pro"
+  push:
+    branches:
+      - pipe
+    paths:
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/reproducibility.yml"
+      - "scripts/**"
+      - "buildSrc/**"
+      - "gradle/**"
+      - "gradlew"
+      - "gradlew.bat"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle.properties"
+      - "app/build.gradle.kts"
+      - "app/proguard-rules.pro"
+
+concurrency:
+  group: reproducibility-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  reproducible-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create and checkout branch
+        if: github.event_name == 'pull_request'
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: git checkout -B "$BRANCH"
+
+      - uses: gradle/actions/wrapper-validation@v6
+
+      - name: Set up pinned JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21.0.12+8.0.LTS
+          distribution: temurin
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build release APK twice and compare SHA-256
+        run: scripts/reproducible-build.sh --verify --output-dir "$RUNNER_TEMP/reproducible-release"
+
+      - name: Verify release packaged resources
+        run: |
+          APK_PATH="$(find app/build/outputs/apk/release -name '*.apk' | head -n 1)"
+          test -s "$APK_PATH"
+          BUILD_TOOLS_VERSION="36.1.0"
+          AAPT="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt"
+          "$AAPT" dump resources "$APK_PATH" > "$RUNNER_TEMP/release-resources.txt"
+          grep -q "layout/list_search_no_results" "$RUNNER_TEMP/release-resources.txt"
+          grep -q "layout/list_empty_view_subscriptions" "$RUNNER_TEMP/release-resources.txt"
+          scripts/verify-apk-abis.sh "$APK_PATH" arm64-v8a armeabi-v7a
+
+      - name: Upload reproducibility result
+        uses: actions/upload-artifact@v7
+        with:
+          name: wizestream-reproducible-release
+          path: ${{ runner.temp }}/reproducible-release/**

--- a/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ReproducibleBuildConfigurationTest.java
@@ -28,12 +28,30 @@ public class ReproducibleBuildConfigurationTest {
     }
 
     @Test
-    public void ciAndPublishingUseTheSharedReproducibleEntryPoint() throws Exception {
+    public void targetedChecksAndPublishingUseTheSharedReproducibleEntryPoint()
+            throws Exception {
         final String ciWorkflow = read(".github/workflows/ci.yml");
+        final String reproducibilityWorkflow = read(
+                ".github/workflows/reproducibility.yml");
         final String releaseWorkflow = read(".github/workflows/release.yml");
 
-        assertEquals(1, occurrences(ciWorkflow, "scripts/reproducible-build.sh"));
+        assertEquals(0, occurrences(ciWorkflow, "scripts/reproducible-build.sh"));
+        assertEquals(1, occurrences(
+                reproducibilityWorkflow, "scripts/reproducible-build.sh"));
         assertEquals(2, occurrences(releaseWorkflow, "scripts/reproducible-build.sh"));
+    }
+
+    @Test
+    public void reproducibilityWorkflowIsManualWeeklyAndPathFiltered() throws Exception {
+        final String workflow = read(".github/workflows/reproducibility.yml");
+
+        assertTrue(workflow.contains("workflow_dispatch:"));
+        assertTrue(workflow.contains("schedule:"));
+        assertTrue(workflow.contains("pull_request:"));
+        assertTrue(workflow.contains("push:"));
+        assertTrue(workflow.contains("paths:"));
+        assertTrue(workflow.contains("- \"gradle/**\""));
+        assertTrue(workflow.contains("- \"scripts/**\""));
     }
 
     @Test


### PR DESCRIPTION
- Remove the double release build from ordinary CI runs.
- Add a dedicated reproducibility workflow with manual and weekly triggers.
- Run reproducibility checks automatically for build-system, dependency, release-workflow, script, wrapper, and ProGuard changes.
- Keep signed ARM and x86_64 double-build verification unchanged in the publishing workflow.
- Add regression coverage for the new workflow split.