### PR TITLE
Restore playlist uploader avatars

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.stream.model.StreamStateEntity;
+import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
@@ -25,6 +26,7 @@ import org.schabi.newpipe.util.image.CoilHelper;
 import org.schabi.newpipe.util.image.ExtractorImageCompat;
 import org.schabi.newpipe.views.AnimatedProgressBar;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class StreamMiniInfoItemHolder extends InfoItemHolder {
@@ -164,8 +166,14 @@ public class StreamMiniInfoItemHolder extends InfoItemHolder {
             return;
         }
 
-        CoilHelper.INSTANCE.loadAvatar(itemUploaderAvatarView,
-                ExtractorImageCompat.uploaderAvatarImages(item));
+        final List<Image> uploaderAvatars = ExtractorImageCompat.uploaderAvatarImages(item);
+        if (uploaderAvatars.isEmpty()) {
+            CoilHelper.INSTANCE.clearAvatar(itemUploaderAvatarView);
+            itemUploaderAvatarView.setVisibility(View.GONE);
+        } else {
+            itemUploaderAvatarView.setVisibility(View.VISIBLE);
+            CoilHelper.INSTANCE.loadAvatar(itemUploaderAvatarView, uploaderAvatars);
+        }
 
         final ChannelInfoItem channel = StreamUploaderNavigation.fromStream(item);
         final OnClickGesture<ChannelInfoItem> listener =

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -63,7 +63,11 @@ import org.schabi.newpipe.util.text.TextLinkifier;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -424,6 +428,11 @@ public final class ExtractorHelper {
         final PlaylistInfo playlistInfo =
                 PlaylistInfo.getInfo(NewPipe.getService(serviceId), url);
         backfillYouTubePlaylistUploaderAvatarFromChannel(serviceId, playlistInfo);
+        backfillYouTubePlaylistItemUploaderAvatars(
+                serviceId,
+                playlistInfo.getRelatedItems(),
+                playlistInfo.getUploaderUrl(),
+                playlistInfo.getUploaderAvatarUrl());
         return playlistInfo;
     }
 
@@ -456,12 +465,94 @@ public final class ExtractorHelper {
                 && isNullOrEmpty(uploaderAvatarUrl);
     }
 
+    private static void backfillYouTubePlaylistItemUploaderAvatars(
+            final int serviceId,
+            @Nullable final List<StreamInfoItem> items,
+            @Nullable final String playlistUploaderUrl,
+            @Nullable final String playlistUploaderAvatarUrl) {
+        if (serviceId != ServiceList.YouTube.getServiceId()
+                || items == null || items.isEmpty()) {
+            return;
+        }
+
+        final String unresolvedUploaderUrl = enrichKnownPlaylistItemUploaderAvatars(
+                items, playlistUploaderUrl, playlistUploaderAvatarUrl);
+        if (isNullOrEmpty(unresolvedUploaderUrl)) {
+            return;
+        }
+
+        try {
+            final ChannelInfo channelInfo = getChannelInfo(
+                    serviceId, unresolvedUploaderUrl, false).blockingGet();
+            final String avatarUrl = findLastNonEmptyImageUrl(channelInfo.getAvatars());
+            applyPlaylistItemUploaderAvatar(items, unresolvedUploaderUrl, avatarUrl);
+        } catch (final Exception ignored) {
+            // Keep the playlist usable if the optional shared-uploader lookup fails.
+        }
+    }
+
+    @Nullable
+    static String enrichKnownPlaylistItemUploaderAvatars(
+            final List<StreamInfoItem> items,
+            @Nullable final String playlistUploaderUrl,
+            @Nullable final String playlistUploaderAvatarUrl) {
+        final Map<String, String> knownAvatars = new HashMap<>();
+        if (!isNullOrEmpty(playlistUploaderUrl)
+                && !isNullOrEmpty(playlistUploaderAvatarUrl)) {
+            knownAvatars.put(playlistUploaderUrl, playlistUploaderAvatarUrl);
+        }
+
+        for (final StreamInfoItem item : items) {
+            if (!isNullOrEmpty(item.getUploaderUrl())
+                    && !isNullOrEmpty(item.getUploaderAvatarUrl())) {
+                knownAvatars.putIfAbsent(item.getUploaderUrl(), item.getUploaderAvatarUrl());
+            }
+        }
+
+        for (final Map.Entry<String, String> entry : knownAvatars.entrySet()) {
+            applyPlaylistItemUploaderAvatar(items, entry.getKey(), entry.getValue());
+        }
+
+        final Set<String> unresolvedUploaderUrls = new LinkedHashSet<>();
+        for (final StreamInfoItem item : items) {
+            if (isNullOrEmpty(item.getUploaderAvatarUrl())
+                    && !isNullOrEmpty(item.getUploaderUrl())) {
+                unresolvedUploaderUrls.add(item.getUploaderUrl());
+                if (unresolvedUploaderUrls.size() > 1) {
+                    return null;
+                }
+            }
+        }
+        return unresolvedUploaderUrls.stream().findFirst().orElse(null);
+    }
+
+    static void applyPlaylistItemUploaderAvatar(
+            final List<StreamInfoItem> items,
+            @Nullable final String uploaderUrl,
+            @Nullable final String uploaderAvatarUrl) {
+        if (isNullOrEmpty(uploaderUrl) || isNullOrEmpty(uploaderAvatarUrl)) {
+            return;
+        }
+
+        for (final StreamInfoItem item : items) {
+            if (uploaderUrl.equals(item.getUploaderUrl())
+                    && isNullOrEmpty(item.getUploaderAvatarUrl())) {
+                item.setUploaderAvatarUrl(uploaderAvatarUrl);
+            }
+        }
+    }
+
     public static Single<InfoItemsPage<StreamInfoItem>> getMorePlaylistItems(final int serviceId,
                                                                              final String url,
                                                                              final Page nextPage) {
         checkServiceId(serviceId);
-        return Single.fromCallable(() ->
-                PlaylistInfo.getMoreItems(NewPipe.getService(serviceId), url, nextPage));
+        return Single.fromCallable(() -> {
+            final InfoItemsPage<StreamInfoItem> page = PlaylistInfo.getMoreItems(
+                    NewPipe.getService(serviceId), url, nextPage);
+            backfillYouTubePlaylistItemUploaderAvatars(
+                    serviceId, page.getItems(), null, null);
+            return page;
+        });
     }
 
     public static Single<KioskInfo> getKioskInfo(final int serviceId,

--- a/app/src/test/java/org/schabi/newpipe/info_list/StreamUploaderIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/info_list/StreamUploaderIntegrationTest.java
@@ -58,6 +58,17 @@ public class StreamUploaderIntegrationTest {
     }
 
     @Test
+    public void recycledStreamRowsResetMissingAndAvailableAvatarVisibility() throws Exception {
+        final String holder = read(
+                "src/main/java/org/schabi/newpipe/info_list/holder/StreamMiniInfoItemHolder.java"
+        );
+
+        assertTrue(holder.contains("clearAvatar(itemUploaderAvatarView)"));
+        assertTrue(holder.contains("itemUploaderAvatarView.setVisibility(View.GONE)"));
+        assertTrue(holder.contains("itemUploaderAvatarView.setVisibility(View.VISIBLE)"));
+    }
+
+    @Test
     public void feedRefreshAndImportUseCachedSubscriptionAvatarWithoutExtraLookup()
             throws Exception {
         final String feedLoadManager = read(

--- a/app/src/test/java/org/schabi/newpipe/util/ExtractorHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ExtractorHelperTest.java
@@ -9,6 +9,8 @@ import org.junit.Test;
 import org.schabi.newpipe.extractor.Image;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -70,11 +72,78 @@ public class ExtractorHelperTest {
         assertNull(ExtractorHelper.findLastNonEmptyImageUrl(Collections.emptyList()));
     }
 
+    @Test
+    public void playlistOwnerAvatarIsReusedWithoutAnotherLookup() {
+        final List<StreamInfoItem> items = Arrays.asList(
+                stream("first", "channel", null),
+                stream("second", "channel", null));
+
+        assertNull(ExtractorHelper.enrichKnownPlaylistItemUploaderAvatars(
+                items, "channel", "avatar"));
+        assertEquals("avatar", items.get(0).getUploaderAvatarUrl());
+        assertEquals("avatar", items.get(1).getUploaderAvatarUrl());
+    }
+
+    @Test
+    public void knownItemAvatarIsReusedForMatchingPlaylistItems() {
+        final List<StreamInfoItem> items = Arrays.asList(
+                stream("first", "channel", "cached-avatar"),
+                stream("second", "channel", null));
+
+        assertNull(ExtractorHelper.enrichKnownPlaylistItemUploaderAvatars(
+                items, null, null));
+        assertEquals("cached-avatar", items.get(1).getUploaderAvatarUrl());
+    }
+
+    @Test
+    public void singleMissingUploaderRequestsOnlyOneChannelLookup() {
+        final List<StreamInfoItem> items = Arrays.asList(
+                stream("first", "channel", null),
+                stream("second", "channel", null));
+
+        assertEquals("channel", ExtractorHelper.enrichKnownPlaylistItemUploaderAvatars(
+                items, null, null));
+    }
+
+    @Test
+    public void mixedMissingUploadersDoNotTriggerPerVideoLookups() {
+        final List<StreamInfoItem> items = Arrays.asList(
+                stream("first", "channel-one", null),
+                stream("second", "channel-two", null));
+
+        assertNull(ExtractorHelper.enrichKnownPlaylistItemUploaderAvatars(
+                items, null, null));
+    }
+
+    @Test
+    public void resolvedAvatarDoesNotOverwriteExistingAvatar() {
+        final List<StreamInfoItem> items = Arrays.asList(
+                stream("first", "channel", "existing-avatar"),
+                stream("second", "channel", null),
+                stream("third", "other-channel", null));
+
+        ExtractorHelper.applyPlaylistItemUploaderAvatar(items, "channel", "resolved-avatar");
+
+        assertEquals("existing-avatar", items.get(0).getUploaderAvatarUrl());
+        assertEquals("resolved-avatar", items.get(1).getUploaderAvatarUrl());
+        assertNull(items.get(2).getUploaderAvatarUrl());
+    }
+
     private static Image image(final String url) {
         return new Image(
                 url,
                 Image.HEIGHT_UNKNOWN,
                 Image.WIDTH_UNKNOWN,
                 Image.ResolutionLevel.UNKNOWN);
+    }
+
+    private static StreamInfoItem stream(final String url,
+                                         final String uploaderUrl,
+                                         final String uploaderAvatarUrl) {
+        final StreamInfoItem item = new StreamInfoItem(
+                ServiceList.YouTube.getServiceId(), url, url, StreamType.VIDEO_STREAM);
+        item.setUploaderUrl(uploaderUrl);
+        item.setUploaderAvatarUrl(uploaderAvatarUrl);
+        return item;
     }
 }


### PR DESCRIPTION
- Reuse playlist-owner and already-known uploader avatars across matching videos.
- Resolve a shared missing uploader with at most one cached channel lookup per playlist page.
- Avoid per-video channel requests for mixed-uploader playlists.
- Hide unavailable avatar placeholders while preserving uploader navigation.
- Reset avatar visibility safely when stream rows are recycled.
- Cover owner reuse, cached reuse, single- and mixed-uploader behavior, and recycled visibility.
- Fixes #292