### PR TITLE
Keep contextual search action above the keyboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,7 +63,8 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:supportsPictureInPicture="true">
+            android:supportsPictureInPicture="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -29,7 +29,10 @@ import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.graphics.Insets;
 import androidx.core.view.MenuItemCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapterMenuWorkaround;
@@ -93,6 +96,8 @@ public class MainFragment extends BaseFragment
     private boolean tabsSetupInProgress;
     private String contextualSearchQuery = "";
     private int contextualSearchTabPosition = -1;
+    private int contextualSearchFabBaseBottomMargin;
+    private int contextualSearchImeBottomInset;
 
     private final List<Tab> tabsList = new ArrayList<>();
     private TabsManager tabsManager;
@@ -179,6 +184,7 @@ public class MainFragment extends BaseFragment
         });
         setupTabs();
         initContextualSearchToolbar();
+        initContextualSearchInsets();
         if (contextualSearchOpen) {
             binding.pager.post(this::restoreContextualSearch);
         }
@@ -261,6 +267,10 @@ public class MainFragment extends BaseFragment
     @Override
     public void onDestroyView() {
         contextualSearchHandler.removeCallbacksAndMessages(null);
+        if (binding != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(binding.getRoot(), null);
+        }
+        contextualSearchImeBottomInset = 0;
         setActivityContextualSearchToolbarActive(false);
         if (contextualSearchEditText != null && contextualSearchTextWatcher != null) {
             contextualSearchEditText.removeTextChangedListener(contextualSearchTextWatcher);
@@ -459,6 +469,26 @@ public class MainFragment extends BaseFragment
     /*//////////////////////////////////////////////////////////////////////////
     // Contextual local search
     //////////////////////////////////////////////////////////////////////////*/
+
+    private void initContextualSearchInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.getRoot(), (view, windowInsets) -> {
+            final WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(view);
+            final WindowInsetsCompat effectiveInsets =
+                    rootInsets == null ? windowInsets : rootInsets;
+            final Insets imeInsets = effectiveInsets.getInsets(
+                    WindowInsetsCompat.Type.ime());
+            final Insets navigationBarInsets = effectiveInsets.getInsets(
+                    WindowInsetsCompat.Type.navigationBars());
+            final int newImeBottomInset = Math.max(
+                    0, imeInsets.bottom - navigationBarInsets.bottom);
+            if (contextualSearchImeBottomInset != newImeBottomInset) {
+                contextualSearchImeBottomInset = newImeBottomInset;
+                updateGlobalSearchFabBottomMargin();
+            }
+            return windowInsets;
+        });
+        ViewCompat.requestApplyInsets(binding.getRoot());
+    }
 
     private void initContextualSearchToolbar() {
         contextualSearchContainer = requireActivity()
@@ -825,17 +855,29 @@ public class MainFragment extends BaseFragment
                 binding.contextualGlobalSearchFab.getLayoutParams();
         fabParams.removeRule(ABOVE);
         fabParams.removeRule(ALIGN_PARENT_BOTTOM);
-        fabParams.bottomMargin = getResources()
+        contextualSearchFabBaseBottomMargin = getResources()
                 .getDimensionPixelSize(R.dimen.margin_normal);
         if (showBottomTabs) {
             fabParams.addRule(ABOVE, R.id.main_tab_layout);
         } else {
             fabParams.addRule(ALIGN_PARENT_BOTTOM);
             if (showBottomNavigation && !isNavigationRail()) {
-                fabParams.bottomMargin += getResources()
+                contextualSearchFabBaseBottomMargin += getResources()
                         .getDimensionPixelSize(R.dimen.main_bottom_navigation_height);
             }
         }
+        updateGlobalSearchFabBottomMargin();
+    }
+
+    private void updateGlobalSearchFabBottomMargin() {
+        if (binding == null) {
+            return;
+        }
+
+        final var fabParams = (RelativeLayout.LayoutParams)
+                binding.contextualGlobalSearchFab.getLayoutParams();
+        fabParams.bottomMargin =
+                contextualSearchFabBaseBottomMargin + contextualSearchImeBottomInset;
         binding.contextualGlobalSearchFab.setLayoutParams(fabParams);
     }
 

--- a/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
@@ -90,6 +90,20 @@ public class ContextualSearchIntegrationTest {
     }
 
     @Test
+    public void contextualSearchFabStaysAboveTheKeyboard() throws Exception {
+        final String mainFragment = read("org/schabi/newpipe/fragments/MainFragment.java");
+        final String manifest = Files.readString(
+                resourceDirectory.resolve("../AndroidManifest.xml").normalize());
+
+        assertTrue(mainFragment.contains("WindowInsetsCompat.Type.ime()"));
+        assertTrue(mainFragment.contains(
+                "imeInsets.bottom - navigationBarInsets.bottom"));
+        assertTrue(mainFragment.contains(
+                "contextualSearchFabBaseBottomMargin + contextualSearchImeBottomInset"));
+        assertTrue(manifest.contains("android:windowSoftInputMode=\"adjustResize\""));
+    }
+
+    @Test
     public void downloadsSearchIsBufferedFilteredAndRefreshSafe() throws Exception {
         final String mainFragment = read("org/schabi/newpipe/fragments/MainFragment.java");
         assertTrue(mainFragment.contains("searchItem.setVisible(!contextualSearchOpen)"));


### PR DESCRIPTION
- Keep the contextual Search YouTube action above the software keyboard using IME insets.
- Preserve existing bottom-tab and bottom-navigation spacing and restore the normal position when the keyboard closes.
- Enable legacy Android resize-inset delivery for the main activity.
- Add regression coverage for the IME adjustment and Android 6-compatible window mode.
- Fixes #322