### PR TITLE
Fix BiliBili CDN playback requests

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -24,6 +24,7 @@ import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvicto
 import com.google.android.exoplayer2.upstream.cache.SimpleCache;
 
 import org.schabi.newpipe.DownloaderImpl;
+import org.schabi.newpipe.extractor.services.bilibili.BilibiliService;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeOtfDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubePostLiveStreamDvrDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeProgressiveDashManifestCreator;
@@ -31,6 +32,7 @@ import org.schabi.newpipe.player.datasource.NonUriHlsDataSourceFactory;
 import org.schabi.newpipe.player.datasource.YoutubeHttpDataSource;
 
 import java.io.File;
+import java.util.Map;
 
 public class PlayerDataSource {
     public static final String TAG = PlayerDataSource.class.getSimpleName();
@@ -73,6 +75,7 @@ public class PlayerDataSource {
     // Generic Data Source Factories (without or with cache)
     private final DataSource.Factory cachelessDataSourceFactory;
     private final CacheFactory cacheDataSourceFactory;
+    private final CacheFactory bilibiliCacheDataSourceFactory;
 
     // YouTube-specific Data Source Factories (with cache)
     // They use YoutubeHttpDataSource.Factory, with different parameters each
@@ -95,6 +98,10 @@ public class PlayerDataSource {
                 .setTransferListener(transferListener);
         cacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
                 new DefaultHttpDataSource.Factory().setUserAgent(DownloaderImpl.USER_AGENT));
+        bilibiliCacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
+                new DefaultHttpDataSource.Factory()
+                        .setUserAgent(DownloaderImpl.USER_AGENT)
+                        .setDefaultRequestProperties(getBilibiliPlaybackHeaders()));
 
         // YouTube-specific data source factories use getYoutubeHttpDataSourceFactory()
         ytHlsCacheDataSourceFactory = new CacheFactory(context, transferListener, cache,
@@ -164,6 +171,11 @@ public class PlayerDataSource {
                 .setContinueLoadingCheckIntervalBytes(progressiveLoadIntervalBytes);
     }
 
+    public ProgressiveMediaSource.Factory getBilibiliProgressiveMediaSourceFactory() {
+        return new ProgressiveMediaSource.Factory(bilibiliCacheDataSourceFactory)
+                .setContinueLoadingCheckIntervalBytes(progressiveLoadIntervalBytes);
+    }
+
     public SsMediaSource.Factory getSSMediaSourceFactory() {
         return new SsMediaSource.Factory(
                 new DefaultSsChunkSource.Factory(cachelessDataSourceFactory),
@@ -212,6 +224,12 @@ public class PlayerDataSource {
         YoutubeProgressiveDashManifestCreator.getCache().clear();
         YoutubeOtfDashManifestCreator.getCache().clear();
         YoutubePostLiveStreamDvrDashManifestCreator.getCache().clear();
+    }
+
+    static Map<String, String> getBilibiliPlaybackHeaders() {
+        return Map.of(
+                "Referer", BilibiliService.WWW_REFERER,
+                "Accept-Language", "zh-CN,zh;q=0.9");
     }
 
     private static YoutubeHttpDataSource.Factory getYoutubeHttpDataSourceFactory(

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -306,7 +306,11 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
             throw new ResolverException("Non URI progressive contents are not supported");
         }
         throwResolverExceptionIfUrlNullOrEmpty(stream.getContent());
-        return dataSource.getProgressiveMediaSourceFactory().createMediaSource(
+        final ProgressiveMediaSource.Factory factory =
+                metadata.getServiceId() == ServiceList.BiliBili.getServiceId()
+                        ? dataSource.getBilibiliProgressiveMediaSourceFactory()
+                        : dataSource.getProgressiveMediaSourceFactory();
+        return factory.createMediaSource(
                 new MediaItem.Builder()
                         .setTag(metadata)
                         .setUri(Uri.parse(stream.getContent()))

--- a/app/src/test/java/org/schabi/newpipe/player/helper/PlayerDataSourceTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/PlayerDataSourceTest.java
@@ -1,11 +1,14 @@
 package org.schabi.newpipe.player.helper;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeOtfDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubePostLiveStreamDvrDashManifestCreator;
 import org.schabi.newpipe.extractor.services.youtube.dashmanifestcreators.YoutubeProgressiveDashManifestCreator;
+
+import java.util.Map;
 
 public class PlayerDataSourceTest {
     @Test
@@ -19,5 +22,14 @@ public class PlayerDataSourceTest {
         assertEquals(0, YoutubeProgressiveDashManifestCreator.getCache().size());
         assertEquals(0, YoutubeOtfDashManifestCreator.getCache().size());
         assertEquals(0, YoutubePostLiveStreamDvrDashManifestCreator.getCache().size());
+    }
+
+    @Test
+    public void bilibiliPlaybackUsesCanonicalAntiLeechHeadersWithoutCookies() {
+        final Map<String, String> headers = PlayerDataSource.getBilibiliPlaybackHeaders();
+
+        assertEquals("https://www.bilibili.com/", headers.get("Referer"));
+        assertEquals("zh-CN,zh;q=0.9", headers.get("Accept-Language"));
+        assertFalse(headers.containsKey("Cookie"));
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/util/AdditionalServicesIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/AdditionalServicesIntegrationTest.java
@@ -67,9 +67,18 @@ public class AdditionalServicesIntegrationTest {
     public void serviceSpecificTransportAndCachePoliciesAreConfigured() throws Exception {
         final String downloader = read("src/main/java/org/schabi/newpipe/DownloaderImpl.java");
         final String helper = read("src/main/java/org/schabi/newpipe/util/ServiceHelper.kt");
+        final String playerDataSource = read(
+                "src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java");
+        final String playbackResolver = read(
+                "src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java");
 
         assertTrue(downloader.contains("BilibiliService.isBiliBiliDownloadUrl(url)"));
         assertTrue(downloader.contains("BilibiliService.getUserAgentHeaders(WWW_REFERER)"));
+        assertTrue(playerDataSource.contains(
+                ".setDefaultRequestProperties(getBilibiliPlaybackHeaders())"));
+        assertTrue(playbackResolver.contains(
+                "metadata.getServiceId() == ServiceList.BiliBili.getServiceId()"));
+        assertTrue(playbackResolver.contains("getBilibiliProgressiveMediaSourceFactory()"));
         assertTrue(helper.contains("ServiceList.NicoNico.serviceId"));
         assertTrue(helper.contains("TimeUnit.MILLISECONDS.convert(2, TimeUnit.MINUTES)"));
         assertTrue(helper.contains(


### PR DESCRIPTION
- Route BiliBili progressive video and separated audio through a dedicated cached ExoPlayer transport.
- Send the canonical `https://www.bilibili.com/` referer and BiliBili language header with CDN playback requests.
- Keep authentication cookies out of media requests and leave other services on the existing generic transport.
- Add regression coverage for the anti-leech headers and service-specific resolver routing.
- Fixes #324