### PR TITLE
Optimize wide video detail layout

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -64,7 +64,6 @@ import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.navigation.NavigationBarView;
-import com.google.android.material.navigationrail.NavigationRailView;
 
 import org.schabi.newpipe.App;
 import org.schabi.newpipe.R;
@@ -1388,7 +1387,8 @@ public final class VideoDetailFragment
                 pageAdapter.updateItem(RELATED_TAB_TAG, RelatedItemsFragment.getInstance(info));
             } else { // tablet + TV
                 getChildFragmentManager().beginTransaction()
-                        .replace(R.id.relatedItemsLayout, RelatedItemsFragment.getInstance(info))
+                        .replace(R.id.relatedItemsLayout,
+                                RelatedItemsFragment.getInstance(info, true))
                         .commitAllowingStateLoss();
                 binding.relatedItemsLayout.setVisibility(isFullscreen() ? View.GONE : View.VISIBLE);
             }
@@ -1435,7 +1435,7 @@ public final class VideoDetailFragment
             // Hide navigation if there is only one destination or if the pager is hidden.
             detailNavigation.setVisibility(View.GONE);
         } else {
-            if (detailNavigation instanceof NavigationRailView) {
+            if (binding.relatedItemsLayout != null) {
                 detailNavigation.setTranslationY(0.0f);
                 detailNavigation.setVisibility(View.VISIBLE);
                 return;
@@ -1891,10 +1891,10 @@ public final class VideoDetailFragment
     }
 
     static int getDetailNavigationBottomInset(final boolean fullscreen,
-                                              final boolean navigationRail,
+                                              final boolean wideDetailLayout,
                                               final int navigationBarInset,
                                               final int displayCutoutInset) {
-        if (fullscreen || navigationRail) {
+        if (fullscreen || wideDetailLayout) {
             return 0;
         }
         return Math.max(Math.max(navigationBarInset, displayCutoutInset), 0);
@@ -1915,7 +1915,7 @@ public final class VideoDetailFragment
                     WindowInsetsCompat.Type.displayCutout());
         }
         final int bottomInset = getDetailNavigationBottomInset(
-                isFullscreen(), detailNavigation instanceof NavigationRailView,
+                isFullscreen(), binding.relatedItemsLayout != null,
                 navigationBarInsets.bottom, displayCutoutInsets.bottom);
 
         final ViewGroup.MarginLayoutParams navigationParams =

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
@@ -33,6 +33,7 @@ import io.reactivex.rxjava3.core.Single;
 public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, RelatedItemsInfo>
         implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String INFO_KEY = "related_info_key";
+    private static final String WIDE_DETAIL_LAYOUT_KEY = "wide_detail_layout_key";
 
     private RelatedItemsInfo relatedItemsInfo;
 
@@ -43,7 +44,15 @@ public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, Related
     private RelatedItemsHeaderBinding headerBinding;
 
     public static RelatedItemsFragment getInstance(final StreamInfo info) {
+        return getInstance(info, false);
+    }
+
+    public static RelatedItemsFragment getInstance(final StreamInfo info,
+                                                   final boolean wideDetailLayout) {
         final RelatedItemsFragment instance = new RelatedItemsFragment();
+        final Bundle arguments = new Bundle();
+        arguments.putBoolean(WIDE_DETAIL_LAYOUT_KEY, wideDetailLayout);
+        instance.setArguments(arguments);
         instance.setInitialData(info);
         return instance;
     }
@@ -61,6 +70,14 @@ public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, Related
                              @Nullable final ViewGroup container,
                              @Nullable final Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_related_items, container, false);
+    }
+
+    @Override
+    protected void initViews(final View rootView, final Bundle savedInstanceState) {
+        final Bundle arguments = getArguments();
+        infoListAdapter.setUseWideRelatedVariant(
+                arguments != null && arguments.getBoolean(WIDE_DETAIL_LAYOUT_KEY, false));
+        super.initViews(rootView, savedInstanceState);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.PignateFooterBinding;
 import org.schabi.newpipe.dearrow.DeArrowService;
 import org.schabi.newpipe.extractor.InfoItem;
@@ -76,6 +77,7 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private static final int STREAM_HOLDER_TYPE = 0x101;
     private static final int GRID_STREAM_HOLDER_TYPE = 0x102;
     private static final int CARD_STREAM_HOLDER_TYPE = 0x103;
+    private static final int WIDE_RELATED_STREAM_HOLDER_TYPE = 0x104;
     private static final int MINI_CHANNEL_HOLDER_TYPE = 0x200;
     private static final int CHANNEL_HOLDER_TYPE = 0x201;
     private static final int GRID_CHANNEL_HOLDER_TYPE = 0x202;
@@ -93,6 +95,7 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private final HistoryRecordManager recordManager;
 
     private boolean useMiniVariant = false;
+    private boolean useWideRelatedVariant = false;
     private boolean showFooter = false;
 
     private ItemViewMode itemMode = ItemViewMode.LIST;
@@ -124,6 +127,10 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     public void setUseMiniVariant(final boolean useMiniVariant) {
         this.useMiniVariant = useMiniVariant;
+    }
+
+    public void setUseWideRelatedVariant(final boolean useWideRelatedVariant) {
+        this.useWideRelatedVariant = useWideRelatedVariant;
     }
 
     public void setItemViewMode(final ItemViewMode itemViewMode) {
@@ -287,6 +294,8 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                     return CARD_STREAM_HOLDER_TYPE;
                 } else if (itemMode == ItemViewMode.GRID) {
                     return GRID_STREAM_HOLDER_TYPE;
+                } else if (useWideRelatedVariant) {
+                    return WIDE_RELATED_STREAM_HOLDER_TYPE;
                 } else if (useMiniVariant) {
                     return MINI_STREAM_HOLDER_TYPE;
                 } else {
@@ -344,6 +353,9 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 return new StreamMiniInfoItemHolder(infoItemBuilder, parent);
             case STREAM_HOLDER_TYPE:
                 return new StreamInfoItemHolder(infoItemBuilder, parent);
+            case WIDE_RELATED_STREAM_HOLDER_TYPE:
+                return new StreamInfoItemHolder(
+                        infoItemBuilder, R.layout.list_stream_related_wide_item, parent);
             case GRID_STREAM_HOLDER_TYPE:
                 return new StreamGridInfoItemHolder(infoItemBuilder, parent);
             case CARD_STREAM_HOLDER_TYPE:

--- a/app/src/main/res/layout-w840dp-land/fragment_video_detail.xml
+++ b/app/src/main/res/layout-w840dp-land/fragment_video_detail.xml
@@ -26,7 +26,6 @@
                 android:id="@+id/app_bar_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/main_navigation_rail_width"
                 android:background="@android:color/transparent"
                 android:touchscreenBlocksFocus="false"
                 app:elevation="0dp"
@@ -611,34 +610,31 @@
 
                     </LinearLayout>
                 </RelativeLayout>
+
+                <com.google.android.material.bottomnavigation.BottomNavigationView
+                    android:id="@+id/detail_navigation"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/video_detail_navigation_height"
+                    android:background="?attr/colorSurfaceContainer"
+                    android:elevation="0dp"
+                    android:visibility="gone"
+                    app:itemActiveIndicatorStyle="@style/wizestreamBottomNavigationActiveIndicator"
+                    app:itemIconTint="@color/tab_layout_material_item_color"
+                    app:itemPaddingBottom="@dimen/video_detail_navigation_item_padding"
+                    app:itemPaddingTop="@dimen/video_detail_navigation_item_padding"
+                    app:itemRippleColor="?attr/colorControlHighlight"
+                    app:itemTextColor="@color/tab_layout_material_item_color"
+                    app:labelVisibilityMode="labeled"
+                    app:menu="@menu/video_detail_navigation"
+                    tools:visibility="visible" />
+
             </com.google.android.material.appbar.AppBarLayout>
 
             <androidx.viewpager.widget.ViewPager
                 android:id="@+id/view_pager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/main_navigation_rail_width"
                 app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-            <com.google.android.material.navigationrail.NavigationRailView
-                android:id="@+id/detail_navigation"
-                android:layout_width="@dimen/main_navigation_rail_width"
-                android:layout_height="match_parent"
-                android:layout_gravity="start"
-                android:background="?attr/colorSurfaceContainer"
-                android:elevation="0dp"
-                android:paddingVertical="8dp"
-                android:visibility="gone"
-                app:itemActiveIndicatorStyle="@style/wizestreamBottomNavigationActiveIndicator"
-                app:itemIconTint="@color/tab_layout_material_item_color"
-                app:itemPaddingBottom="@dimen/video_detail_navigation_item_padding"
-                app:itemPaddingTop="@dimen/video_detail_navigation_item_padding"
-                app:itemRippleColor="?attr/colorControlHighlight"
-                app:itemTextColor="@color/tab_layout_material_item_color"
-                app:labelVisibilityMode="labeled"
-                app:menuGravity="center"
-                app:menu="@menu/video_detail_navigation"
-                tools:visibility="visible" />
 
         </org.schabi.newpipe.views.FocusAwareCoordinator>
 
@@ -647,7 +643,7 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_marginTop="10dp"
-            android:layout_weight="3" />
+            android:layout_weight="4" />
     </LinearLayout>
 
 

--- a/app/src/main/res/layout/list_stream_related_wide_item.xml
+++ b/app/src/main/res/layout/list_stream_related_wide_item.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/itemRoot"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:padding="@dimen/video_item_search_padding">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/itemThumbnailView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/placeholder_thumbnail_video"
+        app:layout_constraintDimensionRatio="16:9"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.42"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+    <org.schabi.newpipe.views.NewPipeTextView
+        android:id="@+id/itemDurationView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/video_item_search_duration_margin"
+        android:layout_marginBottom="@dimen/video_item_search_duration_margin"
+        android:background="@color/info_list_duration_badge_background_color"
+        android:paddingHorizontal="@dimen/video_item_search_duration_horizontal_padding"
+        android:paddingVertical="@dimen/video_item_search_duration_vertical_padding"
+        android:textAllCaps="true"
+        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+        android:textColor="@color/info_list_thumbnail_badge_text_color"
+        android:textSize="@dimen/video_item_search_duration_text_size"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintRight_toRightOf="@id/itemThumbnailView"
+        tools:text="1:09:10" />
+
+    <org.schabi.newpipe.views.NewPipeTextView
+        android:id="@+id/itemMembersOnlyView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/video_item_search_duration_margin"
+        android:layout_marginTop="@dimen/video_item_search_duration_margin"
+        android:background="@drawable/members_only_badge_background"
+        android:paddingHorizontal="@dimen/video_item_search_duration_horizontal_padding"
+        android:paddingVertical="@dimen/video_item_search_duration_vertical_padding"
+        android:text="@string/members_only"
+        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+        android:textColor="@color/info_list_thumbnail_badge_text_color"
+        android:textSize="@dimen/video_item_search_duration_text_size"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        tools:visibility="visible" />
+
+    <org.schabi.newpipe.views.NewPipeTextView
+        android:id="@+id/itemVideoTitleView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/video_item_search_image_right_margin"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="@dimen/video_item_search_title_text_size"
+        app:layout_constraintBottom_toTopOf="@+id/itemUploaderRoot"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="A related video title that wraps onto a second line" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/itemUploaderRoot"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:focusable="true"
+        android:minHeight="@dimen/stream_item_uploader_touch_target"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/itemVideoTitleView"
+        app:layout_constraintStart_toStartOf="@+id/itemVideoTitleView"
+        app:layout_constraintTop_toBottomOf="@+id/itemVideoTitleView"
+        tools:contentDescription="Open channel Uploader">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemUploaderAvatarView"
+            android:layout_width="@dimen/video_item_detail_uploader_image_size"
+            android:layout_height="@dimen/video_item_detail_uploader_image_size"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            android:scaleType="centerCrop"
+            android:src="@drawable/placeholder_person"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/CircularImageView" />
+
+        <org.schabi.newpipe.views.NewPipeTextView
+            android:id="@+id/itemUploaderView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_small"
+            android:ellipsize="end"
+            android:lines="1"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textSize="@dimen/video_item_search_uploader_text_size"
+            app:layout_constraintBottom_toTopOf="@+id/itemAdditionalDetails"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/itemUploaderAvatarView"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="Uploader" />
+
+        <org.schabi.newpipe.views.NewPipeTextView
+            android:id="@+id/itemAdditionalDetails"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:lines="1"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:textSize="@dimen/video_item_search_upload_date_text_size"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/itemUploaderView"
+            app:layout_constraintTop_toBottomOf="@+id/itemUploaderView"
+            tools:text="2 years ago • 10M views" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <org.schabi.newpipe.views.AnimatedProgressBar
+        android:id="@+id/itemProgressView"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/stream_thumbnail_progress_height"
+        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
+        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
+        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
+        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLayoutStateTest.java
@@ -67,7 +67,7 @@ public class VideoDetailLayoutStateTest {
     }
 
     @Test
-    public void fullscreenAndNavigationRailDoNotMoveDetailNavigation() {
+    public void fullscreenAndWideDetailNavigationDoNotMoveForBottomInsets() {
         assertEquals(0,
                 VideoDetailFragment.getDetailNavigationBottomInset(
                         true, false, 48, 52));

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailNavigationResourcesTest.java
@@ -27,7 +27,7 @@ public class VideoDetailNavigationResourcesTest {
     @Test
     public void phoneAndLargeLandscapeLayoutsUseExpressiveNavigation() throws Exception {
         assertPhoneBottomNavigation();
-        assertLargeLandscapeNavigationRail();
+        assertLargeLandscapeHorizontalNavigation();
     }
 
     @Test
@@ -150,12 +150,12 @@ public class VideoDetailNavigationResourcesTest {
         assertEquals("", viewPager.getAttribute("android:paddingBottom"));
     }
 
-    private void assertLargeLandscapeNavigationRail() throws Exception {
+    private void assertLargeLandscapeHorizontalNavigation() throws Exception {
         final Document document = parse("layout-w840dp-land/fragment_video_detail.xml");
 
         assertEquals(0, document.getElementsByTagName(TAB_LAYOUT).getLength());
-        assertEquals(0, document.getElementsByTagName(BOTTOM_NAVIGATION_VIEW).getLength());
-        final var navigationViews = document.getElementsByTagName(NAVIGATION_RAIL_VIEW);
+        assertEquals(0, document.getElementsByTagName(NAVIGATION_RAIL_VIEW).getLength());
+        final var navigationViews = document.getElementsByTagName(BOTTOM_NAVIGATION_VIEW);
         assertEquals(1, navigationViews.getLength());
 
         final var navigation = (Element) navigationViews.item(0);
@@ -165,9 +165,12 @@ public class VideoDetailNavigationResourcesTest {
         assertEquals("?attr/colorSurfaceContainer",
                 navigation.getAttribute("android:background"));
         assertEquals("0dp", navigation.getAttribute("android:elevation"));
-        assertEquals("@dimen/main_navigation_rail_width",
+        assertEquals("match_parent",
                 navigation.getAttribute("android:layout_width"));
-        assertEquals("match_parent", navigation.getAttribute("android:layout_height"));
+        assertEquals("@dimen/video_detail_navigation_height",
+                navigation.getAttribute("android:layout_height"));
+        assertEquals("com.google.android.material.appbar.AppBarLayout",
+                navigation.getParentNode().getNodeName());
         assertEquals("@style/wizestreamBottomNavigationActiveIndicator",
                 navigation.getAttribute("app:itemActiveIndicatorStyle"));
         assertEquals("@color/tab_layout_material_item_color",
@@ -179,8 +182,7 @@ public class VideoDetailNavigationResourcesTest {
                 "androidx.viewpager.widget.ViewPager");
         assertEquals(1, viewPagers.getLength());
         final var viewPager = (Element) viewPagers.item(0);
-        assertEquals("@dimen/main_navigation_rail_width",
-                viewPager.getAttribute("android:layout_marginStart"));
+        assertEquals("", viewPager.getAttribute("android:layout_marginStart"));
         assertEquals("", viewPager.getAttribute("android:layout_marginBottom"));
     }
 

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/WideRelatedItemsIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/WideRelatedItemsIntegrationTest.java
@@ -1,0 +1,32 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class WideRelatedItemsIntegrationTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java")
+            : Path.of("app/src/main/java");
+
+    @Test
+    public void onlyEmbeddedWideRelatedItemsUseResponsiveListRows() throws Exception {
+        final String videoDetail = read("org/schabi/newpipe/fragments/detail/"
+                + "VideoDetailFragment.java");
+        final String relatedItems = read("org/schabi/newpipe/fragments/list/videos/"
+                + "RelatedItemsFragment.java");
+        final String adapter = read("org/schabi/newpipe/info_list/InfoListAdapter.java");
+
+        assertTrue(videoDetail.contains("RelatedItemsFragment.getInstance(info, true)"));
+        assertTrue(videoDetail.contains("RelatedItemsFragment.getInstance(info)"));
+        assertTrue(relatedItems.contains("setUseWideRelatedVariant("));
+        assertTrue(adapter.contains("R.layout.list_stream_related_wide_item"));
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(sourceDirectory.resolve(relativePath));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/WideVideoDetailResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/WideVideoDetailResourcesTest.java
@@ -1,0 +1,58 @@
+package org.schabi.newpipe.fragments.detail;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class WideVideoDetailResourcesTest {
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res")
+            : Path.of("app/src/main/res");
+
+    @Test
+    public void wideDetailGivesRelatedItemsMoreSpaceWithoutShrinkingMainContent() throws Exception {
+        final Document document = parse("layout-w840dp-land/fragment_video_detail.xml");
+
+        final Element mainContent = findById(document, "@+id/detail_main_content");
+        final Element relatedItems = findById(document, "@+id/relatedItemsLayout");
+        final Element appBar = findById(document, "@+id/app_bar_layout");
+
+        assertEquals("5", mainContent.getAttribute("android:layout_weight"));
+        assertEquals("4", relatedItems.getAttribute("android:layout_weight"));
+        assertEquals("", appBar.getAttribute("android:layout_marginStart"));
+    }
+
+    @Test
+    public void wideRelatedThumbnailsScaleWithTheAvailablePaneWidth() throws Exception {
+        final Document document = parse("layout/list_stream_related_wide_item.xml");
+        final Element thumbnail = findById(document, "@+id/itemThumbnailView");
+
+        assertEquals("0dp", thumbnail.getAttribute("android:layout_width"));
+        assertEquals("0dp", thumbnail.getAttribute("android:layout_height"));
+        assertEquals("0.42", thumbnail.getAttribute("app:layout_constraintWidth_percent"));
+        assertEquals("16:9", thumbnail.getAttribute("app:layout_constraintDimensionRatio"));
+    }
+
+    private Element findById(final Document document, final String id) {
+        final var elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            if (id.equals(element.getAttribute("android:id"))) {
+                return element;
+            }
+        }
+        throw new AssertionError("Missing view: " + id);
+    }
+
+    private Document parse(final String relativePath) throws Exception {
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                .parse(resourcesDirectory.resolve(relativePath).toFile());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/EdgeToEdgeIntegrationTest.java
@@ -217,6 +217,6 @@ public class EdgeToEdgeIntegrationTest {
         assertTrue(detailSource.contains(
                 "detailNavigationBaseBottomMargin + bottomInset"));
         assertTrue(detailSource.contains("viewPagerBaseBottomMargin + bottomInset"));
-        assertTrue(detailSource.contains("detailNavigation instanceof NavigationRailView"));
+        assertTrue(detailSource.contains("binding.relatedItemsLayout != null"));
     }
 }


### PR DESCRIPTION
- Move the wide-screen detail navigation from the vertical rail to a compact horizontal bar above the pager content.
- Rebalance the two-pane layout from 5:3 to 5:4 so related videos gain width without reducing the effective player width.
- Use responsive 16:9 thumbnails only for related-video list rows embedded in the wide detail layout.
- Preserve phone, portrait, fullscreen, card, and ordinary list layouts.
- Add regression coverage for navigation placement, pane weights, responsive thumbnails, and wide-only adapter routing.
- Closes #326.