### PR TITLE
Add configurable comment text size

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -50,6 +50,7 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
     protected org.schabi.newpipe.util.SavedState savedState;
 
     private boolean useDefaultStateSaving = true;
+    private boolean commentTextSizeUpdatePending = false;
     private int updateFlags = 0;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -100,6 +101,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
                 refreshItemViewMode();
             }
             updateFlags = 0;
+        }
+        if (commentTextSizeUpdatePending) {
+            applyPendingCommentTextSizeUpdate();
         }
     }
 
@@ -510,9 +514,19 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         if (getString(R.string.list_view_mode_key).equals(key)
                 || getString(R.string.grid_columns_key).equals(key)) {
             updateFlags |= LIST_MODE_UPDATE_FLAG;
+        } else if (getString(R.string.comment_text_size_key).equals(key)) {
+            commentTextSizeUpdatePending = true;
+            if (isResumed()) {
+                applyPendingCommentTextSizeUpdate();
+            }
         } else if (ContentBlockingHelper.isPreferenceKey(requireContext(), key)) {
             reloadContent();
         }
+    }
+
+    private void applyPendingCommentTextSizeUpdate() {
+        infoListAdapter.notifyDataSetChanged();
+        commentTextSizeUpdatePending = false;
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.fragments.list.comments;
 
 import static org.schabi.newpipe.util.ServiceHelper.getServiceById;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -22,6 +23,7 @@ import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
+import org.schabi.newpipe.util.CommentTextSizeHelper;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
@@ -45,6 +47,7 @@ public final class CommentRepliesFragment
     @State
     CommentsInfoItem commentsInfoItem; // the comment to show replies of
     private final CompositeDisposable disposables = new CompositeDisposable();
+    private CommentRepliesHeaderBinding headerBinding;
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -74,14 +77,34 @@ public final class CommentRepliesFragment
     @Override
     public void onDestroyView() {
         disposables.clear();
+        headerBinding = null;
         super.onDestroyView();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (headerBinding != null) {
+            CommentTextSizeHelper.applyCommentTextSize(headerBinding.commentContent);
+        }
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences,
+                                          final String key) {
+        super.onSharedPreferenceChanged(sharedPreferences, key);
+        if (getString(R.string.comment_text_size_key).equals(key)
+                && isResumed() && headerBinding != null) {
+            CommentTextSizeHelper.applyCommentTextSize(headerBinding.commentContent);
+        }
     }
 
     @Override
     protected Supplier<View> getListHeaderSupplier() {
         return () -> {
-            final CommentRepliesHeaderBinding binding = CommentRepliesHeaderBinding
+            headerBinding = CommentRepliesHeaderBinding
                     .inflate(activity.getLayoutInflater(), itemsList, false);
+            final CommentRepliesHeaderBinding binding = headerBinding;
             final CommentsInfoItem item = commentsInfoItem;
 
             // load the author avatar
@@ -110,6 +133,7 @@ public final class CommentRepliesFragment
             binding.pinnedImage.setVisibility(item.isPinned() ? View.VISIBLE : View.GONE);
 
             // setup comment content
+            CommentTextSizeHelper.applyCommentTextSize(binding.commentContent);
             TextLinkifier.fromDescription(binding.commentContent,
                     new Description(item.getCommentText(), Description.PLAIN_TEXT),
                     HtmlCompat.FROM_HTML_MODE_LEGACY, getServiceById(item.getServiceId()),

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentInfoItemHolder.java
@@ -24,6 +24,7 @@ import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.info_list.InfoItemBuilder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.CommentTextSizeHelper;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -86,6 +87,8 @@ public class CommentInfoItemHolder extends InfoItemHolder {
         if (!(infoItem instanceof CommentsInfoItem item)) {
             return;
         }
+
+        CommentTextSizeHelper.applyCommentTextSize(itemContentView);
 
         // load the author avatar
         CoilHelper.INSTANCE.loadCommentAvatar(itemThumbnailView, item.getUploaderAvatarUrl());

--- a/app/src/main/java/org/schabi/newpipe/util/CommentTextSizeHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/CommentTextSizeHelper.java
@@ -1,0 +1,43 @@
+package org.schabi.newpipe.util;
+
+import android.content.Context;
+import android.util.TypedValue;
+import android.widget.TextView;
+
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.R;
+
+public final class CommentTextSizeHelper {
+    static final int DEFAULT_COMMENT_TEXT_SIZE_SP = 14;
+
+    private CommentTextSizeHelper() { }
+
+    public static void applyCommentTextSize(final TextView textView) {
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_SP,
+                getCommentTextSizeSp(textView.getContext()));
+    }
+
+    public static int getCommentTextSizeSp(final Context context) {
+        final String value = PreferenceManager.getDefaultSharedPreferences(context).getString(
+                context.getString(R.string.comment_text_size_key),
+                context.getString(R.string.comment_text_size_medium_key));
+        return parseCommentTextSize(value);
+    }
+
+    static int parseCommentTextSize(final String value) {
+        if (value == null) {
+            return DEFAULT_COMMENT_TEXT_SIZE_SP;
+        }
+
+        try {
+            final int size = Integer.parseInt(value);
+            if (size == 12 || size == 14 || size == 16 || size == 18) {
+                return size;
+            }
+        } catch (final NumberFormatException ignored) {
+            // Fall back to the default when a restored or synchronized preference is malformed.
+        }
+        return DEFAULT_COMMENT_TEXT_SIZE_SP;
+    }
+}

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -150,7 +150,7 @@
 
     <!-- Text Size -->
     <dimen name="comment_item_title_text_size">12sp</dimen>
-    <dimen name="comment_item_content_text_size">12sp</dimen>
+    <dimen name="comment_item_content_text_size">14sp</dimen>
 
     <!-- Feed Groups dimensions-->
 

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1547,6 +1547,23 @@
         <item>@string/grid_columns_four</item>
     </string-array>
     <string name="show_full_grid_titles_key">show_full_grid_titles</string>
+    <string name="comment_text_size_key">comment_text_size</string>
+    <string name="comment_text_size_small_key">12</string>
+    <string name="comment_text_size_medium_key">14</string>
+    <string name="comment_text_size_large_key">16</string>
+    <string name="comment_text_size_extra_large_key">18</string>
+    <string-array name="comment_text_size_values">
+        <item>@string/comment_text_size_small_key</item>
+        <item>@string/comment_text_size_medium_key</item>
+        <item>@string/comment_text_size_large_key</item>
+        <item>@string/comment_text_size_extra_large_key</item>
+    </string-array>
+    <string-array name="comment_text_size_description">
+        <item>@string/comment_text_size_small</item>
+        <item>@string/comment_text_size_medium</item>
+        <item>@string/comment_text_size_large</item>
+        <item>@string/comment_text_size_extra_large</item>
+    </string-array>
     <string name="list_view_mode_value">@string/list_view_mode_auto_key</string>
 
     <!-- TODO: Use these across the app instead of hardcoding it -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -957,6 +957,11 @@
     <string name="grid_columns_four">4 columns</string>
     <string name="show_full_grid_titles_title">Show full video titles in grid view</string>
     <string name="show_full_grid_titles_summary">Allow video titles to wrap instead of limiting them to two lines</string>
+    <string name="comment_text_size_title">Comment text size</string>
+    <string name="comment_text_size_small">Small (12 sp)</string>
+    <string name="comment_text_size_medium">Medium (14 sp)</string>
+    <string name="comment_text_size_large">Large (16 sp)</string>
+    <string name="comment_text_size_extra_large">Extra large (18 sp)</string>
     <string name="show_service_sections_title">Show service sections in navigation drawer</string>
     <string name="show_service_sections_summary">Show service-provided sections such as Trending, Shorts, Podcasts, and Recommended Lives</string>
     <string name="list">List</string>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -80,6 +80,16 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <ListPreference
+        android:defaultValue="@string/comment_text_size_medium_key"
+        android:entries="@array/comment_text_size_description"
+        android:entryValues="@array/comment_text_size_values"
+        android:key="@string/comment_text_size_key"
+        android:title="@string/comment_text_size_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="true" />
+
     <Preference
         android:key="@string/caption_settings_key"
         android:summary="@string/caption_setting_description"

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/comments/CommentTextSizeIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/comments/CommentTextSizeIntegrationTest.java
@@ -1,0 +1,34 @@
+package org.schabi.newpipe.fragments.list.comments;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CommentTextSizeIntegrationTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java")
+            : Path.of("app/src/main/java");
+
+    @Test
+    public void commentBodiesAndReplyHeadersUseTheSharedPreference() throws Exception {
+        final String holder = read("org/schabi/newpipe/info_list/holder/"
+                + "CommentInfoItemHolder.java");
+        final String replies = read("org/schabi/newpipe/fragments/list/comments/"
+                + "CommentRepliesFragment.java");
+        final String baseList = read("org/schabi/newpipe/fragments/list/"
+                + "BaseListFragment.java");
+
+        assertTrue(holder.contains("applyCommentTextSize(itemContentView)"));
+        assertTrue(replies.contains("applyCommentTextSize(binding.commentContent)"));
+        assertTrue(replies.contains("applyCommentTextSize(headerBinding.commentContent)"));
+        assertTrue(baseList.contains("R.string.comment_text_size_key"));
+        assertTrue(baseList.contains("applyPendingCommentTextSizeUpdate()"));
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(sourceDirectory.resolve(relativePath));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/comments/CommentTextSizeResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/comments/CommentTextSizeResourcesTest.java
@@ -1,0 +1,62 @@
+package org.schabi.newpipe.fragments.list.comments;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class CommentTextSizeResourcesTest {
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res")
+            : Path.of("app/src/main/res");
+
+    @Test
+    public void appearanceSettingsExposeTheFourCommentTextSizes() throws Exception {
+        final Document document = parse("xml/appearance_settings.xml");
+        final Element preference = findListPreference(document, "@string/comment_text_size_key");
+
+        assertEquals("@string/comment_text_size_medium_key",
+                preference.getAttribute("android:defaultValue"));
+        assertEquals("@array/comment_text_size_description",
+                preference.getAttribute("android:entries"));
+        assertEquals("@array/comment_text_size_values",
+                preference.getAttribute("android:entryValues"));
+        assertEquals("true", preference.getAttribute("app:useSimpleSummaryProvider"));
+
+        final String keys = Files.readString(
+                resourcesDirectory.resolve("values/settings_keys.xml"));
+        assertTrue(keys.contains("<string name=\"comment_text_size_small_key\">12</string>"));
+        assertTrue(keys.contains("<string name=\"comment_text_size_medium_key\">14</string>"));
+        assertTrue(keys.contains("<string name=\"comment_text_size_large_key\">16</string>"));
+        assertTrue(keys.contains(
+                "<string name=\"comment_text_size_extra_large_key\">18</string>"));
+
+        final String dimensions = Files.readString(
+                resourcesDirectory.resolve("values/dimens.xml"));
+        assertTrue(dimensions.contains(
+                "<dimen name=\"comment_item_content_text_size\">14sp</dimen>"));
+    }
+
+    private Element findListPreference(final Document document, final String key) {
+        final var preferences = document.getElementsByTagName("ListPreference");
+        for (int index = 0; index < preferences.getLength(); index++) {
+            final Element preference = (Element) preferences.item(index);
+            if (key.equals(preference.getAttribute("android:key"))) {
+                return preference;
+            }
+        }
+        throw new AssertionError("Missing preference: " + key);
+    }
+
+    private Document parse(final String relativePath) throws Exception {
+        return DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                .parse(resourcesDirectory.resolve(relativePath).toFile());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/util/CommentTextSizeHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/CommentTextSizeHelperTest.java
@@ -1,0 +1,23 @@
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CommentTextSizeHelperTest {
+    @Test
+    public void acceptsEverySupportedCommentTextSize() {
+        assertEquals(12, CommentTextSizeHelper.parseCommentTextSize("12"));
+        assertEquals(14, CommentTextSizeHelper.parseCommentTextSize("14"));
+        assertEquals(16, CommentTextSizeHelper.parseCommentTextSize("16"));
+        assertEquals(18, CommentTextSizeHelper.parseCommentTextSize("18"));
+    }
+
+    @Test
+    public void invalidOrMissingValuesFallBackToMedium() {
+        assertEquals(14, CommentTextSizeHelper.parseCommentTextSize(null));
+        assertEquals(14, CommentTextSizeHelper.parseCommentTextSize(""));
+        assertEquals(14, CommentTextSizeHelper.parseCommentTextSize("15"));
+        assertEquals(14, CommentTextSizeHelper.parseCommentTextSize("large"));
+    }
+}


### PR DESCRIPTION
- Add a Comment text size preference under Appearance with 12sp, 14sp, 16sp, and 18sp choices.
- Use Material-aligned 14sp as the default while preserving Android system font scaling.
- Apply the selected size to normal comments, pinned comments, replies, and the original comment in reply threads.
- Keep author names, dates, like counts, and controls unchanged.
- Refresh visible comment content immediately and safely fall back to 14sp for malformed restored values.
- Add preference-resource, integration, supported-value, and invalid-value regression coverage.
- Closes #323.