### PR TITLE
Fix player fullscreen orientation sync

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -436,8 +436,13 @@ public final class VideoDetailFragment
         if (binding == null) {
             return;
         }
+        final int orientation = newConfig.orientation;
         if (shouldRecreateDetailLayout(binding.relatedItemsLayout != null,
-                newConfig.orientation, newConfig.screenWidthDp)) {
+                orientation, newConfig.screenWidthDp)) {
+            if (player != null) {
+                syncFullscreenWithOrientation(
+                        player.UIs().get(MainPlayerUi.class), orientation);
+            }
             detailLayoutRecreationRequested = true;
             recreateDetailLayoutForConfigurationChange();
             return;
@@ -450,20 +455,54 @@ public final class VideoDetailFragment
         // transition that previously ran when the player reconnected after rotation.
         binding.getRoot().post(() -> {
             if (binding != null && player != null && isAdded()) {
-                syncFullscreenWithOrientation(player.UIs().get(MainPlayerUi.class));
+                syncFullscreenWithOrientation(
+                        player.UIs().get(MainPlayerUi.class), orientation);
             }
         });
     }
 
     private void syncFullscreenWithOrientation(
             @NonNull final Optional<MainPlayerUi> playerUi) {
-        if (DeviceUtils.isLandscape(requireContext())) {
-            checkLandscape();
-        } else if (playerUi.map(ui -> ui.isFullscreen() && !ui.isVerticalVideo()).orElse(false)
-                // Tablet UI has orientation-independent fullscreen.
-                && !DeviceUtils.isTablet(activity)) {
-            playerUi.ifPresent(MainPlayerUi::toggleFullscreen);
+        syncFullscreenWithOrientation(
+                playerUi, getResources().getConfiguration().orientation);
+    }
+
+    private void syncFullscreenWithOrientation(
+            @NonNull final Optional<MainPlayerUi> playerUi,
+            final int orientation) {
+        if (player == null) {
+            return;
         }
+
+        playerUi.ifPresent(ui -> ui.setFullscreen(fullscreenStateForOrientation(
+                orientation,
+                ui.isFullscreen(),
+                ui.isVerticalVideo(),
+                DeviceUtils.isTablet(activity),
+                player.isAudioOnly())));
+
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            // Preserve the existing landscape playback preparation after applying the
+            // fullscreen state independently from the player's current state.
+            checkLandscape();
+        }
+    }
+
+    static boolean fullscreenStateForOrientation(final int orientation,
+                                                 final boolean fullscreen,
+                                                 final boolean verticalVideo,
+                                                 final boolean tablet,
+                                                 final boolean audioOnly) {
+        if (tablet || audioOnly) {
+            return fullscreen;
+        }
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            return true;
+        }
+        if (orientation == Configuration.ORIENTATION_PORTRAIT && !verticalVideo) {
+            return false;
+        }
+        return fullscreen;
     }
 
     static boolean shouldUseWideLandscapeDetailLayout(final int orientation,
@@ -2687,18 +2726,24 @@ public final class VideoDetailFragment
         // from landscape to portrait every time.
         // Just turn on fullscreen mode in landscape orientation
         // or portrait & unlocked global orientation
-        final boolean isLandscape = DeviceUtils.isLandscape(requireContext());
+        final Optional<MainPlayerUi> playerUi = player.UIs().get(MainPlayerUi.class);
+        final boolean isLandscape = getResources().getConfiguration().orientation
+                == Configuration.ORIENTATION_LANDSCAPE;
         if (DeviceUtils.isTv(activity) || DeviceUtils.isTablet(activity)
                 && (!globalScreenOrientationLocked(activity) || isLandscape)) {
-            player.UIs().get(MainPlayerUi.class).ifPresent(MainPlayerUi::toggleFullscreen);
+            playerUi.ifPresent(ui -> ui.setFullscreen(!ui.isFullscreen()));
             return;
         }
 
-        final int newOrientation = isLandscape
-                ? ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                : ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
+        playerUi.ifPresent(ui -> {
+            final boolean fullscreen = !ui.isFullscreen();
+            ui.setFullscreen(fullscreen);
 
-        activity.setRequestedOrientation(newOrientation);
+            final int newOrientation = fullscreen
+                    ? ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                    : ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+            activity.setRequestedOrientation(newOrientation);
+        });
     }
 
     /*

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -5,8 +5,6 @@ import static org.schabi.newpipe.MainActivity.DEBUG;
 import static org.schabi.newpipe.QueueItemMenuUtil.openPopupMenu;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.ktx.ViewUtils.animate;
-import static org.schabi.newpipe.player.Player.STATE_COMPLETED;
-import static org.schabi.newpipe.player.Player.STATE_PAUSED;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_BACKGROUND;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_NONE;
 import static org.schabi.newpipe.player.helper.PlayerHelper.MinimizeMode.MINIMIZE_ON_EXIT_MODE_POPUP;
@@ -1048,13 +1046,28 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         if (DEBUG) {
             Log.d(TAG, "toggleFullscreen() called");
         }
+        setFullscreen(!isFullscreen);
+    }
+
+    /**
+     * Applies the requested fullscreen state without toggling an already-correct state.
+     * Configuration changes may deliver more than one callback, so orientation-driven
+     * fullscreen synchronization must be idempotent.
+     *
+     * @param fullscreen whether the player should be fullscreen
+     */
+    public void setFullscreen(final boolean fullscreen) {
+        if (isFullscreen == fullscreen) {
+            return;
+        }
+
         final PlayerServiceEventListener fragmentListener = player.getFragmentListener()
                 .orElse(null);
         if (fragmentListener == null || player.exoPlayerIsNull()) {
             return;
         }
 
-        isFullscreen = !isFullscreen;
+        isFullscreen = fullscreen;
         if (isFullscreen) {
             // Android needs tens milliseconds to send new insets but a user is able to see
             // how controls changes it's position from `0` to `nav bar height` padding.
@@ -1098,13 +1111,10 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         final boolean videoInLandscapeButNotInFullscreen = isLandscape()
                 && !isFullscreen
                 && !player.isAudioOnly();
-        final boolean notPaused = player.getCurrentState() != STATE_COMPLETED
-                && player.getCurrentState() != STATE_PAUSED;
 
         if (videoInLandscapeButNotInFullscreen
-                && notPaused
                 && !DeviceUtils.isTablet(context)) {
-            toggleFullscreen();
+            setFullscreen(true);
         }
     }
     //endregion

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -1,6 +1,9 @@
 package org.schabi.newpipe.fragments.detail;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import android.content.res.Configuration;
 
 import org.junit.Test;
 
@@ -22,11 +25,59 @@ public class VideoDetailOrientationHandlingTest {
                 + "\"screenSize|smallestScreenSize|screenLayout|orientation\""));
         assertTrue(fragment.contains("public void onConfigurationChanged("));
         assertTrue(fragment.contains("syncFullscreenWithOrientation("));
+        assertTrue(fragment.contains("newConfig.orientation"));
+        assertTrue(fragment.contains("ui.setFullscreen(fullscreenStateForOrientation("));
         assertTrue(fragment.contains("binding.getRoot().post("));
         assertTrue(fragment.contains("detailLayoutRecreationRequested"));
         assertTrue(fragment.contains("reconcileDetailLayoutAfterConfigurationChange"));
         assertTrue(fragment.contains("restoreDetailLayoutAfterConfigurationChange"));
         assertTrue(fragment.contains("prepareAndHandleInfo(currentInfo, false)"));
         assertTrue(fragment.contains("fullscreen ? View.GONE : View.VISIBLE"));
+    }
+
+    @Test
+    public void landscapePhoneVideoEntersFullscreenRegardlessOfPlaybackState() {
+        assertTrue(VideoDetailFragment.fullscreenStateForOrientation(
+                Configuration.ORIENTATION_LANDSCAPE,
+                false,
+                false,
+                false,
+                false));
+    }
+
+    @Test
+    public void portraitHorizontalVideoExitsFullscreen() {
+        assertFalse(VideoDetailFragment.fullscreenStateForOrientation(
+                Configuration.ORIENTATION_PORTRAIT,
+                true,
+                false,
+                false,
+                false));
+    }
+
+    @Test
+    public void portraitVerticalVideoKeepsDirectFullscreenState() {
+        assertTrue(VideoDetailFragment.fullscreenStateForOrientation(
+                Configuration.ORIENTATION_PORTRAIT,
+                true,
+                true,
+                false,
+                false));
+    }
+
+    @Test
+    public void tabletAndAudioOnlyPlaybackIgnoreOrientationChanges() {
+        assertFalse(VideoDetailFragment.fullscreenStateForOrientation(
+                Configuration.ORIENTATION_LANDSCAPE,
+                false,
+                false,
+                true,
+                false));
+        assertFalse(VideoDetailFragment.fullscreenStateForOrientation(
+                Configuration.ORIENTATION_LANDSCAPE,
+                false,
+                false,
+                false,
+                true));
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
@@ -32,6 +32,29 @@ public class FullscreenExitIntegrationTest {
     }
 
     @Test
+    public void rotationButtonAppliesFullscreenBeforeRequestingOrientation() throws Exception {
+        final String source = read(
+                "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
+        final String rotation = methodBody(source,
+                "public void onScreenRotationButtonClicked()");
+
+        assertTrue(rotation.contains("ui.setFullscreen(fullscreen);"));
+        assertTrue(rotation.contains("SCREEN_ORIENTATION_SENSOR_LANDSCAPE"));
+        assertTrue(rotation.contains("SCREEN_ORIENTATION_PORTRAIT"));
+        assertFalse(rotation.contains("DeviceUtils.isLandscape(requireContext())"));
+    }
+
+    @Test
+    public void explicitFullscreenSetterIsIdempotent() throws Exception {
+        final String source = read("org/schabi/newpipe/player/ui/MainPlayerUi.java");
+        final String setter = methodBody(source, "public void setFullscreen(");
+
+        assertTrue(setter.contains("if (isFullscreen == fullscreen)"));
+        assertTrue(setter.contains("isFullscreen = fullscreen;"));
+        assertFalse(setter.contains("isFullscreen = !isFullscreen;"));
+    }
+
+    @Test
     public void backExitsFullscreenWithoutPausingPlayback() throws Exception {
         final String source = read(
                 "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");


### PR DESCRIPTION
- Synchronize fullscreen directly from Android configuration orientation instead of display dimensions or playback state.
- Apply fullscreen state before requesting landscape or portrait and make repeated configuration callbacks idempotent.
- Preserve the existing fullscreen-control visibility policy and tablet, TV, vertical-video, and audio-only behavior.
- Add regression coverage for rotation, explicit fullscreen transitions, duplicate callbacks, and wide-layout recreation.
- Closes #327.