### PR TITLE
Preserve video proportions on manual fullscreen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -268,6 +268,7 @@ public final class VideoDetailFragment
     private int viewPagerBaseBottomMargin;
     private boolean detailLayoutRecreationPending;
     private boolean detailLayoutRecreationRequested;
+    private int pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
 
     private ContentObserver settingsContentObserver;
     @Nullable
@@ -439,9 +440,31 @@ public final class VideoDetailFragment
         final int orientation = newConfig.orientation;
         if (shouldRecreateDetailLayout(binding.relatedItemsLayout != null,
                 orientation, newConfig.screenWidthDp)) {
+            pendingFullscreenOrientation = orientation;
+            final Optional<MainPlayerUi> playerUi = player == null
+                    ? Optional.empty() : player.UIs().get(MainPlayerUi.class);
             if (player != null) {
-                syncFullscreenWithOrientation(
-                        player.UIs().get(MainPlayerUi.class), orientation);
+                // The new configuration is already authoritative here. Apply fullscreen before
+                // detaching the detail layout so the transition cannot be lost while the player
+                // reconnects; the restored layout will recalculate the surface dimensions.
+                syncFullscreenWithOrientation(playerUi, orientation);
+            }
+            if (shouldKeepDetailLayoutWhileFullscreen(
+                    orientation,
+                    playerUi.map(MainPlayerUi::isFullscreen).orElse(false),
+                    DeviceUtils.isTablet(activity)
+                            || DeviceUtils.isTv(activity)
+                            || DeviceUtils.isDesktopMode(activity))) {
+                // Phone details are hidden in fullscreen, so replacing them with the wide layout
+                // only creates a detach/reconnect race when the device returns to portrait.
+                pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
+                detailLayoutRecreationRequested = false;
+                binding.getRoot().post(() -> {
+                    if (binding != null && player != null && isAdded()) {
+                        tryAddVideoPlayerView();
+                    }
+                });
+                return;
             }
             detailLayoutRecreationRequested = true;
             recreateDetailLayoutForConfigurationChange();
@@ -463,8 +486,12 @@ public final class VideoDetailFragment
 
     private void syncFullscreenWithOrientation(
             @NonNull final Optional<MainPlayerUi> playerUi) {
-        syncFullscreenWithOrientation(
-                playerUi, getResources().getConfiguration().orientation);
+        final int orientation = pendingFullscreenOrientation
+                != Configuration.ORIENTATION_UNDEFINED
+                ? pendingFullscreenOrientation
+                : getResources().getConfiguration().orientation;
+        pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
+        syncFullscreenWithOrientation(playerUi, orientation);
     }
 
     private void syncFullscreenWithOrientation(
@@ -516,6 +543,14 @@ public final class VideoDetailFragment
                                               final int screenWidthDp) {
         return wideLandscapeLayout
                 != shouldUseWideLandscapeDetailLayout(orientation, screenWidthDp);
+    }
+
+    static boolean shouldKeepDetailLayoutWhileFullscreen(final int orientation,
+                                                         final boolean fullscreen,
+                                                         final boolean largeScreenDevice) {
+        return orientation == Configuration.ORIENTATION_LANDSCAPE
+                && fullscreen
+                && !largeScreenDevice;
     }
 
     private void recreateDetailLayoutForConfigurationChange() {
@@ -2727,8 +2762,8 @@ public final class VideoDetailFragment
         // Just turn on fullscreen mode in landscape orientation
         // or portrait & unlocked global orientation
         final Optional<MainPlayerUi> playerUi = player.UIs().get(MainPlayerUi.class);
-        final boolean isLandscape = getResources().getConfiguration().orientation
-                == Configuration.ORIENTATION_LANDSCAPE;
+        final int currentOrientation = getResources().getConfiguration().orientation;
+        final boolean isLandscape = currentOrientation == Configuration.ORIENTATION_LANDSCAPE;
         if (DeviceUtils.isTv(activity) || DeviceUtils.isTablet(activity)
                 && (!globalScreenOrientationLocked(activity) || isLandscape)) {
             playerUi.ifPresent(ui -> ui.setFullscreen(!ui.isFullscreen()));
@@ -2737,13 +2772,26 @@ public final class VideoDetailFragment
 
         playerUi.ifPresent(ui -> {
             final boolean fullscreen = !ui.isFullscreen();
-            ui.setFullscreen(fullscreen);
-
             final int newOrientation = fullscreen
                     ? ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
                     : ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+
+            // Applying fullscreen while the old orientation is still laid out makes the
+            // surface cache the old window height and can stretch the video after rotation.
+            // Normally onConfigurationChanged() applies the state after the target layout.
+            // Apply it here only when no orientation change (and thus no callback) is needed.
+            if (isTargetFullscreenOrientation(currentOrientation, fullscreen)) {
+                ui.setFullscreen(fullscreen);
+            }
             activity.setRequestedOrientation(newOrientation);
         });
+    }
+
+    static boolean isTargetFullscreenOrientation(final int orientation,
+                                                 final boolean fullscreen) {
+        return fullscreen
+                ? orientation == Configuration.ORIENTATION_LANDSCAPE
+                : orientation == Configuration.ORIENTATION_PORTRAIT;
     }
 
     /*

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -29,10 +29,25 @@ public class VideoDetailOrientationHandlingTest {
         assertTrue(fragment.contains("ui.setFullscreen(fullscreenStateForOrientation("));
         assertTrue(fragment.contains("binding.getRoot().post("));
         assertTrue(fragment.contains("detailLayoutRecreationRequested"));
+        assertTrue(fragment.contains("pendingFullscreenOrientation = orientation"));
+        assertTrue(fragment.contains("pendingFullscreenOrientation\n"
+                + "                != Configuration.ORIENTATION_UNDEFINED"));
         assertTrue(fragment.contains("reconcileDetailLayoutAfterConfigurationChange"));
         assertTrue(fragment.contains("restoreDetailLayoutAfterConfigurationChange"));
+        assertTrue(fragment.contains(
+                "syncFullscreenWithOrientation(player.UIs().get(MainPlayerUi.class));"));
         assertTrue(fragment.contains("prepareAndHandleInfo(currentInfo, false)"));
         assertTrue(fragment.contains("fullscreen ? View.GONE : View.VISIBLE"));
+
+        final int pendingOrientation = fragment.indexOf(
+                "pendingFullscreenOrientation = orientation");
+        final int immediateSync = fragment.indexOf(
+                "syncFullscreenWithOrientation(", pendingOrientation);
+        final int layoutRecreation = fragment.indexOf(
+                "recreateDetailLayoutForConfigurationChange();", pendingOrientation);
+        assertTrue(pendingOrientation >= 0
+                && pendingOrientation < immediateSync
+                && immediateSync < layoutRecreation);
     }
 
     @Test
@@ -79,5 +94,29 @@ public class VideoDetailOrientationHandlingTest {
                 false,
                 false,
                 true));
+    }
+
+    @Test
+    public void manualFullscreenWaitsForItsTargetOrientation() {
+        assertFalse(VideoDetailFragment.isTargetFullscreenOrientation(
+                Configuration.ORIENTATION_PORTRAIT, true));
+        assertTrue(VideoDetailFragment.isTargetFullscreenOrientation(
+                Configuration.ORIENTATION_LANDSCAPE, true));
+        assertFalse(VideoDetailFragment.isTargetFullscreenOrientation(
+                Configuration.ORIENTATION_LANDSCAPE, false));
+        assertTrue(VideoDetailFragment.isTargetFullscreenOrientation(
+                Configuration.ORIENTATION_PORTRAIT, false));
+    }
+
+    @Test
+    public void phoneFullscreenKeepsCurrentDetailLayoutDuringLandscapeRotation() {
+        assertTrue(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
+                Configuration.ORIENTATION_LANDSCAPE, true, false));
+        assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
+                Configuration.ORIENTATION_PORTRAIT, true, false));
+        assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
+                Configuration.ORIENTATION_LANDSCAPE, false, false));
+        assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
+                Configuration.ORIENTATION_LANDSCAPE, true, true));
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
@@ -32,12 +32,14 @@ public class FullscreenExitIntegrationTest {
     }
 
     @Test
-    public void rotationButtonAppliesFullscreenBeforeRequestingOrientation() throws Exception {
+    public void rotationButtonDefersFullscreenUntilTargetOrientation() throws Exception {
         final String source = read(
                 "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
         final String rotation = methodBody(source,
                 "public void onScreenRotationButtonClicked()");
 
+        assertTrue(rotation.contains(
+                "if (isTargetFullscreenOrientation(currentOrientation, fullscreen))"));
         assertTrue(rotation.contains("ui.setFullscreen(fullscreen);"));
         assertTrue(rotation.contains("SCREEN_ORIENTATION_SENSOR_LANDSCAPE"));
         assertTrue(rotation.contains("SCREEN_ORIENTATION_PORTRAIT"));


### PR DESCRIPTION
- Defer manual fullscreen activation until the requested landscape layout is active, preventing the player surface from caching the portrait window height.
- Apply fullscreen immediately only when the device is already in the target orientation and no configuration callback will occur.
- Carry the target orientation through wide-detail layout recreation before sizing the player surface.
- Add regression coverage for manual enter and exit orientation targets.
- Follow-up to #327.