### PR TITLE
Show full titles on video details

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -117,6 +117,7 @@ import org.schabi.newpipe.util.Constants;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.EdgeToEdgeHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
+import org.schabi.newpipe.util.GridTitleDisplayPolicy;
 import org.schabi.newpipe.util.InfoCache;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.Localization;
@@ -410,6 +411,8 @@ public final class VideoDetailFragment
         activity.sendBroadcast(new Intent(ACTION_VIDEO_FRAGMENT_RESUMED));
 
         updateOverlayPlayQueueButtonVisibility();
+        applyTitleDisplayPolicy(
+                binding.detailSecondaryControlPanel.getVisibility() != View.GONE);
 
         setupBrightness();
 
@@ -882,19 +885,29 @@ public final class VideoDetailFragment
     }
 
     private void toggleTitleAndSecondaryControls() {
-        if (binding.detailSecondaryControlPanel.getVisibility() == View.GONE) {
-            binding.detailVideoTitleView.setMaxLines(10);
+        final boolean expandSecondaryControls =
+                binding.detailSecondaryControlPanel.getVisibility() == View.GONE;
+        applyTitleDisplayPolicy(expandSecondaryControls);
+        if (expandSecondaryControls) {
             animateRotation(binding.detailToggleSecondaryControlsView,
                     VideoPlayerUi.DEFAULT_CONTROLS_DURATION, 180);
             binding.detailSecondaryControlPanel.setVisibility(View.VISIBLE);
         } else {
-            binding.detailVideoTitleView.setMaxLines(1);
             animateRotation(binding.detailToggleSecondaryControlsView,
                     VideoPlayerUi.DEFAULT_CONTROLS_DURATION, 0);
             binding.detailSecondaryControlPanel.setVisibility(View.GONE);
         }
         // ViewPager height has changed, update the detail navigation.
         updateDetailNavigationVisibility();
+    }
+
+    private void applyTitleDisplayPolicy(final boolean manuallyExpanded) {
+        if (currentLocalItem == null) {
+            GridTitleDisplayPolicy.applyToDetail(
+                    binding.detailVideoTitleView, manuallyExpanded);
+        } else {
+            GridTitleDisplayPolicy.applyToLocalDetail(binding.detailVideoTitleView);
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -904,6 +917,7 @@ public final class VideoDetailFragment
     @Override // called from onViewCreated in {@link BaseFragment#onViewCreated}
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
+        applyTitleDisplayPolicy(false);
 
         detailNavigation = rootView.findViewById(R.id.detail_navigation);
         detailNavigationBaseBottomMargin = ((ViewGroup.MarginLayoutParams)
@@ -1210,7 +1224,7 @@ public final class VideoDetailFragment
         }
 
         binding.detailVideoTitleView.setText(item.getTitle());
-        binding.detailVideoTitleView.setMaxLines(3);
+        applyTitleDisplayPolicy(false);
         binding.detailToggleSecondaryControlsView.setVisibility(View.GONE);
         binding.detailSecondaryControlPanel.setVisibility(View.GONE);
 
@@ -2235,7 +2249,7 @@ public final class VideoDetailFragment
         binding.positionView.setVisibility(View.GONE);
 
         binding.detailVideoTitleView.setText(title);
-        binding.detailVideoTitleView.setMaxLines(1);
+        applyTitleDisplayPolicy(false);
         animate(binding.detailVideoTitleView, true, 0);
 
         binding.detailToggleSecondaryControlsView.setVisibility(View.GONE);
@@ -2292,7 +2306,7 @@ public final class VideoDetailFragment
         currentInfo = info;
         setInitialData(info.getServiceId(), info.getOriginalUrl(), info.getName(), playQueue);
 
-        binding.detailVideoTitleView.setMaxLines(1);
+        applyTitleDisplayPolicy(false);
         binding.detailUploaderRootLayout.setClickable(true);
         binding.detailsPanel.setVisibility(View.VISIBLE);
         binding.detailControlsShare.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/schabi/newpipe/util/GridTitleDisplayPolicy.java
+++ b/app/src/main/java/org/schabi/newpipe/util/GridTitleDisplayPolicy.java
@@ -14,26 +14,54 @@ import org.schabi.newpipe.R;
 
 public final class GridTitleDisplayPolicy {
     static final int COMPACT_TITLE_LINES = 2;
+    static final int COMPACT_DETAIL_TITLE_LINES = 1;
+    static final int COMPACT_LOCAL_DETAIL_TITLE_LINES = 3;
 
     private GridTitleDisplayPolicy() {
     }
 
     public static void apply(final TextView titleView) {
+        apply(titleView, COMPACT_TITLE_LINES, false);
+    }
+
+    public static void applyToDetail(final TextView titleView,
+                                     final boolean manuallyExpanded) {
+        apply(titleView, COMPACT_DETAIL_TITLE_LINES, manuallyExpanded);
+    }
+
+    public static void applyToLocalDetail(final TextView titleView) {
+        apply(titleView, COMPACT_LOCAL_DETAIL_TITLE_LINES, false);
+    }
+
+    private static void apply(final TextView titleView,
+                              final int compactTitleLines,
+                              final boolean manuallyExpanded) {
         final boolean showFullTitles = PreferenceManager
                 .getDefaultSharedPreferences(titleView.getContext())
                 .getBoolean(titleView.getContext().getString(
                         R.string.show_full_grid_titles_key), false);
 
-        titleView.setMaxLines(maxLines(showFullTitles));
-        titleView.setEllipsize(shouldEllipsize(showFullTitles)
+        titleView.setMaxLines(maxLines(showFullTitles, manuallyExpanded, compactTitleLines));
+        titleView.setEllipsize(shouldEllipsize(showFullTitles, manuallyExpanded)
                 ? TextUtils.TruncateAt.END : null);
     }
 
     static int maxLines(final boolean showFullTitles) {
-        return showFullTitles ? Integer.MAX_VALUE : COMPACT_TITLE_LINES;
+        return maxLines(showFullTitles, false, COMPACT_TITLE_LINES);
+    }
+
+    static int maxLines(final boolean showFullTitles,
+                        final boolean manuallyExpanded,
+                        final int compactTitleLines) {
+        return showFullTitles || manuallyExpanded ? Integer.MAX_VALUE : compactTitleLines;
     }
 
     static boolean shouldEllipsize(final boolean showFullTitles) {
-        return !showFullTitles;
+        return shouldEllipsize(showFullTitles, false);
+    }
+
+    static boolean shouldEllipsize(final boolean showFullTitles,
+                                   final boolean manuallyExpanded) {
+        return !showFullTitles && !manuallyExpanded;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -955,8 +955,8 @@
     <string name="grid_columns_two">2 columns</string>
     <string name="grid_columns_three">3 columns</string>
     <string name="grid_columns_four">4 columns</string>
-    <string name="show_full_grid_titles_title">Show full video titles in grid view</string>
-    <string name="show_full_grid_titles_summary">Allow video titles to wrap instead of limiting them to two lines</string>
+    <string name="show_full_grid_titles_title">Show full video titles</string>
+    <string name="show_full_grid_titles_summary">Display complete titles in grids and while watching videos</string>
     <string name="comment_text_size_title">Comment text size</string>
     <string name="comment_text_size_small">Small (12 sp)</string>
     <string name="comment_text_size_medium">Medium (14 sp)</string>

--- a/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
@@ -33,6 +33,29 @@ public class GridTitleDisplayPolicyTest {
     }
 
     @Test
+    public void compactDetailModeKeepsOneLineAndEllipsizing() {
+        assertEquals(1, GridTitleDisplayPolicy.maxLines(false, false, 1));
+        assertTrue(GridTitleDisplayPolicy.shouldEllipsize(false, false));
+    }
+
+    @Test
+    public void manuallyExpandedDetailAllowsUnlimitedLines() {
+        assertEquals(Integer.MAX_VALUE, GridTitleDisplayPolicy.maxLines(false, true, 1));
+        assertFalse(GridTitleDisplayPolicy.shouldEllipsize(false, true));
+    }
+
+    @Test
+    public void fullDetailModeStaysExpandedWhenSecondaryControlsClose() {
+        assertEquals(Integer.MAX_VALUE, GridTitleDisplayPolicy.maxLines(true, false, 1));
+        assertFalse(GridTitleDisplayPolicy.shouldEllipsize(true, false));
+    }
+
+    @Test
+    public void compactLocalDetailModeKeepsThreeLines() {
+        assertEquals(3, GridTitleDisplayPolicy.maxLines(false, false, 3));
+    }
+
+    @Test
     public void settingIsDisabledByDefault() throws Exception {
         final String appearanceSettings = read(
                 "app/src/main/res/xml/appearance_settings.xml");
@@ -70,6 +93,37 @@ public class GridTitleDisplayPolicyTest {
                 "itemVersion == ItemVersion.GRID || itemVersion == ItemVersion.CARD"));
         assertTrue(streamItem.contains(
                 "GridTitleDisplayPolicy.apply(viewBinding.itemVideoTitleView)"));
+    }
+
+    @Test
+    public void videoDetailsApplyTheDisplayPolicyAcrossEveryState() throws Exception {
+        final String videoDetailFragment = read(
+                "app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
+
+        assertTrue(videoDetailFragment.contains(
+                "applyTitleDisplayPolicy(expandSecondaryControls);"));
+        assertTrue(videoDetailFragment.contains(
+                "GridTitleDisplayPolicy.applyToLocalDetail(binding.detailVideoTitleView);"));
+        assertTrue(videoDetailFragment.contains(
+                "binding.detailSecondaryControlPanel.getVisibility() != View.GONE"));
+        assertEquals(4, occurrences(videoDetailFragment,
+                "applyTitleDisplayPolicy(false);"));
+        assertFalse(videoDetailFragment.contains("detailVideoTitleView.setMaxLines"));
+    }
+
+    @Test
+    public void settingCopyCoversGridsAndVideoDetails() throws Exception {
+        final String strings = read("app/src/main/res/values/strings.xml");
+
+        assertTrue(strings.contains(
+                "<string name=\"show_full_grid_titles_title\">"
+                        + "Show full video titles</string>"));
+        assertTrue(strings.contains(
+                "Display complete titles in grids and while watching videos"));
+    }
+
+    private int occurrences(final String value, final String target) {
+        return (value.length() - value.replace(target, "").length()) / target.length();
     }
 
     private String read(final String relativePath) throws Exception {


### PR DESCRIPTION
- Broaden the existing full-title Appearance setting while preserving its stored key, value, and compact default.
- Apply full-title wrapping to the active video title on phone, wide-screen, and local-media detail layouts.
- Keep full titles expanded across video changes, layout recreation, Settings returns, and secondary-control toggles.
- Preserve the existing tap-to-expand behavior when the preference is disabled.
- Add regression coverage for compact, manually expanded, full-title, local-media, and lifecycle states.
- Closes #305