### PR TITLE
Add YouTube Music search filter chips

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFilterDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFilterDialog.java
@@ -55,8 +55,7 @@ final class SearchFilterDialog {
         this.context = context;
         this.service = service;
         this.listener = listener;
-        contentFilters = filterContentTypes(
-                flatten(service.getSearchQHFactory().getAvailableContentFilter()), musicOnly);
+        contentFilters = getContentFilters(service, musicOnly);
         selectedContentFilter = findByName(contentFilters,
                 currentContentFilters.length == 0 ? null : currentContentFilters[0]);
         if (selectedContentFilter == null && !contentFilters.isEmpty()) {
@@ -92,6 +91,13 @@ final class SearchFilterDialog {
         final Filter content = service.getSearchQHFactory().getAvailableContentFilter();
         final Filter sort = service.getSearchQHFactory().getAvailableSortFilter();
         return !flatten(content).isEmpty() || !flatten(sort).isEmpty();
+    }
+
+    @NonNull
+    static List<FilterItem> getContentFilters(@NonNull final StreamingService service,
+                                              final boolean musicOnly) {
+        return filterContentTypes(
+                flatten(service.getSearchQHFactory().getAvailableContentFilter()), musicOnly);
     }
 
     private void show() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -41,6 +41,8 @@ import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.evernote.android.state.State;
+import com.google.android.material.chip.Chip;
+import com.google.android.material.chip.ChipGroup;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.feed.model.SavedSearchFeedEntity;
@@ -59,6 +61,7 @@ import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 import org.schabi.newpipe.extractor.search.SearchInfo;
+import org.schabi.newpipe.extractor.search.filter.FilterItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.fragments.list.BaseListFragment;
@@ -176,6 +179,8 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     private EditText searchEditText;
     private View searchClear;
     private View searchFilter;
+    private View searchMusicFilters;
+    private ChipGroup searchMusicFilterChipGroup;
 
     private boolean suggestionsPanelVisible = false;
 
@@ -278,11 +283,86 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
             return;
         }
         final boolean hasFilters = SearchFilterDialog.hasFilters(service);
-        searchFilter.setVisibility(hasFilters ? View.VISIBLE : View.GONE);
+        final boolean youtubeMusicMode = serviceId == ServiceList.YouTube.getServiceId()
+                && ServiceHelper.isYoutubeMusicMode(requireContext());
+        final List<FilterItem> musicFilters = service == null || !youtubeMusicMode
+                ? Collections.emptyList()
+                : SearchFilterDialog.getContentFilters(service, true);
+        final boolean showMusicFilterChips = shouldShowMusicFilterChips(
+                serviceId == ServiceList.YouTube.getServiceId(), youtubeMusicMode,
+                !musicFilters.isEmpty());
+        searchFilter.setVisibility(hasFilters && !showMusicFilterChips
+                ? View.VISIBLE : View.GONE);
         final ViewGroup.MarginLayoutParams layoutParams =
                 (ViewGroup.MarginLayoutParams) searchEditText.getLayoutParams();
-        layoutParams.rightMargin = DeviceUtils.dpToPx(hasFilters ? 96 : 48, requireContext());
+        layoutParams.rightMargin = DeviceUtils.dpToPx(
+                hasFilters && !showMusicFilterChips ? 96 : 48, requireContext());
         searchEditText.setLayoutParams(layoutParams);
+        updateMusicFilterChips(showMusicFilterChips ? musicFilters : Collections.emptyList());
+    }
+
+    static boolean shouldShowMusicFilterChips(final boolean youtubeService,
+                                              final boolean youtubeMusicMode,
+                                              final boolean hasMusicFilters) {
+        return youtubeService && youtubeMusicMode && hasMusicFilters;
+    }
+
+    private void updateMusicFilterChips(@NonNull final List<FilterItem> musicFilters) {
+        if (searchMusicFilters == null || searchMusicFilterChipGroup == null) {
+            return;
+        }
+        searchMusicFilterChipGroup.setOnCheckedStateChangeListener(null);
+        searchMusicFilterChipGroup.removeAllViews();
+        if (musicFilters.isEmpty()) {
+            searchMusicFilters.setVisibility(View.GONE);
+            return;
+        }
+
+        final String restoredFilter = contentFilter.length == 0 ? "" : contentFilter[0];
+        final String selectedFilter = resolveMusicFilterName(musicFilters, contentFilter);
+        if (!selectedFilter.equals(restoredFilter) || sortFilter.length > 0) {
+            contentFilter = new String[]{selectedFilter};
+            sortFilter = new int[0];
+        }
+        int checkedChipId = View.NO_ID;
+        for (final FilterItem filter : musicFilters) {
+            final Chip chip = (Chip) getLayoutInflater().inflate(
+                    R.layout.item_search_music_filter_chip,
+                    searchMusicFilterChipGroup, false);
+            chip.setId(View.generateViewId());
+            chip.setText(ServiceHelper.getTranslatedFilterString(
+                    filter.getName(), requireContext()));
+            chip.setTag(filter.getName());
+            searchMusicFilterChipGroup.addView(chip);
+            if (filter.getName().equals(selectedFilter)) {
+                checkedChipId = chip.getId();
+            }
+        }
+
+        searchMusicFilterChipGroup.check(checkedChipId);
+        searchMusicFilterChipGroup.setOnCheckedStateChangeListener((group, checkedIds) -> {
+            if (checkedIds.isEmpty()) {
+                return;
+            }
+            final Chip selectedChip = group.findViewById(checkedIds.get(0));
+            if (selectedChip != null && selectedChip.getTag() instanceof String) {
+                applySearchFilters((String) selectedChip.getTag(), Collections.emptyList());
+            }
+        });
+        searchMusicFilters.setVisibility(View.VISIBLE);
+    }
+
+    @NonNull
+    static String resolveMusicFilterName(@NonNull final List<FilterItem> musicFilters,
+                                         @NonNull final String[] currentContentFilter) {
+        final String restoredFilter = currentContentFilter.length == 0
+                ? "" : currentContentFilter[0];
+        for (final FilterItem filter : musicFilters) {
+            if (filter.getName().equals(restoredFilter)) {
+                return restoredFilter;
+            }
+        }
+        return musicFilters.isEmpty() ? "" : musicFilters.get(0).getName();
     }
 
     @Override
@@ -360,6 +440,16 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         }
         unsetSearchListeners();
 
+        if (searchMusicFilterChipGroup != null) {
+            searchMusicFilterChipGroup.setOnCheckedStateChangeListener(null);
+            searchMusicFilterChipGroup.removeAllViews();
+        }
+        if (searchMusicFilters != null) {
+            searchMusicFilters.setVisibility(View.GONE);
+        }
+        searchMusicFilterChipGroup = null;
+        searchMusicFilters = null;
+
         searchBinding = null;
         super.onDestroyView();
     }
@@ -425,6 +515,9 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         searchEditText = searchToolbarContainer.findViewById(R.id.toolbar_search_edit_text);
         searchClear = searchToolbarContainer.findViewById(R.id.toolbar_search_clear);
         searchFilter = searchToolbarContainer.findViewById(R.id.toolbar_search_filter);
+        searchMusicFilters = activity.findViewById(R.id.toolbar_search_music_filters);
+        searchMusicFilterChipGroup = searchMusicFilters.findViewById(
+                R.id.toolbar_search_music_filter_chip_group);
         updateSearchFilterVisibility();
         loadSavedSearchCache();
     }
@@ -763,6 +856,7 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         }
         searchClear.setOnClickListener(null);
         searchClear.setOnLongClickListener(null);
+        searchFilter.setOnClickListener(null);
         searchEditText.setOnClickListener(null);
         searchEditText.setOnFocusChangeListener(null);
         searchEditText.setOnEditorActionListener(null);
@@ -1099,23 +1193,32 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         SearchFilterDialog.show(requireContext(), service, contentFilter, sortFilter,
                 serviceId == ServiceList.YouTube.getServiceId()
                         && ServiceHelper.isYoutubeMusicMode(requireContext()),
-                (selectedContentFilter, selectedSortFilters) -> {
-                    if (savedSearchFeedId != SavedSearchFeedManager.NO_SAVED_SEARCH_FEED) {
-                        savedSearchFeedId = SavedSearchFeedManager.NO_SAVED_SEARCH_FEED;
-                        activity.invalidateOptionsMenu();
-                    }
-                    contentFilter = selectedContentFilter.isEmpty()
-                            ? new String[0] : new String[]{selectedContentFilter};
-                    sortFilter = selectedSortFilters.stream()
-                            .mapToInt(Integer::intValue)
-                            .toArray();
-                    if (!selectedContentFilter.isEmpty()) {
-                        updateSearchHint(selectedContentFilter);
-                    }
-                    if (!TextUtils.isEmpty(searchString)) {
-                        search(searchString, contentFilter, sortFilter);
-                    }
-                });
+                this::applySearchFilters);
+    }
+
+    private void applySearchFilters(@NonNull final String selectedContentFilter,
+                                    @NonNull final List<Integer> selectedSortFilters) {
+        final boolean contentFilterUnchanged = contentFilter.length == 1
+                && selectedContentFilter.equals(contentFilter[0]);
+        final int[] newSortFilters = selectedSortFilters.stream()
+                .mapToInt(Integer::intValue)
+                .toArray();
+        if (contentFilterUnchanged && Arrays.equals(sortFilter, newSortFilters)) {
+            return;
+        }
+        if (savedSearchFeedId != SavedSearchFeedManager.NO_SAVED_SEARCH_FEED) {
+            savedSearchFeedId = SavedSearchFeedManager.NO_SAVED_SEARCH_FEED;
+            activity.invalidateOptionsMenu();
+        }
+        contentFilter = selectedContentFilter.isEmpty()
+                ? new String[0] : new String[]{selectedContentFilter};
+        sortFilter = newSortFilters;
+        if (!selectedContentFilter.isEmpty()) {
+            updateSearchHint(selectedContentFilter);
+        }
+        if (!TextUtils.isEmpty(searchString)) {
+            search(searchString, contentFilter, sortFilter);
+        }
     }
 
     private void updateSearchHint(@NonNull final String selectedContentFilter) {

--- a/app/src/main/res/layout/item_search_music_filter_chip.xml
+++ b/app/src/main/res/layout/item_search_music_filter_chip.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.Material3.Chip.Filter"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:checkable="true" />

--- a/app/src/main/res/layout/toolbar_layout.xml
+++ b/app/src/main/res/layout/toolbar_layout.xml
@@ -33,4 +33,10 @@
 
     </com.google.android.material.appbar.MaterialToolbar>
 
+    <include
+        android:id="@+id/toolbar_search_music_filters"
+        layout="@layout/toolbar_search_music_filter_chips"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/toolbar_search_music_filter_chips.xml
+++ b/app/src/main/res/layout/toolbar_search_music_filter_chips.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorSurface"
+    android:fillViewport="true"
+    android:overScrollMode="never"
+    android:scrollbars="none">
+
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/toolbar_search_music_filter_chip_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        app:selectionRequired="true"
+        app:singleLine="true"
+        app:singleSelection="true" />
+</HorizontalScrollView>

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/search/YoutubeMusicSearchChipsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/search/YoutubeMusicSearchChipsTest.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.fragments.list.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.search.filter.FilterItem;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class YoutubeMusicSearchChipsTest {
+    private final Path repositoryRoot =
+            Files.exists(Path.of("app/src/main/res/layout/toolbar_layout.xml"))
+                    ? Path.of(".") : Path.of("..");
+
+    @Test
+    public void chipsAreLimitedToYoutubeMusicWithAvailableFilters() {
+        assertTrue(SearchFragment.shouldShowMusicFilterChips(true, true, true));
+        assertFalse(SearchFragment.shouldShowMusicFilterChips(false, true, true));
+        assertFalse(SearchFragment.shouldShowMusicFilterChips(true, false, true));
+        assertFalse(SearchFragment.shouldShowMusicFilterChips(true, true, false));
+    }
+
+    @Test
+    public void restoredMusicFilterRemainsSelected() {
+        assertEquals("music_videos", SearchFragment.resolveMusicFilterName(
+                musicFilters(), new String[]{"music_videos"}));
+    }
+
+    @Test
+    public void missingOrInvalidSelectionFallsBackToSongs() {
+        assertEquals("music_songs", SearchFragment.resolveMusicFilterName(
+                musicFilters(), new String[0]));
+        assertEquals("music_songs", SearchFragment.resolveMusicFilterName(
+                musicFilters(), new String[]{"videos"}));
+    }
+
+    @Test
+    public void toolbarHostsSingleSelectionScrollableFilterChips() throws Exception {
+        final String toolbar = read("app/src/main/res/layout/toolbar_layout.xml");
+        final String chipGroup = read(
+                "app/src/main/res/layout/toolbar_search_music_filter_chips.xml");
+        final String chip = read(
+                "app/src/main/res/layout/item_search_music_filter_chip.xml");
+
+        assertTrue(toolbar.contains("@layout/toolbar_search_music_filter_chips"));
+        assertTrue(chipGroup.contains("<HorizontalScrollView"));
+        assertTrue(chipGroup.contains("app:singleSelection=\"true\""));
+        assertTrue(chipGroup.contains("app:selectionRequired=\"true\""));
+        assertTrue(chip.contains("@style/Widget.Material3.Chip.Filter"));
+    }
+
+    @Test
+    public void chipsReuseExtractorFiltersAndApplySelectionsImmediately() throws Exception {
+        final String searchFragment = read(
+                "app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java");
+
+        assertTrue(searchFragment.contains(
+                "SearchFilterDialog.getContentFilters(service, true)"));
+        assertTrue(searchFragment.contains(
+                "applySearchFilters((String) selectedChip.getTag(), Collections.emptyList())"));
+        assertTrue(searchFragment.contains("this::applySearchFilters"));
+        assertTrue(searchFragment.contains(
+                "searchFilter.setVisibility(hasFilters && !showMusicFilterChips"));
+    }
+
+    private static List<FilterItem> musicFilters() {
+        return List.of(
+                new FilterItem(1, "music_songs"),
+                new FilterItem(2, "music_videos"),
+                new FilterItem(3, "music_albums"),
+                new FilterItem(4, "music_playlists"),
+                new FilterItem(5, "music_artists"));
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(repositoryRoot.resolve(relativePath));
+    }
+}


### PR DESCRIPTION
- Add a horizontally scrollable Material 3 filter-chip row directly beneath the search bar in YouTube Music mode.
- Populate Songs, Videos, Albums, Playlists, and Artists from the extractor’s existing content-filter definitions.
- Apply category changes immediately, update the search hint, clear incompatible sort filters, and detach modified saved searches.
- Restore the selected category after view recreation and clean up the shared toolbar state when leaving search.
- Hide the modal filter button only in YouTube Music while preserving the existing dialog for regular YouTube and every other service.
- Add regression coverage for visibility, fallback selection, restoration, layout configuration, and one-tap filter application.
- Closes #333