### PR TITLE
Harden full backup imports

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/BackupDatabaseValidationTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/BackupDatabaseValidationTest.kt
@@ -1,0 +1,63 @@
+package org.schabi.newpipe.settings
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.Migrations
+
+@RunWith(AndroidJUnit4::class)
+class BackupDatabaseValidationTest {
+    companion object {
+        private const val VALID_DATABASE = "valid-backup-import.db"
+        private const val FOREIGN_DATABASE = "foreign-backup-import.db"
+    }
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @get:Rule
+    val migrationHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java
+    )
+
+    @Test
+    fun compatibleDatabasePassesRoomValidation() {
+        context.deleteDatabase(VALID_DATABASE)
+        migrationHelper.createDatabase(VALID_DATABASE, Migrations.DB_VER_23).close()
+
+        try {
+            NewPipeDatabase.validateImportDatabase(context, VALID_DATABASE)
+        } finally {
+            context.deleteDatabase(VALID_DATABASE)
+        }
+    }
+
+    @Test
+    fun sameVersionForeignDatabaseFailsBeforeReplacingLiveData() {
+        context.deleteDatabase(FOREIGN_DATABASE)
+        SQLiteDatabase.openOrCreateDatabase(
+            context.getDatabasePath(FOREIGN_DATABASE),
+            null
+        ).use { database ->
+            database.execSQL("CREATE TABLE foreign_data (id INTEGER PRIMARY KEY)")
+            database.version = Migrations.DB_VER_23
+        }
+
+        try {
+            assertThrows(IllegalStateException::class.java) {
+                NewPipeDatabase.validateImportDatabase(context, FOREIGN_DATABASE)
+            }
+        } finally {
+            context.deleteDatabase(FOREIGN_DATABASE)
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.kt
+++ b/app/src/main/java/org/schabi/newpipe/NewPipeDatabase.kt
@@ -38,11 +38,11 @@ object NewPipeDatabase {
     @Volatile
     private var databaseInstance: AppDatabase? = null
 
-    private fun getDatabase(context: Context): AppDatabase {
+    private fun getDatabase(context: Context, databaseName: String): AppDatabase {
         return databaseBuilder(
             context.applicationContext,
             AppDatabase::class.java,
-            AppDatabase.Companion.DATABASE_NAME
+            databaseName
         ).addMigrations(
             MIGRATION_1_2,
             MIGRATION_2_3,
@@ -76,7 +76,7 @@ object NewPipeDatabase {
             synchronized(NewPipeDatabase::class.java) {
                 result = databaseInstance
                 if (result == null) {
-                    databaseInstance = getDatabase(context)
+                    databaseInstance = getDatabase(context, AppDatabase.DATABASE_NAME)
                     result = databaseInstance
                 }
             }
@@ -103,6 +103,27 @@ object NewPipeDatabase {
                     databaseInstance = null
                 }
             }
+        }
+    }
+
+    /**
+     * Opens and migrates a staged database with the same Room configuration used by the app.
+     * Room validates every expected table and column before this method returns, so callers can
+     * reject foreign databases without replacing the live database first.
+     */
+    @JvmStatic
+    fun validateImportDatabase(context: Context, databaseName: String) {
+        val database = getDatabase(context, databaseName)
+        try {
+            database.openHelper.writableDatabase
+            database.query("PRAGMA quick_check", null).use { cursor ->
+                check(cursor.moveToFirst() && cursor.getString(0) == "ok") {
+                    "The imported database failed SQLite integrity validation"
+                }
+            }
+            database.query("PRAGMA wal_checkpoint(TRUNCATE)", null).close()
+        } finally {
+            database.close()
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -18,7 +18,6 @@ import androidx.annotation.Nullable;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceManager;
 
-import com.grack.nanojson.JsonParserException;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.snackbar.Snackbar;
 
@@ -35,9 +34,12 @@ import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.NavigationHelper;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -190,6 +192,14 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                         .show();
                 return;
             }
+            if (contents.getSource() != ImportExportManager.BackupSource.WIZESTREAM) {
+                new MaterialAlertDialogBuilder(requireActivity())
+                        .setTitle(R.string.backup_incompatible_title)
+                        .setMessage(R.string.backup_incompatible_message)
+                        .setPositiveButton(R.string.ok, null)
+                        .show();
+                return;
+            }
 
             new MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.import_full_backup_title)
@@ -197,7 +207,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                             + getString(R.string.import_full_backup_detected_contents,
                             describeBackupContents(contents)))
                     .setPositiveButton(R.string.import_full_backup_button, (d, id) ->
-                            importDatabase(file, importDataUri, contents))
+                            chooseSettingsImport(file, importDataUri, contents))
                     .setNegativeButton(R.string.cancel, (d, id) -> d.cancel())
                     .show();
         } catch (final Exception e) {
@@ -229,54 +239,90 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         builder.append(getString(stringRes));
     }
 
+    private void chooseSettingsImport(final StoredFileHelper file, final Uri importDataUri,
+                                      final ImportExportManager.BackupContents contents) {
+        final boolean hasJsonPrefs = contents.getHasJsonPreferences();
+        if (!hasJsonPrefs && !contents.getHasSerializedPreferences()) {
+            importDatabase(file, importDataUri, contents, false);
+            return;
+        }
+
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.import_settings)
+                .setMessage(hasJsonPrefs ? null : requireContext()
+                        .getString(R.string.import_settings_vulnerable_format))
+                .setNegativeButton(R.string.cancel, (dialog, which) -> {
+                    dialog.dismiss();
+                    importDatabase(file, importDataUri, contents, false);
+                })
+                .setPositiveButton(R.string.ok, (dialog, which) -> {
+                    dialog.dismiss();
+                    importDatabase(file, importDataUri, contents, true);
+                })
+                .show();
+    }
+
     private void importDatabase(final StoredFileHelper file, final Uri importDataUri,
-                                final ImportExportManager.BackupContents contents) {
+                                final ImportExportManager.BackupContents contents,
+                                final boolean importSettings) {
+        final Context context = requireContext();
+        final SharedPreferences preferences = PreferenceManager
+                .getDefaultSharedPreferences(context);
+        final Map<String, ?> previousPreferences = new HashMap<>(preferences.getAll());
+        ImportExportManager.DatabaseRollback databaseRollback = null;
+        Path stagedDatabase = null;
+
         try {
             manager.ensureDbDirectoryExists();
 
-            // replace the current database
-            if (contents.getHasDatabase() && !manager.extractDb(file)) {
-                Toast.makeText(requireContext(), R.string.could_not_import_all_files,
-                                Toast.LENGTH_LONG)
-                        .show();
-                return;
+            final Map<String, ?> importedPreferences;
+            if (!importSettings) {
+                importedPreferences = null;
+            } else if (contents.getHasJsonPreferences()) {
+                importedPreferences = manager.readJsonPrefs(file);
+            } else {
+                importedPreferences = manager.readSerializedPrefs(file);
             }
 
-            // if settings file exist, ask if it should be imported.
-            final boolean hasJsonPrefs = contents.getHasJsonPreferences();
-            if (hasJsonPrefs || contents.getHasSerializedPreferences()) {
-                new MaterialAlertDialogBuilder(requireContext())
-                        .setTitle(R.string.import_settings)
-                        .setMessage(hasJsonPrefs ? null : requireContext()
-                                .getString(R.string.import_settings_vulnerable_format))
-                        .setNegativeButton(R.string.cancel, (dialog, which) -> {
-                            dialog.dismiss();
-                            finishImport(importDataUri);
-                        })
-                        .setPositiveButton(R.string.ok, (dialog, which) -> {
-                            dialog.dismiss();
-                            final Context context = requireContext();
-                            final SharedPreferences prefs = PreferenceManager
-                                    .getDefaultSharedPreferences(context);
-                            try {
-                                if (hasJsonPrefs) {
-                                    manager.loadJsonPrefs(file, prefs);
-                                } else {
-                                    manager.loadSerializedPrefs(file, prefs);
-                                }
-                            } catch (IOException | ClassNotFoundException | JsonParserException e) {
-                                createErrorNotification(e, "Importing preferences");
-                                return;
-                            }
-                            cleanImport(context, prefs);
-                            finishImport(importDataUri);
-                        })
-                        .show();
-            } else {
-                finishImport(importDataUri);
+            if (contents.getHasDatabase()) {
+                stagedDatabase = manager.stageDb(file);
+                if (stagedDatabase == null) {
+                    throw new IOException("The backup database could not be staged");
+                }
+                NewPipeDatabase.validateImportDatabase(
+                        context, stagedDatabase.getFileName().toString());
+                try {
+                    NewPipeDatabase.checkpoint();
+                } catch (final IllegalStateException ignored) {
+                    // The database has not been opened during this process.
+                }
+                NewPipeDatabase.close();
+                databaseRollback = manager.replaceDb(stagedDatabase);
             }
+
+            if (importedPreferences != null) {
+                manager.replacePreferences(preferences, importedPreferences);
+                cleanImport(context, preferences);
+            }
+
+            if (databaseRollback != null) {
+                manager.finishDbReplacement(databaseRollback);
+            }
+            finishImport(importDataUri);
         } catch (final Exception e) {
+            try {
+                manager.replacePreferences(preferences, previousPreferences);
+                if (databaseRollback != null) {
+                    manager.rollbackDb(databaseRollback);
+                }
+            } catch (final Exception rollbackError) {
+                e.addSuppressed(rollbackError);
+            }
             showErrorSnackbar(e, "Importing database and settings");
+        } finally {
+            if (stagedDatabase != null) {
+                manager.discardStagedDb(stagedDatabase);
+            }
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
@@ -8,8 +8,11 @@ import com.grack.nanojson.JsonWriter
 import java.io.DataInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
-import java.nio.file.StandardCopyOption
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlin.io.path.createParentDirectories
@@ -36,11 +39,26 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
         val hasJsonPreferences: Boolean,
         val hasSerializedPreferences: Boolean,
         val hasManifest: Boolean,
-        val manifest: String?
+        val manifest: String?,
+        val source: BackupSource,
+        val backupFormatVersion: Int?
     ) {
         val hasRecognizableBackupData: Boolean
             get() = hasDatabase || hasJsonPreferences || hasSerializedPreferences
     }
+
+    enum class BackupSource {
+        WIZESTREAM,
+        FOREIGN,
+        LEGACY_OR_UNKNOWN,
+        INVALID_MANIFEST,
+        UNSUPPORTED_WIZESTREAM
+    }
+
+    data class DatabaseRollback internal constructor(
+        internal val backup: Path,
+        internal val previousDatabaseExisted: Boolean
+    )
 
     /**
      * Exports given [SharedPreferences] to the file in given outputPath.
@@ -108,27 +126,96 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
      * @return true if the database was successfully extracted, false otherwise
      */
     fun extractDb(file: StoredFileHelper): Boolean {
+        val importedDb = stageDb(file) ?: return false
+        return try {
+            val rollback = replaceDb(importedDb)
+            finishDbReplacement(rollback)
+            true
+        } catch (error: IOException) {
+            false
+        } finally {
+            discardStagedDb(importedDb)
+        }
+    }
+
+    /** Extracts a database into a temporary sibling without touching the live database. */
+    fun stageDb(file: StoredFileHelper): Path? {
         val name = BackupFileLocator.FILE_NAME_DB
         val importedDb = fileLocator.db.resolveSibling("${fileLocator.db.fileName}.import")
         importedDb.deleteIfExists()
 
-        try {
+        return try {
             if (!ZipHelper.extractFileFromZip(file, name, importedDb)) {
-                return false
+                return null
             }
             val databaseVersion = readSqliteUserVersion(importedDb)
             if (databaseVersion !in Migrations.DB_VER_1..Migrations.DB_VER_23) {
-                return false
+                importedDb.deleteIfExists()
+                return null
             }
-
-            Files.move(importedDb, fileLocator.db, StandardCopyOption.REPLACE_EXISTING)
-            fileLocator.dbJournal.deleteIfExists()
-            fileLocator.dbWal.deleteIfExists()
-            fileLocator.dbShm.deleteIfExists()
-            return true
-        } finally {
+            importedDb
+        } catch (error: IOException) {
             importedDb.deleteIfExists()
+            null
         }
+    }
+
+    /** Replaces the live database while retaining a rollback copy until the caller commits. */
+    @Throws(IOException::class)
+    fun replaceDb(importedDb: Path): DatabaseRollback {
+        val rollback = fileLocator.db.resolveSibling("${fileLocator.db.fileName}.rollback")
+        rollback.deleteIfExists()
+        val previousDatabaseExisted = Files.exists(fileLocator.db)
+        if (previousDatabaseExisted) {
+            Files.copy(fileLocator.db, rollback, REPLACE_EXISTING)
+        }
+
+        try {
+            moveReplacing(importedDb, fileLocator.db)
+            deleteLiveDatabaseSidecars()
+        } catch (error: IOException) {
+            if (previousDatabaseExisted && Files.exists(rollback)) {
+                Files.copy(rollback, fileLocator.db, REPLACE_EXISTING)
+            }
+            rollback.deleteIfExists()
+            throw error
+        }
+        return DatabaseRollback(rollback, previousDatabaseExisted)
+    }
+
+    fun rollbackDb(recovery: DatabaseRollback) {
+        if (recovery.previousDatabaseExisted) {
+            Files.copy(recovery.backup, fileLocator.db, REPLACE_EXISTING)
+        } else {
+            fileLocator.db.deleteIfExists()
+        }
+        deleteLiveDatabaseSidecars()
+        recovery.backup.deleteIfExists()
+    }
+
+    fun finishDbReplacement(recovery: DatabaseRollback) {
+        recovery.backup.deleteIfExists()
+    }
+
+    fun discardStagedDb(importedDb: Path) {
+        importedDb.deleteIfExists()
+        importedDb.resolveSibling("${importedDb.fileName}-journal").deleteIfExists()
+        importedDb.resolveSibling("${importedDb.fileName}-wal").deleteIfExists()
+        importedDb.resolveSibling("${importedDb.fileName}-shm").deleteIfExists()
+    }
+
+    private fun moveReplacing(source: Path, destination: Path) {
+        try {
+            Files.move(source, destination, ATOMIC_MOVE, REPLACE_EXISTING)
+        } catch (error: AtomicMoveNotSupportedException) {
+            Files.move(source, destination, REPLACE_EXISTING)
+        }
+    }
+
+    private fun deleteLiveDatabaseSidecars() {
+        fileLocator.dbJournal.deleteIfExists()
+        fileLocator.dbWal.deleteIfExists()
+        fileLocator.dbShm.deleteIfExists()
     }
 
     private fun readSqliteUserVersion(database: java.nio.file.Path): Int? {
@@ -190,13 +277,40 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
             }
         }
 
+        val manifestInfo = inspectManifest(hasManifest, manifest)
         return BackupContents(
             hasDatabase,
             hasJsonPreferences,
             hasSerializedPreferences,
             hasManifest,
-            manifest
+            manifest,
+            manifestInfo.first,
+            manifestInfo.second
         )
+    }
+
+    private fun inspectManifest(
+        hasManifest: Boolean,
+        manifest: String?
+    ): Pair<BackupSource, Int?> {
+        if (!hasManifest) {
+            return BackupSource.LEGACY_OR_UNKNOWN to null
+        }
+        return try {
+            val json = JsonParser.`object`().from(checkNotNull(manifest))
+            val appName = json.getString("appName")
+            val formatVersion = json.getInt("backupFormatVersion")
+            when {
+                appName != "WizeStream" -> BackupSource.FOREIGN to formatVersion
+
+                formatVersion != MANIFEST_FORMAT_VERSION ->
+                    BackupSource.UNSUPPORTED_WIZESTREAM to formatVersion
+
+                else -> BackupSource.WIZESTREAM to formatVersion
+            }
+        } catch (error: JsonParserException) {
+            BackupSource.INVALID_MANIFEST to null
+        }
     }
 
     /**
@@ -208,43 +322,23 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
     )
     @Throws(IOException::class, ClassNotFoundException::class)
     fun loadSerializedPrefs(zipFile: StoredFileHelper, preferences: SharedPreferences) {
+        replacePreferences(preferences, readSerializedPrefs(zipFile))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Throws(IOException::class, ClassNotFoundException::class)
+    fun readSerializedPrefs(zipFile: StoredFileHelper): Map<String, Any?> {
+        var entries: Map<String, Any?>? = null
         ZipHelper.extractFileFromZip(zipFile, BackupFileLocator.FILE_NAME_SERIALIZED_PREFS) {
             PreferencesObjectInputStream(it).use { input ->
-                @Suppress("UNCHECKED_CAST")
-                val entries = input.readObject() as Map<String, *>
-
-                val editor = preferences.edit()
-                editor.clear()
-
-                for ((key, value) in entries) {
-                    when (value) {
-                        is Boolean -> editor.putBoolean(key, value)
-
-                        is Float -> editor.putFloat(key, value)
-
-                        is Int -> editor.putInt(key, value)
-
-                        is Long -> editor.putLong(key, value)
-
-                        is String -> editor.putString(key, value)
-
-                        is Set<*> -> {
-                            // There are currently only Sets with type String possible
-                            @Suppress("UNCHECKED_CAST")
-                            editor.putStringSet(key, value as Set<String>?)
-                        }
-                    }
-                }
-
-                if (!editor.commit()) {
-                    throw IOException("Unable to commit loadSerializedPrefs")
-                }
+                entries = sanitizePreferences(input.readObject() as Map<String, *>)
             }
         }.let { fileExists ->
             if (!fileExists) {
                 throw FileNotFoundException(BackupFileLocator.FILE_NAME_SERIALIZED_PREFS)
             }
         }
+        return checkNotNull(entries)
     }
 
     /**
@@ -252,39 +346,65 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
      */
     @Throws(IOException::class, JsonParserException::class)
     fun loadJsonPrefs(zipFile: StoredFileHelper, preferences: SharedPreferences) {
+        replacePreferences(preferences, readJsonPrefs(zipFile))
+    }
+
+    @Throws(IOException::class, JsonParserException::class)
+    fun readJsonPrefs(zipFile: StoredFileHelper): Map<String, Any?> {
+        var entries: Map<String, Any?>? = null
         ZipHelper.extractFileFromZip(zipFile, BackupFileLocator.FILE_NAME_JSON_PREFS) {
             val jsonObject = JsonParser.`object`().from(it)
-            val entries = mutableMapOf<String, Any?>()
+            val parsedEntries = mutableMapOf<String, Any?>()
 
             for ((key, value) in jsonObject) {
                 when (value) {
-                    is Boolean, is Float, is Int, is Long, is String -> entries[key] = value
-                    is JsonArray -> entries[key] = value.mapNotNull { e -> e as? String }.toSet()
+                    is Boolean, is Float, is Int, is Long, is String ->
+                        parsedEntries[key] = value
+
+                    is JsonArray ->
+                        parsedEntries[key] = value.mapNotNull { e -> e as? String }.toSet()
                 }
             }
-
-            val editor = preferences.edit()
-            editor.clear()
-
-            for ((key, value) in entries) {
-                @Suppress("UNCHECKED_CAST")
-                when (value) {
-                    is Boolean -> editor.putBoolean(key, value)
-                    is Float -> editor.putFloat(key, value)
-                    is Int -> editor.putInt(key, value)
-                    is Long -> editor.putLong(key, value)
-                    is String -> editor.putString(key, value)
-                    is Set<*> -> editor.putStringSet(key, value as Set<String>?)
-                }
-            }
-
-            if (!editor.commit()) {
-                throw IOException("Unable to commit loadJsonPrefs")
-            }
+            entries = parsedEntries
         }.let { fileExists ->
             if (!fileExists) {
                 throw FileNotFoundException(BackupFileLocator.FILE_NAME_JSON_PREFS)
             }
         }
+        return checkNotNull(entries)
+    }
+
+    fun replacePreferences(preferences: SharedPreferences, entries: Map<String, *>) {
+        val editor = preferences.edit()
+        editor.clear()
+        for ((key, value) in sanitizePreferences(entries)) {
+            @Suppress("UNCHECKED_CAST")
+            when (value) {
+                is Boolean -> editor.putBoolean(key, value)
+                is Float -> editor.putFloat(key, value)
+                is Int -> editor.putInt(key, value)
+                is Long -> editor.putLong(key, value)
+                is String -> editor.putString(key, value)
+                is Set<*> -> editor.putStringSet(key, value as Set<String>)
+            }
+        }
+        if (!editor.commit()) {
+            throw IOException("Unable to commit imported preferences")
+        }
+    }
+
+    private fun sanitizePreferences(entries: Map<String, *>): Map<String, Any?> {
+        return entries.mapNotNull { (key, value) ->
+            when (value) {
+                is Boolean, is Float, is Int, is Long, is String -> key to value
+
+                is Set<*> -> {
+                    val strings = value.filterIsInstance<String>().toSet()
+                    if (strings.size == value.size) key to strings else null
+                }
+
+                else -> null
+            }
+        }.toMap()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -504,6 +504,8 @@
     <string name="backup_contents_manifest">backup manifest</string>
     <string name="backup_contents_none">no recognizable backup contents</string>
     <string name="backup_invalid_or_empty">This ZIP does not contain recognizable WizeStream backup data.</string>
+    <string name="backup_incompatible_title">Backup cannot be restored</string>
+    <string name="backup_incompatible_message">Full restore accepts only backups created by a supported version of WizeStream. This archive may be from another app, an older unverified format, or an incompatible WizeStream version. Nothing on this device was changed.</string>
     <string name="backup_exported_with_file">Backup exported: %s</string>
     <string name="backup_import_succeeded_restart">Import succeeded. WizeStream will restart to finish loading the backup.</string>
     <string name="restart">Restart</string>

--- a/app/src/test/java/org/schabi/newpipe/settings/ImportExportManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/ImportExportManagerTest.kt
@@ -37,6 +37,7 @@ import org.mockito.Mockito.withSettings
 import org.mockito.junit.MockitoJUnitRunner
 import org.schabi.newpipe.settings.export.BackupFileLocator
 import org.schabi.newpipe.settings.export.ImportExportManager
+import org.schabi.newpipe.settings.export.ImportExportManager.BackupSource
 import org.schabi.newpipe.streams.io.StoredFileHelper
 import us.shandian.giga.io.FileStream
 
@@ -110,6 +111,60 @@ class ImportExportManagerTest {
                 assertTrue(manifest.getBoolean("includesPreferences"))
                 assertFalse(manifest.getBoolean("includesSponsorBlockSettings"))
             }
+        }
+    }
+
+    @Test
+    fun `A supported WizeStream manifest must be accepted for full restore`() {
+        val zip = backupWithManifest(
+            """{"appName":"WizeStream","backupFormatVersion":1}"""
+        )
+        `when`(storedFileHelper.stream).thenReturn(FileStream(zip.toFile()))
+
+        val contents = ImportExportManager(fileLocator).inspectBackup(storedFileHelper)
+
+        assertEquals(BackupSource.WIZESTREAM, contents.source)
+        assertEquals(1, contents.backupFormatVersion)
+    }
+
+    @Test
+    fun `A foreign manifest must not be accepted as a WizeStream backup`() {
+        val zip = backupWithManifest(
+            """{"appName":"PipePipe","backupFormatVersion":1}"""
+        )
+        `when`(storedFileHelper.stream).thenReturn(FileStream(zip.toFile()))
+
+        val contents = ImportExportManager(fileLocator).inspectBackup(storedFileHelper)
+
+        assertEquals(BackupSource.FOREIGN, contents.source)
+    }
+
+    @Test
+    fun `A manifest-less archive must remain untrusted`() {
+        val zip = createTempFile("legacy_backup_", ".zip")
+        ZipOutputStream(zip.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(BackupFileLocator.FILE_NAME_DB))
+            output.write("legacy database".toByteArray())
+            output.closeEntry()
+        }
+        `when`(storedFileHelper.stream).thenReturn(FileStream(zip.toFile()))
+
+        val contents = ImportExportManager(fileLocator).inspectBackup(storedFileHelper)
+
+        assertEquals(BackupSource.LEGACY_OR_UNKNOWN, contents.source)
+    }
+
+    private fun backupWithManifest(manifest: String) = createTempFile(
+        "backup_manifest_",
+        ".zip"
+    ).also { zip ->
+        ZipOutputStream(zip.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(BackupFileLocator.FILE_NAME_DB))
+            output.write("database".toByteArray())
+            output.closeEntry()
+            output.putNextEntry(ZipEntry(BackupFileLocator.FILE_NAME_MANIFEST))
+            output.write(manifest.toByteArray())
+            output.closeEntry()
         }
     }
 


### PR DESCRIPTION
- Require a supported WizeStream manifest before full restore can modify application data
- Stage, migrate, integrity-check, and Room-validate databases before replacing the live database
- Keep a rollback copy until database and preference restoration both succeed
- Parse preferences before mutation and restore existing preferences on failure
- Add coverage for foreign, manifest-less, valid, and same-version incompatible databases
- Part of #337