### PR TITLE
Import history and playlists from NewPipe backups

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
@@ -1,0 +1,137 @@
+package org.schabi.newpipe.settings
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.nio.file.Path
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.playlist.model.PlaylistEntity
+import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager
+
+@RunWith(AndroidJUnit4::class)
+class NewPipeDataMigrationManagerTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var sourcePath: Path
+
+    @Before
+    fun setUp() {
+        NewPipeDatabase.close()
+        context.deleteDatabase(AppDatabase.DATABASE_NAME)
+        sourcePath = context.cacheDir.resolve("newpipe-migration-source.db").toPath()
+        sourcePath.toFile().delete()
+        createSourceDatabase(sourcePath)
+    }
+
+    @After
+    fun tearDown() {
+        NewPipeDatabase.close()
+        context.deleteDatabase(AppDatabase.DATABASE_NAME)
+        sourcePath.toFile().delete()
+    }
+
+    @Test
+    fun historyProgressAndPlaylistsAreMergedWithoutReplacingExistingData() {
+        val target = NewPipeDatabase.getInstance(context)
+        target.playlistDAO().insert(
+            PlaylistEntity(
+                name = "Lessons",
+                isThumbnailPermanent = false,
+                thumbnailStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID,
+                displayIndex = 0
+            )
+        )
+        val manager = NewPipeDataMigrationManager(context)
+
+        val preview = manager.inspect(sourcePath)
+        assertEquals(1, preview.historyItems)
+        assertEquals(1, preview.progressItems)
+        assertEquals(1, preview.playlists)
+        assertEquals(1, preview.playlistItems)
+
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = true,
+                importPlaylists = true
+            )
+        )
+
+        assertEquals(1, result.historyItems)
+        assertEquals(1, result.progressItems)
+        assertEquals(1, result.playlists)
+        assertEquals(1, result.playlistItems)
+        assertEquals(1, target.streamDAO().getAll().blockingFirst().size)
+        assertEquals(1, target.streamHistoryDAO().getAllDirect().size)
+        assertEquals(90_000, target.streamStateDAO().getAllDirect().single().progressMillis)
+        val playlists = target.playlistDAO().getAllDirect()
+        assertEquals(2, playlists.size)
+        assertTrue(playlists.any { it.name == "Lessons (Imported)" })
+        val imported = playlists.single { it.name == "Lessons (Imported)" }
+        assertEquals(1, target.playlistStreamDAO().getOrderedStreamsDirect(imported.uid).size)
+    }
+
+    @Test
+    fun unselectedHistoryIsNotImportedWithPlaylists() {
+        val manager = NewPipeDataMigrationManager(context)
+
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = false,
+                importPlaylists = true
+            )
+        )
+
+        val target = NewPipeDatabase.getInstance(context)
+        assertEquals(0, result.historyItems)
+        assertEquals(0, result.progressItems)
+        assertTrue(target.streamHistoryDAO().getAllDirect().isEmpty())
+        assertTrue(target.streamStateDAO().getAllDirect().isEmpty())
+        assertEquals(1, target.playlistDAO().getAllDirect().size)
+    }
+
+    private fun createSourceDatabase(path: Path) {
+        SQLiteDatabase.openOrCreateDatabase(path.toFile(), null).use { source ->
+            source.execSQL(
+                "CREATE TABLE streams (" +
+                    "uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, " +
+                    "url TEXT NOT NULL, title TEXT NOT NULL, stream_type TEXT NOT NULL, " +
+                    "duration INTEGER NOT NULL, uploader TEXT NOT NULL)"
+            )
+            source.execSQL(
+                "CREATE TABLE stream_history (" +
+                    "stream_id INTEGER NOT NULL, access_date INTEGER NOT NULL, " +
+                    "repeat_count INTEGER NOT NULL)"
+            )
+            source.execSQL(
+                "CREATE TABLE stream_state (" +
+                    "stream_id INTEGER PRIMARY KEY, progress_time INTEGER NOT NULL)"
+            )
+            source.execSQL(
+                "CREATE TABLE playlists (uid INTEGER PRIMARY KEY, name TEXT)"
+            )
+            source.execSQL(
+                "CREATE TABLE playlist_stream_join (" +
+                    "playlist_id INTEGER NOT NULL, stream_id INTEGER NOT NULL, " +
+                    "join_index INTEGER NOT NULL)"
+            )
+            source.execSQL(
+                "INSERT INTO streams VALUES " +
+                    "(1, 0, 'https://example.com/watch/1', 'Lesson one', " +
+                    "'VIDEO_STREAM', 300, 'Teacher')"
+            )
+            source.execSQL("INSERT INTO stream_history VALUES (1, 1788253200000, 2)")
+            source.execSQL("INSERT INTO stream_state VALUES (1, 90000)")
+            source.execSQL("INSERT INTO playlists VALUES (10, 'Lessons')")
+            source.execSQL("INSERT INTO playlist_stream_join VALUES (10, 1, 0)")
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -4,6 +4,7 @@ import static org.schabi.newpipe.extractor.utils.Utils.isBlank;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -29,6 +30,7 @@ import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.local.subscription.SubscriptionsImportExportHelper;
 import org.schabi.newpipe.settings.export.BackupFileLocator;
 import org.schabi.newpipe.settings.export.ImportExportManager;
+import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -36,8 +38,10 @@ import org.schabi.newpipe.util.NavigationHelper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -57,7 +61,11 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private final ActivityResultLauncher<Intent> requestExportPathLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
                     this::requestExportPathResult);
+    private final ActivityResultLauncher<Intent> requestMigrationPathLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
+                    this::requestMigrationPathResult);
     private SubscriptionsImportExportHelper importExportHelper;
+    private NewPipeDataMigrationManager migrationManager;
 
 
     @Override
@@ -70,6 +78,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     public void onCreatePreferences(@Nullable final Bundle savedInstanceState,
                                     @Nullable final String rootKey) {
         manager = new ImportExportManager(new BackupFileLocator(requireContext()));
+        migrationManager = new NewPipeDataMigrationManager(requireContext());
 
         importExportDataPathKey = getString(R.string.import_export_data_path);
 
@@ -85,6 +94,19 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                     getContext()
             );
 
+            return true;
+        });
+
+        final Preference importCompatiblePreference =
+                requirePreference(R.string.import_compatible_data_key);
+        importCompatiblePreference.setOnPreferenceClickListener(preference -> {
+            NoFileManagerSafeGuard.launchSafe(
+                    requestMigrationPathLauncher,
+                    StoredFileHelper.getSystemPicker(requireContext(),
+                            ZIP_MIME_TYPE, getImportExportDataUri()),
+                    TAG,
+                    getContext()
+            );
             return true;
         });
 
@@ -164,6 +186,164 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
 
             showImportConfirmation(file, lastImportDataUri);
         }
+    }
+
+    private void requestMigrationPathResult(final ActivityResult result) {
+        if (result.getResultCode() != Activity.RESULT_OK || result.getData() == null) {
+            return;
+        }
+        final Uri importDataUri = result.getData().getData();
+        final StoredFileHelper file = new StoredFileHelper(
+                requireContext(), importDataUri, ZIP_MIME_TYPE);
+        inspectMigrationBackup(file, importDataUri);
+    }
+
+    private void inspectMigrationBackup(final StoredFileHelper file, final Uri importDataUri) {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            Path stagedDatabase = null;
+            try {
+                manager.ensureDbDirectoryExists();
+                stagedDatabase = manager.stageMigrationDb(file);
+                if (stagedDatabase == null) {
+                    throw new IOException("The backup does not contain a SQLite database");
+                }
+                final NewPipeDataMigrationManager.Preview preview =
+                        migrationManager.inspect(stagedDatabase);
+                final Path readyDatabase = stagedDatabase;
+                stagedDatabase = null;
+                if (getActivity() != null) {
+                    requireActivity().runOnUiThread(() ->
+                            showMigrationConfirmation(readyDatabase, importDataUri, preview));
+                } else {
+                    manager.discardStagedDb(readyDatabase);
+                }
+            } catch (final Exception e) {
+                final Path failedDatabase = stagedDatabase;
+                if (getActivity() != null) {
+                    requireActivity().runOnUiThread(() -> {
+                        Toast.makeText(requireContext(), R.string.migration_invalid_backup,
+                                Toast.LENGTH_LONG).show();
+                        if (failedDatabase != null) {
+                            manager.discardStagedDb(failedDatabase);
+                        }
+                    });
+                } else if (failedDatabase != null) {
+                    manager.discardStagedDb(failedDatabase);
+                }
+            } finally {
+                executor.shutdown();
+            }
+        });
+    }
+
+    private void showMigrationConfirmation(
+            final Path stagedDatabase,
+            final Uri importDataUri,
+            final NewPipeDataMigrationManager.Preview preview) {
+        if (!preview.getHasImportableData()) {
+            manager.discardStagedDb(stagedDatabase);
+            Toast.makeText(requireContext(), R.string.migration_invalid_backup,
+                    Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        final List<String> optionLabels = new ArrayList<>();
+        final List<Boolean> optionTypes = new ArrayList<>();
+        if (preview.getHasHistory()) {
+            optionLabels.add(getString(
+                    R.string.migration_history_option,
+                    preview.getHistoryItems(),
+                    preview.getProgressItems()));
+            optionTypes.add(true);
+        }
+        if (preview.getHasPlaylists()) {
+            optionLabels.add(getString(
+                    R.string.migration_playlists_option,
+                    preview.getPlaylists(),
+                    preview.getPlaylistItems()));
+            optionTypes.add(false);
+        }
+        final boolean[] checkedItems = new boolean[optionLabels.size()];
+        java.util.Arrays.fill(checkedItems, true);
+
+        final androidx.appcompat.app.AlertDialog dialog =
+                new MaterialAlertDialogBuilder(requireContext())
+                        .setTitle(R.string.migration_choose_data_title)
+                        .setMultiChoiceItems(
+                                optionLabels.toArray(new String[0]),
+                                checkedItems,
+                                (ignored, which, isChecked) -> checkedItems[which] = isChecked)
+                        .setNegativeButton(R.string.cancel, (ignored, which) ->
+                                manager.discardStagedDb(stagedDatabase))
+                        .setPositiveButton(R.string.migration_import_button, null)
+                        .create();
+        dialog.setOnCancelListener(ignored -> manager.discardStagedDb(stagedDatabase));
+        dialog.setOnShowListener(ignored -> dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+                .setOnClickListener(button -> {
+                    boolean importHistory = false;
+                    boolean importPlaylists = false;
+                    for (int i = 0; i < checkedItems.length; i++) {
+                        if (!checkedItems[i]) {
+                            continue;
+                        }
+                        if (optionTypes.get(i)) {
+                            importHistory = true;
+                        } else {
+                            importPlaylists = true;
+                        }
+                    }
+                    if (!importHistory && !importPlaylists) {
+                        Toast.makeText(requireContext(), R.string.migration_nothing_selected,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+                    dialog.dismiss();
+                    importMigratedData(
+                            stagedDatabase,
+                            importDataUri,
+                            new NewPipeDataMigrationManager.Selection(
+                                    importHistory,
+                                    importPlaylists));
+                }));
+        dialog.show();
+    }
+
+    private void importMigratedData(
+            final Path stagedDatabase,
+            final Uri importDataUri,
+            final NewPipeDataMigrationManager.Selection selection) {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            try {
+                final NewPipeDataMigrationManager.Result migrationResult =
+                        migrationManager.importData(stagedDatabase, selection);
+                if (getActivity() != null) {
+                    requireActivity().runOnUiThread(() -> {
+                        saveLastImportExportDataUri(importDataUri);
+                        new MaterialAlertDialogBuilder(requireContext())
+                                .setTitle(R.string.migration_complete_title)
+                                .setMessage(getString(
+                                        R.string.migration_complete_message,
+                                        migrationResult.getHistoryItems(),
+                                        migrationResult.getProgressItems(),
+                                        migrationResult.getPlaylists(),
+                                        migrationResult.getPlaylistItems(),
+                                        migrationResult.getSkippedItems()))
+                                .setPositiveButton(R.string.ok, null)
+                                .show();
+                    });
+                }
+            } catch (final Exception e) {
+                if (getActivity() != null) {
+                    requireActivity().runOnUiThread(() ->
+                            showErrorSnackbar(e, "Migrating NewPipe data"));
+                }
+            } finally {
+                manager.discardStagedDb(stagedDatabase);
+                executor.shutdown();
+            }
+        });
     }
 
     private void exportDatabase(final StoredFileHelper file, final Uri exportDataUri) {

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
@@ -160,6 +160,28 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
         }
     }
 
+    /** Stages a foreign NewPipe-style database for selective, read-only migration. */
+    fun stageMigrationDb(file: StoredFileHelper): Path? {
+        val importedDb = fileLocator.db.resolveSibling("${fileLocator.db.fileName}.migration")
+        importedDb.deleteIfExists()
+        return try {
+            if (!ZipHelper.extractFileFromZip(
+                    file,
+                    BackupFileLocator.FILE_NAME_DB,
+                    importedDb
+                ) || readSqliteUserVersion(importedDb) == null
+            ) {
+                importedDb.deleteIfExists()
+                null
+            } else {
+                importedDb
+            }
+        } catch (error: IOException) {
+            importedDb.deleteIfExists()
+            null
+        }
+    }
+
     /** Replaces the live database while retaining a rollback copy until the caller commits. */
     @Throws(IOException::class)
     fun replaceDb(importedDb: Path): DatabaseRollback {

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
@@ -1,0 +1,379 @@
+package org.schabi.newpipe.settings.export
+
+import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import java.nio.file.Path
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.database.playlist.model.PlaylistEntity
+import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
+import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.database.stream.model.StreamStateEntity
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class NewPipeDataMigrationManager(private val context: Context) {
+    data class Preview(
+        val historyItems: Int,
+        val progressItems: Int,
+        val playlists: Int,
+        val playlistItems: Int
+    ) {
+        val hasHistory: Boolean
+            get() = historyItems > 0 || progressItems > 0
+        val hasPlaylists: Boolean
+            get() = playlists > 0
+        val hasImportableData: Boolean
+            get() = hasHistory || hasPlaylists
+    }
+
+    data class Selection(
+        val importHistory: Boolean,
+        val importPlaylists: Boolean
+    )
+
+    data class Result(
+        val historyItems: Int,
+        val progressItems: Int,
+        val playlists: Int,
+        val playlistItems: Int,
+        val skippedItems: Int
+    )
+
+    class UnsupportedSourceException(message: String) : Exception(message)
+
+    fun inspect(databasePath: Path): Preview = openSource(databasePath).use { source ->
+        val schema = inspectSchema(source)
+        Preview(
+            historyItems = if (schema.hasHistory) source.countRows(HISTORY_TABLE) else 0,
+            progressItems = if (schema.hasProgress) source.countRows(STATE_TABLE) else 0,
+            playlists = if (schema.hasPlaylists) source.countRows(PLAYLIST_TABLE) else 0,
+            playlistItems = if (schema.hasPlaylists) source.countRows(PLAYLIST_JOIN_TABLE) else 0
+        )
+    }
+
+    fun importData(databasePath: Path, selection: Selection): Result = openSource(
+        databasePath
+    ).use { source ->
+        val schema = inspectSchema(source)
+        val streams = readStreams(source)
+        val target = NewPipeDatabase.getInstance(context)
+        var result = Result(0, 0, 0, 0, 0)
+
+        target.runInTransaction {
+            val streamIds = mutableMapOf<Long, Long>()
+            fun targetStreamId(sourceId: Long): Long? {
+                streamIds[sourceId]?.let { return it }
+                val stream = streams[sourceId] ?: return null
+                val streamDao = target.streamDAO()
+                val existing = streamDao.getStreamDirect(stream.serviceId, stream.url)
+                val targetId = existing?.uid ?: streamDao.insert(stream)
+                streamIds[sourceId] = targetId
+                return targetId
+            }
+
+            var historyItems = 0
+            var progressItems = 0
+            var playlists = 0
+            var playlistItems = 0
+            var skippedItems = 0
+
+            if (selection.importHistory && schema.hasHistory) {
+                source.rawQuery(
+                    "SELECT stream_id, access_date, repeat_count FROM $HISTORY_TABLE",
+                    null
+                ).use { cursor ->
+                    val writable = target.openHelper.writableDatabase
+                    while (cursor.moveToNext()) {
+                        val targetId = targetStreamId(cursor.getLong(0))
+                        val accessDate = cursor.getLong(1)
+                        if (targetId == null || accessDate <= 0) {
+                            skippedItems++
+                            continue
+                        }
+                        val repeatCount = cursor.getLong(2).coerceAtLeast(0)
+                        writable.execSQL(
+                            "INSERT OR IGNORE INTO $HISTORY_TABLE " +
+                                "(stream_id, access_date, repeat_count) VALUES (?, ?, ?)",
+                            arrayOf(targetId, accessDate, repeatCount)
+                        )
+                        writable.execSQL(
+                            "UPDATE $HISTORY_TABLE SET repeat_count = " +
+                                "MAX(repeat_count, ?) WHERE stream_id = ? AND access_date = ?",
+                            arrayOf(repeatCount, targetId, accessDate)
+                        )
+                        historyItems++
+                    }
+                }
+            }
+
+            if (selection.importHistory && schema.hasProgress) {
+                val existingStates = target.streamStateDAO().getAllDirect()
+                    .associateBy { it.streamUid }
+                source.rawQuery(
+                    "SELECT stream_id, progress_time FROM $STATE_TABLE",
+                    null
+                ).use { cursor ->
+                    while (cursor.moveToNext()) {
+                        val targetId = targetStreamId(cursor.getLong(0))
+                        if (targetId == null) {
+                            skippedItems++
+                            continue
+                        }
+                        val progress = cursor.getLong(1).coerceAtLeast(0)
+                        val currentProgress = existingStates[targetId]?.progressMillis ?: -1
+                        if (progress > currentProgress) {
+                            target.streamStateDAO().upsert(
+                                StreamStateEntity(targetId, progress)
+                            )
+                            progressItems++
+                        }
+                    }
+                }
+            }
+
+            if (selection.importPlaylists && schema.hasPlaylists) {
+                val playlistDao = target.playlistDAO()
+                val playlistStreamDao = target.playlistStreamDAO()
+                val usedNames = playlistDao.getAllDirect()
+                    .mapNotNullTo(mutableSetOf()) { it.name }
+                var displayIndex = playlistDao.getAllDirect()
+                    .maxOfOrNull { it.displayIndex }?.plus(1) ?: 0L
+                val playlistOrder = if (schema.playlistColumns.contains("display_index")) {
+                    "display_index, uid"
+                } else {
+                    "uid"
+                }
+
+                source.rawQuery(
+                    "SELECT uid, name FROM $PLAYLIST_TABLE ORDER BY $playlistOrder",
+                    null
+                ).use { playlistCursor ->
+                    while (playlistCursor.moveToNext()) {
+                        val sourcePlaylistId = playlistCursor.getLong(0)
+                        val sourceName = playlistCursor.getString(1)?.trim().orEmpty()
+                        val targetName = uniquePlaylistName(
+                            sourceName.ifBlank { "Imported playlist" },
+                            usedNames
+                        )
+                        val playlist = PlaylistEntity(
+                            name = targetName,
+                            isThumbnailPermanent = false,
+                            thumbnailStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID,
+                            displayIndex = displayIndex++
+                        )
+                        val targetPlaylistId = playlistDao.insert(playlist)
+                        var targetIndex = 0
+                        var firstStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID
+
+                        source.rawQuery(
+                            "SELECT stream_id FROM $PLAYLIST_JOIN_TABLE " +
+                                "WHERE playlist_id = ? ORDER BY join_index",
+                            arrayOf(sourcePlaylistId.toString())
+                        ).use { itemCursor ->
+                            while (itemCursor.moveToNext()) {
+                                val targetId = targetStreamId(itemCursor.getLong(0))
+                                if (targetId == null) {
+                                    skippedItems++
+                                    continue
+                                }
+                                if (firstStreamId == PlaylistEntity.DEFAULT_THUMBNAIL_ID) {
+                                    firstStreamId = targetId
+                                }
+                                playlistStreamDao.insert(
+                                    PlaylistStreamEntity(
+                                        targetPlaylistId,
+                                        targetId,
+                                        targetIndex++
+                                    )
+                                )
+                                playlistItems++
+                            }
+                        }
+                        if (firstStreamId != PlaylistEntity.DEFAULT_THUMBNAIL_ID) {
+                            playlist.thumbnailStreamId = firstStreamId
+                            playlist.uid = targetPlaylistId
+                            playlistDao.update(playlist)
+                        }
+                        playlists++
+                    }
+                }
+            }
+
+            result = Result(
+                historyItems,
+                progressItems,
+                playlists,
+                playlistItems,
+                skippedItems
+            )
+        }
+        result
+    }
+
+    private fun openSource(databasePath: Path): SQLiteDatabase = SQLiteDatabase.openDatabase(
+        databasePath.toString(),
+        null,
+        SQLiteDatabase.OPEN_READONLY
+    )
+
+    private fun inspectSchema(source: SQLiteDatabase): SourceSchema {
+        val streamColumns = source.columnsOf(STREAM_TABLE)
+        if (!streamColumns.containsAll(REQUIRED_STREAM_COLUMNS)) {
+            throw UnsupportedSourceException(
+                "The source database does not contain a compatible NewPipe streams table"
+            )
+        }
+        val historyColumns = source.columnsOf(HISTORY_TABLE)
+        val stateColumns = source.columnsOf(STATE_TABLE)
+        val playlistColumns = source.columnsOf(PLAYLIST_TABLE)
+        val joinColumns = source.columnsOf(PLAYLIST_JOIN_TABLE)
+        val schema = SourceSchema(
+            hasHistory = historyColumns.containsAll(REQUIRED_HISTORY_COLUMNS),
+            hasProgress = stateColumns.containsAll(REQUIRED_STATE_COLUMNS),
+            hasPlaylists = playlistColumns.containsAll(REQUIRED_PLAYLIST_COLUMNS) &&
+                joinColumns.containsAll(REQUIRED_PLAYLIST_JOIN_COLUMNS),
+            playlistColumns = playlistColumns
+        )
+        if (!schema.hasHistory && !schema.hasProgress && !schema.hasPlaylists) {
+            throw UnsupportedSourceException(
+                "The source database does not contain compatible history or playlist data"
+            )
+        }
+        return schema
+    }
+
+    private fun readStreams(source: SQLiteDatabase): Map<Long, StreamEntity> {
+        val result = mutableMapOf<Long, StreamEntity>()
+        source.rawQuery("SELECT * FROM $STREAM_TABLE", null).use { cursor ->
+            while (cursor.moveToNext()) {
+                val uid = cursor.long("uid") ?: continue
+                val serviceId = cursor.long("service_id")?.toInt() ?: continue
+                val url = cursor.string("url") ?: continue
+                val streamType = cursor.string("stream_type")
+                    ?.let { runCatching { StreamType.valueOf(it) }.getOrNull() }
+                    ?: continue
+                result[uid] = StreamEntity(
+                    serviceId = serviceId,
+                    url = url,
+                    title = cursor.string("title").orEmpty(),
+                    streamType = streamType,
+                    duration = cursor.long("duration") ?: -1,
+                    uploader = cursor.string("uploader").orEmpty(),
+                    uploaderUrl = cursor.string("uploader_url"),
+                    thumbnailUrl = cursor.string("thumbnail_url"),
+                    viewCount = cursor.long("view_count"),
+                    textualUploadDate = cursor.string("textual_upload_date"),
+                    uploadDate = cursor.long("upload_date")?.toOffsetDateTime(),
+                    isUploadDateApproximation = cursor.long("is_upload_date_approximation")
+                        ?.let { it != 0L },
+                    uploaderAvatarUrl = cursor.string("uploader_avatar_url"),
+                    requiresMembership = cursor.long("requires_membership") == 1L
+                )
+            }
+        }
+        return result
+    }
+
+    private fun uniquePlaylistName(sourceName: String, usedNames: MutableSet<String>): String {
+        if (usedNames.add(sourceName)) {
+            return sourceName
+        }
+        var suffix = 1
+        while (true) {
+            val candidate = if (suffix == 1) {
+                "$sourceName (Imported)"
+            } else {
+                "$sourceName (Imported $suffix)"
+            }
+            if (usedNames.add(candidate)) {
+                return candidate
+            }
+            suffix++
+        }
+    }
+
+    private fun SQLiteDatabase.columnsOf(table: String): Set<String> {
+        if (!tableExists(table)) {
+            return emptySet()
+        }
+        return rawQuery("PRAGMA table_info(`$table`)", null).use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            buildSet {
+                while (cursor.moveToNext()) {
+                    add(cursor.getString(nameIndex))
+                }
+            }
+        }
+    }
+
+    private fun SQLiteDatabase.tableExists(table: String): Boolean = rawQuery(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+        arrayOf(table)
+    ).use { it.moveToFirst() }
+
+    private fun SQLiteDatabase.countRows(table: String): Int = rawQuery(
+        "SELECT COUNT(*) FROM `$table`",
+        null
+    ).use { cursor ->
+        if (!cursor.moveToFirst()) {
+            0
+        } else {
+            cursor.getLong(0).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        }
+    }
+
+    private fun Cursor.string(column: String): String? {
+        val index = getColumnIndex(column)
+        return if (index < 0 || isNull(index)) null else getString(index)
+    }
+
+    private fun Cursor.long(column: String): Long? {
+        val index = getColumnIndex(column)
+        return if (index < 0 || isNull(index)) null else getLong(index)
+    }
+
+    private fun Long.toOffsetDateTime(): OffsetDateTime = OffsetDateTime.ofInstant(
+        Instant.ofEpochMilli(this),
+        ZoneOffset.UTC
+    )
+
+    private data class SourceSchema(
+        val hasHistory: Boolean,
+        val hasProgress: Boolean,
+        val hasPlaylists: Boolean,
+        val playlistColumns: Set<String>
+    )
+
+    companion object {
+        private const val STREAM_TABLE = "streams"
+        private const val HISTORY_TABLE = "stream_history"
+        private const val STATE_TABLE = "stream_state"
+        private const val PLAYLIST_TABLE = "playlists"
+        private const val PLAYLIST_JOIN_TABLE = "playlist_stream_join"
+
+        private val REQUIRED_STREAM_COLUMNS = setOf(
+            "uid",
+            "service_id",
+            "url",
+            "title",
+            "stream_type",
+            "duration",
+            "uploader"
+        )
+        private val REQUIRED_HISTORY_COLUMNS = setOf(
+            "stream_id",
+            "access_date",
+            "repeat_count"
+        )
+        private val REQUIRED_STATE_COLUMNS = setOf("stream_id", "progress_time")
+        private val REQUIRED_PLAYLIST_COLUMNS = setOf("uid", "name")
+        private val REQUIRED_PLAYLIST_JOIN_COLUMNS = setOf(
+            "playlist_id",
+            "stream_id",
+            "join_index"
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,9 @@
     <string name="switch_to_popup">Switch to Popup</string>
     <string name="switch_to_main">Switch to Main</string>
     <string name="import_data_title">Import full backup</string>
+    <string name="import_compatible_data_key" translatable="false">import_compatible_data</string>
+    <string name="import_compatible_data_title">Import from NewPipe or compatible app</string>
+    <string name="import_compatible_data_summary">Merge watch history, playback positions, and local playlists from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
     <string name="export_data_title">Export full backup</string>
     <string name="clear_cookie_title">Clear reCAPTCHA cookies</string>
     <string name="recaptcha_cookies_cleared">reCAPTCHA cookies have been cleared</string>
@@ -506,6 +509,14 @@
     <string name="backup_invalid_or_empty">This ZIP does not contain recognizable WizeStream backup data.</string>
     <string name="backup_incompatible_title">Backup cannot be restored</string>
     <string name="backup_incompatible_message">Full restore accepts only backups created by a supported version of WizeStream. This archive may be from another app, an older unverified format, or an incompatible WizeStream version. Nothing on this device was changed.</string>
+    <string name="migration_invalid_backup">This backup does not contain compatible NewPipe history or playlist data.</string>
+    <string name="migration_choose_data_title">Choose data to merge</string>
+    <string name="migration_history_option">Watch history: %1$d entries and %2$d playback positions</string>
+    <string name="migration_playlists_option">Local playlists: %1$d playlists and %2$d items</string>
+    <string name="migration_import_button">Merge data</string>
+    <string name="migration_nothing_selected">Select at least one data category.</string>
+    <string name="migration_complete_title">Migration complete</string>
+    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, and %4$d playlist items. Skipped %5$d incompatible items.</string>
     <string name="backup_exported_with_file">Backup exported: %s</string>
     <string name="backup_import_succeeded_restart">Import succeeded. WizeStream will restart to finish loading the backup.</string>
     <string name="restart">Restart</string>

--- a/app/src/main/res/xml/backup_restore_settings.xml
+++ b/app/src/main/res/xml/backup_restore_settings.xml
@@ -17,6 +17,13 @@
         app:iconSpaceReserved="false" />
 
     <Preference
+        android:key="@string/import_compatible_data_key"
+        android:summary="@string/import_compatible_data_summary"
+        android:title="@string/import_compatible_data_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
+    <Preference
         android:key="@string/export_data"
         android:summary="@string/export_data_summary"
         android:title="@string/export_data_title"

--- a/app/src/test/java/org/schabi/newpipe/settings/WizeStreamBrandingTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/WizeStreamBrandingTest.kt
@@ -20,7 +20,10 @@ class WizeStreamBrandingTest {
     fun `localized product strings do not restore the legacy brand`() {
         val upstreamOnlyResources = setOf(
             "donation_encouragement",
-            "import_settings_vulnerable_format"
+            "import_settings_vulnerable_format",
+            "import_compatible_data_title",
+            "import_compatible_data_summary",
+            "migration_invalid_backup"
         )
 
         Files.walk(resourcesDirectory).use { paths ->


### PR DESCRIPTION
- Add a separate NewPipe-compatible migration option under Backup & Restore
- Detect compatible history, playback-position, playlist, and stream schemas without trusting app-specific database versions
- Preview available categories and let users choose what to merge
- Merge history and playback progress while preserving newer existing progress
- Import local playlists with ordering, duplicates, thumbnails, and conflict-safe names
- Preserve all existing WizeStream data and roll back the transaction on failure
- Add Android regression coverage for previews, data merging, deduplication, and playlist-name conflicts
- Implements the first two priorities from #337