### PR TITLE
Fix blocked keyword filtering

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/ContentBlockingSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/ContentBlockingSettingsFragment.java
@@ -38,7 +38,13 @@ public final class ContentBlockingSettingsFragment extends BasePreferenceFragmen
             editText.setMinLines(4);
         });
         blockedKeywordsPreference.setOnPreferenceChangeListener((preference, value) -> {
-            preference.setSummary(keywordSummary(value == null ? "" : value.toString()));
+            final String proposed = value == null ? "" : value.toString();
+            final String sanitized = ContentBlockingHelper.sanitizeKeywords(proposed);
+            preference.setSummary(keywordSummary(sanitized));
+            if (!sanitized.equals(proposed)) {
+                blockedKeywordsPreference.setText(sanitized);
+                return false;
+            }
             return true;
         });
         blockedChannelsPreference.setOnPreferenceClickListener(preference -> {
@@ -140,12 +146,8 @@ public final class ContentBlockingSettingsFragment extends BasePreferenceFragmen
 
     @NonNull
     private String keywordSummary(@Nullable final String value) {
-        int count = 0;
-        for (final String keyword : (value == null ? "" : value).split("[,\\n]")) {
-            if (!keyword.trim().isEmpty()) {
-                count++;
-            }
-        }
+        final String sanitized = ContentBlockingHelper.sanitizeKeywords(value);
+        final int count = sanitized.isEmpty() ? 0 : sanitized.split("\\n").length;
         return getResources().getQuantityString(R.plurals.blocked_keywords_count, count, count);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/ContentBlockingHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ContentBlockingHelper.java
@@ -169,7 +169,50 @@ public final class ContentBlockingHelper {
 
     @NonNull
     private static String normalize(@Nullable final String value) {
-        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        return value == null ? "" : trimWhitespace(value).toLowerCase(Locale.ROOT);
+    }
+
+    @NonNull
+    private static String trimWhitespace(@NonNull final String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && isWhitespace(value.charAt(start))) {
+            start++;
+        }
+        while (end > start && isWhitespace(value.charAt(end - 1))) {
+            end--;
+        }
+        return value.substring(start, end);
+    }
+
+    private static boolean isWhitespace(final char value) {
+        return Character.isWhitespace(value) || Character.isSpaceChar(value);
+    }
+
+    /**
+     * Returns the canonical persisted representation of keyword rules.
+     *
+     * <p>Commas and line breaks separate rules. Surrounding Unicode whitespace, empty rules, and
+     * case-insensitive duplicates are removed while the first spelling of each rule is retained.
+     *
+     * @param keywords raw comma- or line-break-separated keyword rules
+     * @return canonical line-break-separated keyword rules
+     */
+    @NonNull
+    public static String sanitizeKeywords(@Nullable final String keywords) {
+        if (keywords == null) {
+            return "";
+        }
+
+        final List<String> sanitized = new ArrayList<>();
+        final Set<String> seen = new HashSet<>();
+        for (final String value : keywords.split("[,\\n]")) {
+            final String keyword = trimWhitespace(value);
+            if (!keyword.isEmpty() && seen.add(normalize(keyword))) {
+                sanitized.add(keyword);
+            }
+        }
+        return String.join("\n", sanitized);
     }
 
     public static final class Entry {
@@ -231,12 +274,10 @@ public final class ContentBlockingHelper {
             }
 
             final List<String> keywordList = new ArrayList<>();
-            if (keywords != null) {
-                for (final String value : keywords.split("[,\\n]")) {
-                    final String keyword = normalize(value);
-                    if (!keyword.isEmpty() && !keywordList.contains(keyword)) {
-                        keywordList.add(keyword);
-                    }
+            for (final String value : sanitizeKeywords(keywords).split("\\n")) {
+                final String keyword = normalize(value);
+                if (!keyword.isEmpty()) {
+                    keywordList.add(keyword);
                 }
             }
             return new Rules(enabled, videos, channels, channelNames, keywordList);
@@ -250,7 +291,7 @@ public final class ContentBlockingHelper {
                 final StreamInfoItem stream = (StreamInfoItem) item;
                 return blockedVideoUrls.contains(normalize(stream.getUrl()))
                         || isBlockedChannel(stream.getUploaderUrl(), stream.getUploaderName())
-                        || containsKeyword(stream.getName(), stream.getUploaderName());
+                        || containsKeyword(stream.getName());
             }
             if (item instanceof ChannelInfoItem) {
                 return isBlockedChannel(item.getUrl(), item.getName())
@@ -259,13 +300,12 @@ public final class ContentBlockingHelper {
             if (item instanceof PlaylistInfoItem) {
                 final PlaylistInfoItem playlist = (PlaylistInfoItem) item;
                 return isBlockedChannel(null, playlist.getUploaderName())
-                        || containsKeyword(playlist.getName(), playlist.getUploaderName());
+                        || containsKeyword(playlist.getName());
             }
             if (item instanceof PostInfoItem) {
                 final PostInfoItem post = (PostInfoItem) item;
                 return isBlockedChannel(post.getUploaderUrl(), post.getUploaderName())
-                        || containsKeyword(post.getName(), post.getContent(),
-                                post.getUploaderName());
+                        || containsKeyword(post.getName(), post.getContent());
             }
             return containsKeyword(item.getName());
         }

--- a/app/src/test/java/org/schabi/newpipe/util/ContentBlockingHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ContentBlockingHelperTest.java
@@ -1,9 +1,12 @@
 package org.schabi.newpipe.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
+import org.schabi.newpipe.extractor.post.PostInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamType;
 
@@ -37,8 +40,37 @@ class ContentBlockingHelperTest {
                 true, Set.of(), Set.of(), "Spoiler, clickbait\nRumor");
 
         assertTrue(rules.isBlocked(stream("video-1", "Major SPOILER", "Channel", null)));
-        assertTrue(rules.isBlocked(stream("video-2", "Normal", "Rumor Network", null)));
+        assertTrue(rules.isBlocked(stream("video-2", "Rumor report", "Network", null)));
         assertFalse(rules.isBlocked(stream("video-3", "Documentary", "Science", null)));
+    }
+
+    @Test
+    void surroundingWhitespaceDoesNotTurnUploaderNamesIntoKeywordMatches() {
+        final ContentBlockingHelper.Rules rules = ContentBlockingHelper.Rules.create(
+                true, Set.of(), Set.of(), " ki ");
+
+        assertTrue(rules.isBlocked(stream("video-1", "A KI lesson", "Science", null)));
+        assertFalse(rules.isBlocked(stream("video-2", "Allowed title", "Ki Channel", null)));
+    }
+
+    @Test
+    void uploaderNamesDoNotTriggerPlaylistOrPostKeywordRules() {
+        final ContentBlockingHelper.Rules rules = ContentBlockingHelper.Rules.create(
+                true, Set.of(), Set.of(), "ki");
+        final PlaylistInfoItem playlist = new PlaylistInfoItem(0, "playlist-1", "Allowed list");
+        playlist.setUploaderName("Ki Channel");
+        final PostInfoItem post = new PostInfoItem(0, "post-1", "Allowed post");
+        post.setUploaderName("Ki Channel");
+        post.setContent("Allowed content");
+
+        assertFalse(rules.isBlocked(playlist));
+        assertFalse(rules.isBlocked(post));
+    }
+
+    @Test
+    void sanitizesWhitespaceBlankEntriesAndCaseInsensitiveDuplicates() {
+        assertEquals("Ki\nnews", ContentBlockingHelper.sanitizeKeywords(
+                "  Ki  ,\n , ki\nnews\u00a0"));
     }
 
     @Test

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,10 +65,11 @@ and choose the folders under **Settings > Download** before starting a batch.
 ## How does content blocking work?
 
 Long-press a video to block that video or its channel. Under **Settings > Content > Blocked
-content**, you can enable or disable filtering, add title or uploader keywords, review blocked
-videos and channels, remove individual rules, or clear everything. Matching remote videos,
-channels, posts, playlists, feeds, search results, and related content are hidden locally. Blocking
-does not unsubscribe from channels, delete history, or report anything to a service.
+content**, you can enable or disable filtering, add title or content keywords, review blocked videos
+and channels, remove individual rules, or clear everything. Keyword rules do not match uploader
+names; use **Block channel** when you want to hide all content from a channel. Matching remote
+videos, channels, posts, playlists, feeds, search results, and related content are hidden locally.
+Blocking does not unsubscribe from channels, delete history, or report anything to a service.
 
 ## How do proxy settings work?
 


### PR DESCRIPTION
- Restrict blocked keywords to video and playlist titles plus post title/content instead of uploader names
- Keep explicit blocked-channel rules responsible for hiding all content from an uploader
- Normalize surrounding Unicode whitespace, blank entries, and case-insensitive duplicate keywords before saving
- Add regression coverage for the reporter’s `" ki "` case across videos, playlists, and posts
- Update the content-blocking FAQ to explain the corrected behavior
- Fixes #334