### PR TITLE
Prioritize tab swipes on pinned playlists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -939,13 +939,14 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
 
             @Override
             public boolean isItemViewSwipeEnabled() {
-                return true;
+                return LocalPlaylistSwipePolicy.isItemRemovalSwipeEnabled(useAsFrontPage);
             }
 
             @Override
             public int getSwipeDirs(@NonNull final RecyclerView recyclerView,
                                     @NonNull final RecyclerView.ViewHolder viewHolder) {
-                if (itemListAdapter == null) {
+                if (!LocalPlaylistSwipePolicy.isItemRemovalSwipeEnabled(useAsFrontPage)
+                        || itemListAdapter == null) {
                     return ItemTouchHelper.ACTION_STATE_IDLE;
                 }
 

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistSwipePolicy.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistSwipePolicy.java
@@ -1,0 +1,15 @@
+package org.schabi.newpipe.local.playlist;
+
+/** Resolves gesture ownership for local playlists shown inside or outside the main pager. */
+public final class LocalPlaylistSwipePolicy {
+    private LocalPlaylistSwipePolicy() {
+    }
+
+    /**
+     * @param useAsFrontPage whether the playlist is hosted inside the main tab pager
+     * @return whether horizontal item-removal swipes may consume the pager gesture
+     */
+    public static boolean isItemRemovalSwipeEnabled(final boolean useAsFrontPage) {
+        return !useAsFrontPage;
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistSwipePolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistSwipePolicyTest.java
@@ -1,0 +1,18 @@
+package org.schabi.newpipe.local.playlist;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class LocalPlaylistSwipePolicyTest {
+    @Test
+    void pinnedPlaylistLeavesHorizontalSwipesToTheMainPager() {
+        assertFalse(LocalPlaylistSwipePolicy.isItemRemovalSwipeEnabled(true));
+    }
+
+    @Test
+    void standalonePlaylistKeepsSwipeToRemove() {
+        assertTrue(LocalPlaylistSwipePolicy.isItemRemovalSwipeEnabled(false));
+    }
+}


### PR DESCRIPTION
- Disable item-removal swipes when a local playlist is pinned as a home-screen page
- Leave horizontal gestures to the main pager so users can switch home tabs reliably
- Preserve swipe-to-remove when the playlist is opened as a standalone screen
- Preserve drag reordering and long-press deletion in both contexts
- Add regression coverage for pinned and standalone playlist swipe policy
- Fixes #342