### PR TITLE
Align feed and thumbnail progress

### DIFF
--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -172,10 +172,11 @@
 
                         <org.schabi.newpipe.views.NewPipeTextView
                             android:id="@+id/loading_progress_text"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
                             android:accessibilityLiveRegion="polite"
+                            android:gravity="center"
+                            android:includeFontPadding="false"
                             android:text="0/0"
                             android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
                             android:textColor="?attr/colorOnSurface"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -45,8 +45,8 @@
     <dimen name="video_item_grid_thumbnail_image_height">92dp</dimen>
     <dimen name="stream_thumbnail_corner_radius">12dp</dimen>
     <dimen name="stream_thumbnail_progress_height">3dp</dimen>
-    <dimen name="stream_thumbnail_progress_bottom_margin">3dp</dimen>
-    <dimen name="stream_thumbnail_progress_horizontal_inset">2dp</dimen>
+    <dimen name="stream_thumbnail_progress_bottom_margin">0dp</dimen>
+    <dimen name="stream_thumbnail_progress_horizontal_inset">12dp</dimen>
     <dimen name="stream_thumbnail_duration_margin_with_progress">20dp</dimen>
     <dimen name="stream_card_horizontal_margin">12dp</dimen>
     <dimen name="stream_item_uploader_touch_target">48dp</dimen>

--- a/app/src/test/java/org/schabi/newpipe/info_list/StreamThumbnailProgressResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/info_list/StreamThumbnailProgressResourcesTest.java
@@ -1,0 +1,109 @@
+package org.schabi.newpipe.info_list;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class StreamThumbnailProgressResourcesTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+    private static final String APP_NAMESPACE =
+            "http://schemas.android.com/apk/res-auto";
+    private static final String[] STREAM_LAYOUTS = {
+        "list_stream_item.xml",
+        "list_stream_mini_item.xml",
+        "list_stream_grid_item.xml",
+        "list_stream_card_item.xml",
+        "list_stream_related_wide_item.xml",
+        "list_stream_playlist_item.xml",
+        "list_stream_playlist_grid_item.xml",
+        "list_stream_playlist_card_item.xml"
+    };
+
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void progressGeometryFitsTheRoundedThumbnailBottomEdge() throws Exception {
+        final Document document = parse(resourcesDirectory.resolve("values/dimens.xml"));
+
+        assertEquals("0dp", findDimension(document,
+                "stream_thumbnail_progress_bottom_margin"));
+        assertEquals("12dp", findDimension(document,
+                "stream_thumbnail_progress_horizontal_inset"));
+        assertEquals(findDimension(document, "stream_thumbnail_corner_radius"),
+                findDimension(document, "stream_thumbnail_progress_horizontal_inset"));
+    }
+
+    @Test
+    public void everyStreamLayoutUsesTheSharedThumbnailProgressGeometry() throws Exception {
+        for (final String layout : STREAM_LAYOUTS) {
+            final Document document = parse(resourcesDirectory.resolve("layout").resolve(layout));
+            final Element progress = findByAndroidId(document, "@+id/itemProgressView");
+
+            assertNotNull(layout, progress);
+            assertEquals(layout, "@dimen/stream_thumbnail_progress_height",
+                    progress.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
+            assertEquals(layout, "@dimen/stream_thumbnail_progress_bottom_margin",
+                    progress.getAttributeNS(ANDROID_NAMESPACE, "layout_marginBottom"));
+            assertEquals(layout, "@dimen/stream_thumbnail_progress_horizontal_inset",
+                    progress.getAttributeNS(ANDROID_NAMESPACE, "layout_marginHorizontal"));
+            assertTrue(layout, isAnchoredToThumbnailBottom(progress));
+        }
+    }
+
+    private boolean isAnchoredToThumbnailBottom(final Element progress) {
+        final String constraint = progress.getAttributeNS(
+                APP_NAMESPACE, "layout_constraintBottom_toBottomOf");
+        final String relative = progress.getAttributeNS(ANDROID_NAMESPACE, "layout_alignBottom");
+        return isThumbnailReference(constraint) || isThumbnailReference(relative);
+    }
+
+    private boolean isThumbnailReference(final String value) {
+        return "@id/itemThumbnailView".equals(value)
+                || "@+id/itemThumbnailView".equals(value);
+    }
+
+    private String findDimension(final Document document, final String name) {
+        final NodeList dimensions = document.getElementsByTagName("dimen");
+        for (int index = 0; index < dimensions.getLength(); index++) {
+            final Element dimension = (Element) dimensions.item(index);
+            if (name.equals(dimension.getAttribute("name"))) {
+                return dimension.getTextContent().trim();
+            }
+        }
+        return null;
+    }
+
+    private Element findByAndroidId(final Document document, final String id) {
+        final NodeList elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            if (id.equals(element.getAttributeNS(ANDROID_NAMESPACE, "id"))) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private Document parse(final Path path) throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-parameter-entities", false);
+        return factory.newDocumentBuilder().parse(path.toFile());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
@@ -73,6 +73,8 @@ public class FeedRefreshControlsTest {
                 document, "@+id/loading_progress_bar");
         final Element indeterminateProgress = findByAndroidId(
                 document, "@+id/loading_indeterminate_progress_bar");
+        final Element progressText = findByAndroidId(
+                document, "@+id/loading_progress_text");
         final Element cancel = findByAndroidId(
                 document, "@+id/cancel_refresh_button");
 
@@ -95,6 +97,15 @@ public class FeedRefreshControlsTest {
                 indeterminateProgress.getAttributeNS(APP_NAMESPACE, "indicatorSize"));
         assertEquals("6dp", progress.getAttributeNS(APP_NAMESPACE, "trackThickness"));
         assertEquals("3dp", progress.getAttributeNS(APP_NAMESPACE, "trackCornerRadius"));
+
+        assertNotNull(progressText);
+        assertEquals("match_parent",
+                progressText.getAttributeNS(ANDROID_NAMESPACE, "layout_width"));
+        assertEquals("match_parent",
+                progressText.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
+        assertEquals("center", progressText.getAttributeNS(ANDROID_NAMESPACE, "gravity"));
+        assertEquals("false",
+                progressText.getAttributeNS(ANDROID_NAMESPACE, "includeFontPadding"));
 
         assertNotNull(cancel);
         assertEquals(


### PR DESCRIPTION
- Center the What’s New refresh count geometrically inside its progress ring
- Remove extra font padding while preserving progress semantics and accessibility
- Attach watched-progress strips to thumbnail bottom edges
- Inset progress strips by the shared 12dp thumbnail corner radius across all stream layouts
- Add regression coverage for the feed counter and all eight thumbnail variants
- Fixes #343