### PR TITLE
Build local media library foundation

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAccess.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAccess.kt
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+data class LocalMediaAccess(
+    val canReadAudio: Boolean,
+    val canReadVideo: Boolean
+) {
+    val hasAnyAccess: Boolean
+        get() = canReadAudio || canReadVideo
+}
+
+object LocalMediaPermissionPolicy {
+    fun requiredPermissions(sdk: Int = Build.VERSION.SDK_INT): Array<String> = when {
+        sdk >= 33 -> arrayOf(
+            Manifest.permission.READ_MEDIA_AUDIO,
+            Manifest.permission.READ_MEDIA_VIDEO
+        )
+
+        sdk >= 23 -> arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+
+        else -> emptyArray()
+    }
+
+    fun access(
+        context: Context,
+        sdk: Int = Build.VERSION.SDK_INT
+    ): LocalMediaAccess = when {
+        sdk < 23 -> LocalMediaAccess(canReadAudio = true, canReadVideo = true)
+
+        sdk < 33 -> {
+            val granted = isGranted(context, Manifest.permission.READ_EXTERNAL_STORAGE)
+            LocalMediaAccess(canReadAudio = granted, canReadVideo = granted)
+        }
+
+        else -> LocalMediaAccess(
+            canReadAudio = isGranted(context, Manifest.permission.READ_MEDIA_AUDIO),
+            canReadVideo = isGranted(context, Manifest.permission.READ_MEDIA_VIDEO)
+        )
+    }
+
+    private fun isGranted(context: Context, permission: String): Boolean = ContextCompat
+        .checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -3,12 +3,7 @@
  */
 package org.schabi.newpipe.local.media
 
-import android.Manifest
-import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -19,8 +14,8 @@ import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.Chip
@@ -28,7 +23,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import java.util.Locale
-import java.util.concurrent.Executors
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.info_list.ItemViewMode
@@ -50,8 +44,6 @@ class LocalMediaFragment : Fragment() {
     private enum class Filter { ALL, AUDIO, VIDEO }
     private enum class Sort { TITLE, ARTIST, ALBUM, FOLDER, RECENT }
 
-    private val executor = Executors.newSingleThreadExecutor()
-    private val mainHandler = Handler(Looper.getMainLooper())
     private val disposables = CompositeDisposable()
     private var allItems = emptyList<LocalMediaItem>()
     private var shownItems = emptyList<LocalMediaItem>()
@@ -60,6 +52,7 @@ class LocalMediaFragment : Fragment() {
     private var query = ""
     private lateinit var adapter: LocalMediaAdapter
     private lateinit var list: RecyclerView
+    private lateinit var viewModel: LocalMediaViewModel
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
@@ -76,6 +69,7 @@ class LocalMediaFragment : Fragment() {
     override fun onViewCreated(view: View, state: Bundle?) {
         super.onViewCreated(view, state)
         list = view.findViewById(R.id.localMediaList)
+        viewModel = ViewModelProvider(this)[LocalMediaViewModel::class.java]
         adapter = LocalMediaAdapter(::play, ::showActions)
         list.adapter = adapter
         applyItemViewMode()
@@ -106,6 +100,7 @@ class LocalMediaFragment : Fragment() {
                 override fun afterTextChanged(s: Editable?) = Unit
             }
         )
+        viewModel.state.observe(viewLifecycleOwner, ::renderState)
         loadOrExplainPermission()
     }
 
@@ -117,44 +112,28 @@ class LocalMediaFragment : Fragment() {
 
     override fun onDestroy() {
         disposables.dispose()
-        executor.shutdownNow()
         super.onDestroy()
     }
 
-    private fun requiredPermissions(): Array<String> = when {
-        Build.VERSION.SDK_INT >= 33 -> arrayOf(
-            Manifest.permission.READ_MEDIA_AUDIO,
-            Manifest.permission.READ_MEDIA_VIDEO
-        )
-
-        Build.VERSION.SDK_INT >= 23 -> arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
-
-        else -> emptyArray()
-    }
-
-    private fun hasAnyPermission(): Boolean = requiredPermissions().isEmpty() ||
-        requiredPermissions().any {
-            ContextCompat.checkSelfPermission(requireContext(), it) ==
-                PackageManager.PERMISSION_GRANTED
-        }
+    private fun requiredPermissions(): Array<String> = LocalMediaPermissionPolicy
+        .requiredPermissions()
 
     private fun loadOrExplainPermission() {
-        if (!hasAnyPermission()) {
+        val access = LocalMediaPermissionPolicy.access(requireContext())
+        if (!access.hasAnyAccess) {
             showMessage(R.string.local_media_permission_description, true)
             return
         }
         view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.GONE
-        view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.VISIBLE
-        val appContext = requireContext().applicationContext
-        executor.execute {
-            val result = LocalMediaRepository(appContext).query()
-            mainHandler.post {
-                if (!isAdded || view == null) return@post
-                allItems = result
-                view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.GONE
-                updateList()
-            }
-        }
+        viewModel.load(access)
+    }
+
+    private fun renderState(state: LocalMediaLibraryState) {
+        if (!isAdded || view == null) return
+        view?.findViewById<View>(R.id.localMediaProgress)?.visibility =
+            if (state.isLoading) View.VISIBLE else View.GONE
+        allItems = state.library.allItems
+        if (!state.isLoading) updateList()
     }
 
     private fun updateList() {

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaItem.kt
@@ -19,8 +19,21 @@ data class LocalMediaItem(
     val durationSeconds: Long,
     val addedAtSeconds: Long,
     val isVideo: Boolean,
-    val thumbnailUri: String? = contentUri
+    val thumbnailUri: String? = contentUri,
+    val artistId: Long = -1L,
+    val albumId: Long = -1L,
+    val trackNumber: Int = 0,
+    val discNumber: Int = 0,
+    val relativePath: String = "",
+    val volumeName: String = "",
+    val sizeBytes: Long = 0L
 ) : Serializable {
+    val stableId: String
+        get() = contentUri
+
+    val isAudio: Boolean
+        get() = !isVideo
+
     fun toPlayQueueItem(): PlayQueueItem = PlayQueueItem.localMedia(
         title,
         contentUri,

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaLibrary.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaLibrary.kt
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+data class LocalMediaLibrary(
+    val audioItems: List<LocalMediaItem>,
+    val videoItems: List<LocalMediaItem>
+) {
+    val allItems: List<LocalMediaItem>
+        get() = audioItems + videoItems
+
+    companion object {
+        val EMPTY = LocalMediaLibrary(emptyList(), emptyList())
+    }
+}
+
+data class LocalMediaLibraryState(
+    val isLoading: Boolean,
+    val library: LocalMediaLibrary = LocalMediaLibrary.EMPTY
+)

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaRepository.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaRepository.kt
@@ -12,10 +12,10 @@ import android.provider.MediaStore
 import java.io.File
 
 class LocalMediaRepository(private val context: Context) {
-    fun query(): List<LocalMediaItem> = buildList {
-        addAll(queryAudio())
-        addAll(queryVideo())
-    }
+    fun query(access: LocalMediaAccess): LocalMediaLibrary = LocalMediaLibrary(
+        audioItems = if (access.canReadAudio) queryAudio() else emptyList(),
+        videoItems = if (access.canReadVideo) queryVideo() else emptyList()
+    )
 
     private fun queryAudio(): List<LocalMediaItem> {
         val columns = mutableListOf(
@@ -23,11 +23,14 @@ class LocalMediaRepository(private val context: Context) {
             MediaStore.Audio.Media.DISPLAY_NAME,
             MediaStore.Audio.Media.TITLE,
             MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ARTIST_ID,
             MediaStore.Audio.Media.ALBUM,
             MediaStore.Audio.Media.ALBUM_ID,
+            MediaStore.Audio.Media.TRACK,
             MediaStore.Audio.Media.DURATION,
             MediaStore.Audio.Media.DATE_ADDED,
-            MediaStore.Audio.Media.MIME_TYPE
+            MediaStore.Audio.Media.MIME_TYPE,
+            MediaStore.Audio.Media.SIZE
         ).apply {
             add(
                 if (Build.VERSION.SDK_INT >= 29) {
@@ -36,6 +39,9 @@ class LocalMediaRepository(private val context: Context) {
                     MediaStore.Audio.Media.DATA
                 }
             )
+            if (Build.VERSION.SDK_INT >= 29) {
+                add(MediaStore.Audio.Media.VOLUME_NAME)
+            }
         }.toTypedArray()
 
         return queryCollection(
@@ -45,23 +51,35 @@ class LocalMediaRepository(private val context: Context) {
         ) { cursor ->
             val id = cursor.long(MediaStore.Audio.Media._ID)
             val albumId = cursor.long(MediaStore.Audio.Media.ALBUM_ID)
+            val location = cursor.location()
+            val track = splitMediaStoreTrack(cursor.int(MediaStore.Audio.Media.TRACK))
             LocalMediaItem(
                 mediaStoreId = id,
                 contentUri = ContentUris.withAppendedId(
                     MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                     id
                 ).toString(),
-                title = cursor.title(MediaStore.Audio.Media.TITLE, MediaStore.Audio.Media.DISPLAY_NAME),
+                title = cursor.title(
+                    MediaStore.Audio.Media.TITLE,
+                    MediaStore.Audio.Media.DISPLAY_NAME
+                ),
                 artist = cursor.text(MediaStore.Audio.Media.ARTIST),
                 album = cursor.text(MediaStore.Audio.Media.ALBUM),
-                folder = cursor.folder(),
+                folder = location.folder,
                 mimeType = cursor.text(MediaStore.Audio.Media.MIME_TYPE),
                 durationSeconds = cursor.long(MediaStore.Audio.Media.DURATION) / 1_000L,
                 addedAtSeconds = cursor.long(MediaStore.Audio.Media.DATE_ADDED),
                 isVideo = false,
                 thumbnailUri = albumId.takeIf { it > 0 }?.let {
                     ContentUris.withAppendedId(ALBUM_ART_URI, it).toString()
-                }
+                },
+                artistId = cursor.long(MediaStore.Audio.Media.ARTIST_ID),
+                albumId = albumId,
+                trackNumber = track.first,
+                discNumber = track.second,
+                relativePath = location.relativePath,
+                volumeName = cursor.text(MediaStore.Audio.Media.VOLUME_NAME),
+                sizeBytes = cursor.long(MediaStore.Audio.Media.SIZE)
             )
         }
     }
@@ -73,7 +91,8 @@ class LocalMediaRepository(private val context: Context) {
             MediaStore.Video.Media.TITLE,
             MediaStore.Video.Media.DURATION,
             MediaStore.Video.Media.DATE_ADDED,
-            MediaStore.Video.Media.MIME_TYPE
+            MediaStore.Video.Media.MIME_TYPE,
+            MediaStore.Video.Media.SIZE
         ).apply {
             add(
                 if (Build.VERSION.SDK_INT >= 29) {
@@ -82,26 +101,40 @@ class LocalMediaRepository(private val context: Context) {
                     MediaStore.Video.Media.DATA
                 }
             )
+            if (Build.VERSION.SDK_INT >= 29) {
+                add(MediaStore.Video.Media.VOLUME_NAME)
+            }
         }.toTypedArray()
 
-        return queryCollection(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, columns, null) { cursor ->
+        return queryCollection(
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
+            columns,
+            null
+        ) { cursor ->
             val id = cursor.long(MediaStore.Video.Media._ID)
             val uri = ContentUris.withAppendedId(
                 MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
                 id
             ).toString()
+            val location = cursor.location()
             LocalMediaItem(
                 mediaStoreId = id,
                 contentUri = uri,
-                title = cursor.title(MediaStore.Video.Media.TITLE, MediaStore.Video.Media.DISPLAY_NAME),
+                title = cursor.title(
+                    MediaStore.Video.Media.TITLE,
+                    MediaStore.Video.Media.DISPLAY_NAME
+                ),
                 artist = "",
                 album = "",
-                folder = cursor.folder(),
+                folder = location.folder,
                 mimeType = cursor.text(MediaStore.Video.Media.MIME_TYPE),
                 durationSeconds = cursor.long(MediaStore.Video.Media.DURATION) / 1_000L,
                 addedAtSeconds = cursor.long(MediaStore.Video.Media.DATE_ADDED),
                 isVideo = true,
-                thumbnailUri = uri
+                thumbnailUri = uri,
+                relativePath = location.relativePath,
+                volumeName = cursor.text(MediaStore.Video.Media.VOLUME_NAME),
+                sizeBytes = cursor.long(MediaStore.Video.Media.SIZE)
             )
         }
     }
@@ -132,25 +165,40 @@ class LocalMediaRepository(private val context: Context) {
         return getColumnIndex(column).takeIf { it >= 0 }?.let(::getLong) ?: 0L
     }
 
+    private fun Cursor.int(column: String): Int {
+        return getColumnIndex(column).takeIf { it >= 0 }?.let(::getInt) ?: 0
+    }
+
     private fun Cursor.title(titleColumn: String, displayNameColumn: String): String {
         return text(titleColumn).ifBlank { text(displayNameColumn).substringBeforeLast('.') }
     }
 
-    private fun Cursor.folder(): String {
+    private fun Cursor.location(): LocalMediaLocation {
         val column = if (Build.VERSION.SDK_INT >= 29) {
             MediaStore.MediaColumns.RELATIVE_PATH
         } else {
             MediaStore.MediaColumns.DATA
         }
-        val value = text(column)
-        return if (Build.VERSION.SDK_INT >= 29) {
-            value.trimEnd('/').substringAfterLast('/')
-        } else {
-            File(value).parentFile?.name.orEmpty()
-        }
+        return localMediaLocation(text(column), Build.VERSION.SDK_INT)
     }
 
     private companion object {
         val ALBUM_ART_URI: Uri = Uri.parse("content://media/external/audio/albumart")
     }
+}
+
+internal data class LocalMediaLocation(val relativePath: String, val folder: String)
+
+internal fun localMediaLocation(value: String, sdk: Int): LocalMediaLocation {
+    val path = if (sdk >= 29) {
+        value.trim('/').trim()
+    } else {
+        File(value).parent.orEmpty().trimEnd(File.separatorChar)
+    }
+    return LocalMediaLocation(path, path.substringAfterLast(File.separatorChar))
+}
+
+internal fun splitMediaStoreTrack(value: Int): Pair<Int, Int> {
+    if (value <= 0) return 0 to 0
+    return value % 1_000 to value / 1_000
 }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaViewModel.kt
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.app.Application
+import android.database.ContentObserver
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+class LocalMediaViewModel(application: Application) : AndroidViewModel(application) {
+    private val repository = LocalMediaRepository(application)
+    private val executor = Executors.newSingleThreadExecutor()
+    private val generation = AtomicInteger()
+    private val mutableState = MutableLiveData(LocalMediaLibraryState(isLoading = false))
+    private var currentAccess: LocalMediaAccess? = null
+
+    val state: LiveData<LocalMediaLibraryState> = mutableState
+
+    private val mediaObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+        override fun onChange(selfChange: Boolean) {
+            currentAccess?.let { load(it, force = true) }
+        }
+    }
+
+    init {
+        application.contentResolver.registerContentObserver(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            true,
+            mediaObserver
+        )
+        application.contentResolver.registerContentObserver(
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
+            true,
+            mediaObserver
+        )
+    }
+
+    fun load(access: LocalMediaAccess, force: Boolean = false) {
+        if (!access.hasAnyAccess) {
+            currentAccess = access
+            mutableState.value = LocalMediaLibraryState(isLoading = false)
+            return
+        }
+        if (
+            !force && currentAccess == access &&
+            mutableState.value?.library != LocalMediaLibrary.EMPTY
+        ) {
+            return
+        }
+
+        currentAccess = access
+        val requestedGeneration = generation.incrementAndGet()
+        mutableState.value = LocalMediaLibraryState(
+            isLoading = true,
+            library = mutableState.value?.library ?: LocalMediaLibrary.EMPTY
+        )
+        executor.execute {
+            val library = repository.query(access)
+            if (generation.get() == requestedGeneration) {
+                mutableState.postValue(
+                    LocalMediaLibraryState(isLoading = false, library = library)
+                )
+            }
+        }
+    }
+
+    override fun onCleared() {
+        generation.incrementAndGet()
+        getApplication<Application>().contentResolver.unregisterContentObserver(mediaObserver)
+        executor.shutdownNow()
+        super.onCleared()
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaPermissionPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaPermissionPolicyTest.kt
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.Manifest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class LocalMediaPermissionPolicyTest {
+    @Test
+    fun `pre runtime permission devices need no media permission`() {
+        assertArrayEquals(
+            emptyArray<String>(),
+            LocalMediaPermissionPolicy.requiredPermissions(22)
+        )
+    }
+
+    @Test
+    fun `legacy devices use the shared storage permission`() {
+        assertArrayEquals(
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE),
+            LocalMediaPermissionPolicy.requiredPermissions(32)
+        )
+    }
+
+    @Test
+    fun `android 13 requests audio and video independently`() {
+        assertArrayEquals(
+            arrayOf(
+                Manifest.permission.READ_MEDIA_AUDIO,
+                Manifest.permission.READ_MEDIA_VIDEO
+            ),
+            LocalMediaPermissionPolicy.requiredPermissions(33)
+        )
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaRepositoryTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaRepositoryTest.kt
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalMediaRepositoryTest {
+    @Test
+    fun `modern media locations retain the complete relative path`() {
+        val location = localMediaLocation("Music/Artist/Album/", 29)
+
+        assertEquals("Music/Artist/Album", location.relativePath)
+        assertEquals("Album", location.folder)
+    }
+
+    @Test
+    fun `legacy media locations use the parent file path`() {
+        val location = localMediaLocation("/storage/emulated/0/Music/Track.mp3", 28)
+
+        assertEquals("/storage/emulated/0/Music", location.relativePath)
+        assertEquals("Music", location.folder)
+    }
+
+    @Test
+    fun `media store track values preserve disc and track numbers`() {
+        assertEquals(7 to 2, splitMediaStoreTrack(2_007))
+        assertEquals(7 to 0, splitMediaStoreTrack(7))
+        assertEquals(0 to 0, splitMediaStoreTrack(0))
+    }
+}


### PR DESCRIPTION
- Separate local audio and video permission and query paths
- Preserve stable content URI identities and complete folder paths
- Capture artist, album, track, disc, volume, and size metadata
- Retain library state across configuration changes
- Refresh the library when MediaStore content changes
- Add permission, path, and track metadata regression tests
- Part of #247