### PR TITLE
Add local audio library sections

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAudioIndex.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAudioIndex.kt
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+enum class LocalMediaAudioCategory { TRACKS, ARTISTS, ALBUMS, GENRES }
+
+data class LocalMediaGroup(
+    val stableKey: String,
+    val title: String,
+    val subtitle: String,
+    val items: List<LocalMediaItem>,
+    val thumbnailUri: String?
+)
+
+object LocalMediaAudioIndex {
+    fun groups(
+        items: List<LocalMediaItem>,
+        category: LocalMediaAudioCategory,
+        unknownArtist: String,
+        unknownAlbum: String,
+        unknownGenre: String
+    ): List<LocalMediaGroup> = when (category) {
+        LocalMediaAudioCategory.TRACKS -> emptyList()
+        LocalMediaAudioCategory.ARTISTS -> groupArtists(items, unknownArtist)
+        LocalMediaAudioCategory.ALBUMS -> groupAlbums(items, unknownArtist, unknownAlbum)
+        LocalMediaAudioCategory.GENRES -> groupGenres(items, unknownGenre)
+    }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaGroup::title))
+
+    private fun groupArtists(
+        items: List<LocalMediaItem>,
+        unknownArtist: String
+    ): List<LocalMediaGroup> = items.groupBy { item ->
+        item.artistId.takeIf { it > 0 }?.let { "artist:$it" }
+            ?: "artist-name:${item.artist.ifBlank { unknownArtist }}"
+    }.map { (key, groupedItems) ->
+        val title = groupedItems.first().artist.ifBlank { unknownArtist }
+        LocalMediaGroup(
+            stableKey = key,
+            title = title,
+            subtitle = "",
+            items = groupedItems.sortedWith(trackComparator),
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+        )
+    }
+
+    private fun groupAlbums(
+        items: List<LocalMediaItem>,
+        unknownArtist: String,
+        unknownAlbum: String
+    ): List<LocalMediaGroup> = items.groupBy { item ->
+        item.albumId.takeIf { it > 0 }?.let { "album:$it" }
+            ?: "album-name:${item.artist}:${item.album}"
+    }.map { (key, groupedItems) ->
+        val first = groupedItems.first()
+        LocalMediaGroup(
+            stableKey = key,
+            title = first.album.ifBlank { unknownAlbum },
+            subtitle = first.artist.ifBlank { unknownArtist },
+            items = groupedItems.sortedWith(trackComparator),
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+        )
+    }
+
+    private fun groupGenres(
+        items: List<LocalMediaItem>,
+        unknownGenre: String
+    ): List<LocalMediaGroup> {
+        val groups = linkedMapOf<String, MutableList<LocalMediaItem>>()
+        items.forEach { item ->
+            val genres = item.genres.ifEmpty { setOf(unknownGenre) }
+            genres.forEach { genre -> groups.getOrPut(genre) { mutableListOf() } += item }
+        }
+        return groups.map { (genre, groupedItems) ->
+            LocalMediaGroup(
+                stableKey = "genre:$genre",
+                title = genre,
+                subtitle = "",
+                items = groupedItems.sortedWith(trackComparator),
+                thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+            )
+        }
+    }
+
+    private val trackComparator = compareBy<LocalMediaItem>(
+        LocalMediaItem::discNumber,
+        LocalMediaItem::trackNumber,
+        LocalMediaItem::title
+    )
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -50,7 +50,10 @@ class LocalMediaFragment : Fragment() {
     private var filter = Filter.ALL
     private var sort = Sort.TITLE
     private var query = ""
+    private var audioCategory = LocalMediaAudioCategory.TRACKS
+    private var activeGroup: LocalMediaGroup? = null
     private lateinit var adapter: LocalMediaAdapter
+    private lateinit var groupAdapter: LocalMediaGroupAdapter
     private lateinit var list: RecyclerView
     private lateinit var viewModel: LocalMediaViewModel
 
@@ -71,6 +74,7 @@ class LocalMediaFragment : Fragment() {
         list = view.findViewById(R.id.localMediaList)
         viewModel = ViewModelProvider(this)[LocalMediaViewModel::class.java]
         adapter = LocalMediaAdapter(::play, ::showActions)
+        groupAdapter = LocalMediaGroupAdapter(::openGroup) { audioCategory }
         list.adapter = adapter
         applyItemViewMode()
 
@@ -78,21 +82,42 @@ class LocalMediaFragment : Fragment() {
             permissionLauncher.launch(requiredPermissions())
         }
         view.findViewById<Chip>(R.id.localMediaAll).setOnClickListener {
-            filter = Filter.ALL
-            updateList()
+            selectFilter(Filter.ALL)
         }
         view.findViewById<Chip>(R.id.localMediaAudio).setOnClickListener {
-            filter = Filter.AUDIO
-            updateList()
+            selectFilter(Filter.AUDIO)
         }
         view.findViewById<Chip>(R.id.localMediaVideo).setOnClickListener {
-            filter = Filter.VIDEO
-            updateList()
+            selectFilter(Filter.VIDEO)
         }
         view.findViewById<Chip>(R.id.localMediaSort).setOnClickListener { showSortDialog() }
+        view.findViewById<Chip>(R.id.localMediaAudioTracks).setOnClickListener {
+            selectAudioCategory(LocalMediaAudioCategory.TRACKS)
+        }
+        view.findViewById<Chip>(R.id.localMediaAudioArtists).setOnClickListener {
+            selectAudioCategory(LocalMediaAudioCategory.ARTISTS)
+        }
+        view.findViewById<Chip>(R.id.localMediaAudioAlbums).setOnClickListener {
+            selectAudioCategory(LocalMediaAudioCategory.ALBUMS)
+        }
+        view.findViewById<Chip>(R.id.localMediaAudioGenres).setOnClickListener {
+            selectAudioCategory(LocalMediaAudioCategory.GENRES)
+        }
+        view.findViewById<Chip>(R.id.localMediaAudioPlaylists).setOnClickListener {
+            NavigationHelper.openBookmarksFragment(parentFragmentManager)
+        }
+        view.findViewById<View>(R.id.localMediaGroupBack).setOnClickListener {
+            activeGroup = null
+            updateList()
+        }
         view.findViewById<TextInputEditText>(R.id.localMediaSearch).addTextChangedListener(
             object : TextWatcher {
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+                override fun beforeTextChanged(
+                    s: CharSequence?,
+                    start: Int,
+                    count: Int,
+                    after: Int
+                ) = Unit
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                     query = s?.toString().orEmpty()
                     updateList()
@@ -136,9 +161,36 @@ class LocalMediaFragment : Fragment() {
         if (!state.isLoading) updateList()
     }
 
+    private fun selectFilter(selected: Filter) {
+        filter = selected
+        activeGroup = null
+        view?.findViewById<View>(R.id.localMediaAudioNavigation)?.visibility =
+            if (selected == Filter.AUDIO) View.VISIBLE else View.GONE
+        updateList()
+    }
+
+    private fun selectAudioCategory(selected: LocalMediaAudioCategory) {
+        audioCategory = selected
+        activeGroup = null
+        updateList()
+    }
+
+    private fun openGroup(group: LocalMediaGroup) {
+        activeGroup = group
+        updateList()
+    }
+
     private fun updateList() {
         if (!::adapter.isInitialized) return
         val term = query.trim().lowercase(Locale.getDefault())
+        if (
+            filter == Filter.AUDIO &&
+            audioCategory != LocalMediaAudioCategory.TRACKS &&
+            activeGroup == null
+        ) {
+            showAudioGroups(term)
+            return
+        }
         val comparator: Comparator<LocalMediaItem> = when (sort) {
             Sort.TITLE -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
             Sort.ARTIST -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::artist)
@@ -146,7 +198,8 @@ class LocalMediaFragment : Fragment() {
             Sort.FOLDER -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::folder)
             Sort.RECENT -> compareByDescending(LocalMediaItem::addedAtSeconds)
         }
-        shownItems = allItems.asSequence()
+        val sourceItems = activeGroup?.items ?: allItems
+        shownItems = sourceItems.asSequence()
             .filter {
                 filter == Filter.ALL ||
                     filter == Filter.VIDEO && it.isVideo ||
@@ -159,6 +212,9 @@ class LocalMediaFragment : Fragment() {
             }
             .sortedWith(comparator)
             .toList()
+        list.adapter = adapter
+        applyItemViewMode()
+        renderGroupHeader()
         adapter.submit(shownItems)
         if (shownItems.isEmpty()) {
             showMessage(R.string.local_media_empty, false)
@@ -167,8 +223,39 @@ class LocalMediaFragment : Fragment() {
         }
     }
 
+    private fun showAudioGroups(term: String) {
+        val groups = LocalMediaAudioIndex.groups(
+            items = allItems.filter(LocalMediaItem::isAudio),
+            category = audioCategory,
+            unknownArtist = getString(R.string.local_media_unknown_artist),
+            unknownAlbum = getString(R.string.local_media_unknown_album),
+            unknownGenre = getString(R.string.local_media_unknown_genre)
+        ).filter { group ->
+            term.isEmpty() || listOf(group.title, group.subtitle).any { value ->
+                value.lowercase(Locale.getDefault()).contains(term)
+            }
+        }
+        list.adapter = groupAdapter
+        list.layoutManager = LinearLayoutManager(requireContext())
+        view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility = View.GONE
+        groupAdapter.submit(groups)
+        if (groups.isEmpty()) {
+            showMessage(R.string.local_media_empty, false)
+        } else {
+            view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.GONE
+        }
+    }
+
+    private fun renderGroupHeader() {
+        val group = activeGroup
+        view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility =
+            if (group == null) View.GONE else View.VISIBLE
+        view?.findViewById<TextView>(R.id.localMediaGroupTitle)?.text = group?.title
+    }
+
     private fun applyItemViewMode() {
         val mode = ThemeHelper.getItemViewMode(requireContext())
+        list.adapter = adapter
         list.layoutManager = if (mode == ItemViewMode.GRID) {
             val minimumItemWidth = resources.getDimensionPixelSize(
                 R.dimen.video_item_grid_thumbnail_image_width
@@ -243,6 +330,56 @@ class LocalMediaFragment : Fragment() {
                 updateList()
                 dialog.dismiss()
             }.show()
+    }
+}
+
+private class LocalMediaGroupAdapter(
+    private val onClick: (LocalMediaGroup) -> Unit,
+    private val category: () -> LocalMediaAudioCategory
+) : RecyclerView.Adapter<LocalMediaGroupAdapter.Holder>() {
+    private var items = emptyList<LocalMediaGroup>()
+
+    fun submit(updated: List<LocalMediaGroup>) {
+        items = updated
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder = Holder(
+        LayoutInflater.from(parent.context).inflate(
+            R.layout.list_local_media_group_item,
+            parent,
+            false
+        )
+    )
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: Holder, position: Int) = holder.bind(items[position])
+
+    inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
+        private val icon = view.findViewById<ImageView>(R.id.localMediaGroupIcon)
+        private val title = view.findViewById<TextView>(R.id.localMediaGroupItemTitle)
+        private val subtitle = view.findViewById<TextView>(R.id.localMediaGroupItemSubtitle)
+
+        fun bind(group: LocalMediaGroup) {
+            val count = itemView.resources.getQuantityString(
+                R.plurals.local_media_track_count,
+                group.items.size,
+                group.items.size
+            )
+            icon.setImageResource(
+                if (category() == LocalMediaAudioCategory.ARTISTS) {
+                    R.drawable.ic_person
+                } else {
+                    R.drawable.ic_music_note
+                }
+            )
+            title.text = group.title
+            subtitle.text = listOf(group.subtitle, count)
+                .filter(String::isNotBlank)
+                .joinToString(" • ")
+            itemView.setOnClickListener { onClick(group) }
+        }
     }
 }
 

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaItem.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaItem.kt
@@ -26,7 +26,8 @@ data class LocalMediaItem(
     val discNumber: Int = 0,
     val relativePath: String = "",
     val volumeName: String = "",
-    val sizeBytes: Long = 0L
+    val sizeBytes: Long = 0L,
+    val genres: Set<String> = emptySet()
 ) : Serializable {
     val stableId: String
         get() = contentUri

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaRepository.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaRepository.kt
@@ -44,7 +44,7 @@ class LocalMediaRepository(private val context: Context) {
             }
         }.toTypedArray()
 
-        return queryCollection(
+        val items = queryCollection(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             columns,
             "${MediaStore.Audio.Media.IS_MUSIC} != 0"
@@ -82,6 +82,8 @@ class LocalMediaRepository(private val context: Context) {
                 sizeBytes = cursor.long(MediaStore.Audio.Media.SIZE)
             )
         }
+        val genres = queryAudioGenres()
+        return items.map { item -> item.copy(genres = genres[item.mediaStoreId].orEmpty()) }
     }
 
     private fun queryVideo(): List<LocalMediaItem> {
@@ -152,6 +154,55 @@ class LocalMediaRepository(private val context: Context) {
             }
         } catch (_: SecurityException) {
             // Android 13+ may grant audio and video independently.
+        }
+        return result
+    }
+
+    private fun queryAudioGenres(): Map<Long, Set<String>> {
+        val result = mutableMapOf<Long, MutableSet<String>>()
+        val projection = arrayOf(
+            MediaStore.Audio.Genres._ID,
+            MediaStore.Audio.Genres.NAME
+        )
+        try {
+            context.contentResolver.query(
+                MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI,
+                projection,
+                null,
+                null,
+                null
+            )?.use { genres ->
+                while (genres.moveToNext()) {
+                    val genreId = genres.long(MediaStore.Audio.Genres._ID)
+                    val genreName = genres.text(MediaStore.Audio.Genres.NAME)
+                    if (genreId <= 0 || genreName.isBlank()) continue
+                    queryGenreMembers(genreId).forEach { audioId ->
+                        result.getOrPut(audioId) { linkedSetOf() } += genreName
+                    }
+                }
+            }
+        } catch (_: SecurityException) {
+            return emptyMap()
+        } catch (_: IllegalArgumentException) {
+            return emptyMap()
+        }
+        return result
+    }
+
+    private fun queryGenreMembers(genreId: Long): List<Long> {
+        val volume = if (Build.VERSION.SDK_INT >= 29) MediaStore.VOLUME_EXTERNAL else "external"
+        val uri = MediaStore.Audio.Genres.Members.getContentUri(volume, genreId)
+        val result = mutableListOf<Long>()
+        context.contentResolver.query(
+            uri,
+            arrayOf(MediaStore.Audio.Genres.Members.AUDIO_ID),
+            null,
+            null,
+            null
+        )?.use { members ->
+            while (members.moveToNext()) {
+                result += members.long(MediaStore.Audio.Genres.Members.AUDIO_ID)
+            }
         }
         return result
     }

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -69,6 +69,90 @@
         </com.google.android.material.chip.ChipGroup>
     </HorizontalScrollView>
 
+    <HorizontalScrollView
+        android:id="@+id/localMediaAudioNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:visibility="gone">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/localMediaAudioCategories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="12dp"
+            android:paddingBottom="8dp"
+            app:selectionRequired="true"
+            app:singleSelection="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaAudioTracks"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="@string/local_media_tracks" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaAudioArtists"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_media_artists" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaAudioAlbums"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_media_albums" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaAudioGenres"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_media_genres" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaAudioPlaylists"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checkable="false"
+                android:text="@string/playlists" />
+        </com.google.android.material.chip.ChipGroup>
+    </HorizontalScrollView>
+
+    <LinearLayout
+        android:id="@+id/localMediaGroupHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="12dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone">
+
+        <ImageButton
+            android:id="@+id/localMediaGroupBack"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_back_to_categories"
+            android:src="@drawable/ic_arrow_back"
+            app:tint="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/localMediaGroupTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:maxLines="2"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+    </LinearLayout>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/list_local_media_group_item.xml
+++ b/app/src/main/res/layout/list_local_media_group_item.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.Material3.CardView.Filled"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="12dp"
+    android:layout_marginVertical="4dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:minHeight="72dp"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <ImageView
+            android:id="@+id/localMediaGroupIcon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@null"
+            android:padding="10dp"
+            android:src="@drawable/ic_music_note"
+            app:tint="?attr/colorOnSecondaryContainer" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/localMediaGroupItemTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="2"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+            <TextView
+                android:id="@+id/localMediaGroupItemSubtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="2"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/local_media_library_strings.xml
+++ b/app/src/main/res/values/local_media_library_strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="local_media_tracks">Tracks</string>
+    <string name="local_media_artists">Artists</string>
+    <string name="local_media_albums">Albums</string>
+    <string name="local_media_genres">Genres</string>
+    <string name="local_media_unknown_artist">Unknown artist</string>
+    <string name="local_media_unknown_album">Unknown album</string>
+    <string name="local_media_unknown_genre">Unknown genre</string>
+    <string name="local_media_back_to_categories">Back to categories</string>
+    <plurals name="local_media_track_count">
+        <item quantity="one">%d track</item>
+        <item quantity="other">%d tracks</item>
+    </plurals>
+</resources>

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaAudioIndexTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaAudioIndexTest.kt
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalMediaAudioIndexTest {
+    @Test
+    fun `artists use stable media store identities`() {
+        val groups = LocalMediaAudioIndex.groups(
+            listOf(
+                audio(1, artist = "Artist", artistId = 10),
+                audio(2, artist = "Artist", artistId = 11)
+            ),
+            LocalMediaAudioCategory.ARTISTS,
+            "Unknown artist",
+            "Unknown album",
+            "Unknown genre"
+        )
+
+        assertEquals(listOf("artist:10", "artist:11"), groups.map(LocalMediaGroup::stableKey))
+    }
+
+    @Test
+    fun `album tracks are ordered by disc and track`() {
+        val groups = LocalMediaAudioIndex.groups(
+            listOf(
+                audio(1, albumId = 20, disc = 2, track = 1),
+                audio(2, albumId = 20, disc = 1, track = 2),
+                audio(3, albumId = 20, disc = 1, track = 1)
+            ),
+            LocalMediaAudioCategory.ALBUMS,
+            "Unknown artist",
+            "Unknown album",
+            "Unknown genre"
+        )
+
+        assertEquals(listOf(3L, 2L, 1L), groups.single().items.map(LocalMediaItem::mediaStoreId))
+    }
+
+    @Test
+    fun `tracks can appear in each assigned genre`() {
+        val groups = LocalMediaAudioIndex.groups(
+            listOf(audio(1, genres = setOf("Jazz", "Fusion"))),
+            LocalMediaAudioCategory.GENRES,
+            "Unknown artist",
+            "Unknown album",
+            "Unknown genre"
+        )
+
+        assertEquals(listOf("Fusion", "Jazz"), groups.map(LocalMediaGroup::title))
+    }
+
+    private fun audio(
+        id: Long,
+        artist: String = "Artist",
+        artistId: Long = 10,
+        albumId: Long = 20,
+        disc: Int = 1,
+        track: Int = 1,
+        genres: Set<String> = emptySet()
+    ) = LocalMediaItem(
+        mediaStoreId = id,
+        contentUri = "content://audio/$id",
+        title = "Track $id",
+        artist = artist,
+        album = "Album",
+        folder = "Music",
+        mimeType = "audio/mpeg",
+        durationSeconds = 60,
+        addedAtSeconds = id,
+        isVideo = false,
+        artistId = artistId,
+        albumId = albumId,
+        trackNumber = track,
+        discNumber = disc,
+        genres = genres
+    )
+}


### PR DESCRIPTION
- Add Tracks, Artists, Albums, Genres, and Playlists navigation for local audio
- Group artists and albums by stable MediaStore identities
- Preserve disc and track ordering inside album groups
- Read MediaStore genre membership without duplicating the media library
- Reuse the existing WizeStream playlists destination
- Add audio grouping and ordering regression tests
- Part of #247