### PR TITLE
Add local video and folder sections

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAudioIndex.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAudioIndex.kt
@@ -5,12 +5,15 @@ package org.schabi.newpipe.local.media
 
 enum class LocalMediaAudioCategory { TRACKS, ARTISTS, ALBUMS, GENRES }
 
+enum class LocalMediaGroupKind { ARTIST, ALBUM, GENRE, VIDEO_FOLDER }
+
 data class LocalMediaGroup(
     val stableKey: String,
     val title: String,
     val subtitle: String,
     val items: List<LocalMediaItem>,
-    val thumbnailUri: String?
+    val thumbnailUri: String?,
+    val kind: LocalMediaGroupKind
 )
 
 object LocalMediaAudioIndex {
@@ -40,7 +43,8 @@ object LocalMediaAudioIndex {
             title = title,
             subtitle = "",
             items = groupedItems.sortedWith(trackComparator),
-            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+            kind = LocalMediaGroupKind.ARTIST
         )
     }
 
@@ -58,7 +62,8 @@ object LocalMediaAudioIndex {
             title = first.album.ifBlank { unknownAlbum },
             subtitle = first.artist.ifBlank { unknownArtist },
             items = groupedItems.sortedWith(trackComparator),
-            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+            kind = LocalMediaGroupKind.ALBUM
         )
     }
 
@@ -77,7 +82,8 @@ object LocalMediaAudioIndex {
                 title = genre,
                 subtitle = "",
                 items = groupedItems.sortedWith(trackComparator),
-                thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+                thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+                kind = LocalMediaGroupKind.GENRE
             )
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.app.Application
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+data class LocalMediaBrowserState(
+    val location: LocalMediaDocumentLocation? = null,
+    val title: String = "",
+    val entries: List<LocalMediaDocumentEntry> = emptyList(),
+    val isLoading: Boolean = false,
+    val isUnavailable: Boolean = false
+)
+
+class LocalMediaBrowserViewModel(application: Application) : AndroidViewModel(application) {
+    private val browser = LocalMediaDocumentBrowser(application)
+    private val store = LocalMediaTreeStore(application)
+    private val executor = Executors.newSingleThreadExecutor()
+    private val scanExecutor = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val generation = AtomicInteger()
+    private val mutableState = MutableLiveData(LocalMediaBrowserState())
+
+    val state: LiveData<LocalMediaBrowserState> = mutableState
+
+    init {
+        showRoots()
+    }
+
+    fun showRoots() {
+        load(null, "") { browser.roots(store.roots()) }
+    }
+
+    fun open(entry: LocalMediaDocumentEntry) {
+        if (!entry.isDirectory || !entry.isAvailable) return
+        load(entry.location, entry.name) { browser.list(entry.location) }
+    }
+
+    fun goBack(): Boolean {
+        val current = mutableState.value?.location ?: return false
+        if (current.path.isEmpty()) {
+            showRoots()
+        } else {
+            val parent = current.copy(path = current.path.dropLast(1))
+            val title = parent.path.lastOrNull().orEmpty().ifBlank { rootName(current.rootUri) }
+            load(parent, title) { browser.list(parent) }
+        }
+        return true
+    }
+
+    fun addRoot(uri: Uri) {
+        store.add(uri)
+        val entry = browser.roots(setOf(uri.toString())).firstOrNull()
+        if (entry == null || !entry.isAvailable) showRoots() else open(entry)
+    }
+
+    fun removeRoot(rootUri: String) {
+        store.remove(rootUri)
+        runCatching {
+            getApplication<Application>().contentResolver.releasePersistableUriPermission(
+                Uri.parse(rootUri),
+                android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        }
+        showRoots()
+    }
+
+    fun mediaItem(entry: LocalMediaDocumentEntry): LocalMediaItem? = browser.mediaItem(entry)
+
+    fun collect(
+        location: LocalMediaDocumentLocation,
+        onReady: (List<LocalMediaItem>) -> Unit
+    ) {
+        scanExecutor.execute {
+            val items = browser.collectMedia(location)
+            mainHandler.post { onReady(items) }
+        }
+    }
+
+    private fun load(
+        location: LocalMediaDocumentLocation?,
+        title: String,
+        query: () -> List<LocalMediaDocumentEntry>
+    ) {
+        val requestedGeneration = generation.incrementAndGet()
+        mutableState.value = LocalMediaBrowserState(
+            location = location,
+            title = title,
+            entries = mutableState.value?.entries.orEmpty(),
+            isLoading = true
+        )
+        executor.execute {
+            val entries = runCatching(query).getOrDefault(emptyList())
+            if (generation.get() == requestedGeneration) {
+                mutableState.postValue(
+                    LocalMediaBrowserState(
+                        location = location,
+                        title = title,
+                        entries = entries,
+                        isUnavailable = location != null && entries.isEmpty() &&
+                            !isLocationAvailable(location)
+                    )
+                )
+            }
+        }
+    }
+
+    private fun rootName(rootUri: String): String = browser.roots(setOf(rootUri))
+        .firstOrNull()
+        ?.name
+        .orEmpty()
+
+    private fun isLocationAvailable(location: LocalMediaDocumentLocation): Boolean {
+        return browser.isAvailable(location)
+    }
+
+    override fun onCleared() {
+        generation.incrementAndGet()
+        executor.shutdownNow()
+        scanExecutor.shutdownNow()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentAdapter.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentAdapter.kt
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import org.schabi.newpipe.R
+
+class LocalMediaDocumentAdapter(
+    private val onClick: (LocalMediaDocumentEntry) -> Unit,
+    private val onLongClick: (LocalMediaDocumentEntry) -> Unit
+) : RecyclerView.Adapter<LocalMediaDocumentAdapter.Holder>() {
+    private var entries = emptyList<LocalMediaDocumentEntry>()
+
+    fun submit(updated: List<LocalMediaDocumentEntry>) {
+        entries = updated
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder = Holder(
+        LayoutInflater.from(parent.context).inflate(
+            R.layout.list_local_media_document_item,
+            parent,
+            false
+        )
+    )
+
+    override fun getItemCount(): Int = entries.size
+
+    override fun onBindViewHolder(holder: Holder, position: Int) = holder.bind(entries[position])
+
+    inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
+        private val icon = view.findViewById<ImageView>(R.id.localMediaDocumentIcon)
+        private val title = view.findViewById<TextView>(R.id.localMediaDocumentTitle)
+        private val subtitle = view.findViewById<TextView>(R.id.localMediaDocumentSubtitle)
+
+        fun bind(entry: LocalMediaDocumentEntry) {
+            icon.setImageResource(
+                when {
+                    entry.isDirectory -> R.drawable.ic_create_new_folder
+                    entry.isVideo -> R.drawable.ic_movie
+                    else -> R.drawable.ic_music_note
+                }
+            )
+            title.text = entry.name
+            subtitle.text = when {
+                !entry.isAvailable -> itemView.context.getString(
+                    R.string.local_media_folder_unavailable
+                )
+
+                entry.isRoot -> itemView.context.getString(R.string.local_media_storage_locations)
+
+                entry.isDirectory -> itemView.context.getString(R.string.local_media_folders)
+
+                entry.sizeBytes > 0L -> itemView.context.getString(
+                    R.string.local_media_size_megabytes,
+                    entry.sizeBytes / 1_048_576.0
+                )
+
+                else -> entry.mimeType
+            }
+            itemView.alpha = if (entry.isAvailable) 1F else 0.5F
+            itemView.setOnClickListener { if (entry.isAvailable) onClick(entry) }
+            itemView.setOnLongClickListener {
+                if (entry.isAvailable) onLongClick(entry)
+                entry.isAvailable
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowser.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowser.kt
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import java.util.ArrayDeque
+
+data class LocalMediaDocumentLocation(
+    val rootUri: String,
+    val path: List<String> = emptyList()
+)
+
+data class LocalMediaDocumentEntry(
+    val location: LocalMediaDocumentLocation,
+    val contentUri: String,
+    val name: String,
+    val mimeType: String,
+    val isDirectory: Boolean,
+    val isRoot: Boolean = false,
+    val isAvailable: Boolean = true,
+    val sizeBytes: Long = 0L,
+    val lastModified: Long = 0L
+) {
+    val isVideo: Boolean
+        get() = mimeType.startsWith("video/")
+}
+
+class LocalMediaDocumentBrowser(private val context: Context) {
+    fun roots(rootUris: Set<String>): List<LocalMediaDocumentEntry> = rootUris.map { rootUri ->
+        val document = runCatching {
+            DocumentFile.fromTreeUri(context, Uri.parse(rootUri))
+        }.getOrNull()
+        val available = runCatching {
+            document?.exists() == true && document.canRead() && document.isDirectory
+        }.getOrDefault(false)
+        LocalMediaDocumentEntry(
+            location = LocalMediaDocumentLocation(rootUri),
+            contentUri = rootUri,
+            name = document?.name.orEmpty().ifBlank { rootUri },
+            mimeType = document?.type.orEmpty(),
+            isDirectory = true,
+            isRoot = true,
+            isAvailable = available
+        )
+    }.sortedWith(entryComparator)
+
+    fun list(location: LocalMediaDocumentLocation): List<LocalMediaDocumentEntry> {
+        val directory = resolve(location) ?: return emptyList()
+        return runCatching { directory.listFiles().toList() }
+            .getOrDefault(emptyList())
+            .filter { it.isDirectory || isSupportedMedia(it.name.orEmpty(), it.type) }
+            .map { document -> document.toEntry(location) }
+            .sortedWith(entryComparator)
+    }
+
+    fun collectMedia(
+        location: LocalMediaDocumentLocation,
+        maximumItems: Int = MAXIMUM_GROUP_ITEMS
+    ): List<LocalMediaItem> {
+        val root = resolve(location) ?: return emptyList()
+        val pending = ArrayDeque<Pair<DocumentFile, String>>()
+        val visited = mutableSetOf<String>()
+        val result = mutableListOf<LocalMediaItem>()
+        pending.add(root to root.name.orEmpty())
+        while (pending.isNotEmpty() && result.size < maximumItems) {
+            val (directory, folder) = pending.removeFirst()
+            if (!visited.add(directory.uri.toString())) continue
+            val children = runCatching { directory.listFiles() }.getOrDefault(emptyArray())
+            children.forEach { document ->
+                if (result.size >= maximumItems) return@forEach
+                when {
+                    document.isDirectory -> pending.add(document to document.name.orEmpty())
+
+                    isSupportedMedia(document.name.orEmpty(), document.type) -> {
+                        result += document.toMediaItem(folder)
+                    }
+                }
+            }
+        }
+        return result.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title))
+    }
+
+    fun mediaItem(entry: LocalMediaDocumentEntry): LocalMediaItem? {
+        if (entry.isDirectory || !entry.isAvailable) return null
+        val contentType = entry.mimeType.ifBlank { mimeTypeForName(entry.name) }
+        val video = contentType.startsWith("video/")
+        return LocalMediaItem(
+            mediaStoreId = -1L,
+            contentUri = entry.contentUri,
+            title = entry.name.substringBeforeLast('.').ifBlank { entry.name },
+            artist = "",
+            album = "",
+            folder = entry.location.path.dropLast(1).lastOrNull().orEmpty(),
+            mimeType = contentType,
+            durationSeconds = 0L,
+            addedAtSeconds = entry.lastModified / 1000L,
+            isVideo = video,
+            thumbnailUri = entry.contentUri.takeIf { video },
+            relativePath = entry.location.path.dropLast(1).joinToString("/"),
+            sizeBytes = entry.sizeBytes
+        )
+    }
+
+    fun isAvailable(location: LocalMediaDocumentLocation): Boolean = resolve(location) != null
+
+    private fun resolve(location: LocalMediaDocumentLocation): DocumentFile? {
+        var document = runCatching {
+            DocumentFile.fromTreeUri(context, Uri.parse(location.rootUri))
+        }.getOrNull() ?: return null
+        location.path.forEach { name ->
+            document = runCatching { document.findFile(name) }.getOrNull() ?: return null
+        }
+        return document.takeIf { it.isDirectory && it.canRead() }
+    }
+
+    private fun DocumentFile.toEntry(
+        parent: LocalMediaDocumentLocation
+    ): LocalMediaDocumentEntry {
+        val displayName = name.orEmpty().ifBlank { uri.lastPathSegment.orEmpty() }
+        return LocalMediaDocumentEntry(
+            location = parent.copy(path = parent.path + displayName),
+            contentUri = uri.toString(),
+            name = displayName,
+            mimeType = type.orEmpty().ifBlank { mimeTypeForName(displayName) },
+            isDirectory = isDirectory,
+            sizeBytes = runCatching { length() }.getOrDefault(0L),
+            lastModified = runCatching { lastModified() }.getOrDefault(0L)
+        )
+    }
+
+    private fun DocumentFile.toMediaItem(folder: String): LocalMediaItem {
+        val displayName = name.orEmpty().ifBlank { uri.lastPathSegment.orEmpty() }
+        val contentType = type.orEmpty().ifBlank { mimeTypeForName(displayName) }
+        val video = contentType.startsWith("video/")
+        return LocalMediaItem(
+            mediaStoreId = -1L,
+            contentUri = uri.toString(),
+            title = displayName.substringBeforeLast('.').ifBlank { displayName },
+            artist = "",
+            album = "",
+            folder = folder,
+            mimeType = contentType,
+            durationSeconds = 0L,
+            addedAtSeconds = runCatching { lastModified() / 1000L }.getOrDefault(0L),
+            isVideo = video,
+            thumbnailUri = uri.toString().takeIf { video },
+            relativePath = folder,
+            sizeBytes = runCatching { length() }.getOrDefault(0L)
+        )
+    }
+
+    companion object {
+        const val MAXIMUM_GROUP_ITEMS = 5000
+
+        private val audioExtensions = setOf(
+            "aac", "flac", "m4a", "mp3", "oga", "ogg", "opus", "wav", "wma"
+        )
+        private val videoExtensions = setOf(
+            "3gp", "avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "webm", "wmv"
+        )
+        private val entryComparator = compareByDescending<LocalMediaDocumentEntry> {
+            it.isDirectory
+        }.thenBy(String.CASE_INSENSITIVE_ORDER, LocalMediaDocumentEntry::name)
+
+        internal fun isSupportedMedia(name: String, mimeType: String?): Boolean {
+            if (mimeType?.startsWith("audio/") == true) return true
+            if (mimeType?.startsWith("video/") == true) return true
+            return name.substringAfterLast('.', "").lowercase() in audioExtensions + videoExtensions
+        }
+
+        internal fun mimeTypeForName(name: String): String {
+            val extension = name.substringAfterLast('.', "").lowercase()
+            return when (extension) {
+                in audioExtensions -> "audio/$extension"
+                in videoExtensions -> "video/$extension"
+                else -> "application/octet-stream"
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -3,6 +3,7 @@
  */
 package org.schabi.newpipe.local.media
 
+import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -11,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
@@ -41,7 +43,7 @@ internal fun localMediaItemLayout(itemViewMode: ItemViewMode): Int = when (itemV
 }
 
 class LocalMediaFragment : Fragment() {
-    private enum class Filter { ALL, AUDIO, VIDEO }
+    private enum class Filter { ALL, AUDIO, VIDEO, BROWSE }
     private enum class Sort { TITLE, ARTIST, ALBUM, FOLDER, RECENT }
 
     private val disposables = CompositeDisposable()
@@ -55,12 +57,30 @@ class LocalMediaFragment : Fragment() {
     private var activeGroup: LocalMediaGroup? = null
     private lateinit var adapter: LocalMediaAdapter
     private lateinit var groupAdapter: LocalMediaGroupAdapter
+    private lateinit var documentAdapter: LocalMediaDocumentAdapter
     private lateinit var list: RecyclerView
     private lateinit var viewModel: LocalMediaViewModel
+    private lateinit var browserViewModel: LocalMediaBrowserViewModel
+    private var browserState = LocalMediaBrowserState()
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { loadOrExplainPermission() }
+
+    private val folderLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri ?: return@registerForActivityResult
+        runCatching {
+            requireContext().contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        }.onSuccess {
+            browserViewModel.addRoot(uri)
+            selectFilter(Filter.BROWSE)
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -74,8 +94,10 @@ class LocalMediaFragment : Fragment() {
         super.onViewCreated(view, state)
         list = view.findViewById(R.id.localMediaList)
         viewModel = ViewModelProvider(this)[LocalMediaViewModel::class.java]
+        browserViewModel = ViewModelProvider(this)[LocalMediaBrowserViewModel::class.java]
         adapter = LocalMediaAdapter(::play, ::showActions)
         groupAdapter = LocalMediaGroupAdapter(::openGroup)
+        documentAdapter = LocalMediaDocumentAdapter(::openDocument, ::showDocumentActions)
         list.adapter = adapter
         applyItemViewMode()
 
@@ -90,6 +112,9 @@ class LocalMediaFragment : Fragment() {
         }
         view.findViewById<Chip>(R.id.localMediaVideo).setOnClickListener {
             selectFilter(Filter.VIDEO)
+        }
+        view.findViewById<Chip>(R.id.localMediaBrowse).setOnClickListener {
+            selectFilter(Filter.BROWSE)
         }
         view.findViewById<Chip>(R.id.localMediaSort).setOnClickListener { showSortDialog() }
         view.findViewById<Chip>(R.id.localMediaAudioTracks).setOnClickListener {
@@ -126,6 +151,15 @@ class LocalMediaFragment : Fragment() {
         view.findViewById<View>(R.id.localMediaGroupMore).setOnClickListener {
             showActiveGroupActions()
         }
+        view.findViewById<View>(R.id.localMediaBrowseBack).setOnClickListener {
+            browserViewModel.goBack()
+        }
+        view.findViewById<View>(R.id.localMediaBrowseAdd).setOnClickListener {
+            folderLauncher.launch(null)
+        }
+        view.findViewById<View>(R.id.localMediaBrowseMore).setOnClickListener {
+            browserState.location?.let { showFolderActions(it, browserState.title, false) }
+        }
         view.findViewById<TextInputEditText>(R.id.localMediaSearch).addTextChangedListener(
             object : TextWatcher {
                 override fun beforeTextChanged(
@@ -142,6 +176,18 @@ class LocalMediaFragment : Fragment() {
             }
         )
         viewModel.state.observe(viewLifecycleOwner, ::renderState)
+        browserViewModel.state.observe(viewLifecycleOwner, ::renderBrowserState)
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (filter == Filter.BROWSE && browserViewModel.goBack()) return
+                    isEnabled = false
+                    requireActivity().onBackPressedDispatcher.onBackPressed()
+                    isEnabled = true
+                }
+            }
+        )
         loadOrExplainPermission()
     }
 
@@ -174,7 +220,7 @@ class LocalMediaFragment : Fragment() {
         view?.findViewById<View>(R.id.localMediaProgress)?.visibility =
             if (state.isLoading) View.VISIBLE else View.GONE
         allItems = state.library.allItems
-        if (!state.isLoading) updateList()
+        if (!state.isLoading && filter != Filter.BROWSE) updateList()
     }
 
     private fun selectFilter(selected: Filter) {
@@ -184,7 +230,14 @@ class LocalMediaFragment : Fragment() {
             if (selected == Filter.AUDIO) View.VISIBLE else View.GONE
         view?.findViewById<View>(R.id.localMediaVideoNavigation)?.visibility =
             if (selected == Filter.VIDEO) View.VISIBLE else View.GONE
-        updateList()
+        view?.findViewById<View>(R.id.localMediaBrowseNavigation)?.visibility =
+            if (selected == Filter.BROWSE) View.VISIBLE else View.GONE
+        view?.findViewById<View>(R.id.localMediaSearchLayout)?.visibility =
+            if (selected == Filter.BROWSE) View.GONE else View.VISIBLE
+        view?.findViewById<View>(R.id.localMediaSort)?.visibility =
+            if (selected == Filter.BROWSE) View.GONE else View.VISIBLE
+        view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility = View.GONE
+        if (selected == Filter.BROWSE) renderBrowserState(browserState) else updateList()
     }
 
     private fun selectAudioCategory(selected: LocalMediaAudioCategory) {
@@ -205,7 +258,7 @@ class LocalMediaFragment : Fragment() {
     }
 
     private fun updateList() {
-        if (!::adapter.isInitialized) return
+        if (!::adapter.isInitialized || filter == Filter.BROWSE) return
         val term = query.trim().lowercase(Locale.getDefault())
         if (
             filter == Filter.AUDIO &&
@@ -292,6 +345,129 @@ class LocalMediaFragment : Fragment() {
         renderGroups(groups)
     }
 
+    private fun renderBrowserState(state: LocalMediaBrowserState) {
+        browserState = state
+        if (!::documentAdapter.isInitialized || filter != Filter.BROWSE || view == null) return
+        view?.findViewById<View>(R.id.localMediaProgress)?.visibility =
+            if (state.isLoading) View.VISIBLE else View.GONE
+        view?.findViewById<View>(R.id.localMediaBrowseBack)?.visibility =
+            if (state.location == null) View.GONE else View.VISIBLE
+        view?.findViewById<View>(R.id.localMediaBrowseMore)?.visibility =
+            if (state.location == null) View.GONE else View.VISIBLE
+        view?.findViewById<TextView>(R.id.localMediaBrowseTitle)?.text = state.title.ifBlank {
+            getString(R.string.local_media_storage_locations)
+        }
+        list.adapter = documentAdapter
+        list.layoutManager = LinearLayoutManager(requireContext())
+        documentAdapter.submit(state.entries)
+        if (state.isLoading) {
+            view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.GONE
+        } else {
+            when {
+                state.isUnavailable -> showMessage(R.string.local_media_folder_unavailable, false)
+
+                state.entries.isNotEmpty() -> {
+                    view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.GONE
+                }
+
+                state.location == null -> showAddFolderMessage()
+
+                else -> showMessage(R.string.local_media_folder_empty, false)
+            }
+        }
+    }
+
+    private fun openDocument(entry: LocalMediaDocumentEntry) {
+        if (entry.isDirectory) {
+            browserViewModel.open(entry)
+            return
+        }
+        browserViewModel.mediaItem(entry)?.let { item ->
+            val queue = LocalMediaPlayQueue(listOf(item.toPlayQueueItem()), 0)
+            NavigationHelper.playOnMainPlayer(requireActivity() as AppCompatActivity, queue)
+        }
+    }
+
+    private fun showDocumentActions(entry: LocalMediaDocumentEntry) {
+        if (entry.isDirectory) {
+            showFolderActions(entry.location, entry.name, entry.isRoot)
+        } else {
+            browserViewModel.mediaItem(entry)?.let(::showActions)
+        }
+    }
+
+    private fun showFolderActions(
+        location: LocalMediaDocumentLocation,
+        title: String,
+        allowRemoval: Boolean
+    ) {
+        val actions = mutableListOf(
+            R.string.local_media_play_all,
+            R.string.local_media_shuffle_all,
+            R.string.local_media_play_background,
+            R.string.enqueue,
+            R.string.local_media_enqueue_next,
+            R.string.add_to_playlist
+        )
+        if (allowRemoval || location.path.isEmpty()) actions += R.string.local_media_remove_folder
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(title)
+            .setItems(actions.map(::getString).toTypedArray()) { _, which ->
+                if (actions[which] == R.string.local_media_remove_folder) {
+                    browserViewModel.removeRoot(location.rootUri)
+                } else {
+                    collectFolderForAction(location, title, actions[which])
+                }
+            }.show()
+    }
+
+    private fun collectFolderForAction(
+        location: LocalMediaDocumentLocation,
+        title: String,
+        action: Int
+    ) {
+        view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.VISIBLE
+        browserViewModel.collect(location) { items ->
+            if (!isAdded || view == null) return@collect
+            view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.GONE
+            if (items.isEmpty()) {
+                showMessage(R.string.local_media_folder_empty, false)
+                return@collect
+            }
+            val group = LocalMediaGroup(
+                stableKey = "document:${location.rootUri}:${location.path.joinToString("/")}",
+                title = title,
+                subtitle = "",
+                items = items,
+                thumbnailUri = items.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+                kind = LocalMediaGroupKind.VIDEO_FOLDER
+            )
+            val queue = LocalMediaGroupQueueBuilder.queue(
+                group,
+                shuffle = action == R.string.local_media_shuffle_all
+            )
+            when (action) {
+                R.string.local_media_play_all,
+                R.string.local_media_shuffle_all -> NavigationHelper.playOnMainPlayer(
+                    requireActivity() as AppCompatActivity,
+                    queue
+                )
+
+                R.string.local_media_play_background -> {
+                    NavigationHelper.playOnBackgroundPlayer(requireContext(), queue, true)
+                }
+
+                R.string.enqueue -> NavigationHelper.enqueueOnPlayer(requireContext(), queue)
+
+                R.string.local_media_enqueue_next -> {
+                    NavigationHelper.enqueueNextOnPlayer(requireContext(), queue)
+                }
+
+                R.string.add_to_playlist -> addGroupToPlaylist(group)
+            }
+        }
+    }
+
     private fun renderGroups(groups: List<LocalMediaGroup>) {
         list.adapter = groupAdapter
         list.layoutManager = LinearLayoutManager(requireContext())
@@ -327,8 +503,26 @@ class LocalMediaFragment : Fragment() {
 
     private fun showMessage(message: Int, showButton: Boolean) {
         view?.findViewById<TextView>(R.id.localMediaMessage)?.setText(message)
-        view?.findViewById<View>(R.id.localMediaGrantAccess)?.visibility =
-            if (showButton) View.VISIBLE else View.GONE
+        view?.findViewById<View>(R.id.localMediaGrantAccess)?.apply {
+            visibility = if (showButton) View.VISIBLE else View.GONE
+            if (showButton) {
+                (this as TextView).setText(R.string.local_media_grant_access)
+                setOnClickListener { permissionLauncher.launch(requiredPermissions()) }
+            }
+        }
+        view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.VISIBLE
+        view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.GONE
+    }
+
+    private fun showAddFolderMessage() {
+        view?.findViewById<TextView>(R.id.localMediaMessage)?.setText(
+            R.string.local_media_browse_folders
+        )
+        view?.findViewById<View>(R.id.localMediaGrantAccess)?.apply {
+            visibility = View.VISIBLE
+            (this as TextView).setText(R.string.local_media_add_folder)
+            setOnClickListener { folderLauncher.launch(null) }
+        }
         view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.VISIBLE
         view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.GONE
     }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -51,6 +51,7 @@ class LocalMediaFragment : Fragment() {
     private var sort = Sort.TITLE
     private var query = ""
     private var audioCategory = LocalMediaAudioCategory.TRACKS
+    private var videoCategory = LocalMediaVideoCategory.VIDEOS
     private var activeGroup: LocalMediaGroup? = null
     private lateinit var adapter: LocalMediaAdapter
     private lateinit var groupAdapter: LocalMediaGroupAdapter
@@ -74,7 +75,7 @@ class LocalMediaFragment : Fragment() {
         list = view.findViewById(R.id.localMediaList)
         viewModel = ViewModelProvider(this)[LocalMediaViewModel::class.java]
         adapter = LocalMediaAdapter(::play, ::showActions)
-        groupAdapter = LocalMediaGroupAdapter(::openGroup) { audioCategory }
+        groupAdapter = LocalMediaGroupAdapter(::openGroup)
         list.adapter = adapter
         applyItemViewMode()
 
@@ -105,6 +106,12 @@ class LocalMediaFragment : Fragment() {
         }
         view.findViewById<Chip>(R.id.localMediaAudioPlaylists).setOnClickListener {
             NavigationHelper.openBookmarksFragment(parentFragmentManager)
+        }
+        view.findViewById<Chip>(R.id.localMediaVideoVideos).setOnClickListener {
+            selectVideoCategory(LocalMediaVideoCategory.VIDEOS)
+        }
+        view.findViewById<Chip>(R.id.localMediaVideoFolders).setOnClickListener {
+            selectVideoCategory(LocalMediaVideoCategory.FOLDERS)
         }
         view.findViewById<View>(R.id.localMediaGroupBack).setOnClickListener {
             activeGroup = null
@@ -166,11 +173,19 @@ class LocalMediaFragment : Fragment() {
         activeGroup = null
         view?.findViewById<View>(R.id.localMediaAudioNavigation)?.visibility =
             if (selected == Filter.AUDIO) View.VISIBLE else View.GONE
+        view?.findViewById<View>(R.id.localMediaVideoNavigation)?.visibility =
+            if (selected == Filter.VIDEO) View.VISIBLE else View.GONE
         updateList()
     }
 
     private fun selectAudioCategory(selected: LocalMediaAudioCategory) {
         audioCategory = selected
+        activeGroup = null
+        updateList()
+    }
+
+    private fun selectVideoCategory(selected: LocalMediaVideoCategory) {
+        videoCategory = selected
         activeGroup = null
         updateList()
     }
@@ -189,6 +204,14 @@ class LocalMediaFragment : Fragment() {
             activeGroup == null
         ) {
             showAudioGroups(term)
+            return
+        }
+        if (
+            filter == Filter.VIDEO &&
+            videoCategory == LocalMediaVideoCategory.FOLDERS &&
+            activeGroup == null
+        ) {
+            showVideoGroups(term)
             return
         }
         val comparator: Comparator<LocalMediaItem> = when (sort) {
@@ -235,6 +258,22 @@ class LocalMediaFragment : Fragment() {
                 value.lowercase(Locale.getDefault()).contains(term)
             }
         }
+        renderGroups(groups)
+    }
+
+    private fun showVideoGroups(term: String) {
+        val groups = LocalMediaVideoIndex.folders(
+            allItems.filter(LocalMediaItem::isVideo),
+            getString(R.string.local_media_unknown_folder)
+        ).filter { group ->
+            term.isEmpty() || listOf(group.title, group.subtitle).any { value ->
+                value.lowercase(Locale.getDefault()).contains(term)
+            }
+        }
+        renderGroups(groups)
+    }
+
+    private fun renderGroups(groups: List<LocalMediaGroup>) {
         list.adapter = groupAdapter
         list.layoutManager = LinearLayoutManager(requireContext())
         view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility = View.GONE
@@ -334,8 +373,7 @@ class LocalMediaFragment : Fragment() {
 }
 
 private class LocalMediaGroupAdapter(
-    private val onClick: (LocalMediaGroup) -> Unit,
-    private val category: () -> LocalMediaAudioCategory
+    private val onClick: (LocalMediaGroup) -> Unit
 ) : RecyclerView.Adapter<LocalMediaGroupAdapter.Holder>() {
     private var items = emptyList<LocalMediaGroup>()
 
@@ -362,16 +400,21 @@ private class LocalMediaGroupAdapter(
         private val subtitle = view.findViewById<TextView>(R.id.localMediaGroupItemSubtitle)
 
         fun bind(group: LocalMediaGroup) {
+            val countPlural = if (group.kind == LocalMediaGroupKind.VIDEO_FOLDER) {
+                R.plurals.videos
+            } else {
+                R.plurals.local_media_track_count
+            }
             val count = itemView.resources.getQuantityString(
-                R.plurals.local_media_track_count,
+                countPlural,
                 group.items.size,
                 group.items.size
             )
             icon.setImageResource(
-                if (category() == LocalMediaAudioCategory.ARTISTS) {
-                    R.drawable.ic_person
-                } else {
-                    R.drawable.ic_music_note
+                when (group.kind) {
+                    LocalMediaGroupKind.ARTIST -> R.drawable.ic_person
+                    LocalMediaGroupKind.VIDEO_FOLDER -> R.drawable.ic_movie
+                    else -> R.drawable.ic_music_note
                 }
             )
             title.text = group.title

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -117,6 +117,15 @@ class LocalMediaFragment : Fragment() {
             activeGroup = null
             updateList()
         }
+        view.findViewById<View>(R.id.localMediaGroupPlay).setOnClickListener {
+            playActiveGroup(shuffle = false)
+        }
+        view.findViewById<View>(R.id.localMediaGroupShuffle).setOnClickListener {
+            playActiveGroup(shuffle = true)
+        }
+        view.findViewById<View>(R.id.localMediaGroupMore).setOnClickListener {
+            showActiveGroupActions()
+        }
         view.findViewById<TextInputEditText>(R.id.localMediaSearch).addTextChangedListener(
             object : TextWatcher {
                 override fun beforeTextChanged(
@@ -214,12 +223,22 @@ class LocalMediaFragment : Fragment() {
             showVideoGroups(term)
             return
         }
-        val comparator: Comparator<LocalMediaItem> = when (sort) {
-            Sort.TITLE -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
-            Sort.ARTIST -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::artist)
-            Sort.ALBUM -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::album)
-            Sort.FOLDER -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::folder)
-            Sort.RECENT -> compareByDescending(LocalMediaItem::addedAtSeconds)
+        val comparator: Comparator<LocalMediaItem> = if (
+            activeGroup?.kind == LocalMediaGroupKind.ALBUM
+        ) {
+            compareBy(
+                LocalMediaItem::discNumber,
+                LocalMediaItem::trackNumber,
+                LocalMediaItem::title
+            )
+        } else {
+            when (sort) {
+                Sort.TITLE -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
+                Sort.ARTIST -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::artist)
+                Sort.ALBUM -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::album)
+                Sort.FOLDER -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::folder)
+                Sort.RECENT -> compareByDescending(LocalMediaItem::addedAtSeconds)
+            }
         }
         val sourceItems = activeGroup?.items ?: allItems
         shownItems = sourceItems.asSequence()
@@ -318,6 +337,44 @@ class LocalMediaFragment : Fragment() {
         val index = shownItems.indexOf(item).coerceAtLeast(0)
         val queue = LocalMediaPlayQueue(shownItems.map(LocalMediaItem::toPlayQueueItem), index)
         NavigationHelper.playOnMainPlayer(requireActivity() as AppCompatActivity, queue)
+    }
+
+    private fun playActiveGroup(shuffle: Boolean) {
+        val group = activeGroup ?: return
+        val queue = LocalMediaGroupQueueBuilder.queue(group, shuffle)
+        NavigationHelper.playOnMainPlayer(requireActivity() as AppCompatActivity, queue)
+    }
+
+    private fun showActiveGroupActions() {
+        val group = activeGroup ?: return
+        val actions = arrayOf(
+            getString(R.string.local_media_play_background),
+            getString(R.string.enqueue),
+            getString(R.string.local_media_enqueue_next),
+            getString(R.string.add_to_playlist)
+        )
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(group.title)
+            .setItems(actions) { _, which ->
+                val queue = LocalMediaGroupQueueBuilder.queue(group, shuffle = false)
+                when (which) {
+                    0 -> NavigationHelper.playOnBackgroundPlayer(requireContext(), queue, true)
+                    1 -> NavigationHelper.enqueueOnPlayer(requireContext(), queue)
+                    2 -> NavigationHelper.enqueueNextOnPlayer(requireContext(), queue)
+                    3 -> addGroupToPlaylist(group)
+                }
+            }.show()
+    }
+
+    private fun addGroupToPlaylist(group: LocalMediaGroup) {
+        disposables.add(
+            PlaylistDialog.createCorrespondingDialog(
+                requireContext(),
+                group.items.map { StreamEntity(it.toPlayQueueItem()) }
+            ) { dialog ->
+                dialog.show(parentFragmentManager, "LocalMediaGroupPlaylist")
+            }
+        )
     }
 
     private fun showActions(item: LocalMediaItem) {

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import kotlin.random.Random
+import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue
+
+object LocalMediaGroupQueueBuilder {
+    fun queue(
+        group: LocalMediaGroup,
+        shuffle: Boolean,
+        random: Random = Random.Default
+    ): LocalMediaPlayQueue = LocalMediaPlayQueue(
+        items(group, shuffle, random).map(LocalMediaItem::toPlayQueueItem),
+        0
+    )
+
+    internal fun items(
+        group: LocalMediaGroup,
+        shuffle: Boolean,
+        random: Random = Random.Default
+    ): List<LocalMediaItem> = if (shuffle) group.items.shuffled(random) else group.items
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaTreeStore.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaTreeStore.kt
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import android.content.Context
+import android.net.Uri
+
+class LocalMediaTreeStore(context: Context) {
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    fun roots(): Set<String> = preferences.getStringSet(ROOTS_KEY, emptySet())
+        ?.toSet()
+        .orEmpty()
+
+    fun add(uri: Uri) {
+        preferences.edit().putStringSet(ROOTS_KEY, roots() + uri.toString()).apply()
+    }
+
+    fun remove(uri: String) {
+        preferences.edit().putStringSet(ROOTS_KEY, roots() - uri).apply()
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "local_media_document_roots"
+        private const val ROOTS_KEY = "roots"
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaVideoIndex.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaVideoIndex.kt
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+enum class LocalMediaVideoCategory { VIDEOS, FOLDERS }
+
+object LocalMediaVideoIndex {
+    fun folders(
+        items: List<LocalMediaItem>,
+        unknownFolder: String
+    ): List<LocalMediaGroup> = items.groupBy { item ->
+        "${item.volumeName}:${item.relativePath}"
+    }.map { (key, groupedItems) ->
+        val first = groupedItems.first()
+        LocalMediaGroup(
+            stableKey = "folder:$key",
+            title = first.folder.ifBlank { unknownFolder },
+            subtitle = folderSubtitle(first),
+            items = groupedItems.sortedWith(
+                compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
+            ),
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+            kind = LocalMediaGroupKind.VIDEO_FOLDER
+        )
+    }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaGroup::title))
+
+    private fun folderSubtitle(item: LocalMediaItem): String = listOf(
+        item.volumeName,
+        item.relativePath
+    ).filter(String::isNotBlank).joinToString(" • ")
+}

--- a/app/src/main/res/drawable/ic_create_new_folder.xml
+++ b/app/src/main/res/drawable/ic_create_new_folder.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,6h-8l-2,-2H4c-1.11,0 -1.99,0.89 -1.99,2L2,18c0,1.11 0.89,2 2,2h16c1.11,0 2,-0.89 2,-2V8c0,-1.11 -0.89,-2 -2,-2zM19,14h-3v3h-2v-3h-3v-2h3V9h2v3h3v2z" />
+</vector>

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -60,6 +60,13 @@
                 android:text="@string/videos_string" />
 
             <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaBrowse"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_media_browse_folders" />
+
+            <com.google.android.material.chip.Chip
                 android:id="@+id/localMediaSort"
                 style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
@@ -156,6 +163,57 @@
                 android:text="@string/local_media_folders" />
         </com.google.android.material.chip.ChipGroup>
     </HorizontalScrollView>
+
+    <LinearLayout
+        android:id="@+id/localMediaBrowseNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="12dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone">
+
+        <ImageButton
+            android:id="@+id/localMediaBrowseBack"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_browse_back"
+            android:src="@drawable/ic_arrow_back"
+            android:visibility="gone"
+            app:tint="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/localMediaBrowseTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:text="@string/local_media_storage_locations"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+        <ImageButton
+            android:id="@+id/localMediaBrowseAdd"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_add_folder"
+            android:src="@drawable/ic_create_new_folder"
+            app:tint="?attr/colorOnSurface" />
+
+        <ImageButton
+            android:id="@+id/localMediaBrowseMore"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_group_more_actions"
+            android:src="@drawable/ic_more_vert"
+            android:visibility="gone"
+            app:tint="?attr/colorOnSurface" />
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/localMediaGroupHeader"

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -124,6 +124,39 @@
         </com.google.android.material.chip.ChipGroup>
     </HorizontalScrollView>
 
+    <HorizontalScrollView
+        android:id="@+id/localMediaVideoNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:visibility="gone">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/localMediaVideoCategories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="12dp"
+            android:paddingBottom="8dp"
+            app:selectionRequired="true"
+            app:singleSelection="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaVideoVideos"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="@string/videos_string" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaVideoFolders"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_media_folders" />
+        </com.google.android.material.chip.ChipGroup>
+    </HorizontalScrollView>
+
     <LinearLayout
         android:id="@+id/localMediaGroupHeader"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -184,6 +184,33 @@
             android:layout_weight="1"
             android:maxLines="2"
             android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+        <ImageButton
+            android:id="@+id/localMediaGroupPlay"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_play_all"
+            android:src="@drawable/ic_play_arrow"
+            app:tint="?attr/colorOnSurface" />
+
+        <ImageButton
+            android:id="@+id/localMediaGroupShuffle"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_shuffle_all"
+            android:src="@drawable/ic_shuffle"
+            app:tint="?attr/colorOnSurface" />
+
+        <ImageButton
+            android:id="@+id/localMediaGroupMore"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_group_more_actions"
+            android:src="@drawable/ic_more_vert"
+            app:tint="?attr/colorOnSurface" />
     </LinearLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/list_local_media_document_item.xml
+++ b/app/src/main/res/layout/list_local_media_document_item.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="64dp"
+    android:orientation="horizontal"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp">
+
+    <ImageView
+        android:id="@+id/localMediaDocumentIcon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:contentDescription="@null"
+        android:padding="8dp"
+        app:tint="?attr/colorOnSurfaceVariant" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/localMediaDocumentTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+
+        <TextView
+            android:id="@+id/localMediaDocumentSubtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/local_media_library_strings.xml
+++ b/app/src/main/res/values/local_media_library_strings.xml
@@ -13,6 +13,14 @@
     <string name="local_media_play_all">Play all</string>
     <string name="local_media_shuffle_all">Shuffle all</string>
     <string name="local_media_group_more_actions">More group actions</string>
+    <string name="local_media_browse_folders">Browse folders</string>
+    <string name="local_media_storage_locations">Storage locations</string>
+    <string name="local_media_add_folder">Add folder</string>
+    <string name="local_media_browse_back">Back to parent folder</string>
+    <string name="local_media_folder_unavailable">This folder is unavailable</string>
+    <string name="local_media_remove_folder">Remove selected folder</string>
+    <string name="local_media_folder_empty">No supported media in this folder</string>
+    <string name="local_media_size_megabytes">%1$.1f MB</string>
     <plurals name="local_media_track_count">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>

--- a/app/src/main/res/values/local_media_library_strings.xml
+++ b/app/src/main/res/values/local_media_library_strings.xml
@@ -8,6 +8,8 @@
     <string name="local_media_unknown_album">Unknown album</string>
     <string name="local_media_unknown_genre">Unknown genre</string>
     <string name="local_media_back_to_categories">Back to categories</string>
+    <string name="local_media_folders">Folders</string>
+    <string name="local_media_unknown_folder">Unknown folder</string>
     <plurals name="local_media_track_count">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>

--- a/app/src/main/res/values/local_media_library_strings.xml
+++ b/app/src/main/res/values/local_media_library_strings.xml
@@ -10,6 +10,9 @@
     <string name="local_media_back_to_categories">Back to categories</string>
     <string name="local_media_folders">Folders</string>
     <string name="local_media_unknown_folder">Unknown folder</string>
+    <string name="local_media_play_all">Play all</string>
+    <string name="local_media_shuffle_all">Shuffle all</string>
+    <string name="local_media_group_more_actions">More group actions</string>
     <plurals name="local_media_track_count">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowserTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowserTest.kt
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalMediaDocumentBrowserTest {
+    @Test
+    fun `audio and video mime types are supported`() {
+        assertTrue(LocalMediaDocumentBrowser.isSupportedMedia("track.bin", "audio/flac"))
+        assertTrue(LocalMediaDocumentBrowser.isSupportedMedia("movie.bin", "video/mp4"))
+    }
+
+    @Test
+    fun `known extensions recover missing provider mime types`() {
+        assertTrue(LocalMediaDocumentBrowser.isSupportedMedia("track.OPUS", null))
+        assertTrue(LocalMediaDocumentBrowser.isSupportedMedia("movie.MKV", ""))
+        assertEquals("audio/mp3", LocalMediaDocumentBrowser.mimeTypeForName("track.mp3"))
+        assertEquals("video/webm", LocalMediaDocumentBrowser.mimeTypeForName("movie.webm"))
+    }
+
+    @Test
+    fun `unrelated documents stay out of the media browser`() {
+        assertFalse(LocalMediaDocumentBrowser.isSupportedMedia("notes.pdf", "application/pdf"))
+        assertFalse(LocalMediaDocumentBrowser.isSupportedMedia("archive.zip", null))
+    }
+
+    @Test
+    fun `whole folder scans have a defensive item limit`() {
+        assertEquals(5000, LocalMediaDocumentBrowser.MAXIMUM_GROUP_ITEMS)
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilderTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilderTest.kt
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class LocalMediaGroupQueueBuilderTest {
+    @Test
+    fun `ordered group playback preserves library order`() {
+        val group = group()
+
+        assertEquals(group.items, LocalMediaGroupQueueBuilder.items(group, shuffle = false))
+    }
+
+    @Test
+    fun `shuffled group playback retains every item exactly once`() {
+        val group = group()
+        val shuffled = LocalMediaGroupQueueBuilder.items(
+            group,
+            shuffle = true,
+            random = Random(7)
+        )
+
+        assertEquals(group.items.toSet(), shuffled.toSet())
+        assertNotEquals(group.items, shuffled)
+    }
+
+    private fun group(): LocalMediaGroup = LocalMediaGroup(
+        stableKey = "album:1",
+        title = "Album",
+        subtitle = "Artist",
+        items = (1L..5L).map(::audio),
+        thumbnailUri = null,
+        kind = LocalMediaGroupKind.ALBUM
+    )
+
+    private fun audio(id: Long) = LocalMediaItem(
+        mediaStoreId = id,
+        contentUri = "content://audio/$id",
+        title = "Track $id",
+        artist = "Artist",
+        album = "Album",
+        folder = "Music",
+        mimeType = "audio/mpeg",
+        durationSeconds = 60,
+        addedAtSeconds = id,
+        isVideo = false
+    )
+}

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaSafIntegrationTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaSafIntegrationTest.kt
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalMediaSafIntegrationTest {
+    private val projectDirectory = if (Files.exists(Path.of("src/main"))) {
+        Path.of("src/main")
+    } else {
+        Path.of("app/src/main")
+    }
+
+    @Test
+    fun `folder access uses persisted storage access framework grants`() {
+        val fragment = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaFragment.kt"
+            )
+        )
+        assertTrue(fragment.contains("ActivityResultContracts.OpenDocumentTree()"))
+        assertTrue(fragment.contains("takePersistableUriPermission"))
+        assertTrue(fragment.contains("Intent.FLAG_GRANT_READ_URI_PERMISSION"))
+    }
+
+    @Test
+    fun `folder browser does not request all files access`() {
+        val manifest = Files.readString(projectDirectory.resolve("AndroidManifest.xml"))
+        assertFalse(manifest.contains("MANAGE_EXTERNAL_STORAGE"))
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaVideoIndexTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaVideoIndexTest.kt
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalMediaVideoIndexTest {
+    @Test
+    fun `folders use volume and complete path identities`() {
+        val groups = LocalMediaVideoIndex.folders(
+            listOf(
+                video(1, volume = "external", path = "Movies/Family", folder = "Family"),
+                video(2, volume = "sdcard", path = "Movies/Family", folder = "Family")
+            ),
+            "Unknown folder"
+        )
+
+        assertEquals(2, groups.size)
+        assertEquals(
+            setOf(
+                "folder:external:Movies/Family",
+                "folder:sdcard:Movies/Family"
+            ),
+            groups.map(LocalMediaGroup::stableKey).toSet()
+        )
+    }
+
+    @Test
+    fun `videos inside folders are sorted by title`() {
+        val groups = LocalMediaVideoIndex.folders(
+            listOf(video(1, title = "Zulu"), video(2, title = "Alpha")),
+            "Unknown folder"
+        )
+
+        assertEquals(listOf(2L, 1L), groups.single().items.map(LocalMediaItem::mediaStoreId))
+    }
+
+    private fun video(
+        id: Long,
+        title: String = "Video $id",
+        volume: String = "external",
+        path: String = "Movies",
+        folder: String = "Movies"
+    ) = LocalMediaItem(
+        mediaStoreId = id,
+        contentUri = "content://video/$id",
+        title = title,
+        artist = "",
+        album = "",
+        folder = folder,
+        mimeType = "video/mp4",
+        durationSeconds = 60,
+        addedAtSeconds = id,
+        isVideo = true,
+        relativePath = path,
+        volumeName = volume
+    )
+}


### PR DESCRIPTION
- Add dedicated Videos and Folders navigation for local media
- Group folders by storage volume and complete relative path
- Distinguish duplicate folder names on internal and removable storage
- Preserve deterministic title ordering inside folders
- Display folder paths, video counts, and appropriate Material icons
- Add folder identity and ordering regression tests
- Part of #247