### PR TITLE
Add local video and folder sections

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAudioIndex.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaAudioIndex.kt
@@ -5,12 +5,15 @@ package org.schabi.newpipe.local.media
 
 enum class LocalMediaAudioCategory { TRACKS, ARTISTS, ALBUMS, GENRES }
 
+enum class LocalMediaGroupKind { ARTIST, ALBUM, GENRE, VIDEO_FOLDER }
+
 data class LocalMediaGroup(
     val stableKey: String,
     val title: String,
     val subtitle: String,
     val items: List<LocalMediaItem>,
-    val thumbnailUri: String?
+    val thumbnailUri: String?,
+    val kind: LocalMediaGroupKind
 )
 
 object LocalMediaAudioIndex {
@@ -40,7 +43,8 @@ object LocalMediaAudioIndex {
             title = title,
             subtitle = "",
             items = groupedItems.sortedWith(trackComparator),
-            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+            kind = LocalMediaGroupKind.ARTIST
         )
     }
 
@@ -58,7 +62,8 @@ object LocalMediaAudioIndex {
             title = first.album.ifBlank { unknownAlbum },
             subtitle = first.artist.ifBlank { unknownArtist },
             items = groupedItems.sortedWith(trackComparator),
-            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+            kind = LocalMediaGroupKind.ALBUM
         )
     }
 
@@ -77,7 +82,8 @@ object LocalMediaAudioIndex {
                 title = genre,
                 subtitle = "",
                 items = groupedItems.sortedWith(trackComparator),
-                thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri)
+                thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+                kind = LocalMediaGroupKind.GENRE
             )
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -51,6 +51,7 @@ class LocalMediaFragment : Fragment() {
     private var sort = Sort.TITLE
     private var query = ""
     private var audioCategory = LocalMediaAudioCategory.TRACKS
+    private var videoCategory = LocalMediaVideoCategory.VIDEOS
     private var activeGroup: LocalMediaGroup? = null
     private lateinit var adapter: LocalMediaAdapter
     private lateinit var groupAdapter: LocalMediaGroupAdapter
@@ -74,7 +75,7 @@ class LocalMediaFragment : Fragment() {
         list = view.findViewById(R.id.localMediaList)
         viewModel = ViewModelProvider(this)[LocalMediaViewModel::class.java]
         adapter = LocalMediaAdapter(::play, ::showActions)
-        groupAdapter = LocalMediaGroupAdapter(::openGroup) { audioCategory }
+        groupAdapter = LocalMediaGroupAdapter(::openGroup)
         list.adapter = adapter
         applyItemViewMode()
 
@@ -105,6 +106,12 @@ class LocalMediaFragment : Fragment() {
         }
         view.findViewById<Chip>(R.id.localMediaAudioPlaylists).setOnClickListener {
             NavigationHelper.openBookmarksFragment(parentFragmentManager)
+        }
+        view.findViewById<Chip>(R.id.localMediaVideoVideos).setOnClickListener {
+            selectVideoCategory(LocalMediaVideoCategory.VIDEOS)
+        }
+        view.findViewById<Chip>(R.id.localMediaVideoFolders).setOnClickListener {
+            selectVideoCategory(LocalMediaVideoCategory.FOLDERS)
         }
         view.findViewById<View>(R.id.localMediaGroupBack).setOnClickListener {
             activeGroup = null
@@ -166,11 +173,19 @@ class LocalMediaFragment : Fragment() {
         activeGroup = null
         view?.findViewById<View>(R.id.localMediaAudioNavigation)?.visibility =
             if (selected == Filter.AUDIO) View.VISIBLE else View.GONE
+        view?.findViewById<View>(R.id.localMediaVideoNavigation)?.visibility =
+            if (selected == Filter.VIDEO) View.VISIBLE else View.GONE
         updateList()
     }
 
     private fun selectAudioCategory(selected: LocalMediaAudioCategory) {
         audioCategory = selected
+        activeGroup = null
+        updateList()
+    }
+
+    private fun selectVideoCategory(selected: LocalMediaVideoCategory) {
+        videoCategory = selected
         activeGroup = null
         updateList()
     }
@@ -189,6 +204,14 @@ class LocalMediaFragment : Fragment() {
             activeGroup == null
         ) {
             showAudioGroups(term)
+            return
+        }
+        if (
+            filter == Filter.VIDEO &&
+            videoCategory == LocalMediaVideoCategory.FOLDERS &&
+            activeGroup == null
+        ) {
+            showVideoGroups(term)
             return
         }
         val comparator: Comparator<LocalMediaItem> = when (sort) {
@@ -235,6 +258,22 @@ class LocalMediaFragment : Fragment() {
                 value.lowercase(Locale.getDefault()).contains(term)
             }
         }
+        renderGroups(groups)
+    }
+
+    private fun showVideoGroups(term: String) {
+        val groups = LocalMediaVideoIndex.folders(
+            allItems.filter(LocalMediaItem::isVideo),
+            getString(R.string.local_media_unknown_folder)
+        ).filter { group ->
+            term.isEmpty() || listOf(group.title, group.subtitle).any { value ->
+                value.lowercase(Locale.getDefault()).contains(term)
+            }
+        }
+        renderGroups(groups)
+    }
+
+    private fun renderGroups(groups: List<LocalMediaGroup>) {
         list.adapter = groupAdapter
         list.layoutManager = LinearLayoutManager(requireContext())
         view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility = View.GONE
@@ -334,8 +373,7 @@ class LocalMediaFragment : Fragment() {
 }
 
 private class LocalMediaGroupAdapter(
-    private val onClick: (LocalMediaGroup) -> Unit,
-    private val category: () -> LocalMediaAudioCategory
+    private val onClick: (LocalMediaGroup) -> Unit
 ) : RecyclerView.Adapter<LocalMediaGroupAdapter.Holder>() {
     private var items = emptyList<LocalMediaGroup>()
 
@@ -362,16 +400,21 @@ private class LocalMediaGroupAdapter(
         private val subtitle = view.findViewById<TextView>(R.id.localMediaGroupItemSubtitle)
 
         fun bind(group: LocalMediaGroup) {
+            val countPlural = if (group.kind == LocalMediaGroupKind.VIDEO_FOLDER) {
+                R.plurals.videos
+            } else {
+                R.plurals.local_media_track_count
+            }
             val count = itemView.resources.getQuantityString(
-                R.plurals.local_media_track_count,
+                countPlural,
                 group.items.size,
                 group.items.size
             )
             icon.setImageResource(
-                if (category() == LocalMediaAudioCategory.ARTISTS) {
-                    R.drawable.ic_person
-                } else {
-                    R.drawable.ic_music_note
+                when (group.kind) {
+                    LocalMediaGroupKind.ARTIST -> R.drawable.ic_person
+                    LocalMediaGroupKind.VIDEO_FOLDER -> R.drawable.ic_movie
+                    else -> R.drawable.ic_music_note
                 }
             )
             title.text = group.title

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaVideoIndex.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaVideoIndex.kt
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+enum class LocalMediaVideoCategory { VIDEOS, FOLDERS }
+
+object LocalMediaVideoIndex {
+    fun folders(
+        items: List<LocalMediaItem>,
+        unknownFolder: String
+    ): List<LocalMediaGroup> = items.groupBy { item ->
+        "${item.volumeName}:${item.relativePath}"
+    }.map { (key, groupedItems) ->
+        val first = groupedItems.first()
+        LocalMediaGroup(
+            stableKey = "folder:$key",
+            title = first.folder.ifBlank { unknownFolder },
+            subtitle = folderSubtitle(first),
+            items = groupedItems.sortedWith(
+                compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
+            ),
+            thumbnailUri = groupedItems.firstNotNullOfOrNull(LocalMediaItem::thumbnailUri),
+            kind = LocalMediaGroupKind.VIDEO_FOLDER
+        )
+    }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaGroup::title))
+
+    private fun folderSubtitle(item: LocalMediaItem): String = listOf(
+        item.volumeName,
+        item.relativePath
+    ).filter(String::isNotBlank).joinToString(" • ")
+}

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -124,6 +124,39 @@
         </com.google.android.material.chip.ChipGroup>
     </HorizontalScrollView>
 
+    <HorizontalScrollView
+        android:id="@+id/localMediaVideoNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scrollbars="none"
+        android:visibility="gone">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/localMediaVideoCategories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="12dp"
+            android:paddingBottom="8dp"
+            app:selectionRequired="true"
+            app:singleSelection="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaVideoVideos"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="@string/videos_string" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/localMediaVideoFolders"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/local_media_folders" />
+        </com.google.android.material.chip.ChipGroup>
+    </HorizontalScrollView>
+
     <LinearLayout
         android:id="@+id/localMediaGroupHeader"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/local_media_library_strings.xml
+++ b/app/src/main/res/values/local_media_library_strings.xml
@@ -8,6 +8,8 @@
     <string name="local_media_unknown_album">Unknown album</string>
     <string name="local_media_unknown_genre">Unknown genre</string>
     <string name="local_media_back_to_categories">Back to categories</string>
+    <string name="local_media_folders">Folders</string>
+    <string name="local_media_unknown_folder">Unknown folder</string>
     <plurals name="local_media_track_count">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaVideoIndexTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaVideoIndexTest.kt
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalMediaVideoIndexTest {
+    @Test
+    fun `folders use volume and complete path identities`() {
+        val groups = LocalMediaVideoIndex.folders(
+            listOf(
+                video(1, volume = "external", path = "Movies/Family", folder = "Family"),
+                video(2, volume = "sdcard", path = "Movies/Family", folder = "Family")
+            ),
+            "Unknown folder"
+        )
+
+        assertEquals(2, groups.size)
+        assertEquals(
+            setOf(
+                "folder:external:Movies/Family",
+                "folder:sdcard:Movies/Family"
+            ),
+            groups.map(LocalMediaGroup::stableKey).toSet()
+        )
+    }
+
+    @Test
+    fun `videos inside folders are sorted by title`() {
+        val groups = LocalMediaVideoIndex.folders(
+            listOf(video(1, title = "Zulu"), video(2, title = "Alpha")),
+            "Unknown folder"
+        )
+
+        assertEquals(listOf(2L, 1L), groups.single().items.map(LocalMediaItem::mediaStoreId))
+    }
+
+    private fun video(
+        id: Long,
+        title: String = "Video $id",
+        volume: String = "external",
+        path: String = "Movies",
+        folder: String = "Movies"
+    ) = LocalMediaItem(
+        mediaStoreId = id,
+        contentUri = "content://video/$id",
+        title = title,
+        artist = "",
+        album = "",
+        folder = folder,
+        mimeType = "video/mp4",
+        durationSeconds = 60,
+        addedAtSeconds = id,
+        isVideo = true,
+        relativePath = path,
+        volumeName = volume
+    )
+}


### PR DESCRIPTION
- Add Videos and Folders navigation for local video
- Group folders by storage volume and relative path
- Keep identically named folders on different paths separate
- Show folder paths and video counts
- Preserve the shared local-media list and playback behavior
- Add folder identity and grouping regression tests
- Part of #247