### PR TITLE
Add local media group actions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -117,6 +117,15 @@ class LocalMediaFragment : Fragment() {
             activeGroup = null
             updateList()
         }
+        view.findViewById<View>(R.id.localMediaGroupPlay).setOnClickListener {
+            playActiveGroup(shuffle = false)
+        }
+        view.findViewById<View>(R.id.localMediaGroupShuffle).setOnClickListener {
+            playActiveGroup(shuffle = true)
+        }
+        view.findViewById<View>(R.id.localMediaGroupMore).setOnClickListener {
+            showActiveGroupActions()
+        }
         view.findViewById<TextInputEditText>(R.id.localMediaSearch).addTextChangedListener(
             object : TextWatcher {
                 override fun beforeTextChanged(
@@ -214,12 +223,22 @@ class LocalMediaFragment : Fragment() {
             showVideoGroups(term)
             return
         }
-        val comparator: Comparator<LocalMediaItem> = when (sort) {
-            Sort.TITLE -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
-            Sort.ARTIST -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::artist)
-            Sort.ALBUM -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::album)
-            Sort.FOLDER -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::folder)
-            Sort.RECENT -> compareByDescending(LocalMediaItem::addedAtSeconds)
+        val comparator: Comparator<LocalMediaItem> = if (
+            activeGroup?.kind == LocalMediaGroupKind.ALBUM
+        ) {
+            compareBy(
+                LocalMediaItem::discNumber,
+                LocalMediaItem::trackNumber,
+                LocalMediaItem::title
+            )
+        } else {
+            when (sort) {
+                Sort.TITLE -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::title)
+                Sort.ARTIST -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::artist)
+                Sort.ALBUM -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::album)
+                Sort.FOLDER -> compareBy(String.CASE_INSENSITIVE_ORDER, LocalMediaItem::folder)
+                Sort.RECENT -> compareByDescending(LocalMediaItem::addedAtSeconds)
+            }
         }
         val sourceItems = activeGroup?.items ?: allItems
         shownItems = sourceItems.asSequence()
@@ -318,6 +337,44 @@ class LocalMediaFragment : Fragment() {
         val index = shownItems.indexOf(item).coerceAtLeast(0)
         val queue = LocalMediaPlayQueue(shownItems.map(LocalMediaItem::toPlayQueueItem), index)
         NavigationHelper.playOnMainPlayer(requireActivity() as AppCompatActivity, queue)
+    }
+
+    private fun playActiveGroup(shuffle: Boolean) {
+        val group = activeGroup ?: return
+        val queue = LocalMediaGroupQueueBuilder.queue(group, shuffle)
+        NavigationHelper.playOnMainPlayer(requireActivity() as AppCompatActivity, queue)
+    }
+
+    private fun showActiveGroupActions() {
+        val group = activeGroup ?: return
+        val actions = arrayOf(
+            getString(R.string.local_media_play_background),
+            getString(R.string.enqueue),
+            getString(R.string.local_media_enqueue_next),
+            getString(R.string.add_to_playlist)
+        )
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(group.title)
+            .setItems(actions) { _, which ->
+                val queue = LocalMediaGroupQueueBuilder.queue(group, shuffle = false)
+                when (which) {
+                    0 -> NavigationHelper.playOnBackgroundPlayer(requireContext(), queue, true)
+                    1 -> NavigationHelper.enqueueOnPlayer(requireContext(), queue)
+                    2 -> NavigationHelper.enqueueNextOnPlayer(requireContext(), queue)
+                    3 -> addGroupToPlaylist(group)
+                }
+            }.show()
+    }
+
+    private fun addGroupToPlaylist(group: LocalMediaGroup) {
+        disposables.add(
+            PlaylistDialog.createCorrespondingDialog(
+                requireContext(),
+                group.items.map { StreamEntity(it.toPlayQueueItem()) }
+            ) { dialog ->
+                dialog.show(parentFragmentManager, "LocalMediaGroupPlaylist")
+            }
+        )
     }
 
     private fun showActions(item: LocalMediaItem) {

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import kotlin.random.Random
+import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue
+
+object LocalMediaGroupQueueBuilder {
+    fun queue(
+        group: LocalMediaGroup,
+        shuffle: Boolean,
+        random: Random = Random.Default
+    ): LocalMediaPlayQueue = LocalMediaPlayQueue(
+        items(group, shuffle, random).map(LocalMediaItem::toPlayQueueItem),
+        0
+    )
+
+    internal fun items(
+        group: LocalMediaGroup,
+        shuffle: Boolean,
+        random: Random = Random.Default
+    ): List<LocalMediaItem> = if (shuffle) group.items.shuffled(random) else group.items
+}

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -184,6 +184,33 @@
             android:layout_weight="1"
             android:maxLines="2"
             android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+        <ImageButton
+            android:id="@+id/localMediaGroupPlay"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_play_all"
+            android:src="@drawable/ic_play_arrow"
+            app:tint="?attr/colorOnSurface" />
+
+        <ImageButton
+            android:id="@+id/localMediaGroupShuffle"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_shuffle_all"
+            android:src="@drawable/ic_shuffle"
+            app:tint="?attr/colorOnSurface" />
+
+        <ImageButton
+            android:id="@+id/localMediaGroupMore"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:contentDescription="@string/local_media_group_more_actions"
+            android:src="@drawable/ic_more_vert"
+            app:tint="?attr/colorOnSurface" />
     </LinearLayout>
 
     <FrameLayout

--- a/app/src/main/res/values/local_media_library_strings.xml
+++ b/app/src/main/res/values/local_media_library_strings.xml
@@ -10,6 +10,9 @@
     <string name="local_media_back_to_categories">Back to categories</string>
     <string name="local_media_folders">Folders</string>
     <string name="local_media_unknown_folder">Unknown folder</string>
+    <string name="local_media_play_all">Play all</string>
+    <string name="local_media_shuffle_all">Shuffle all</string>
+    <string name="local_media_group_more_actions">More group actions</string>
     <plurals name="local_media_track_count">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilderTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilderTest.kt
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class LocalMediaGroupQueueBuilderTest {
+    @Test
+    fun `ordered group playback preserves library order`() {
+        val group = group()
+
+        assertEquals(group.items, LocalMediaGroupQueueBuilder.items(group, shuffle = false))
+    }
+
+    @Test
+    fun `shuffled group playback retains every item exactly once`() {
+        val group = group()
+        val shuffled = LocalMediaGroupQueueBuilder.items(
+            group,
+            shuffle = true,
+            random = Random(7)
+        )
+
+        assertEquals(group.items.toSet(), shuffled.toSet())
+        assertNotEquals(group.items, shuffled)
+    }
+
+    private fun group(): LocalMediaGroup = LocalMediaGroup(
+        stableKey = "album:1",
+        title = "Album",
+        subtitle = "Artist",
+        items = (1L..5L).map(::audio),
+        thumbnailUri = null,
+        kind = LocalMediaGroupKind.ALBUM
+    )
+
+    private fun audio(id: Long) = LocalMediaItem(
+        mediaStoreId = id,
+        contentUri = "content://audio/$id",
+        title = "Track $id",
+        artist = "Artist",
+        album = "Album",
+        folder = "Music",
+        mimeType = "audio/mpeg",
+        durationSeconds = 60,
+        addedAtSeconds = id,
+        isVideo = false
+    )
+}


### PR DESCRIPTION
- Add whole-group play and shuffle controls
- Support background playback, enqueue, and play next for artists, albums, genres, and folders
- Add entire groups to existing playlists
- Preserve disc and track order for album playback
- Reuse the local media play queue and playlist database
- Add ordered and shuffled queue regression tests
- Part of #247