### PR TITLE
Center feed and thumbnail progress

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -438,8 +438,8 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             progressState.maxProgress < 0
         feedBinding.loadingProgressBar.isVisible = !isIndeterminate
         feedBinding.loadingIndeterminateProgressBar.isVisible = isIndeterminate
-        feedBinding.loadingProgressText.isVisible = !isIndeterminate
         feedBinding.loadingProgressStatusText.isVisible = isIndeterminate
+        feedBinding.loadingProgressBar.setCounterText(null)
 
         if (isIndeterminate) {
             feedBinding.loadingProgressStatusText.text =
@@ -451,7 +451,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         } else {
             val maxProgress = progressState.maxProgress.coerceAtLeast(1)
             val currentProgress = progressState.currentProgress.coerceIn(0, maxProgress)
-            feedBinding.loadingProgressText.text = "$currentProgress/$maxProgress"
+            feedBinding.loadingProgressBar.setCounterText("$currentProgress/$maxProgress")
             feedBinding.loadingProgressBar.max = maxProgress
             feedBinding.loadingProgressBar.setProgressCompat(currentProgress, true)
         }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedProgressIndicator.java
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedProgressIndicator.java
@@ -1,0 +1,60 @@
+package org.schabi.newpipe.local.feed;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.color.MaterialColors;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
+
+import org.schabi.newpipe.R;
+
+/**
+ * A determinate feed progress indicator that draws its counter around the same center as its ring.
+ */
+public final class FeedProgressIndicator extends CircularProgressIndicator {
+    private final Paint counterPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Rect counterBounds = new Rect();
+    private String counterText = "";
+
+    public FeedProgressIndicator(@NonNull final Context context) {
+        this(context, null);
+    }
+
+    public FeedProgressIndicator(@NonNull final Context context,
+                                 @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+        counterPaint.setColor(MaterialColors.getColor(
+                this, com.google.android.material.R.attr.colorOnSurface));
+        counterPaint.setTextSize(getResources().getDimension(
+                R.dimen.feed_progress_counter_text_size));
+        counterPaint.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+    }
+
+    public void setCounterText(@Nullable final CharSequence text) {
+        counterText = text == null ? "" : text.toString();
+        setContentDescription(counterText);
+        invalidate();
+    }
+
+    @Override
+    protected synchronized void onDraw(@NonNull final Canvas canvas) {
+        super.onDraw(canvas);
+        if (counterText.isEmpty()) {
+            return;
+        }
+
+        counterPaint.getTextBounds(counterText, 0, counterText.length(), counterBounds);
+        final float centerX = (getPaddingLeft() + getWidth() - getPaddingRight()) / 2.0f;
+        final float centerY = (getPaddingTop() + getHeight() - getPaddingBottom()) / 2.0f;
+        final float textX = centerX - counterBounds.exactCenterX();
+        final float baselineY = centerY - counterBounds.exactCenterY();
+        canvas.drawText(counterText, textX, baselineY, counterPaint);
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/views/RoundedThumbnailContainer.java
+++ b/app/src/main/java/org/schabi/newpipe/views/RoundedThumbnailContainer.java
@@ -1,0 +1,48 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Path;
+import android.graphics.RectF;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.R;
+
+/** Clips thumbnail overlays to the same rounded outline as the thumbnail image. */
+public final class RoundedThumbnailContainer extends FrameLayout {
+    private final Path clipPath = new Path();
+    private final RectF clipBounds = new RectF();
+    private final float cornerRadius;
+
+    public RoundedThumbnailContainer(@NonNull final Context context) {
+        this(context, null);
+    }
+
+    public RoundedThumbnailContainer(@NonNull final Context context,
+                                     @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+        cornerRadius = getResources().getDimension(R.dimen.stream_thumbnail_corner_radius);
+        setClipChildren(true);
+    }
+
+    @Override
+    protected void onSizeChanged(final int width, final int height,
+                                 final int oldWidth, final int oldHeight) {
+        super.onSizeChanged(width, height, oldWidth, oldHeight);
+        clipBounds.set(0.0f, 0.0f, width, height);
+        clipPath.reset();
+        clipPath.addRoundRect(clipBounds, cornerRadius, cornerRadius, Path.Direction.CW);
+    }
+
+    @Override
+    protected void dispatchDraw(@NonNull final Canvas canvas) {
+        final int checkpoint = canvas.save();
+        canvas.clipPath(clipPath);
+        super.dispatchDraw(canvas);
+        canvas.restoreToCount(checkpoint);
+    }
+}

--- a/app/src/main/res/layout-land/list_stream_card_item.xml
+++ b/app/src/main/res/layout-land/list_stream_card_item.xml
@@ -10,15 +10,30 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="@dimen/video_item_search_thumbnail_image_width"
         android:layout_height="@dimen/video_item_search_thumbnail_image_height"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -33,8 +48,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintRight_toRightOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintRight_toRightOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -51,8 +66,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -66,7 +81,7 @@
         android:textSize="@dimen/video_item_search_title_text_size"
         app:layout_constraintBottom_toTopOf="@+id/itemUploaderRoot"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintStart_toEndOf="@+id/itemThumbnailContainer"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique vitae sem vitae blanditLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsum" />
 
@@ -128,17 +143,5 @@
             tools:text="2 years ago • 10M views" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-land/list_stream_playlist_card_item.xml
+++ b/app/src/main/res/layout-land/list_stream_playlist_card_item.xml
@@ -10,15 +10,30 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="@dimen/video_item_search_thumbnail_image_width"
         android:layout_height="@dimen/video_item_search_thumbnail_image_height"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -33,8 +48,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -51,8 +66,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -67,7 +82,7 @@
         android:textSize="@dimen/video_item_search_title_text_size"
         app:layout_constraintBottom_toTopOf="@id/itemUploaderRoot"
         app:layout_constraintEnd_toStartOf="@id/itemHandle"
-        app:layout_constraintStart_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toEndOf="@id/itemThumbnailContainer"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
@@ -141,17 +156,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -143,10 +143,11 @@
                         android:layout_width="104dp"
                         android:layout_height="104dp">
 
-                        <com.google.android.material.progressindicator.CircularProgressIndicator
+                        <org.schabi.newpipe.local.feed.FeedProgressIndicator
                             android:id="@+id/loading_progress_bar"
                             android:layout_width="104dp"
                             android:layout_height="104dp"
+                            android:accessibilityLiveRegion="polite"
                             android:indeterminate="false"
                             android:max="1"
                             android:progress="0"
@@ -170,19 +171,6 @@
                             app:trackCornerRadius="3dp"
                             app:trackThickness="6dp" />
 
-                        <org.schabi.newpipe.views.NewPipeTextView
-                            android:id="@+id/loading_progress_text"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent"
-                            android:accessibilityLiveRegion="polite"
-                            android:gravity="center"
-                            android:includeFontPadding="false"
-                            android:text="0/0"
-                            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
-                            android:textColor="?attr/colorOnSurface"
-                            android:textSize="14sp"
-                            android:textStyle="bold"
-                            tools:text="16/47" />
                     </FrameLayout>
 
                     <org.schabi.newpipe.views.NewPipeTextView

--- a/app/src/main/res/layout/list_stream_card_item.xml
+++ b/app/src/main/res/layout/list_stream_card_item.xml
@@ -12,17 +12,31 @@
     android:clickable="true"
     android:focusable="true">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="centerCrop"
-        android:src="@drawable/placeholder_thumbnail_video"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail"
         app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -37,8 +51,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintRight_toRightOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintRight_toRightOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -55,8 +69,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -70,9 +84,9 @@
         android:layout_marginTop="@dimen/margin_small"
         android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
         android:textColor="?attr/colorOnSurface"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique vitae sem vitae blanditLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsum" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -84,7 +98,7 @@
         android:focusable="true"
         android:minHeight="@dimen/stream_item_uploader_touch_target"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
         app:layout_constraintStart_toStartOf="@id/itemVideoTitleView"
         app:layout_constraintTop_toBottomOf="@+id/itemVideoTitleView"
         tools:contentDescription="Open channel Uploader">
@@ -134,17 +148,5 @@
             tools:text="2 years ago • 10M views" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_grid_item.xml
@@ -10,17 +10,31 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail"
         app:layout_constraintDimensionRatio="H,16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -37,8 +51,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailContainer"
+        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -55,8 +69,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -69,9 +83,9 @@
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/video_item_search_title_text_size"
         app:layout_constraintBottom_toTopOf="@+id/itemUploaderRoot"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView"
-        app:layout_constraintTop_toBottomOf="@+id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailContainer"
+        app:layout_constraintStart_toStartOf="@+id/itemThumbnailContainer"
+        app:layout_constraintTop_toBottomOf="@+id/itemThumbnailContainer"
         tools:text="@tools:sample/lorem[10]" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -83,8 +97,8 @@
         android:focusable="true"
         android:minHeight="@dimen/stream_item_uploader_touch_target"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailContainer"
+        app:layout_constraintStart_toStartOf="@+id/itemThumbnailContainer"
         app:layout_constraintTop_toBottomOf="@+id/itemVideoTitleView"
         tools:contentDescription="Open channel Uploader">
 
@@ -134,17 +148,5 @@
             tools:text="2 years ago • 10M views" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_item.xml
+++ b/app/src/main/res/layout/list_stream_item.xml
@@ -10,15 +10,29 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="@dimen/video_item_search_thumbnail_image_width"
         android:layout_height="@dimen/video_item_search_thumbnail_image_height"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -33,8 +47,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintRight_toRightOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintRight_toRightOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -51,8 +65,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -67,7 +81,7 @@
         android:textSize="@dimen/video_item_search_title_text_size"
         app:layout_constraintBottom_toTopOf="@+id/itemUploaderRoot"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintStart_toEndOf="@+id/itemThumbnailContainer"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique vitae sem vitae blanditLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsum" />
 
@@ -131,17 +145,5 @@
             tools:text="2 years ago • 10M views" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_mini_item.xml
+++ b/app/src/main/res/layout/list_stream_mini_item.xml
@@ -10,25 +10,39 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="98dp"
         android:layout_height="55dp"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail"
-        tools:ignore="RtlHardcoded" />
+        tools:ignore="RtlHardcoded">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignRight="@id/itemThumbnailView"
-        android:layout_alignBottom="@id/itemThumbnailView"
+        android:layout_alignRight="@id/itemThumbnailContainer"
+        android:layout_alignBottom="@id/itemThumbnailContainer"
         android:layout_marginRight="@dimen/video_item_search_duration_margin"
         android:layout_marginBottom="@dimen/video_item_search_duration_margin"
         android:background="@color/info_list_duration_badge_background_color"
@@ -47,8 +61,8 @@
         android:id="@+id/itemMembersOnlyView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignStart="@id/itemThumbnailView"
-        android:layout_alignTop="@id/itemThumbnailView"
+        android:layout_alignStart="@id/itemThumbnailContainer"
+        android:layout_alignTop="@id/itemThumbnailContainer"
         android:layout_marginStart="@dimen/video_item_search_duration_margin"
         android:layout_marginTop="@dimen/video_item_search_duration_margin"
         android:background="@drawable/members_only_badge_background"
@@ -67,8 +81,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
-        android:layout_toEndOf="@+id/itemThumbnailView"
-        android:layout_toRightOf="@+id/itemThumbnailView"
+        android:layout_toEndOf="@+id/itemThumbnailContainer"
+        android:layout_toRightOf="@+id/itemThumbnailContainer"
         android:ellipsize="end"
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
@@ -81,24 +95,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/itemVideoTitleView"
-        android:layout_toEndOf="@+id/itemThumbnailView"
-        android:layout_toRightOf="@+id/itemThumbnailView"
+        android:layout_toEndOf="@+id/itemThumbnailContainer"
+        android:layout_toRightOf="@+id/itemThumbnailContainer"
         android:lines="1"
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="?attr/colorOnSurfaceVariant"
         android:textSize="@dimen/video_item_search_uploader_text_size"
         tools:text="Uploader" />
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_alignStart="@id/itemThumbnailView"
-        android:layout_alignEnd="@id/itemThumbnailView"
-        android:layout_alignBottom="@id/itemThumbnailView"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/list_stream_playlist_card_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_card_item.xml
@@ -12,17 +12,31 @@
     android:paddingTop="@dimen/channel_item_grid_padding"
     android:paddingBottom="@dimen/channel_item_grid_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="centerCrop"
-        android:src="@drawable/placeholder_thumbnail_video"
         app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -37,8 +51,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -55,8 +69,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -69,9 +83,9 @@
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
         android:textColor="?attr/colorOnSurface"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -144,17 +158,5 @@
         app:layout_constraintBottom_toBottomOf="@id/itemUploaderRoot"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/itemUploaderRoot" />
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_grid_item.xml
@@ -10,17 +10,31 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
         app:layout_constraintDimensionRatio="H,16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -35,8 +49,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -53,8 +67,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -66,9 +80,9 @@
         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/video_item_search_title_text_size"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -79,7 +93,7 @@
         android:minHeight="@dimen/stream_item_uploader_touch_target"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/itemHandle"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
         app:layout_constraintTop_toBottomOf="@id/itemVideoTitleView">
 
         <com.google.android.material.imageview.ShapeableImageView
@@ -140,19 +154,7 @@
         android:src="@drawable/ic_drag_handle"
         android:tint="?attr/colorOnSurfaceVariant"
         app:layout_constraintBottom_toBottomOf="@id/itemUploaderRoot"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
         app:layout_constraintTop_toTopOf="@id/itemUploaderRoot" />
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_playlist_item.xml
+++ b/app/src/main/res/layout/list_stream_playlist_item.xml
@@ -10,15 +10,29 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="@dimen/video_item_search_thumbnail_image_width"
         android:layout_height="@dimen/video_item_search_thumbnail_image_height"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -33,8 +47,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintEnd_toEndOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -51,8 +65,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -67,7 +81,7 @@
         android:textSize="@dimen/video_item_search_title_text_size"
         app:layout_constraintBottom_toTopOf="@id/itemUploaderRoot"
         app:layout_constraintEnd_toStartOf="@id/itemHandle"
-        app:layout_constraintStart_toEndOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toEndOf="@id/itemThumbnailContainer"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
@@ -142,17 +156,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_stream_related_wide_item.xml
+++ b/app/src/main/res/layout/list_stream_related_wide_item.xml
@@ -10,17 +10,31 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <com.google.android.material.imageview.ShapeableImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_video"
         app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.42"
-        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+        app:layout_constraintWidth_percent="0.42">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/placeholder_thumbnail_video"
+            app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.wizestream.StreamThumbnail" />
+
+        <org.schabi.newpipe.views.AnimatedProgressBar
+            android:id="@+id/itemProgressView"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/stream_thumbnail_progress_height"
+            android:layout_gravity="bottom"
+            android:progressDrawable="@drawable/progress_stream_thumbnail_material" />
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemDurationView"
@@ -35,8 +49,8 @@
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintRight_toRightOf="@id/itemThumbnailView"
+        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailContainer"
+        app:layout_constraintRight_toRightOf="@id/itemThumbnailContainer"
         tools:text="1:09:10" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -53,8 +67,8 @@
         android:textColor="@color/info_list_thumbnail_badge_text_color"
         android:textSize="@dimen/video_item_search_duration_text_size"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toTopOf="@id/itemThumbnailContainer"
         tools:visibility="visible" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -69,7 +83,7 @@
         android:textSize="@dimen/video_item_search_title_text_size"
         app:layout_constraintBottom_toTopOf="@+id/itemUploaderRoot"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/itemThumbnailView"
+        app:layout_constraintStart_toEndOf="@+id/itemThumbnailContainer"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="A related video title that wraps onto a second line" />
 
@@ -133,17 +147,5 @@
             tools:text="2 years ago • 10M views" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <org.schabi.newpipe.views.AnimatedProgressBar
-        android:id="@+id/itemProgressView"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="0dp"
-        android:layout_height="@dimen/stream_thumbnail_progress_height"
-        android:layout_marginHorizontal="@dimen/stream_thumbnail_progress_horizontal_inset"
-        android:layout_marginBottom="@dimen/stream_thumbnail_progress_bottom_margin"
-        android:progressDrawable="@drawable/progress_stream_thumbnail_material"
-        app:layout_constraintBottom_toBottomOf="@+id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@+id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@+id/itemThumbnailView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -45,8 +45,7 @@
     <dimen name="video_item_grid_thumbnail_image_height">92dp</dimen>
     <dimen name="stream_thumbnail_corner_radius">12dp</dimen>
     <dimen name="stream_thumbnail_progress_height">3dp</dimen>
-    <dimen name="stream_thumbnail_progress_bottom_margin">0dp</dimen>
-    <dimen name="stream_thumbnail_progress_horizontal_inset">12dp</dimen>
+    <dimen name="feed_progress_counter_text_size">14sp</dimen>
     <dimen name="stream_thumbnail_duration_margin_with_progress">20dp</dimen>
     <dimen name="stream_card_horizontal_margin">12dp</dimen>
     <dimen name="stream_item_uploader_touch_target">48dp</dimen>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/WideVideoDetailResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/WideVideoDetailResourcesTest.java
@@ -32,12 +32,15 @@ public class WideVideoDetailResourcesTest {
     @Test
     public void wideRelatedThumbnailsScaleWithTheAvailablePaneWidth() throws Exception {
         final Document document = parse("layout/list_stream_related_wide_item.xml");
+        final Element container = findById(document, "@+id/itemThumbnailContainer");
         final Element thumbnail = findById(document, "@+id/itemThumbnailView");
 
-        assertEquals("0dp", thumbnail.getAttribute("android:layout_width"));
-        assertEquals("0dp", thumbnail.getAttribute("android:layout_height"));
-        assertEquals("0.42", thumbnail.getAttribute("app:layout_constraintWidth_percent"));
-        assertEquals("16:9", thumbnail.getAttribute("app:layout_constraintDimensionRatio"));
+        assertEquals("0dp", container.getAttribute("android:layout_width"));
+        assertEquals("0dp", container.getAttribute("android:layout_height"));
+        assertEquals("0.42", container.getAttribute("app:layout_constraintWidth_percent"));
+        assertEquals("16:9", container.getAttribute("app:layout_constraintDimensionRatio"));
+        assertEquals("match_parent", thumbnail.getAttribute("android:layout_width"));
+        assertEquals("match_parent", thumbnail.getAttribute("android:layout_height"));
     }
 
     private Element findById(final Document document, final String id) {

--- a/app/src/test/java/org/schabi/newpipe/info_list/StreamThumbnailProgressResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/info_list/StreamThumbnailProgressResourcesTest.java
@@ -2,11 +2,14 @@ package org.schabi.newpipe.info_list;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.nio.file.Files;
@@ -17,19 +20,21 @@ import javax.xml.parsers.DocumentBuilderFactory;
 public class StreamThumbnailProgressResourcesTest {
     private static final String ANDROID_NAMESPACE =
             "http://schemas.android.com/apk/res/android";
-    private static final String APP_NAMESPACE =
-            "http://schemas.android.com/apk/res-auto";
     private static final String[] STREAM_LAYOUTS = {
-        "list_stream_item.xml",
-        "list_stream_mini_item.xml",
-        "list_stream_grid_item.xml",
-        "list_stream_card_item.xml",
-        "list_stream_related_wide_item.xml",
-        "list_stream_playlist_item.xml",
-        "list_stream_playlist_grid_item.xml",
-        "list_stream_playlist_card_item.xml"
+        "layout/list_stream_item.xml",
+        "layout/list_stream_mini_item.xml",
+        "layout/list_stream_grid_item.xml",
+        "layout/list_stream_card_item.xml",
+        "layout/list_stream_related_wide_item.xml",
+        "layout/list_stream_playlist_item.xml",
+        "layout/list_stream_playlist_grid_item.xml",
+        "layout/list_stream_playlist_card_item.xml",
+        "layout-land/list_stream_card_item.xml",
+        "layout-land/list_stream_playlist_card_item.xml"
     };
 
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
     private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
             ? Path.of("src/main/res") : Path.of("app/src/main/res");
 
@@ -37,41 +42,54 @@ public class StreamThumbnailProgressResourcesTest {
     public void progressGeometryFitsTheRoundedThumbnailBottomEdge() throws Exception {
         final Document document = parse(resourcesDirectory.resolve("values/dimens.xml"));
 
-        assertEquals("0dp", findDimension(document,
-                "stream_thumbnail_progress_bottom_margin"));
-        assertEquals("12dp", findDimension(document,
-                "stream_thumbnail_progress_horizontal_inset"));
-        assertEquals(findDimension(document, "stream_thumbnail_corner_radius"),
-                findDimension(document, "stream_thumbnail_progress_horizontal_inset"));
+        assertEquals("12dp", findDimension(document, "stream_thumbnail_corner_radius"));
+        assertEquals("3dp", findDimension(document, "stream_thumbnail_progress_height"));
+        assertNull(findDimension(document, "stream_thumbnail_progress_bottom_margin"));
+        assertNull(findDimension(document, "stream_thumbnail_progress_horizontal_inset"));
     }
 
     @Test
     public void everyStreamLayoutUsesTheSharedThumbnailProgressGeometry() throws Exception {
         for (final String layout : STREAM_LAYOUTS) {
-            final Document document = parse(resourcesDirectory.resolve("layout").resolve(layout));
+            final Document document = parse(resourcesDirectory.resolve(layout));
+            final Element container = findByAndroidId(
+                    document, "@+id/itemThumbnailContainer");
+            final Element thumbnail = findByAndroidId(document, "@+id/itemThumbnailView");
             final Element progress = findByAndroidId(document, "@+id/itemProgressView");
 
+            assertNotNull(layout, container);
+            assertNotNull(layout, thumbnail);
             assertNotNull(layout, progress);
+            assertEquals(layout, "org.schabi.newpipe.views.RoundedThumbnailContainer",
+                    container.getTagName());
+            assertSame(layout, container, parentOf(thumbnail));
+            assertSame(layout, container, parentOf(progress));
+            assertEquals(layout, "match_parent",
+                    progress.getAttributeNS(ANDROID_NAMESPACE, "layout_width"));
             assertEquals(layout, "@dimen/stream_thumbnail_progress_height",
                     progress.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
-            assertEquals(layout, "@dimen/stream_thumbnail_progress_bottom_margin",
+            assertEquals(layout, "bottom",
+                    progress.getAttributeNS(ANDROID_NAMESPACE, "layout_gravity"));
+            assertEquals(layout, "",
                     progress.getAttributeNS(ANDROID_NAMESPACE, "layout_marginBottom"));
-            assertEquals(layout, "@dimen/stream_thumbnail_progress_horizontal_inset",
+            assertEquals(layout, "",
                     progress.getAttributeNS(ANDROID_NAMESPACE, "layout_marginHorizontal"));
-            assertTrue(layout, isAnchoredToThumbnailBottom(progress));
         }
     }
 
-    private boolean isAnchoredToThumbnailBottom(final Element progress) {
-        final String constraint = progress.getAttributeNS(
-                APP_NAMESPACE, "layout_constraintBottom_toBottomOf");
-        final String relative = progress.getAttributeNS(ANDROID_NAMESPACE, "layout_alignBottom");
-        return isThumbnailReference(constraint) || isThumbnailReference(relative);
+    @Test
+    public void thumbnailContainerClipsChildrenToTheSharedCornerRadius() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/views/RoundedThumbnailContainer.java"));
+
+        assertTrue(source.contains("R.dimen.stream_thumbnail_corner_radius"));
+        assertTrue(source.contains("clipPath.addRoundRect"));
+        assertTrue(source.contains("canvas.clipPath(clipPath)"));
     }
 
-    private boolean isThumbnailReference(final String value) {
-        return "@id/itemThumbnailView".equals(value)
-                || "@+id/itemThumbnailView".equals(value);
+    private Element parentOf(final Element element) {
+        final Node parent = element.getParentNode();
+        return parent instanceof Element ? (Element) parent : null;
     }
 
     private String findDimension(final Document document, final String name) {

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedRefreshControlsTest.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.local.feed;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -73,18 +74,18 @@ public class FeedRefreshControlsTest {
                 document, "@+id/loading_progress_bar");
         final Element indeterminateProgress = findByAndroidId(
                 document, "@+id/loading_indeterminate_progress_bar");
-        final Element progressText = findByAndroidId(
-                document, "@+id/loading_progress_text");
         final Element cancel = findByAndroidId(
                 document, "@+id/cancel_refresh_button");
 
         assertNotNull(progress);
         assertNotNull(indeterminateProgress);
         assertEquals(
-                "com.google.android.material.progressindicator.CircularProgressIndicator",
+                "org.schabi.newpipe.local.feed.FeedProgressIndicator",
                 progress.getTagName());
         assertEquals("104dp", progress.getAttributeNS(ANDROID_NAMESPACE, "layout_width"));
         assertEquals("104dp", progress.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
+        assertEquals("polite",
+                progress.getAttributeNS(ANDROID_NAMESPACE, "accessibilityLiveRegion"));
         assertEquals("88dp", progress.getAttributeNS(APP_NAMESPACE, "indicatorSize"));
         assertEquals(
                 "104dp",
@@ -98,14 +99,7 @@ public class FeedRefreshControlsTest {
         assertEquals("6dp", progress.getAttributeNS(APP_NAMESPACE, "trackThickness"));
         assertEquals("3dp", progress.getAttributeNS(APP_NAMESPACE, "trackCornerRadius"));
 
-        assertNotNull(progressText);
-        assertEquals("match_parent",
-                progressText.getAttributeNS(ANDROID_NAMESPACE, "layout_width"));
-        assertEquals("match_parent",
-                progressText.getAttributeNS(ANDROID_NAMESPACE, "layout_height"));
-        assertEquals("center", progressText.getAttributeNS(ANDROID_NAMESPACE, "gravity"));
-        assertEquals("false",
-                progressText.getAttributeNS(ANDROID_NAMESPACE, "includeFontPadding"));
+        assertNull(findByAndroidId(document, "@+id/loading_progress_text"));
 
         assertNotNull(cancel);
         assertEquals(
@@ -119,6 +113,18 @@ public class FeedRefreshControlsTest {
                 cancel.getAttributeNS(ANDROID_NAMESPACE, "contentDescription"));
         assertEquals("@drawable/ic_close",
                 cancel.getAttributeNS(APP_NAMESPACE, "srcCompat"));
+    }
+
+    @Test
+    public void determinateCounterUsesTheCircularIndicatorsExactCanvasCenter()
+            throws Exception {
+        final String source = readSource(
+                "org/schabi/newpipe/local/feed/FeedProgressIndicator.java");
+
+        assertTrue(source.contains("super.onDraw(canvas)"));
+        assertTrue(source.contains("counterBounds.exactCenterX()"));
+        assertTrue(source.contains("counterBounds.exactCenterY()"));
+        assertTrue(source.contains("canvas.drawText(counterText"));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
@@ -68,17 +68,29 @@ public class TabletGridConfigurationTest {
     public void thumbnailCardsFillTheirColumnAtSixteenByNine() throws Exception {
         for (final String layout : List.of(
                 "app/src/main/res/layout/list_stream_grid_item.xml",
-                "app/src/main/res/layout/list_stream_playlist_grid_item.xml",
-                "app/src/main/res/layout/list_playlist_grid_item.xml")) {
+                "app/src/main/res/layout/list_stream_playlist_grid_item.xml")) {
             final String source = read(layout);
 
             assertTrue(source.contains(
-                    "android:id=\"@+id/itemThumbnailView\"\n"
+                    "android:id=\"@+id/itemThumbnailContainer\"\n"
                             + "        android:layout_width=\"0dp\"\n"
                             + "        android:layout_height=\"0dp\""));
             assertTrue(source.contains(
                     "app:layout_constraintDimensionRatio=\"H,16:9\""));
+            assertTrue(source.contains(
+                    "android:id=\"@+id/itemThumbnailView\"\n"
+                            + "            android:layout_width=\"match_parent\"\n"
+                            + "            android:layout_height=\"match_parent\""));
         }
+
+        final String playlist = read(
+                "app/src/main/res/layout/list_playlist_grid_item.xml");
+        assertTrue(playlist.contains(
+                "android:id=\"@+id/itemThumbnailView\"\n"
+                        + "        android:layout_width=\"0dp\"\n"
+                        + "        android:layout_height=\"0dp\""));
+        assertTrue(playlist.contains(
+                "app:layout_constraintDimensionRatio=\"H,16:9\""));
     }
 
     private String read(final String relativePath) throws Exception {


### PR DESCRIPTION
- Draw the What’s New determinate counter from the circular indicator’s exact center
- Keep indeterminate refresh status and cancellation behavior unchanged
- Clip thumbnails and playback progress inside one shared 12dp rounded container
- Make progress strips span the full thumbnail bottom edge without manual insets
- Apply the geometry to all stream and playlist list, grid, card, and landscape layouts
- Add regression coverage for counter centering and clipped progress hierarchy
- Fixes #343