### PR TITLE
Add background audio tools

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -19,6 +19,7 @@ import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.ItemTouchHelper;
@@ -36,6 +37,7 @@ import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
 import org.schabi.newpipe.local.dialog.PlaylistDialog;
 import org.schabi.newpipe.player.event.PlayerEventListener;
+import org.schabi.newpipe.player.equalizer.EqualizerDialog;
 import org.schabi.newpipe.player.helper.PlaybackParameterDialog;
 import org.schabi.newpipe.player.helper.SleepTimer;
 import org.schabi.newpipe.player.helper.SleepTimerDialog;
@@ -66,6 +68,7 @@ public final class PlayQueueActivity extends AppCompatActivity
     private static final int SMOOTH_SCROLL_MAXIMUM_DISTANCE = 80;
 
     private static final int MENU_ID_AUDIO_TRACK = 71;
+    private static final String STATE_VISUALIZER_VISIBLE = "visualizer_visible";
 
     private Player player;
 
@@ -73,6 +76,7 @@ public final class PlayQueueActivity extends AppCompatActivity
     private ServiceConnection serviceConnection;
 
     private boolean seeking;
+    private boolean visualizerVisible;
 
     ////////////////////////////////////////////////////////////////////////////
     // Views
@@ -97,6 +101,8 @@ public final class PlayQueueActivity extends AppCompatActivity
         queueControlBinding = ActivityPlayerQueueControlBinding.inflate(getLayoutInflater());
         setContentView(queueControlBinding.getRoot());
         EdgeToEdgeHelper.applySystemBarPadding(queueControlBinding.getRoot());
+        visualizerVisible = savedInstanceState != null
+                && savedInstanceState.getBoolean(STATE_VISUALIZER_VISIBLE, false);
 
         setSupportActionBar(queueControlBinding.toolbar);
         if (getSupportActionBar() != null) {
@@ -106,6 +112,24 @@ public final class PlayQueueActivity extends AppCompatActivity
 
         serviceConnection = getServiceConnection();
         bind();
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        updateVisualizerPresentation();
+    }
+
+    @Override
+    protected void onStop() {
+        suspendVisualizerProcessing();
+        super.onStop();
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull final Bundle outState) {
+        outState.putBoolean(STATE_VISUALIZER_VISIBLE, visualizerVisible);
+        super.onSaveInstanceState(outState);
     }
 
     @Override
@@ -132,6 +156,11 @@ public final class PlayQueueActivity extends AppCompatActivity
                     .setVisible(!player.audioPlayerSelected());
             updateSleepTimerMenuItem(player.getSleepTimerMode(),
                     player.getSleepTimerRemainingMillis());
+            menu.findItem(R.id.action_equalizer)
+                    .setChecked(player.getEqualizerState().isEnabled());
+            menu.findItem(R.id.action_visualizer)
+                    .setVisible(player.audioPlayerSelected());
+            updateVisualizerMenuItem();
         }
         return super.onPrepareOptionsMenu(m);
     }
@@ -155,6 +184,15 @@ public final class PlayQueueActivity extends AppCompatActivity
             if (player != null) {
                 SleepTimerDialog.show(this, player);
             }
+            return true;
+        } else if (itemId == R.id.action_equalizer) {
+            if (player != null) {
+                EqualizerDialog.show(this, EqualizerDialog.forPlayer(player),
+                        this::invalidateOptionsMenu);
+            }
+            return true;
+        } else if (itemId == R.id.action_visualizer) {
+            toggleVisualizer();
             return true;
         } else if (itemId == R.id.action_mute) {
             player.toggleMute();
@@ -229,6 +267,7 @@ public final class PlayQueueActivity extends AppCompatActivity
 
     private void unbind() {
         if (serviceBound) {
+            suspendVisualizerProcessing();
             unbindService(serviceConnection);
             serviceBound = false;
             if (player != null) {
@@ -265,6 +304,11 @@ public final class PlayQueueActivity extends AppCompatActivity
                 } else {
                     onQueueUpdate(player.getPlayQueue());
                     buildComponents();
+                    if (!player.audioPlayerSelected()) {
+                        visualizerVisible = false;
+                    }
+                    updateVisualizerPresentation();
+                    invalidateOptionsMenu();
                     if (player != null) {
                         player.setActivityListener(PlayQueueActivity.this);
                     }
@@ -282,6 +326,56 @@ public final class PlayQueueActivity extends AppCompatActivity
         buildMetadata();
         buildSeekBar();
         buildControls();
+    }
+
+    private void toggleVisualizer() {
+        if (player == null || !player.audioPlayerSelected()) {
+            return;
+        }
+        visualizerVisible = !visualizerVisible;
+        updateVisualizerPresentation();
+    }
+
+    private void updateVisualizerPresentation() {
+        final boolean showVisualizer = visualizerVisible
+                && player != null
+                && player.audioPlayerSelected();
+        queueControlBinding.playQueue.setVisibility(showVisualizer ? View.GONE : View.VISIBLE);
+        queueControlBinding.audioVisualizer.setVisibility(
+                showVisualizer ? View.VISIBLE : View.GONE);
+
+        if (showVisualizer) {
+            queueControlBinding.audioVisualizer.setAudioProcessor(
+                    player.getVisualizerAudioProcessor());
+            player.setPlaybackPresentationMode(PlaybackPresentationMode.LISTEN_VISUALIZER);
+        } else {
+            suspendVisualizerProcessing();
+        }
+        updateVisualizerMenuItem();
+    }
+
+    private void suspendVisualizerProcessing() {
+        queueControlBinding.audioVisualizer.setAudioProcessor(null);
+        if (player != null
+                && player.audioPlayerSelected()
+                && player.getPlaybackPresentationMode()
+                        == PlaybackPresentationMode.LISTEN_VISUALIZER) {
+            player.setPlaybackPresentationMode(PlaybackPresentationMode.AUDIO_BACKGROUND);
+        }
+    }
+
+    private void updateVisualizerMenuItem() {
+        if (menu == null) {
+            return;
+        }
+        final MenuItem item = menu.findItem(R.id.action_visualizer);
+        if (item == null) {
+            return;
+        }
+        item.setChecked(visualizerVisible);
+        item.setIcon(visualizerVisible ? R.drawable.ic_list : R.drawable.ic_waveform);
+        item.setTitle(visualizerVisible
+                ? R.string.show_play_queue : R.string.show_visualizer);
     }
 
     private void buildQueue() {

--- a/app/src/main/res/layout/activity_player_queue_control.xml
+++ b/app/src/main/res/layout/activity_player_queue_control.xml
@@ -40,6 +40,17 @@
         app:layoutManager="LinearLayoutManager"
         tools:listitem="@layout/play_queue_item" />
 
+    <org.schabi.newpipe.views.AudioVisualizerView
+        android:id="@+id/audio_visualizer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/metadata"
+        android:layout_below="@id/appbar"
+        android:background="?attr/colorSurface"
+        android:contentDescription="@string/audio_visualizer"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/seek_display"
         android:layout_width="wrap_content"

--- a/app/src/main/res/menu/menu_play_queue.xml
+++ b/app/src/main/res/menu/menu_play_queue.xml
@@ -26,6 +26,22 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/action_equalizer"
+        android:checkable="true"
+        android:icon="@drawable/ic_equalizer"
+        android:title="@string/equalizer"
+        android:visible="true"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_visualizer"
+        android:checkable="true"
+        android:icon="@drawable/ic_waveform"
+        android:title="@string/show_visualizer"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/action_audio_track"
         android:tooltipText="@string/audio_track"
         android:visible="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1473,6 +1473,9 @@
     <string name="sponsor_block_skip_button_content_description">Skip SponsorBlock segment</string>
     <!-- Equalizer -->
     <string name="equalizer">Equalizer</string>
+    <string name="audio_visualizer">Audio visualizer</string>
+    <string name="show_visualizer">Show visualizer</string>
+    <string name="show_play_queue">Show play queue</string>
     <string name="enter_listen_mode">Listen without video</string>
     <string name="exit_listen_mode">Return to video</string>
     <string name="visualizer_style_title">Visualizer style</string>

--- a/app/src/test/java/org/schabi/newpipe/player/BackgroundAudioToolsResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/BackgroundAudioToolsResourcesTest.java
@@ -1,0 +1,123 @@
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class BackgroundAudioToolsResourcesTest {
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+    private static final String APP_NAMESPACE =
+            "http://schemas.android.com/apk/res-auto";
+
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void backgroundPlayerMenuExposesEqualizerAndVisualizer() throws Exception {
+        final Document document = parse(resourcesDirectory.resolve("menu/menu_play_queue.xml"));
+        final Element equalizer = findByAndroidId(document, "@+id/action_equalizer");
+        final Element visualizer = findByAndroidId(document, "@+id/action_visualizer");
+
+        assertNotNull(equalizer);
+        assertEquals("@drawable/ic_equalizer",
+                equalizer.getAttributeNS(ANDROID_NAMESPACE, "icon"));
+        assertEquals("@string/equalizer",
+                equalizer.getAttributeNS(ANDROID_NAMESPACE, "title"));
+        assertEquals("true", equalizer.getAttributeNS(ANDROID_NAMESPACE, "checkable"));
+
+        assertNotNull(visualizer);
+        assertEquals("@drawable/ic_waveform",
+                visualizer.getAttributeNS(ANDROID_NAMESPACE, "icon"));
+        assertEquals("@string/show_visualizer",
+                visualizer.getAttributeNS(ANDROID_NAMESPACE, "title"));
+        assertEquals("false", visualizer.getAttributeNS(ANDROID_NAMESPACE, "visible"));
+        assertEquals("ifRoom", visualizer.getAttributeNS(APP_NAMESPACE, "showAsAction"));
+    }
+
+    @Test
+    public void backgroundPlayerHostsAnAccessibleVisualizerSurface() throws Exception {
+        final Document document = parse(
+                resourcesDirectory.resolve("layout/activity_player_queue_control.xml"));
+        final Element visualizer = findByAndroidId(document, "@+id/audio_visualizer");
+
+        assertNotNull(visualizer);
+        assertEquals("org.schabi.newpipe.views.AudioVisualizerView",
+                visualizer.getTagName());
+        assertEquals("@id/appbar",
+                visualizer.getAttributeNS(ANDROID_NAMESPACE, "layout_below"));
+        assertEquals("@id/metadata",
+                visualizer.getAttributeNS(ANDROID_NAMESPACE, "layout_above"));
+        assertEquals("@string/audio_visualizer",
+                visualizer.getAttributeNS(ANDROID_NAMESPACE, "contentDescription"));
+        assertEquals("gone",
+                visualizer.getAttributeNS(ANDROID_NAMESPACE, "visibility"));
+    }
+
+    @Test
+    public void visualizerProcessingOnlyRunsWhileItsSurfaceIsVisible() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/PlayQueueActivity.java"));
+
+        assertTrue(source.contains("EqualizerDialog.forPlayer(player)"));
+        assertTrue(source.contains("player.getVisualizerAudioProcessor()"));
+        assertTrue(source.contains("PlaybackPresentationMode.LISTEN_VISUALIZER"));
+        assertTrue(source.contains("PlaybackPresentationMode.AUDIO_BACKGROUND"));
+        assertTrue(source.contains("queueControlBinding.audioVisualizer.setAudioProcessor(null)"));
+        assertTrue(methodBody(source, "protected void onStart()",
+                "protected void onStop()").contains("updateVisualizerPresentation()"));
+        assertTrue(methodBody(source, "protected void onStop()",
+                "protected void onSaveInstanceState")
+                .contains("suspendVisualizerProcessing()"));
+    }
+
+    @Test
+    public void backgroundNotificationContinuesToOpenTheSharedQueuePlayer() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/notification/NotificationUtil.java"));
+
+        assertTrue(source.contains("player.audioPlayerSelected()"));
+        assertTrue(source.contains("NavigationHelper.getPlayQueueActivityIntent"));
+    }
+
+    private String methodBody(final String source, final String signature,
+                              final String nextSignature) {
+        final int start = source.indexOf(signature);
+        final int end = source.indexOf(nextSignature, start + signature.length());
+        return source.substring(start, end);
+    }
+
+    private Element findByAndroidId(final Document document, final String id) {
+        final NodeList elements = document.getElementsByTagName("*");
+        for (int index = 0; index < elements.getLength(); index++) {
+            final Element element = (Element) elements.item(index);
+            if (id.equals(element.getAttributeNS(ANDROID_NAMESPACE, "id"))) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private Document parse(final Path path) throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-parameter-entities", false);
+        return factory.newDocumentBuilder().parse(path.toFile());
+    }
+}


### PR DESCRIPTION
- Add Equalizer and Visualizer actions to the background play-queue screen
- Apply equalizer changes live to the active playback audio session
- Let the existing visualizer temporarily replace the queue while preserving playback controls
- Detach visualizer processing and restore low-power background mode whenever its surface is hidden or stopped
- Cover YouTube Music through the shared player and background queue path
- Add lifecycle, accessibility, menu, and notification-path regression coverage
- Fixes #355