### PR TITLE
Preserve PipePipe playlist order

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
@@ -98,6 +98,33 @@ class NewPipeDataMigrationManagerTest {
         assertEquals(1, target.playlistDAO().getAllDirect().size)
     }
 
+    @Test
+    fun pipePipePlaylistAndStreamOrderMatchesItsVisibleOrder() {
+        sourcePath.toFile().delete()
+        createPipePipeSourceDatabase(sourcePath)
+        val manager = NewPipeDataMigrationManager(context)
+
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = false,
+                importPlaylists = true
+            )
+        )
+
+        val target = NewPipeDatabase.getInstance(context)
+        assertEquals(2, result.playlists)
+        assertEquals(4, result.playlistItems)
+        val playlists = target.playlistDAO().getAllDirect().sortedBy { it.displayIndex }
+        assertEquals(listOf("Alpha", "Zulu"), playlists.map { it.name })
+        val alphaStreams = target.playlistStreamDAO()
+            .getOrderedStreamsDirect(playlists.first().uid)
+        assertEquals(
+            listOf("First lesson", "Second lesson", "Third lesson"),
+            alphaStreams.map { it.title }
+        )
+    }
+
     private fun createSourceDatabase(path: Path) {
         SQLiteDatabase.openOrCreateDatabase(path.toFile(), null).use { source ->
             source.execSQL(
@@ -132,6 +159,44 @@ class NewPipeDataMigrationManagerTest {
             source.execSQL("INSERT INTO stream_state VALUES (1, 90000)")
             source.execSQL("INSERT INTO playlists VALUES (10, 'Lessons')")
             source.execSQL("INSERT INTO playlist_stream_join VALUES (10, 1, 0)")
+        }
+    }
+
+    private fun createPipePipeSourceDatabase(path: Path) {
+        SQLiteDatabase.openOrCreateDatabase(path.toFile(), null).use { source ->
+            source.execSQL("PRAGMA user_version = 901")
+            source.execSQL(
+                "CREATE TABLE streams (" +
+                    "uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, " +
+                    "url TEXT NOT NULL, title TEXT NOT NULL, stream_type TEXT NOT NULL, " +
+                    "duration INTEGER NOT NULL, uploader TEXT NOT NULL)"
+            )
+            source.execSQL(
+                "CREATE TABLE playlists (" +
+                    "uid INTEGER PRIMARY KEY, name TEXT, display_index INTEGER NOT NULL)"
+            )
+            source.execSQL(
+                "CREATE TABLE playlist_stream_join (" +
+                    "playlist_id INTEGER NOT NULL, stream_id INTEGER NOT NULL, " +
+                    "join_index INTEGER NOT NULL)"
+            )
+            source.execSQL(
+                "CREATE TABLE sponsorblock_whitelist (uploader TEXT PRIMARY KEY NOT NULL)"
+            )
+            source.execSQL(
+                "INSERT INTO streams VALUES " +
+                    "(1, 0, 'https://example.com/watch/1', 'First lesson', " +
+                    "'VIDEO_STREAM', 300, 'Teacher'), " +
+                    "(2, 0, 'https://example.com/watch/2', 'Second lesson', " +
+                    "'VIDEO_STREAM', 300, 'Teacher'), " +
+                    "(3, 0, 'https://example.com/watch/3', 'Third lesson', " +
+                    "'VIDEO_STREAM', 300, 'Teacher')"
+            )
+            source.execSQL("INSERT INTO playlists VALUES (10, 'Zulu', 0), (20, 'Alpha', 1)")
+            source.execSQL("INSERT INTO playlist_stream_join VALUES (20, 3, 2)")
+            source.execSQL("INSERT INTO playlist_stream_join VALUES (20, 1, 0)")
+            source.execSQL("INSERT INTO playlist_stream_join VALUES (20, 2, 1)")
+            source.execSQL("INSERT INTO playlist_stream_join VALUES (10, 2, 0)")
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
@@ -141,10 +141,10 @@ class NewPipeDataMigrationManager(private val context: Context) {
                     .mapNotNullTo(mutableSetOf()) { it.name }
                 var displayIndex = playlistDao.getAllDirect()
                     .maxOfOrNull { it.displayIndex }?.plus(1) ?: 0L
-                val playlistOrder = if (schema.playlistColumns.contains("display_index")) {
-                    "display_index, uid"
-                } else {
-                    "uid"
+                val playlistOrder = when {
+                    schema.usesAlphabeticalPlaylistOrder -> "name COLLATE NOCASE ASC, uid"
+                    schema.playlistColumns.contains("display_index") -> "display_index, uid"
+                    else -> "uid"
                 }
 
                 source.rawQuery(
@@ -235,7 +235,10 @@ class NewPipeDataMigrationManager(private val context: Context) {
             hasProgress = stateColumns.containsAll(REQUIRED_STATE_COLUMNS),
             hasPlaylists = playlistColumns.containsAll(REQUIRED_PLAYLIST_COLUMNS) &&
                 joinColumns.containsAll(REQUIRED_PLAYLIST_JOIN_COLUMNS),
-            playlistColumns = playlistColumns
+            playlistColumns = playlistColumns,
+            usesAlphabeticalPlaylistOrder =
+                source.tableExists(PIPEPIPE_SPONSORBLOCK_WHITELIST_TABLE) ||
+                    source.userVersion() >= PIPEPIPE_DATABASE_VERSION_FLOOR
         )
         if (!schema.hasHistory && !schema.hasProgress && !schema.hasPlaylists) {
             throw UnsupportedSourceException(
@@ -325,6 +328,13 @@ class NewPipeDataMigrationManager(private val context: Context) {
         }
     }
 
+    private fun SQLiteDatabase.userVersion(): Int = rawQuery(
+        "PRAGMA user_version",
+        null
+    ).use { cursor ->
+        if (cursor.moveToFirst()) cursor.getInt(0) else 0
+    }
+
     private fun Cursor.string(column: String): String? {
         val index = getColumnIndex(column)
         return if (index < 0 || isNull(index)) null else getString(index)
@@ -344,7 +354,8 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val hasHistory: Boolean,
         val hasProgress: Boolean,
         val hasPlaylists: Boolean,
-        val playlistColumns: Set<String>
+        val playlistColumns: Set<String>,
+        val usesAlphabeticalPlaylistOrder: Boolean
     )
 
     companion object {
@@ -353,6 +364,8 @@ class NewPipeDataMigrationManager(private val context: Context) {
         private const val STATE_TABLE = "stream_state"
         private const val PLAYLIST_TABLE = "playlists"
         private const val PLAYLIST_JOIN_TABLE = "playlist_stream_join"
+        private const val PIPEPIPE_SPONSORBLOCK_WHITELIST_TABLE = "sponsorblock_whitelist"
+        private const val PIPEPIPE_DATABASE_VERSION_FLOOR = 900
 
         private val REQUIRED_STREAM_COLUMNS = setOf(
             "uid",


### PR DESCRIPTION
- Preserve PipePipe’s visible case-insensitive alphabetical playlist order during migration
- Keep NewPipe custom `display_index` ordering unchanged
- Preserve each playlist’s video order through `join_index`
- Add multi-playlist and multi-video Android regression coverage
- Address the playlist-order