### PR TITLE
Import compatible NewPipe settings

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
@@ -2,16 +2,19 @@ package org.schabi.newpipe.settings
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
+import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.nio.file.Path
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.R
 import org.schabi.newpipe.database.AppDatabase
 import org.schabi.newpipe.database.playlist.model.PlaylistEntity
 import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager
@@ -25,6 +28,7 @@ class NewPipeDataMigrationManagerTest {
     fun setUp() {
         NewPipeDatabase.close()
         context.deleteDatabase(AppDatabase.DATABASE_NAME)
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
         sourcePath = context.cacheDir.resolve("newpipe-migration-source.db").toPath()
         sourcePath.toFile().delete()
         createSourceDatabase(sourcePath)
@@ -34,6 +38,7 @@ class NewPipeDataMigrationManagerTest {
     fun tearDown() {
         NewPipeDatabase.close()
         context.deleteDatabase(AppDatabase.DATABASE_NAME)
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
         sourcePath.toFile().delete()
     }
 
@@ -123,6 +128,44 @@ class NewPipeDataMigrationManagerTest {
             listOf("First lesson", "Second lesson", "Third lesson"),
             alphaStreams.map { it.title }
         )
+    }
+
+    @Test
+    fun compatibleSettingsAreTypeCheckedAndMergedWithoutClearingOtherPreferences() {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        preferences.edit()
+            .putString("existing_wizestream_setting", "keep me")
+            .putBoolean(context.getString(R.string.show_comments_key), true)
+            .commit()
+        val sourcePreferences = mapOf<String, Any>(
+            context.getString(R.string.current_service_key) to "YouTube",
+            context.getString(R.string.show_comments_key) to false,
+            context.getString(R.string.playback_speed_key) to 1.25f,
+            context.getString(R.string.show_next_video_key) to "wrong type",
+            context.getString(R.string.proxy_password_key) to "secret"
+        )
+        val manager = NewPipeDataMigrationManager(context)
+
+        val preview = manager.inspect(sourcePath, sourcePreferences)
+        assertEquals(2, preview.compatibleSettings)
+
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = false,
+                importPlaylists = false,
+                importSettings = true
+            ),
+            sourcePreferences
+        )
+
+        assertEquals(2, result.compatibleSettings)
+        assertFalse(preferences.contains("service"))
+        assertFalse(preferences.getBoolean("show_comments", true))
+        assertEquals(1.25f, preferences.getFloat("playback_speed_key", 0f))
+        assertFalse(preferences.contains("show_next_video"))
+        assertFalse(preferences.contains("proxy_password"))
+        assertEquals("keep me", preferences.getString("existing_wizestream_setting", null))
     }
 
     private fun createSourceDatabase(path: Path) {

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,12 @@ import java.util.concurrent.Executors;
 public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
 
     private static final String ZIP_MIME_TYPE = "application/zip";
+
+    private enum MigrationOption {
+        HISTORY,
+        PLAYLISTS,
+        SETTINGS
+    }
 
     private final SimpleDateFormat exportDateFormat =
             new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
@@ -208,13 +215,17 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                 if (stagedDatabase == null) {
                     throw new IOException("The backup does not contain a SQLite database");
                 }
+                final Map<String, ?> sourcePreferences = manager.exportHasJsonPrefs(file)
+                        ? manager.readJsonPrefs(file) : Collections.emptyMap();
                 final NewPipeDataMigrationManager.Preview preview =
-                        migrationManager.inspect(stagedDatabase);
+                        migrationManager.inspect(stagedDatabase, sourcePreferences);
                 final Path readyDatabase = stagedDatabase;
+                final Map<String, ?> readyPreferences = sourcePreferences;
                 stagedDatabase = null;
                 if (getActivity() != null) {
                     requireActivity().runOnUiThread(() ->
-                            showMigrationConfirmation(readyDatabase, importDataUri, preview));
+                            showMigrationConfirmation(readyDatabase, importDataUri,
+                                    readyPreferences, preview));
                 } else {
                     manager.discardStagedDb(readyDatabase);
                 }
@@ -240,6 +251,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private void showMigrationConfirmation(
             final Path stagedDatabase,
             final Uri importDataUri,
+            final Map<String, ?> sourcePreferences,
             final NewPipeDataMigrationManager.Preview preview) {
         if (!preview.getHasImportableData()) {
             manager.discardStagedDb(stagedDatabase);
@@ -249,20 +261,26 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         }
 
         final List<String> optionLabels = new ArrayList<>();
-        final List<Boolean> optionTypes = new ArrayList<>();
+        final List<MigrationOption> optionTypes = new ArrayList<>();
         if (preview.getHasHistory()) {
             optionLabels.add(getString(
                     R.string.migration_history_option,
                     preview.getHistoryItems(),
                     preview.getProgressItems()));
-            optionTypes.add(true);
+            optionTypes.add(MigrationOption.HISTORY);
         }
         if (preview.getHasPlaylists()) {
             optionLabels.add(getString(
                     R.string.migration_playlists_option,
                     preview.getPlaylists(),
                     preview.getPlaylistItems()));
-            optionTypes.add(false);
+            optionTypes.add(MigrationOption.PLAYLISTS);
+        }
+        if (preview.getHasCompatibleSettings()) {
+            optionLabels.add(getString(
+                    R.string.migration_settings_option,
+                    preview.getCompatibleSettings()));
+            optionTypes.add(MigrationOption.SETTINGS);
         }
         final boolean[] checkedItems = new boolean[optionLabels.size()];
         java.util.Arrays.fill(checkedItems, true);
@@ -283,17 +301,26 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                 .setOnClickListener(button -> {
                     boolean importHistory = false;
                     boolean importPlaylists = false;
+                    boolean importSettings = false;
                     for (int i = 0; i < checkedItems.length; i++) {
                         if (!checkedItems[i]) {
                             continue;
                         }
-                        if (optionTypes.get(i)) {
-                            importHistory = true;
-                        } else {
-                            importPlaylists = true;
+                        switch (optionTypes.get(i)) {
+                            case HISTORY:
+                                importHistory = true;
+                                break;
+                            case PLAYLISTS:
+                                importPlaylists = true;
+                                break;
+                            case SETTINGS:
+                                importSettings = true;
+                                break;
+                            default:
+                                break;
                         }
                     }
-                    if (!importHistory && !importPlaylists) {
+                    if (!importHistory && !importPlaylists && !importSettings) {
                         Toast.makeText(requireContext(), R.string.migration_nothing_selected,
                                 Toast.LENGTH_SHORT).show();
                         return;
@@ -302,9 +329,11 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                     importMigratedData(
                             stagedDatabase,
                             importDataUri,
+                            sourcePreferences,
                             new NewPipeDataMigrationManager.Selection(
                                     importHistory,
-                                    importPlaylists));
+                                    importPlaylists,
+                                    importSettings));
                 }));
         dialog.show();
     }
@@ -312,12 +341,14 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private void importMigratedData(
             final Path stagedDatabase,
             final Uri importDataUri,
+            final Map<String, ?> sourcePreferences,
             final NewPipeDataMigrationManager.Selection selection) {
         final ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.execute(() -> {
             try {
                 final NewPipeDataMigrationManager.Result migrationResult =
-                        migrationManager.importData(stagedDatabase, selection);
+                        migrationManager.importData(
+                                stagedDatabase, selection, sourcePreferences);
                 if (getActivity() != null) {
                     requireActivity().runOnUiThread(() -> {
                         saveLastImportExportDataUri(importDataUri);
@@ -329,6 +360,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                         migrationResult.getProgressItems(),
                                         migrationResult.getPlaylists(),
                                         migrationResult.getPlaylistItems(),
+                                        migrationResult.getCompatibleSettings(),
                                         migrationResult.getSkippedItems()))
                                 .setPositiveButton(R.string.ok, null)
                                 .show();

--- a/app/src/main/java/org/schabi/newpipe/settings/export/CompatibleSettingsMigration.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/CompatibleSettingsMigration.kt
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.settings.export
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import java.io.IOException
+import org.schabi.newpipe.sync.MAX_PORTABLE_SETTING_VALUE_LENGTH
+import org.schabi.newpipe.sync.PortableSettingId
+import org.schabi.newpipe.sync.PortableSettingValueType
+import org.schabi.newpipe.sync.portableSettingSpecs
+
+internal class CompatibleSettingsMigration(
+    context: Context,
+    private val preferences: SharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(context)
+) {
+    private val specsByKey = portableSettingSpecs(context)
+        // Service identifiers are portable between WizeStream devices, but not necessarily
+        // between NewPipe derivatives whose service sets and identifiers may differ.
+        .filterNot { it.id == PortableSettingId.SERVICE }
+        .associateBy { it.preferenceKey }
+
+    data class Prepared internal constructor(
+        internal val values: Map<String, Any>
+    ) {
+        val size: Int
+            get() = values.size
+    }
+
+    data class Rollback internal constructor(
+        internal val importedKeys: Set<String>,
+        internal val previousValues: Map<String, Any>
+    )
+
+    fun prepare(source: Map<String, *>): Prepared {
+        val compatible = buildMap {
+            source.forEach { (key, value) ->
+                val spec = specsByKey[key] ?: return@forEach
+                val normalized = when (spec.id.valueType) {
+                    PortableSettingValueType.BOOLEAN -> value as? Boolean
+
+                    PortableSettingValueType.STRING -> (value as? String)
+                        ?.trim()
+                        ?.takeIf {
+                            it.isNotEmpty() &&
+                                it.length <= MAX_PORTABLE_SETTING_VALUE_LENGTH
+                        }
+
+                    PortableSettingValueType.FLOAT -> (value as? Float)
+                        ?.takeIf { it.isFinite() }
+                }
+                if (normalized != null) {
+                    put(key, normalized)
+                }
+            }
+        }
+        return Prepared(compatible)
+    }
+
+    @Throws(IOException::class)
+    fun apply(prepared: Prepared): Rollback {
+        val importedKeys = prepared.values.keys
+        val previousValues: Map<String, Any> = preferences.all.entries
+            .mapNotNull { (key, value) ->
+                value?.takeIf { key in importedKeys }?.let { key to it }
+            }
+            .toMap()
+        if (!write(prepared.values, importedKeysToRemove = emptySet())) {
+            throw IOException("Unable to commit migrated settings")
+        }
+        return Rollback(importedKeys, previousValues)
+    }
+
+    @Throws(IOException::class)
+    fun rollback(rollback: Rollback) {
+        if (!write(rollback.previousValues, rollback.importedKeys)) {
+            throw IOException("Unable to roll back migrated settings")
+        }
+    }
+
+    private fun write(
+        values: Map<String, *>,
+        importedKeysToRemove: Set<String>
+    ): Boolean {
+        val editor = preferences.edit()
+        importedKeysToRemove.forEach(editor::remove)
+        values.forEach { (key, value) ->
+            when (value) {
+                is Boolean -> editor.putBoolean(key, value)
+                is Float -> editor.putFloat(key, value)
+                is String -> editor.putString(key, value)
+            }
+        }
+        return editor.commit()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
@@ -19,19 +19,23 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val historyItems: Int,
         val progressItems: Int,
         val playlists: Int,
-        val playlistItems: Int
+        val playlistItems: Int,
+        val compatibleSettings: Int
     ) {
         val hasHistory: Boolean
             get() = historyItems > 0 || progressItems > 0
         val hasPlaylists: Boolean
             get() = playlists > 0
+        val hasCompatibleSettings: Boolean
+            get() = compatibleSettings > 0
         val hasImportableData: Boolean
-            get() = hasHistory || hasPlaylists
+            get() = hasHistory || hasPlaylists || hasCompatibleSettings
     }
 
-    data class Selection(
+    data class Selection @JvmOverloads constructor(
         val importHistory: Boolean,
-        val importPlaylists: Boolean
+        val importPlaylists: Boolean,
+        val importSettings: Boolean = false
     )
 
     data class Result(
@@ -39,176 +43,203 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val progressItems: Int,
         val playlists: Int,
         val playlistItems: Int,
+        val compatibleSettings: Int,
         val skippedItems: Int
     )
 
     class UnsupportedSourceException(message: String) : Exception(message)
 
-    fun inspect(databasePath: Path): Preview = openSource(databasePath).use { source ->
+    fun inspect(
+        databasePath: Path,
+        sourcePreferences: Map<String, *> = emptyMap<String, Any>()
+    ): Preview = openSource(databasePath).use { source ->
         val schema = inspectSchema(source)
+        val compatibleSettings = CompatibleSettingsMigration(context).prepare(sourcePreferences)
         Preview(
             historyItems = if (schema.hasHistory) source.countRows(HISTORY_TABLE) else 0,
             progressItems = if (schema.hasProgress) source.countRows(STATE_TABLE) else 0,
             playlists = if (schema.hasPlaylists) source.countRows(PLAYLIST_TABLE) else 0,
-            playlistItems = if (schema.hasPlaylists) source.countRows(PLAYLIST_JOIN_TABLE) else 0
+            playlistItems = if (schema.hasPlaylists) source.countRows(PLAYLIST_JOIN_TABLE) else 0,
+            compatibleSettings = compatibleSettings.size
         )
     }
 
-    fun importData(databasePath: Path, selection: Selection): Result = openSource(
-        databasePath
-    ).use { source ->
+    fun importData(
+        databasePath: Path,
+        selection: Selection,
+        sourcePreferences: Map<String, *> = emptyMap<String, Any>()
+    ): Result = openSource(databasePath).use { source ->
         val schema = inspectSchema(source)
         val streams = readStreams(source)
         val target = NewPipeDatabase.getInstance(context)
-        var result = Result(0, 0, 0, 0, 0)
+        val settingsMigration = CompatibleSettingsMigration(context)
+        val compatibleSettings = settingsMigration.prepare(sourcePreferences)
+        val settingsRollback = if (selection.importSettings && compatibleSettings.size > 0) {
+            settingsMigration.apply(compatibleSettings)
+        } else {
+            null
+        }
+        var result = Result(0, 0, 0, 0, 0, 0)
 
-        target.runInTransaction {
-            val streamIds = mutableMapOf<Long, Long>()
-            fun targetStreamId(sourceId: Long): Long? {
-                streamIds[sourceId]?.let { return it }
-                val stream = streams[sourceId] ?: return null
-                val streamDao = target.streamDAO()
-                val existing = streamDao.getStreamDirect(stream.serviceId, stream.url)
-                val targetId = existing?.uid ?: streamDao.insert(stream)
-                streamIds[sourceId] = targetId
-                return targetId
-            }
-
-            var historyItems = 0
-            var progressItems = 0
-            var playlists = 0
-            var playlistItems = 0
-            var skippedItems = 0
-
-            if (selection.importHistory && schema.hasHistory) {
-                source.rawQuery(
-                    "SELECT stream_id, access_date, repeat_count FROM $HISTORY_TABLE",
-                    null
-                ).use { cursor ->
-                    val writable = target.openHelper.writableDatabase
-                    while (cursor.moveToNext()) {
-                        val targetId = targetStreamId(cursor.getLong(0))
-                        val accessDate = cursor.getLong(1)
-                        if (targetId == null || accessDate <= 0) {
-                            skippedItems++
-                            continue
-                        }
-                        val repeatCount = cursor.getLong(2).coerceAtLeast(0)
-                        writable.execSQL(
-                            "INSERT OR IGNORE INTO $HISTORY_TABLE " +
-                                "(stream_id, access_date, repeat_count) VALUES (?, ?, ?)",
-                            arrayOf(targetId, accessDate, repeatCount)
-                        )
-                        writable.execSQL(
-                            "UPDATE $HISTORY_TABLE SET repeat_count = " +
-                                "MAX(repeat_count, ?) WHERE stream_id = ? AND access_date = ?",
-                            arrayOf(repeatCount, targetId, accessDate)
-                        )
-                        historyItems++
-                    }
+        try {
+            target.runInTransaction {
+                val streamIds = mutableMapOf<Long, Long>()
+                fun targetStreamId(sourceId: Long): Long? {
+                    streamIds[sourceId]?.let { return it }
+                    val stream = streams[sourceId] ?: return null
+                    val streamDao = target.streamDAO()
+                    val existing = streamDao.getStreamDirect(stream.serviceId, stream.url)
+                    val targetId = existing?.uid ?: streamDao.insert(stream)
+                    streamIds[sourceId] = targetId
+                    return targetId
                 }
-            }
 
-            if (selection.importHistory && schema.hasProgress) {
-                val existingStates = target.streamStateDAO().getAllDirect()
-                    .associateBy { it.streamUid }
-                source.rawQuery(
-                    "SELECT stream_id, progress_time FROM $STATE_TABLE",
-                    null
-                ).use { cursor ->
-                    while (cursor.moveToNext()) {
-                        val targetId = targetStreamId(cursor.getLong(0))
-                        if (targetId == null) {
-                            skippedItems++
-                            continue
-                        }
-                        val progress = cursor.getLong(1).coerceAtLeast(0)
-                        val currentProgress = existingStates[targetId]?.progressMillis ?: -1
-                        if (progress > currentProgress) {
-                            target.streamStateDAO().upsert(
-                                StreamStateEntity(targetId, progress)
+                var historyItems = 0
+                var progressItems = 0
+                var playlists = 0
+                var playlistItems = 0
+                var skippedItems = 0
+
+                if (selection.importHistory && schema.hasHistory) {
+                    source.rawQuery(
+                        "SELECT stream_id, access_date, repeat_count FROM $HISTORY_TABLE",
+                        null
+                    ).use { cursor ->
+                        val writable = target.openHelper.writableDatabase
+                        while (cursor.moveToNext()) {
+                            val targetId = targetStreamId(cursor.getLong(0))
+                            val accessDate = cursor.getLong(1)
+                            if (targetId == null || accessDate <= 0) {
+                                skippedItems++
+                                continue
+                            }
+                            val repeatCount = cursor.getLong(2).coerceAtLeast(0)
+                            writable.execSQL(
+                                "INSERT OR IGNORE INTO $HISTORY_TABLE " +
+                                    "(stream_id, access_date, repeat_count) VALUES (?, ?, ?)",
+                                arrayOf(targetId, accessDate, repeatCount)
                             )
-                            progressItems++
+                            writable.execSQL(
+                                "UPDATE $HISTORY_TABLE SET repeat_count = " +
+                                    "MAX(repeat_count, ?) WHERE stream_id = ? AND access_date = ?",
+                                arrayOf(repeatCount, targetId, accessDate)
+                            )
+                            historyItems++
                         }
                     }
                 }
-            }
 
-            if (selection.importPlaylists && schema.hasPlaylists) {
-                val playlistDao = target.playlistDAO()
-                val playlistStreamDao = target.playlistStreamDAO()
-                val usedNames = playlistDao.getAllDirect()
-                    .mapNotNullTo(mutableSetOf()) { it.name }
-                var displayIndex = playlistDao.getAllDirect()
-                    .maxOfOrNull { it.displayIndex }?.plus(1) ?: 0L
-                val playlistOrder = when {
-                    schema.usesAlphabeticalPlaylistOrder -> "name COLLATE NOCASE ASC, uid"
-                    schema.playlistColumns.contains("display_index") -> "display_index, uid"
-                    else -> "uid"
-                }
-
-                source.rawQuery(
-                    "SELECT uid, name FROM $PLAYLIST_TABLE ORDER BY $playlistOrder",
-                    null
-                ).use { playlistCursor ->
-                    while (playlistCursor.moveToNext()) {
-                        val sourcePlaylistId = playlistCursor.getLong(0)
-                        val sourceName = playlistCursor.getString(1)?.trim().orEmpty()
-                        val targetName = uniquePlaylistName(
-                            sourceName.ifBlank { "Imported playlist" },
-                            usedNames
-                        )
-                        val playlist = PlaylistEntity(
-                            name = targetName,
-                            isThumbnailPermanent = false,
-                            thumbnailStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID,
-                            displayIndex = displayIndex++
-                        )
-                        val targetPlaylistId = playlistDao.insert(playlist)
-                        var targetIndex = 0
-                        var firstStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID
-
-                        source.rawQuery(
-                            "SELECT stream_id FROM $PLAYLIST_JOIN_TABLE " +
-                                "WHERE playlist_id = ? ORDER BY join_index",
-                            arrayOf(sourcePlaylistId.toString())
-                        ).use { itemCursor ->
-                            while (itemCursor.moveToNext()) {
-                                val targetId = targetStreamId(itemCursor.getLong(0))
-                                if (targetId == null) {
-                                    skippedItems++
-                                    continue
-                                }
-                                if (firstStreamId == PlaylistEntity.DEFAULT_THUMBNAIL_ID) {
-                                    firstStreamId = targetId
-                                }
-                                playlistStreamDao.insert(
-                                    PlaylistStreamEntity(
-                                        targetPlaylistId,
-                                        targetId,
-                                        targetIndex++
-                                    )
+                if (selection.importHistory && schema.hasProgress) {
+                    val existingStates = target.streamStateDAO().getAllDirect()
+                        .associateBy { it.streamUid }
+                    source.rawQuery(
+                        "SELECT stream_id, progress_time FROM $STATE_TABLE",
+                        null
+                    ).use { cursor ->
+                        while (cursor.moveToNext()) {
+                            val targetId = targetStreamId(cursor.getLong(0))
+                            if (targetId == null) {
+                                skippedItems++
+                                continue
+                            }
+                            val progress = cursor.getLong(1).coerceAtLeast(0)
+                            val currentProgress = existingStates[targetId]?.progressMillis ?: -1
+                            if (progress > currentProgress) {
+                                target.streamStateDAO().upsert(
+                                    StreamStateEntity(targetId, progress)
                                 )
-                                playlistItems++
+                                progressItems++
                             }
                         }
-                        if (firstStreamId != PlaylistEntity.DEFAULT_THUMBNAIL_ID) {
-                            playlist.thumbnailStreamId = firstStreamId
-                            playlist.uid = targetPlaylistId
-                            playlistDao.update(playlist)
-                        }
-                        playlists++
                     }
                 }
-            }
 
-            result = Result(
-                historyItems,
-                progressItems,
-                playlists,
-                playlistItems,
-                skippedItems
-            )
+                if (selection.importPlaylists && schema.hasPlaylists) {
+                    val playlistDao = target.playlistDAO()
+                    val playlistStreamDao = target.playlistStreamDAO()
+                    val usedNames = playlistDao.getAllDirect()
+                        .mapNotNullTo(mutableSetOf()) { it.name }
+                    var displayIndex = playlistDao.getAllDirect()
+                        .maxOfOrNull { it.displayIndex }?.plus(1) ?: 0L
+                    val playlistOrder = when {
+                        schema.usesAlphabeticalPlaylistOrder -> "name COLLATE NOCASE ASC, uid"
+                        schema.playlistColumns.contains("display_index") -> "display_index, uid"
+                        else -> "uid"
+                    }
+
+                    source.rawQuery(
+                        "SELECT uid, name FROM $PLAYLIST_TABLE ORDER BY $playlistOrder",
+                        null
+                    ).use { playlistCursor ->
+                        while (playlistCursor.moveToNext()) {
+                            val sourcePlaylistId = playlistCursor.getLong(0)
+                            val sourceName = playlistCursor.getString(1)?.trim().orEmpty()
+                            val targetName = uniquePlaylistName(
+                                sourceName.ifBlank { "Imported playlist" },
+                                usedNames
+                            )
+                            val playlist = PlaylistEntity(
+                                name = targetName,
+                                isThumbnailPermanent = false,
+                                thumbnailStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID,
+                                displayIndex = displayIndex++
+                            )
+                            val targetPlaylistId = playlistDao.insert(playlist)
+                            var targetIndex = 0
+                            var firstStreamId = PlaylistEntity.DEFAULT_THUMBNAIL_ID
+
+                            source.rawQuery(
+                                "SELECT stream_id FROM $PLAYLIST_JOIN_TABLE " +
+                                    "WHERE playlist_id = ? ORDER BY join_index",
+                                arrayOf(sourcePlaylistId.toString())
+                            ).use { itemCursor ->
+                                while (itemCursor.moveToNext()) {
+                                    val targetId = targetStreamId(itemCursor.getLong(0))
+                                    if (targetId == null) {
+                                        skippedItems++
+                                        continue
+                                    }
+                                    if (firstStreamId == PlaylistEntity.DEFAULT_THUMBNAIL_ID) {
+                                        firstStreamId = targetId
+                                    }
+                                    playlistStreamDao.insert(
+                                        PlaylistStreamEntity(
+                                            targetPlaylistId,
+                                            targetId,
+                                            targetIndex++
+                                        )
+                                    )
+                                    playlistItems++
+                                }
+                            }
+                            if (firstStreamId != PlaylistEntity.DEFAULT_THUMBNAIL_ID) {
+                                playlist.thumbnailStreamId = firstStreamId
+                                playlist.uid = targetPlaylistId
+                                playlistDao.update(playlist)
+                            }
+                            playlists++
+                        }
+                    }
+                }
+
+                result = Result(
+                    historyItems,
+                    progressItems,
+                    playlists,
+                    playlistItems,
+                    if (selection.importSettings) compatibleSettings.size else 0,
+                    skippedItems
+                )
+            }
+        } catch (error: Throwable) {
+            if (settingsRollback != null) {
+                try {
+                    settingsMigration.rollback(settingsRollback)
+                } catch (rollbackError: Throwable) {
+                    error.addSuppressed(rollbackError)
+                }
+            }
+            throw error
         }
         result
     }

--- a/app/src/main/java/org/schabi/newpipe/sync/PortableSettingSpec.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/PortableSettingSpec.kt
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.sync
+
+import android.content.Context
+import org.schabi.newpipe.R
+
+internal data class PortableSettingSpec(
+    val id: PortableSettingId,
+    val preferenceKey: String
+)
+
+internal fun portableSettingSpecs(context: Context): List<PortableSettingSpec> = listOf(
+    portableSetting(context, PortableSettingId.SERVICE, R.string.current_service_key),
+    portableSetting(context, PortableSettingId.CONTENT_COUNTRY, R.string.content_country_key),
+    portableSetting(context, PortableSettingId.CONTENT_LANGUAGE, R.string.content_language_key),
+    portableSetting(context, PortableSettingId.THEME, R.string.theme_key),
+    portableSetting(context, PortableSettingId.NIGHT_THEME, R.string.night_theme_key),
+    portableSetting(context, PortableSettingId.THEME_COLOR, R.string.theme_color_key),
+    portableSetting(
+        context,
+        PortableSettingId.DEFAULT_RESOLUTION,
+        R.string.default_resolution_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.DEFAULT_POPUP_RESOLUTION,
+        R.string.default_popup_resolution_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.SHOW_HIGHER_RESOLUTIONS,
+        R.string.show_higher_resolutions_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.DEFAULT_VIDEO_FORMAT,
+        R.string.default_video_format_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.DEFAULT_AUDIO_FORMAT,
+        R.string.default_audio_format_key
+    ),
+    portableSetting(context, PortableSettingId.AUTOPLAY, R.string.autoplay_key),
+    portableSetting(
+        context,
+        PortableSettingId.MINIMIZE_ON_EXIT,
+        R.string.minimize_on_exit_key
+    ),
+    portableSetting(context, PortableSettingId.NATIVE_PIP, R.string.native_pip_key),
+    portableSetting(context, PortableSettingId.SEEK_DURATION, R.string.seek_duration_key),
+    portableSetting(
+        context,
+        PortableSettingId.SEEK_PREVIEW_QUALITY,
+        R.string.seekbar_preview_thumbnail_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.PREFER_ORIGINAL_AUDIO,
+        R.string.prefer_original_audio_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.PREFER_DESCRIPTIVE_AUDIO,
+        R.string.prefer_descriptive_audio_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.SHOW_AGE_RESTRICTED_CONTENT,
+        R.string.show_age_restricted_content
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.YOUTUBE_RESTRICTED_MODE,
+        R.string.youtube_restricted_mode_enabled
+    ),
+    portableSetting(context, PortableSettingId.SHOW_COMMENTS, R.string.show_comments_key),
+    portableSetting(
+        context,
+        PortableSettingId.SHOW_DESCRIPTION,
+        R.string.show_description_key
+    ),
+    portableSetting(context, PortableSettingId.SHOW_META_INFO, R.string.show_meta_info_key),
+    portableSetting(context, PortableSettingId.SHOW_NEXT_VIDEO, R.string.show_next_video_key),
+    portableSetting(context, PortableSettingId.SHOW_THUMBNAILS, R.string.show_thumbnail_key),
+    portableSetting(context, PortableSettingId.IMAGE_QUALITY, R.string.image_quality_key),
+    portableSetting(context, PortableSettingId.LIST_VIEW_MODE, R.string.list_view_mode_key),
+    portableSetting(
+        context,
+        PortableSettingId.PREFERRED_OPEN_ACTION,
+        R.string.preferred_open_action_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.SHOW_HOLD_TO_APPEND,
+        R.string.show_hold_to_append_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.SHOW_PLAY_WITH_KODI,
+        R.string.show_play_with_kodi_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.START_FULLSCREEN,
+        R.string.start_main_player_fullscreen_key
+    ),
+    portableSetting(context, PortableSettingId.AUTO_QUEUE, R.string.auto_queue_key),
+    portableSetting(context, PortableSettingId.INEXACT_SEEK, R.string.use_inexact_seek_key),
+    portableSetting(
+        context,
+        PortableSettingId.CLEAR_QUEUE_CONFIRMATION,
+        R.string.clear_queue_confirmation_key
+    ),
+    portableSetting(context, PortableSettingId.PLAYBACK_SPEED, R.string.playback_speed_key),
+    portableSetting(context, PortableSettingId.PLAYBACK_PITCH, R.string.playback_pitch_key),
+    portableSetting(
+        context,
+        PortableSettingId.PLAYBACK_SKIP_SILENCE,
+        R.string.playback_skip_silence_key
+    ),
+    portableSetting(context, PortableSettingId.LEARNING_MODE, R.string.learning_mode_key),
+    portableSetting(context, PortableSettingId.LEARNING_NOTES, R.string.learning_notes_key),
+    portableSetting(
+        context,
+        PortableSettingId.LEARNING_PLAYLIST_PROGRESS,
+        R.string.learning_playlist_progress_key
+    ),
+    portableSetting(
+        context,
+        PortableSettingId.LEARNING_COUNT_BACKGROUND,
+        R.string.learning_count_background_key
+    )
+)
+
+private fun portableSetting(
+    context: Context,
+    id: PortableSettingId,
+    preferenceKeyResource: Int
+): PortableSettingSpec = PortableSettingSpec(id, context.getString(preferenceKeyResource))

--- a/app/src/main/java/org/schabi/newpipe/sync/StructuredPreferenceSyncStore.kt
+++ b/app/src/main/java/org/schabi/newpipe/sync/StructuredPreferenceSyncStore.kt
@@ -406,7 +406,7 @@ internal class RoomStructuredPreferenceSyncStore internal constructor(
     }
 
     private fun reconcileSettings() {
-        val desired = portableSettingSpecs().mapNotNull { spec ->
+        val desired = portableSettingSpecs(context).mapNotNull { spec ->
             currentPortableSetting(spec)?.let { setting ->
                 StructuredPreferenceRecordId.portableSetting(setting.settingId) to setting
             }
@@ -712,7 +712,7 @@ internal class RoomStructuredPreferenceSyncStore internal constructor(
     }
 
     private fun materializeSettings() {
-        val specs = portableSettingSpecs().associateBy(PortableSettingSpec::id)
+        val specs = portableSettingSpecs(context).associateBy(PortableSettingSpec::id)
         val editor = preferences.edit()
         syncDao.getRecordsByType(
             StructuredPreferenceCategory.SETTINGS.name,
@@ -1011,115 +1011,13 @@ internal class RoomStructuredPreferenceSyncStore internal constructor(
             )
 
             StructuredPreferenceCategory.SETTINGS -> JSON.encodeToString(
-                portableSettingSpecs().mapNotNull(::currentPortableSetting)
+                portableSettingSpecs(context).mapNotNull(::currentPortableSetting)
             )
 
             StructuredPreferenceCategory.COMPLETED_DOWNLOADS ->
                 JSON.encodeToString(currentCompletedDownloads())
         }
         return digest(snapshot)
-    }
-
-    private fun portableSettingSpecs(): List<PortableSettingSpec> = listOf(
-        portableSetting(PortableSettingId.SERVICE, R.string.current_service_key),
-        portableSetting(PortableSettingId.CONTENT_COUNTRY, R.string.content_country_key),
-        portableSetting(PortableSettingId.CONTENT_LANGUAGE, R.string.content_language_key),
-        portableSetting(PortableSettingId.THEME, R.string.theme_key),
-        portableSetting(PortableSettingId.NIGHT_THEME, R.string.night_theme_key),
-        portableSetting(PortableSettingId.THEME_COLOR, R.string.theme_color_key),
-        portableSetting(PortableSettingId.DEFAULT_RESOLUTION, R.string.default_resolution_key),
-        portableSetting(
-            PortableSettingId.DEFAULT_POPUP_RESOLUTION,
-            R.string.default_popup_resolution_key
-        ),
-        portableSetting(
-            PortableSettingId.SHOW_HIGHER_RESOLUTIONS,
-            R.string.show_higher_resolutions_key
-        ),
-        portableSetting(
-            PortableSettingId.DEFAULT_VIDEO_FORMAT,
-            R.string.default_video_format_key
-        ),
-        portableSetting(
-            PortableSettingId.DEFAULT_AUDIO_FORMAT,
-            R.string.default_audio_format_key
-        ),
-        portableSetting(PortableSettingId.AUTOPLAY, R.string.autoplay_key),
-        portableSetting(PortableSettingId.MINIMIZE_ON_EXIT, R.string.minimize_on_exit_key),
-        portableSetting(PortableSettingId.NATIVE_PIP, R.string.native_pip_key),
-        portableSetting(PortableSettingId.SEEK_DURATION, R.string.seek_duration_key),
-        portableSetting(
-            PortableSettingId.SEEK_PREVIEW_QUALITY,
-            R.string.seekbar_preview_thumbnail_key
-        ),
-        portableSetting(
-            PortableSettingId.PREFER_ORIGINAL_AUDIO,
-            R.string.prefer_original_audio_key
-        ),
-        portableSetting(
-            PortableSettingId.PREFER_DESCRIPTIVE_AUDIO,
-            R.string.prefer_descriptive_audio_key
-        ),
-        portableSetting(
-            PortableSettingId.SHOW_AGE_RESTRICTED_CONTENT,
-            R.string.show_age_restricted_content
-        ),
-        portableSetting(
-            PortableSettingId.YOUTUBE_RESTRICTED_MODE,
-            R.string.youtube_restricted_mode_enabled
-        ),
-        portableSetting(PortableSettingId.SHOW_COMMENTS, R.string.show_comments_key),
-        portableSetting(PortableSettingId.SHOW_DESCRIPTION, R.string.show_description_key),
-        portableSetting(PortableSettingId.SHOW_META_INFO, R.string.show_meta_info_key),
-        portableSetting(PortableSettingId.SHOW_NEXT_VIDEO, R.string.show_next_video_key),
-        portableSetting(PortableSettingId.SHOW_THUMBNAILS, R.string.show_thumbnail_key),
-        portableSetting(PortableSettingId.IMAGE_QUALITY, R.string.image_quality_key),
-        portableSetting(PortableSettingId.LIST_VIEW_MODE, R.string.list_view_mode_key),
-        portableSetting(
-            PortableSettingId.PREFERRED_OPEN_ACTION,
-            R.string.preferred_open_action_key
-        ),
-        portableSetting(
-            PortableSettingId.SHOW_HOLD_TO_APPEND,
-            R.string.show_hold_to_append_key
-        ),
-        portableSetting(
-            PortableSettingId.SHOW_PLAY_WITH_KODI,
-            R.string.show_play_with_kodi_key
-        ),
-        portableSetting(
-            PortableSettingId.START_FULLSCREEN,
-            R.string.start_main_player_fullscreen_key
-        ),
-        portableSetting(PortableSettingId.AUTO_QUEUE, R.string.auto_queue_key),
-        portableSetting(PortableSettingId.INEXACT_SEEK, R.string.use_inexact_seek_key),
-        portableSetting(
-            PortableSettingId.CLEAR_QUEUE_CONFIRMATION,
-            R.string.clear_queue_confirmation_key
-        ),
-        portableSetting(PortableSettingId.PLAYBACK_SPEED, R.string.playback_speed_key),
-        portableSetting(PortableSettingId.PLAYBACK_PITCH, R.string.playback_pitch_key),
-        portableSetting(
-            PortableSettingId.PLAYBACK_SKIP_SILENCE,
-            R.string.playback_skip_silence_key
-        ),
-        portableSetting(PortableSettingId.LEARNING_MODE, R.string.learning_mode_key),
-        portableSetting(PortableSettingId.LEARNING_NOTES, R.string.learning_notes_key),
-        portableSetting(
-            PortableSettingId.LEARNING_PLAYLIST_PROGRESS,
-            R.string.learning_playlist_progress_key
-        ),
-        portableSetting(
-            PortableSettingId.LEARNING_COUNT_BACKGROUND,
-            R.string.learning_count_background_key
-        )
-    )
-
-    private fun portableSetting(
-        id: PortableSettingId,
-        preferenceKeyResource: Int
-    ): PortableSettingSpec {
-        return PortableSettingSpec(id, context.getString(preferenceKeyResource))
     }
 
     private fun currentPortableSetting(
@@ -1320,11 +1218,6 @@ internal class RoomStructuredPreferenceSyncStore internal constructor(
         val id: StructuredFilterId,
         val preferenceKey: String,
         val defaultValuesResource: Int
-    )
-
-    private data class PortableSettingSpec(
-        val id: PortableSettingId,
-        val preferenceKey: String
     )
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -489,7 +489,7 @@
     <string name="import_data_title">Import full backup</string>
     <string name="import_compatible_data_key" translatable="false">import_compatible_data</string>
     <string name="import_compatible_data_title">Import from NewPipe or compatible app</string>
-    <string name="import_compatible_data_summary">Merge watch history, playback positions, and local playlists from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
+    <string name="import_compatible_data_summary">Merge watch history, playback positions, local playlists, and compatible settings from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
     <string name="export_data_title">Export full backup</string>
     <string name="clear_cookie_title">Clear reCAPTCHA cookies</string>
     <string name="recaptcha_cookies_cleared">reCAPTCHA cookies have been cleared</string>
@@ -509,14 +509,15 @@
     <string name="backup_invalid_or_empty">This ZIP does not contain recognizable WizeStream backup data.</string>
     <string name="backup_incompatible_title">Backup cannot be restored</string>
     <string name="backup_incompatible_message">Full restore accepts only backups created by a supported version of WizeStream. This archive may be from another app, an older unverified format, or an incompatible WizeStream version. Nothing on this device was changed.</string>
-    <string name="migration_invalid_backup">This backup does not contain compatible NewPipe history or playlist data.</string>
+    <string name="migration_invalid_backup">This backup does not contain compatible NewPipe data or settings.</string>
     <string name="migration_choose_data_title">Choose data to merge</string>
     <string name="migration_history_option">Watch history: %1$d entries and %2$d playback positions</string>
     <string name="migration_playlists_option">Local playlists: %1$d playlists and %2$d items</string>
+    <string name="migration_settings_option">Compatible app settings: %1$d</string>
     <string name="migration_import_button">Merge data</string>
     <string name="migration_nothing_selected">Select at least one data category.</string>
     <string name="migration_complete_title">Migration complete</string>
-    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, and %4$d playlist items. Skipped %5$d incompatible items.</string>
+    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, %4$d playlist items, and %5$d compatible settings. Skipped %6$d incompatible items.</string>
     <string name="backup_exported_with_file">Backup exported: %s</string>
     <string name="backup_import_succeeded_restart">Import succeeded. WizeStream will restart to finish loading the backup.</string>
     <string name="restart">Restart</string>


### PR DESCRIPTION
- Import compatible settings from current NewPipe JSON backups without replacing unrelated WizeStream preferences
- Reuse WizeStream’s portable-setting allowlist so credentials, tokens, proxy data, storage paths, and internal state remain excluded
- Exclude the selected streaming service from foreign migration because service sets and identifiers can differ between derivatives
- Type-check and bound imported values before showing or applying them
- Add settings as an independent selectable migration category with result reporting
- Roll back imported preferences if the database merge fails
- Add Android regression coverage for allowed, wrong-typed, sensitive, service-selection, and existing settings