### PR TITLE
Import PipePipe SponsorBlock settings

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
@@ -18,6 +18,8 @@ import org.schabi.newpipe.R
 import org.schabi.newpipe.database.AppDatabase
 import org.schabi.newpipe.database.playlist.model.PlaylistEntity
 import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager
+import org.schabi.newpipe.settings.sponsorblock.SponsorBlockBehavior
+import org.schabi.newpipe.settings.sponsorblock.SponsorBlockCategoryConfig
 
 @RunWith(AndroidJUnit4::class)
 class NewPipeDataMigrationManagerTest {
@@ -166,6 +168,64 @@ class NewPipeDataMigrationManagerTest {
         assertFalse(preferences.contains("show_next_video"))
         assertFalse(preferences.contains("proxy_password"))
         assertEquals("keep me", preferences.getString("existing_wizestream_setting", null))
+    }
+
+    @Test
+    fun pipePipeSponsorBlockSettingsAreConvertedWithoutInventingMissingDefaults() {
+        sourcePath.toFile().delete()
+        createPipePipeSourceDatabase(sourcePath)
+        val sourcePreferences = mapOf<String, Any>(
+            context.getString(R.string.sponsor_block_enable_key) to true,
+            context.getString(R.string.sponsor_block_notifications_key) to false,
+            "sponsor_block_category_sponsor" to true,
+            "sponsor_block_category_intro" to false,
+            "sponsor_block_category_sponsor_mode" to "automatic",
+            "sponsor_block_category_intro_mode" to "manual",
+            "sponsor_block_category_outro_mode" to "highlight",
+            "sponsor_block_category_sponsor_color" to "#123456",
+            context.getString(R.string.sponsor_block_user_id_key) to "do not import"
+        )
+        val manager = NewPipeDataMigrationManager(context)
+
+        val preview = manager.inspect(sourcePath, sourcePreferences)
+        assertEquals(NewPipeDataMigrationManager.SourceApp.PIPEPIPE, preview.sourceApp)
+        assertEquals(8, preview.sponsorBlockSettings)
+
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = false,
+                importPlaylists = false,
+                importSettings = false,
+                importSponsorBlock = true
+            ),
+            sourcePreferences
+        )
+
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        assertEquals(8, result.sponsorBlockSettings)
+        assertTrue(preferences.getBoolean("sponsor_block_enable", false))
+        assertFalse(preferences.getBoolean("sponsor_block_notifications", true))
+        assertFalse(preferences.contains("sponsor_block_graced_rewind"))
+        assertTrue(preferences.getBoolean("sponsor_block_category_sponsor", false))
+        assertFalse(preferences.getBoolean("sponsor_block_category_intro", true))
+        assertEquals(
+            SponsorBlockBehavior.SKIP.value,
+            preferences.getString(SponsorBlockCategoryConfig.SPONSOR.behaviorKey(), null)
+        )
+        assertEquals(
+            SponsorBlockBehavior.MANUAL.value,
+            preferences.getString(SponsorBlockCategoryConfig.INTRO.behaviorKey(), null)
+        )
+        assertEquals(
+            SponsorBlockBehavior.DONT_SKIP.value,
+            preferences.getString(SponsorBlockCategoryConfig.OUTRO.behaviorKey(), null)
+        )
+        assertEquals(
+            0xFF123456L,
+            preferences.getLong(SponsorBlockCategoryConfig.SPONSOR.colorKey(), 0L)
+        )
+        assertFalse(preferences.contains("sponsor_block_user_id"))
     }
 
     private fun createSourceDatabase(path: Path) {

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -55,7 +54,8 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private enum MigrationOption {
         HISTORY,
         PLAYLISTS,
-        SETTINGS
+        SETTINGS,
+        SPONSOR_BLOCK
     }
 
     private final SimpleDateFormat exportDateFormat =
@@ -215,10 +215,15 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                 if (stagedDatabase == null) {
                     throw new IOException("The backup does not contain a SQLite database");
                 }
-                final Map<String, ?> sourcePreferences = manager.exportHasJsonPrefs(file)
-                        ? manager.readJsonPrefs(file) : Collections.emptyMap();
-                final NewPipeDataMigrationManager.Preview preview =
-                        migrationManager.inspect(stagedDatabase, sourcePreferences);
+                final NewPipeDataMigrationManager.Preview databasePreview =
+                        migrationManager.inspect(stagedDatabase);
+                final boolean isPipePipe = databasePreview.getSourceApp()
+                        == NewPipeDataMigrationManager.SourceApp.PIPEPIPE;
+                final Map<String, ?> sourcePreferences = manager.readMigrationPrefs(
+                        file, isPipePipe);
+                final NewPipeDataMigrationManager.Preview preview = sourcePreferences.isEmpty()
+                        ? databasePreview
+                        : migrationManager.inspect(stagedDatabase, sourcePreferences);
                 final Path readyDatabase = stagedDatabase;
                 final Map<String, ?> readyPreferences = sourcePreferences;
                 stagedDatabase = null;
@@ -282,6 +287,12 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                     preview.getCompatibleSettings()));
             optionTypes.add(MigrationOption.SETTINGS);
         }
+        if (preview.getHasSponsorBlockSettings()) {
+            optionLabels.add(getString(
+                    R.string.migration_sponsor_block_option,
+                    preview.getSponsorBlockSettings()));
+            optionTypes.add(MigrationOption.SPONSOR_BLOCK);
+        }
         final boolean[] checkedItems = new boolean[optionLabels.size()];
         java.util.Arrays.fill(checkedItems, true);
 
@@ -302,6 +313,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                     boolean importHistory = false;
                     boolean importPlaylists = false;
                     boolean importSettings = false;
+                    boolean importSponsorBlock = false;
                     for (int i = 0; i < checkedItems.length; i++) {
                         if (!checkedItems[i]) {
                             continue;
@@ -316,11 +328,15 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                             case SETTINGS:
                                 importSettings = true;
                                 break;
+                            case SPONSOR_BLOCK:
+                                importSponsorBlock = true;
+                                break;
                             default:
                                 break;
                         }
                     }
-                    if (!importHistory && !importPlaylists && !importSettings) {
+                    if (!importHistory && !importPlaylists
+                            && !importSettings && !importSponsorBlock) {
                         Toast.makeText(requireContext(), R.string.migration_nothing_selected,
                                 Toast.LENGTH_SHORT).show();
                         return;
@@ -333,7 +349,8 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                             new NewPipeDataMigrationManager.Selection(
                                     importHistory,
                                     importPlaylists,
-                                    importSettings));
+                                    importSettings,
+                                    importSponsorBlock));
                 }));
         dialog.show();
     }
@@ -361,6 +378,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                         migrationResult.getPlaylists(),
                                         migrationResult.getPlaylistItems(),
                                         migrationResult.getCompatibleSettings(),
+                                        migrationResult.getSponsorBlockSettings(),
                                         migrationResult.getSkippedItems()))
                                 .setPositiveButton(R.string.ok, null)
                                 .show();

--- a/app/src/main/java/org/schabi/newpipe/settings/export/CompatibleSettingsMigration.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/CompatibleSettingsMigration.kt
@@ -93,7 +93,15 @@ internal class CompatibleSettingsMigration(
             when (value) {
                 is Boolean -> editor.putBoolean(key, value)
                 is Float -> editor.putFloat(key, value)
+                is Int -> editor.putInt(key, value)
+                is Long -> editor.putLong(key, value)
                 is String -> editor.putString(key, value)
+                is Set<*> -> {
+                    val strings = value.filterIsInstance<String>().toSet()
+                    if (strings.size == value.size) {
+                        editor.putStringSet(key, strings)
+                    }
+                }
             }
         }
         return editor.commit()

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
@@ -5,6 +5,8 @@ import com.grack.nanojson.JsonArray
 import com.grack.nanojson.JsonParser
 import com.grack.nanojson.JsonParserException
 import com.grack.nanojson.JsonWriter
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.DataInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -32,6 +34,9 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
         private const val SQLITE_HEADER_TO_VERSION_LENGTH =
             SQLITE_USER_VERSION_OFFSET - SQLITE_HEADER_LENGTH
         private const val SQLITE_MAGIC = "SQLite format 3\u0000"
+        private const val MAX_MIGRATION_PREFERENCES_BYTES = 1_048_576
+        private const val MAX_MIGRATION_PREFERENCE_ENTRIES = 2_048
+        private const val MAX_MIGRATION_PREFERENCE_KEY_LENGTH = 1_024
     }
 
     data class BackupContents(
@@ -391,6 +396,72 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
         }.let { fileExists ->
             if (!fileExists) {
                 throw FileNotFoundException(BackupFileLocator.FILE_NAME_JSON_PREFS)
+            }
+        }
+        return checkNotNull(entries)
+    }
+
+    /**
+     * Reads preferences for selective migration. JSON is always preferred. The legacy serialized
+     * format is accepted only when the caller has already identified a known PipePipe database.
+     */
+    @Throws(IOException::class, JsonParserException::class, ClassNotFoundException::class)
+    fun readMigrationPrefs(
+        zipFile: StoredFileHelper,
+        allowPipePipeSerializedPreferences: Boolean
+    ): Map<String, Any?> {
+        if (exportHasJsonPrefs(zipFile)) {
+            return readJsonPrefs(zipFile)
+        }
+        if (!allowPipePipeSerializedPreferences ||
+            !ZipHelper.zipContainsFile(zipFile, BackupFileLocator.FILE_NAME_SERIALIZED_PREFS)
+        ) {
+            return emptyMap()
+        }
+        return readBoundedSerializedMigrationPrefs(zipFile)
+    }
+
+    @Throws(IOException::class, ClassNotFoundException::class)
+    private fun readBoundedSerializedMigrationPrefs(
+        zipFile: StoredFileHelper
+    ): Map<String, Any?> {
+        var entries: Map<String, Any?>? = null
+        ZipHelper.extractFileFromZip(zipFile, BackupFileLocator.FILE_NAME_SERIALIZED_PREFS) {
+            val serialized = ByteArrayOutputStream().use { output ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                var total = 0
+                while (true) {
+                    val count = it.read(buffer)
+                    if (count < 0) {
+                        break
+                    }
+                    total += count
+                    if (total > MAX_MIGRATION_PREFERENCES_BYTES) {
+                        throw IOException("PipePipe preferences exceed the migration size limit")
+                    }
+                    output.write(buffer, 0, count)
+                }
+                output.toByteArray()
+            }
+            PreferencesObjectInputStream(ByteArrayInputStream(serialized)).use { input ->
+                val rawEntries = input.readObject() as? Map<*, *>
+                    ?: throw IOException("PipePipe preferences are not a map")
+                if (rawEntries.size > MAX_MIGRATION_PREFERENCE_ENTRIES) {
+                    throw IOException("PipePipe preferences contain too many entries")
+                }
+                val stringKeyedEntries = rawEntries.mapNotNull { (key, value) ->
+                    (key as? String)
+                        ?.takeIf { it.length <= MAX_MIGRATION_PREFERENCE_KEY_LENGTH }
+                        ?.let { it to value }
+                }.toMap()
+                if (stringKeyedEntries.size != rawEntries.size) {
+                    throw IOException("PipePipe preferences contain invalid keys")
+                }
+                entries = sanitizePreferences(stringKeyedEntries)
+            }
+        }.let { fileExists ->
+            if (!fileExists) {
+                throw FileNotFoundException(BackupFileLocator.FILE_NAME_SERIALIZED_PREFS)
             }
         }
         return checkNotNull(entries)

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
@@ -15,12 +15,19 @@ import org.schabi.newpipe.database.stream.model.StreamStateEntity
 import org.schabi.newpipe.extractor.stream.StreamType
 
 class NewPipeDataMigrationManager(private val context: Context) {
+    enum class SourceApp {
+        NEWPIPE,
+        PIPEPIPE
+    }
+
     data class Preview(
         val historyItems: Int,
         val progressItems: Int,
         val playlists: Int,
         val playlistItems: Int,
-        val compatibleSettings: Int
+        val compatibleSettings: Int,
+        val sponsorBlockSettings: Int,
+        val sourceApp: SourceApp
     ) {
         val hasHistory: Boolean
             get() = historyItems > 0 || progressItems > 0
@@ -28,14 +35,18 @@ class NewPipeDataMigrationManager(private val context: Context) {
             get() = playlists > 0
         val hasCompatibleSettings: Boolean
             get() = compatibleSettings > 0
+        val hasSponsorBlockSettings: Boolean
+            get() = sponsorBlockSettings > 0
         val hasImportableData: Boolean
-            get() = hasHistory || hasPlaylists || hasCompatibleSettings
+            get() = hasHistory || hasPlaylists ||
+                hasCompatibleSettings || hasSponsorBlockSettings
     }
 
     data class Selection @JvmOverloads constructor(
         val importHistory: Boolean,
         val importPlaylists: Boolean,
-        val importSettings: Boolean = false
+        val importSettings: Boolean = false,
+        val importSponsorBlock: Boolean = false
     )
 
     data class Result(
@@ -44,23 +55,32 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val playlists: Int,
         val playlistItems: Int,
         val compatibleSettings: Int,
+        val sponsorBlockSettings: Int,
         val skippedItems: Int
     )
 
     class UnsupportedSourceException(message: String) : Exception(message)
 
+    @JvmOverloads
     fun inspect(
         databasePath: Path,
         sourcePreferences: Map<String, *> = emptyMap<String, Any>()
     ): Preview = openSource(databasePath).use { source ->
         val schema = inspectSchema(source)
         val compatibleSettings = CompatibleSettingsMigration(context).prepare(sourcePreferences)
+        val sponsorBlockSettings = if (schema.isPipePipe) {
+            PipePipeSponsorBlockMigration(context).prepare(sourcePreferences)
+        } else {
+            CompatibleSettingsMigration.Prepared(emptyMap<String, Any>())
+        }
         Preview(
             historyItems = if (schema.hasHistory) source.countRows(HISTORY_TABLE) else 0,
             progressItems = if (schema.hasProgress) source.countRows(STATE_TABLE) else 0,
             playlists = if (schema.hasPlaylists) source.countRows(PLAYLIST_TABLE) else 0,
             playlistItems = if (schema.hasPlaylists) source.countRows(PLAYLIST_JOIN_TABLE) else 0,
-            compatibleSettings = compatibleSettings.size
+            compatibleSettings = compatibleSettings.size,
+            sponsorBlockSettings = sponsorBlockSettings.size,
+            sourceApp = if (schema.isPipePipe) SourceApp.PIPEPIPE else SourceApp.NEWPIPE
         )
     }
 
@@ -74,14 +94,22 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val target = NewPipeDatabase.getInstance(context)
         val settingsMigration = CompatibleSettingsMigration(context)
         val compatibleSettings = settingsMigration.prepare(sourcePreferences)
-        val settingsRollback = if (selection.importSettings && compatibleSettings.size > 0) {
-            settingsMigration.apply(compatibleSettings)
+        val sponsorBlockSettings = if (schema.isPipePipe) {
+            PipePipeSponsorBlockMigration(context).prepare(sourcePreferences)
         } else {
-            null
+            CompatibleSettingsMigration.Prepared(emptyMap<String, Any>())
         }
-        var result = Result(0, 0, 0, 0, 0, 0)
+        var settingsRollback: CompatibleSettingsMigration.Rollback? = null
+        var sponsorBlockRollback: CompatibleSettingsMigration.Rollback? = null
+        var result = Result(0, 0, 0, 0, 0, 0, 0)
 
         try {
+            if (selection.importSettings && compatibleSettings.size > 0) {
+                settingsRollback = settingsMigration.apply(compatibleSettings)
+            }
+            if (selection.importSponsorBlock && sponsorBlockSettings.size > 0) {
+                sponsorBlockRollback = settingsMigration.apply(sponsorBlockSettings)
+            }
             target.runInTransaction {
                 val streamIds = mutableMapOf<Long, Long>()
                 fun targetStreamId(sourceId: Long): Long? {
@@ -228,10 +256,18 @@ class NewPipeDataMigrationManager(private val context: Context) {
                     playlists,
                     playlistItems,
                     if (selection.importSettings) compatibleSettings.size else 0,
+                    if (selection.importSponsorBlock) sponsorBlockSettings.size else 0,
                     skippedItems
                 )
             }
         } catch (error: Throwable) {
+            if (sponsorBlockRollback != null) {
+                try {
+                    settingsMigration.rollback(sponsorBlockRollback)
+                } catch (rollbackError: Throwable) {
+                    error.addSuppressed(rollbackError)
+                }
+            }
             if (settingsRollback != null) {
                 try {
                     settingsMigration.rollback(settingsRollback)
@@ -267,9 +303,8 @@ class NewPipeDataMigrationManager(private val context: Context) {
             hasPlaylists = playlistColumns.containsAll(REQUIRED_PLAYLIST_COLUMNS) &&
                 joinColumns.containsAll(REQUIRED_PLAYLIST_JOIN_COLUMNS),
             playlistColumns = playlistColumns,
-            usesAlphabeticalPlaylistOrder =
-                source.tableExists(PIPEPIPE_SPONSORBLOCK_WHITELIST_TABLE) ||
-                    source.userVersion() >= PIPEPIPE_DATABASE_VERSION_FLOOR
+            isPipePipe = source.tableExists(PIPEPIPE_SPONSORBLOCK_WHITELIST_TABLE) ||
+                source.userVersion() >= PIPEPIPE_DATABASE_VERSION_FLOOR
         )
         if (!schema.hasHistory && !schema.hasProgress && !schema.hasPlaylists) {
             throw UnsupportedSourceException(
@@ -386,8 +421,11 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val hasProgress: Boolean,
         val hasPlaylists: Boolean,
         val playlistColumns: Set<String>,
+        val isPipePipe: Boolean
+    ) {
         val usesAlphabeticalPlaylistOrder: Boolean
-    )
+            get() = isPipePipe
+    }
 
     companion object {
         private const val STREAM_TABLE = "streams"

--- a/app/src/main/java/org/schabi/newpipe/settings/export/PipePipeSponsorBlockMigration.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/PipePipeSponsorBlockMigration.kt
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.settings.export
+
+import android.content.Context
+import android.graphics.Color
+import org.schabi.newpipe.R
+import org.schabi.newpipe.settings.sponsorblock.SponsorBlockBehavior
+import org.schabi.newpipe.settings.sponsorblock.SponsorBlockCategoryConfig
+
+internal class PipePipeSponsorBlockMigration(private val context: Context) {
+    fun prepare(source: Map<String, *>): CompatibleSettingsMigration.Prepared {
+        if (!containsRecognizedSetting(source)) {
+            return CompatibleSettingsMigration.Prepared(emptyMap<String, Any>())
+        }
+        val values = buildMap<String, Any> {
+            copyBoolean(source, context.getString(R.string.sponsor_block_enable_key))
+            copyBoolean(source, context.getString(R.string.sponsor_block_notifications_key))
+            copyBoolean(source, context.getString(R.string.sponsor_block_graced_rewind_key))
+
+            SponsorBlockCategoryConfig.ALL.forEach { category ->
+                val enabledKey = context.getString(category.enabledKeyResId)
+                copyBoolean(source, enabledKey)
+
+                val sourceColor = source["sponsor_block_category_${category.id}_color"]
+                parseColor(sourceColor)?.let { put(category.colorKey(), it) }
+
+                if (!category.isMarkerOnly()) {
+                    val modeKey = "sponsor_block_category_${category.id}_mode"
+                    convertBehavior(source[modeKey] as? String)?.let {
+                        put(category.behaviorKey(), it.value)
+                    }
+                }
+            }
+        }
+        return CompatibleSettingsMigration.Prepared(values)
+    }
+
+    private fun containsRecognizedSetting(source: Map<String, *>): Boolean {
+        val globalKeys = setOf(
+            context.getString(R.string.sponsor_block_enable_key),
+            context.getString(R.string.sponsor_block_notifications_key),
+            context.getString(R.string.sponsor_block_graced_rewind_key)
+        )
+        return source.keys.any { key ->
+            key in globalKeys || SponsorBlockCategoryConfig.ALL.any { category ->
+                key == context.getString(category.enabledKeyResId) ||
+                    key == "sponsor_block_category_${category.id}_mode" ||
+                    key == "sponsor_block_category_${category.id}_color"
+            }
+        }
+    }
+
+    private fun MutableMap<String, Any>.copyBoolean(
+        source: Map<String, *>,
+        key: String
+    ) {
+        (source[key] as? Boolean)?.let { put(key, it) }
+    }
+
+    private fun convertBehavior(value: String?): SponsorBlockBehavior? = when (value) {
+        PIPEPIPE_AUTOMATIC -> SponsorBlockBehavior.SKIP
+        PIPEPIPE_MANUAL -> SponsorBlockBehavior.MANUAL
+        PIPEPIPE_HIGHLIGHT -> SponsorBlockBehavior.DONT_SKIP
+        else -> null
+    }
+
+    private fun parseColor(value: Any?): Long? {
+        if (value !is String || value.length > MAX_COLOR_LENGTH) {
+            return null
+        }
+        return runCatching {
+            Color.parseColor(value.trim()).toLong() and 0xFFFFFFFFL
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val PIPEPIPE_AUTOMATIC = "automatic"
+        private const val PIPEPIPE_MANUAL = "manual"
+        private const val PIPEPIPE_HIGHLIGHT = "highlight"
+        private const val MAX_COLOR_LENGTH = 32
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -489,7 +489,7 @@
     <string name="import_data_title">Import full backup</string>
     <string name="import_compatible_data_key" translatable="false">import_compatible_data</string>
     <string name="import_compatible_data_title">Import from NewPipe or compatible app</string>
-    <string name="import_compatible_data_summary">Merge watch history, playback positions, local playlists, and compatible settings from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
+    <string name="import_compatible_data_summary">Merge watch history, playback positions, local playlists, compatible settings, and PipePipe SponsorBlock settings from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
     <string name="export_data_title">Export full backup</string>
     <string name="clear_cookie_title">Clear reCAPTCHA cookies</string>
     <string name="recaptcha_cookies_cleared">reCAPTCHA cookies have been cleared</string>
@@ -514,10 +514,11 @@
     <string name="migration_history_option">Watch history: %1$d entries and %2$d playback positions</string>
     <string name="migration_playlists_option">Local playlists: %1$d playlists and %2$d items</string>
     <string name="migration_settings_option">Compatible app settings: %1$d</string>
+    <string name="migration_sponsor_block_option">PipePipe SponsorBlock settings: %1$d</string>
     <string name="migration_import_button">Merge data</string>
     <string name="migration_nothing_selected">Select at least one data category.</string>
     <string name="migration_complete_title">Migration complete</string>
-    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, %4$d playlist items, and %5$d compatible settings. Skipped %6$d incompatible items.</string>
+    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, %4$d playlist items, %5$d compatible settings, and %6$d SponsorBlock settings. Skipped %7$d incompatible items.</string>
     <string name="backup_exported_with_file">Backup exported: %s</string>
     <string name="backup_import_succeeded_restart">Import succeeded. WizeStream will restart to finish loading the backup.</string>
     <string name="restart">Restart</string>

--- a/app/src/test/java/org/schabi/newpipe/settings/ImportExportManagerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/ImportExportManagerTest.kt
@@ -2,7 +2,10 @@ package org.schabi.newpipe.settings
 
 import android.content.SharedPreferences
 import com.grack.nanojson.JsonParser
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
+import java.io.ObjectOutputStream
 import java.nio.ByteBuffer
 import java.nio.file.Paths
 import java.util.zip.ZipEntry
@@ -295,6 +298,50 @@ class ImportExportManagerTest {
 
         assertThrows(ClassNotFoundException::class.java) {
             ImportExportManager(fileLocator).loadSerializedPrefs(storedFileHelper, preferences)
+        }
+    }
+
+    @Test
+    fun `PipePipe serialized preferences require explicit source approval`() {
+        val serialized = ByteArrayOutputStream().use { bytes ->
+            ObjectOutputStream(bytes).use { output ->
+                output.writeObject(
+                    hashMapOf(
+                        "show_comments" to false,
+                        "sponsor_block_enable" to true
+                    )
+                )
+            }
+            bytes.toByteArray()
+        }
+        val zip = createTempFile("pipepipe_preferences_", ".zip")
+        ZipOutputStream(zip.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(BackupFileLocator.FILE_NAME_SERIALIZED_PREFS))
+            output.write(serialized)
+            output.closeEntry()
+        }
+        `when`(storedFileHelper.stream).thenAnswer { FileStream(zip.toFile()) }
+        val manager = ImportExportManager(fileLocator)
+
+        assertTrue(manager.readMigrationPrefs(storedFileHelper, false).isEmpty())
+        assertEquals(
+            mapOf("show_comments" to false, "sponsor_block_enable" to true),
+            manager.readMigrationPrefs(storedFileHelper, true)
+        )
+    }
+
+    @Test
+    fun `Oversized PipePipe serialized preferences must be rejected`() {
+        val zip = createTempFile("oversized_pipepipe_preferences_", ".zip")
+        ZipOutputStream(zip.outputStream()).use { output ->
+            output.putNextEntry(ZipEntry(BackupFileLocator.FILE_NAME_SERIALIZED_PREFS))
+            output.write(ByteArray(1_048_577))
+            output.closeEntry()
+        }
+        `when`(storedFileHelper.stream).thenAnswer { FileStream(zip.toFile()) }
+
+        assertThrows(IOException::class.java) {
+            ImportExportManager(fileLocator).readMigrationPrefs(storedFileHelper, true)
         }
     }
 }


### PR DESCRIPTION
- Detect PipePipe from its staged database before accepting legacy serialized preferences
- Bound the legacy preference entry to 1 MiB and restrict deserialization to the existing primitive/container class allowlist
- Convert only PipePipe SponsorBlock values actually present in the backup, preserving existing WizeStream choices when source keys are absent
- Map PipePipe automatic, manual, and highlight modes to WizeStream skip, manual, and don’t-skip behavior
- Keep selected service, SponsorBlock identity, API endpoint, whitelist, and unrelated sensitive values excluded
- Add SponsorBlock as an independent selectable migration category with result reporting and rollback
- Add JVM coverage for source approval and size limits plus Android conversion and merge-safety coverage