### PR TITLE
Prevent startup crashes on devices without PiP

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
@@ -76,6 +76,12 @@ public final class NativePipController {
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
     private boolean isSupported() {
+        // Keep this guard before evaluating any newer Activity APIs. Java evaluates method
+        // arguments eagerly, so passing isInMultiWindowMode() into the helper on API 23 would
+        // still invoke that API even though the helper itself rejects pre-Oreo versions.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return false;
+        }
         return isSupportedEnvironment(
                 Build.VERSION.SDK_INT,
                 activity.getPackageManager().hasSystemFeature(

--- a/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.player.pip;
 
 import android.app.PictureInPictureParams;
+import android.content.pm.PackageManager;
 import android.graphics.Rect;
 import android.os.Build;
 import android.util.Rational;
@@ -34,7 +35,11 @@ public final class NativePipController {
         if (!isSupported()) {
             return;
         }
-        activity.setPictureInPictureParams(buildParams(currentFragment().orElse(null)));
+        try {
+            activity.setPictureInPictureParams(buildParams(currentFragment().orElse(null)));
+        } catch (final IllegalStateException ignored) {
+            // Some vendor builds reject PiP calls even after advertising support.
+        }
     }
 
     public void onUserLeaveHint() {
@@ -48,16 +53,16 @@ public final class NativePipController {
 
         fragment.prepareNativePipEntry();
         final PictureInPictureParams params = buildParams(fragment);
-        activity.setPictureInPictureParams(params);
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || !fragment.isNativePipPlaying()) {
-            try {
+        try {
+            activity.setPictureInPictureParams(params);
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+                    || !fragment.isNativePipPlaying()) {
                 if (!activity.enterPictureInPictureMode(params)) {
                     fragment.onNativePipModeChanged(false);
                 }
-            } catch (final IllegalStateException ignored) {
-                fragment.onNativePipModeChanged(false);
             }
+        } catch (final IllegalStateException ignored) {
+            fragment.onNativePipModeChanged(false);
         }
     }
 
@@ -71,8 +76,20 @@ public final class NativePipController {
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
     private boolean isSupported() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-                && !DeviceUtils.isTv(activity) && !activity.isInMultiWindowMode();
+        return isSupportedEnvironment(
+                Build.VERSION.SDK_INT,
+                activity.getPackageManager().hasSystemFeature(
+                        PackageManager.FEATURE_PICTURE_IN_PICTURE),
+                DeviceUtils.isTv(activity),
+                activity.isInMultiWindowMode());
+    }
+
+    static boolean isSupportedEnvironment(final int sdkInt,
+                                          final boolean hasSystemFeature,
+                                          final boolean isTv,
+                                          final boolean isInMultiWindowMode) {
+        return sdkInt >= Build.VERSION_CODES.O && hasSystemFeature
+                && !isTv && !isInMultiWindowMode;
     }
 
     private boolean isEnabled() {

--- a/app/src/test/java/org/schabi/newpipe/player/pip/NativePipControllerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/pip/NativePipControllerTest.java
@@ -1,6 +1,10 @@
 package org.schabi.newpipe.player.pip;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Build;
 
 import org.junit.Test;
 
@@ -23,5 +27,21 @@ public class NativePipControllerTest {
     public void normalVideoAspectRatiosArePreserved() {
         assertEquals(16f / 9f, NativePipController.sanitizeAspectRatio(16f / 9f), TOLERANCE);
         assertEquals(9f / 16f, NativePipController.sanitizeAspectRatio(9f / 16f), TOLERANCE);
+    }
+
+    @Test
+    public void pipRequiresTheSystemFeatureOnSupportedAndroidVersions() {
+        assertFalse(NativePipController.isSupportedEnvironment(
+                Build.VERSION_CODES.O, false, false, false));
+        assertTrue(NativePipController.isSupportedEnvironment(
+                Build.VERSION_CODES.O, true, false, false));
+    }
+
+    @Test
+    public void pipRemainsDisabledOnTvAndInMultiWindowMode() {
+        assertFalse(NativePipController.isSupportedEnvironment(
+                Build.VERSION_CODES.O, true, true, false));
+        assertFalse(NativePipController.isSupportedEnvironment(
+                Build.VERSION_CODES.O, true, false, true));
     }
 }


### PR DESCRIPTION
- Require Android’s picture-in-picture system feature before updating native PiP parameters
- Tolerate vendor PiP rejections during startup and background-entry preparation
- Add regression coverage for unsupported, TV, and multi-window environments