### PR TITLE
Prevent fullscreen startup crash before player connection

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -2775,9 +2775,19 @@ public final class VideoDetailFragment
         // from landscape to portrait every time.
         // Just turn on fullscreen mode in landscape orientation
         // or portrait & unlocked global orientation
-        final Optional<MainPlayerUi> playerUi = player.UIs().get(MainPlayerUi.class);
         final int currentOrientation = getResources().getConfiguration().orientation;
         final boolean isLandscape = currentOrientation == Configuration.ORIENTATION_LANDSCAPE;
+        if (!isPlayerAvailable()) {
+            // The initial start-fullscreen path runs before the player service connects. Rotate
+            // now and let the connection/configuration callbacks apply fullscreen afterward.
+            if (!DeviceUtils.isTv(activity) && !isLandscape) {
+                activity.setRequestedOrientation(
+                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+            }
+            return;
+        }
+
+        final Optional<MainPlayerUi> playerUi = player.UIs().get(MainPlayerUi.class);
         if (DeviceUtils.isTv(activity) || DeviceUtils.isTablet(activity)
                 && (!globalScreenOrientationLocked(activity) || isLandscape)) {
             playerUi.ifPresent(ui -> ui.setFullscreen(!ui.isFullscreen()));

--- a/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
@@ -47,6 +47,22 @@ public class FullscreenExitIntegrationTest {
     }
 
     @Test
+    public void initialFullscreenRotationDoesNotRequireABoundPlayer() throws Exception {
+        final String source = read(
+                "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
+        final String rotation = methodBody(source,
+                "public void onScreenRotationButtonClicked()");
+
+        final int missingPlayerGuard = rotation.indexOf("if (!isPlayerAvailable())");
+        final int playerAccess = rotation.indexOf("player.UIs().get(MainPlayerUi.class)");
+        assertTrue("Missing-player guard must exist", missingPlayerGuard >= 0);
+        assertTrue("Missing-player guard must run before player access",
+                missingPlayerGuard < playerAccess);
+        assertTrue(rotation.substring(missingPlayerGuard, playerAccess).contains(
+                "SCREEN_ORIENTATION_SENSOR_LANDSCAPE"));
+    }
+
+    @Test
     public void explicitFullscreenSetterIsIdempotent() throws Exception {
         final String source = read("org/schabi/newpipe/player/ui/MainPlayerUi.java");
         final String setter = methodBody(source, "public void setFullscreen(");


### PR DESCRIPTION
- Guard the rotation callback before accessing an unbound player
- Preserve direct-fullscreen startup by requesting landscape and letting connection and configuration callbacks apply fullscreen
- Add regression coverage requiring the missing-player guard before player UI access