### PR TITLE
Add Videos filter to What's New

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/StreamListFilter.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamListFilter.kt
@@ -10,6 +10,7 @@ enum class StreamListFilter(@IdRes val chipId: Int) {
     NONE(0),
     UNWATCHED(R.id.filter_unwatched),
     LIVE(R.id.filter_live),
+    VIDEOS(R.id.filter_videos),
     SHORTS(R.id.filter_shorts),
     PARTIALLY_WATCHED(R.id.filter_partially_watched);
 
@@ -31,6 +32,8 @@ enum class StreamListFilter(@IdRes val chipId: Int) {
             UNWATCHED -> state == null || !state.isValid(stream.duration)
 
             LIVE -> StreamTypeUtil.isLiveStream(stream.streamType)
+
+            VIDEOS -> !StreamTypeUtil.isLiveStream(stream.streamType) && !isShort(stream)
 
             SHORTS -> isShort(stream)
 

--- a/app/src/main/res/layout/list_stream_filter_chips.xml
+++ b/app/src/main/res/layout/list_stream_filter_chips.xml
@@ -34,6 +34,14 @@
             android:text="@string/channel_tab_livestreams" />
 
         <com.google.android.material.chip.Chip
+            android:id="@+id/filter_videos"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkable="true"
+            android:text="@string/videos_string" />
+
+        <com.google.android.material.chip.Chip
             android:id="@+id/filter_shorts"
             style="@style/Widget.Material3.Chip.Filter"
             android:layout_width="wrap_content"

--- a/app/src/test/java/org/schabi/newpipe/util/StreamListFilterTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/util/StreamListFilterTest.kt
@@ -64,6 +64,38 @@ class StreamListFilterTest {
     }
 
     @Test
+    fun `videos excludes shorts and live streams`() {
+        assertTrue(
+            StreamListFilter.matches(
+                StreamListFilter.VIDEOS,
+                stream(duration = 181),
+                null
+            )
+        )
+        assertFalse(
+            StreamListFilter.matches(
+                StreamListFilter.VIDEOS,
+                stream(duration = 180),
+                null
+            )
+        )
+        assertFalse(
+            StreamListFilter.matches(
+                StreamListFilter.VIDEOS,
+                stream(url = "https://www.youtube.com/shorts/abcdefghijk", duration = -1),
+                null
+            )
+        )
+        assertFalse(
+            StreamListFilter.matches(
+                StreamListFilter.VIDEOS,
+                stream(duration = 600, type = StreamType.LIVE_STREAM),
+                null
+            )
+        )
+    }
+
+    @Test
     fun `shorts accepts explicit shorts urls and videos up to three minutes`() {
         assertTrue(
             StreamListFilter.matches(
@@ -100,6 +132,12 @@ class StreamListFilterTest {
             StreamListFilter.matches(
                 StreamListFilter.LIVE,
                 historyEntry(type = StreamType.LIVE_STREAM)
+            )
+        )
+        assertTrue(
+            StreamListFilter.matches(
+                StreamListFilter.VIDEOS,
+                historyEntry(duration = 600)
             )
         )
         assertTrue(


### PR DESCRIPTION
- Add a Videos filter chip between Live and Shorts in the What’s New filter bar
- Show standard non-live videos while excluding anything classified by the existing Shorts rules
- Keep the unfiltered What’s New feed behavior unchanged
- Reuse the existing Videos translation string
- Add regression coverage for normal videos, Shorts, explicit Shorts URLs, live streams, and history entries
- Fixes #365