### PR TITLE
Rebind video surface after fullscreen resize

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
@@ -35,7 +35,7 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
 
     @Override
     public void surfaceCreated(final SurfaceHolder holder) {
-        player.setVideoSurface(holder.getSurface());
+        bindVideoSurface(holder);
     }
 
     @Override
@@ -43,6 +43,14 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
                                final int format,
                                final int width,
                                final int height) {
+        // Some devices keep the same SurfaceView across fullscreen/orientation transitions and
+        // only resize its underlying surface. Rebind on every structural surface change so the
+        // decoder cannot remain attached to the placeholder/stale fullscreen output.
+        bindVideoSurface(holder);
+    }
+
+    private void bindVideoSurface(final SurfaceHolder holder) {
+        player.setVideoSurface(holder.getSurface());
     }
 
     @Override

--- a/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceHolderCallbackTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceHolderCallbackTest.java
@@ -1,0 +1,43 @@
+package org.schabi.newpipe.player.playback;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+
+import com.google.android.exoplayer2.Player;
+
+import org.junit.Test;
+
+public class SurfaceHolderCallbackTest {
+    @Test
+    public void surfaceChangedRebindsCurrentVideoSurface() {
+        final Context context = mock(Context.class);
+        final Player player = mock(Player.class);
+        final SurfaceHolder holder = mock(SurfaceHolder.class);
+        final Surface surface = mock(Surface.class);
+        when(holder.getSurface()).thenReturn(surface);
+
+        final SurfaceHolderCallback callback = new SurfaceHolderCallback(context, player);
+        callback.surfaceChanged(holder, 0, 1920, 1080);
+
+        verify(player).setVideoSurface(surface);
+    }
+
+    @Test
+    public void surfaceCreatedBindsCurrentVideoSurface() {
+        final Context context = mock(Context.class);
+        final Player player = mock(Player.class);
+        final SurfaceHolder holder = mock(SurfaceHolder.class);
+        final Surface surface = mock(Surface.class);
+        when(holder.getSurface()).thenReturn(surface);
+
+        final SurfaceHolderCallback callback = new SurfaceHolderCallback(context, player);
+        callback.surfaceCreated(holder);
+
+        verify(player).setVideoSurface(surface);
+    }
+}


### PR DESCRIPTION
- Rebind ExoPlayer to the active SurfaceHolder whenever Android reports a structural surface change
- Preserve playback state and position while recovering from fullscreen-to-normal surface reuse
- Keep the existing placeholder-surface protection for destroyed surfaces
- Add regression coverage for both initial surface binding and resize-time rebinding
- Fixes #373