### PR TITLE
Use native PiP from the player action

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
@@ -66,6 +66,33 @@ public final class NativePipController {
         }
     }
 
+    /**
+     * Enters native PiP immediately from an explicit user action.
+     *
+     * <p>Unlike the Home-button path, this deliberately avoids changing the fullscreen/detail
+     * layout before asking Android to start the PiP transition. The normal PiP mode callback will
+     * perform the existing player preparation after the system has started the transition.</p>
+     *
+     * @return whether Android accepted the PiP entry request
+     */
+    public boolean enterPictureInPicture() {
+        if (!isSupported()) {
+            return false;
+        }
+        final VideoDetailFragment fragment = currentFragment().orElse(null);
+        if (fragment == null || !fragment.isNativePipEligible()) {
+            return false;
+        }
+
+        final PictureInPictureParams params = buildParams(fragment);
+        try {
+            activity.setPictureInPictureParams(params);
+            return activity.enterPictureInPictureMode(params);
+        } catch (final IllegalArgumentException | IllegalStateException ignored) {
+            return false;
+        }
+    }
+
     public void onPictureInPictureModeChanged(final boolean inPictureInPictureMode) {
         currentFragment().ifPresent(fragment ->
                 fragment.onNativePipModeChanged(inPictureInPictureMode));

--- a/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/NewPipeTextView.java
@@ -1,13 +1,20 @@
 package org.schabi.newpipe.views;
 
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.text.method.MovementMethod;
 import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.AppCompatTextView;
 
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.pip.NativePipController;
 import org.schabi.newpipe.util.NewPipeTextViewHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
@@ -22,6 +29,12 @@ import org.schabi.newpipe.util.external_communication.ShareUtils;
  * </p>
  */
 public class NewPipeTextView extends AppCompatTextView {
+    @Nullable
+    private OnClickListener legacyPopupClickListener;
+    @Nullable
+    private OnLongClickListener legacyPopupLongClickListener;
+    @Nullable
+    private OnTouchListener legacyPopupTouchListener;
 
     public NewPipeTextView(@NonNull final Context context) {
         super(context);
@@ -45,6 +58,121 @@ public class NewPipeTextView extends AppCompatTextView {
         final MovementMethod movementMethod = this.getMovementMethod();
         super.setText(text, type);
         setMovementMethod(movementMethod);
+    }
+
+    @Override
+    public void setOnClickListener(@Nullable final OnClickListener listener) {
+        if (!isPrimaryDetailPipAction()) {
+            super.setOnClickListener(listener);
+            return;
+        }
+
+        legacyPopupClickListener = listener;
+        setText(R.string.controls_pip_title);
+        setContentDescription(getContext().getString(R.string.enter_picture_in_picture));
+        super.setOnClickListener(view -> {
+            if (!enterNativePictureInPicture() && legacyPopupClickListener != null) {
+                legacyPopupClickListener.onClick(view);
+            }
+        });
+        post(this::ensureLegacyPopupAction);
+    }
+
+    @Override
+    public void setOnLongClickListener(@Nullable final OnLongClickListener listener) {
+        if (!isPrimaryDetailPipAction()) {
+            super.setOnLongClickListener(listener);
+            return;
+        }
+
+        legacyPopupLongClickListener = listener;
+        super.setOnLongClickListener(null);
+        post(this::ensureLegacyPopupAction);
+    }
+
+    @Override
+    public void setOnTouchListener(@Nullable final OnTouchListener listener) {
+        if (!isPrimaryDetailPipAction()) {
+            super.setOnTouchListener(listener);
+            return;
+        }
+
+        legacyPopupTouchListener = listener;
+        super.setOnTouchListener(null);
+        post(this::ensureLegacyPopupAction);
+    }
+
+    @Override
+    public void setVisibility(final int visibility) {
+        super.setVisibility(visibility);
+        if (isPrimaryDetailPipAction()) {
+            post(this::syncLegacyPopupVisibility);
+        }
+    }
+
+    private boolean isPrimaryDetailPipAction() {
+        return getId() == R.id.detail_controls_popup;
+    }
+
+    private boolean enterNativePictureInPicture() {
+        Context current = getContext();
+        while (current instanceof ContextWrapper) {
+            if (current instanceof AppCompatActivity) {
+                return new NativePipController((AppCompatActivity) current)
+                        .enterPictureInPicture();
+            }
+            final Context base = ((ContextWrapper) current).getBaseContext();
+            if (base == current) {
+                break;
+            }
+            current = base;
+        }
+        return false;
+    }
+
+    private void ensureLegacyPopupAction() {
+        if (!isPrimaryDetailPipAction()) {
+            return;
+        }
+        final View root = getRootView();
+        final LinearLayout secondaryControls =
+                root.findViewById(R.id.detail_secondary_control_panel);
+        if (secondaryControls == null) {
+            return;
+        }
+
+        View legacyPopup = root.findViewById(R.id.detail_controls_legacy_popup);
+        if (legacyPopup == null) {
+            legacyPopup = LayoutInflater.from(getContext()).inflate(
+                    R.layout.detail_legacy_popup_action, secondaryControls, false);
+            secondaryControls.addView(legacyPopup, 0);
+        }
+        legacyPopup.setOnClickListener(legacyPopupClickListener);
+        legacyPopup.setOnLongClickListener(legacyPopupLongClickListener);
+        legacyPopup.setOnTouchListener(legacyPopupTouchListener);
+        legacyPopup.setVisibility(getVisibility());
+        if (getVisibility() == View.VISIBLE) {
+            final View secondaryToggle = root.findViewById(
+                    R.id.detail_toggle_secondary_controls_view);
+            if (secondaryToggle != null) {
+                secondaryToggle.setVisibility(View.VISIBLE);
+            }
+        }
+    }
+
+    private void syncLegacyPopupVisibility() {
+        final View root = getRootView();
+        final View legacyPopup = root.findViewById(R.id.detail_controls_legacy_popup);
+        if (legacyPopup != null) {
+            legacyPopup.setVisibility(getVisibility());
+        }
+        if (getVisibility() == View.VISIBLE) {
+            final View secondaryToggle = root.findViewById(
+                    R.id.detail_toggle_secondary_controls_view);
+            if (secondaryToggle != null) {
+                secondaryToggle.setVisibility(View.VISIBLE);
+            }
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/detail_legacy_popup_action.xml
+++ b/app/src/main/res/layout/detail_legacy_popup_action.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.schabi.newpipe.views.NewPipeTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/detail_controls_legacy_popup"
+    style="@style/VideoDetailActionText"
+    android:layout_width="@dimen/detail_control_width"
+    android:layout_height="@dimen/detail_control_height"
+    android:layout_gravity="center_vertical"
+    android:layout_weight="1"
+    android:background="?attr/selectableItemBackgroundBorderless"
+    android:clickable="true"
+    android:contentDescription="@string/open_in_popup_mode"
+    android:drawableTop="@drawable/ic_smart_display"
+    android:focusable="true"
+    android:gravity="center"
+    android:paddingVertical="@dimen/detail_control_padding"
+    android:text="@string/controls_popup_title"
+    android:textSize="@dimen/detail_control_text_size" />

--- a/app/src/main/res/values/native_pip_action_strings.xml
+++ b/app/src/main/res/values/native_pip_action_strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="controls_pip_title">PiP</string>
+    <string name="enter_picture_in_picture">Enter picture-in-picture</string>
+</resources>

--- a/app/src/test/java/org/schabi/newpipe/player/pip/NativePipButtonIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/pip/NativePipButtonIntegrationTest.java
@@ -1,0 +1,72 @@
+package org.schabi.newpipe.player.pip;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class NativePipButtonIntegrationTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+    private final Path resourceDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void dedicatedPipEntryAvoidsPreTransitionFullscreenPreparation() throws Exception {
+        final String source = readSource(
+                "org/schabi/newpipe/player/pip/NativePipController.java");
+        final String dedicatedEntry = methodBody(source,
+                "public boolean enterPictureInPicture()");
+        final String homeEntry = methodBody(source, "public void onUserLeaveHint()");
+
+        assertTrue(dedicatedEntry.contains("activity.enterPictureInPictureMode(params)"));
+        assertFalse(dedicatedEntry.contains("prepareNativePipEntry()"));
+        assertTrue(homeEntry.contains("prepareNativePipEntry()"));
+    }
+
+    @Test
+    public void primaryPlayerActionUsesNativePipWithPopupFallback() throws Exception {
+        final String source = readSource("org/schabi/newpipe/views/NewPipeTextView.java");
+        final String clickListener = methodBody(source, "public void setOnClickListener(");
+
+        assertTrue(clickListener.contains("enterNativePictureInPicture()"));
+        assertTrue(clickListener.contains("legacyPopupClickListener.onClick(view)"));
+        assertTrue(source.contains("R.id.detail_controls_popup"));
+        assertTrue(source.contains("R.layout.detail_legacy_popup_action"));
+    }
+
+    @Test
+    public void legacyPopupRemainsASeparateSecondaryAction() throws Exception {
+        final String layout = Files.readString(
+                resourceDirectory.resolve("layout/detail_legacy_popup_action.xml"));
+
+        assertTrue(layout.contains("@+id/detail_controls_legacy_popup"));
+        assertTrue(layout.contains("@string/controls_popup_title"));
+        assertTrue(layout.contains("@drawable/ic_smart_display"));
+    }
+
+    private String readSource(final String relativePath) throws Exception {
+        return Files.readString(sourceDirectory.resolve(relativePath));
+    }
+
+    private static String methodBody(final String source, final String signature) {
+        final int signatureIndex = source.indexOf(signature);
+        assertTrue("Missing method: " + signature, signatureIndex >= 0);
+
+        final int bodyStart = source.indexOf('{', signatureIndex);
+        assertTrue("Missing method body: " + signature, bodyStart >= 0);
+
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unclosed method body: " + signature);
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/views/NewPipeTextViewTest.java
+++ b/app/src/test/java/org/schabi/newpipe/views/NewPipeTextViewTest.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.views;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class NewPipeTextViewTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void nativePipInterceptionIsLimitedToTheDetailPopupAction() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/views/NewPipeTextView.java"));
+
+        assertTrue(source.contains("getId() == R.id.detail_controls_popup"));
+        assertTrue(source.contains("if (!isPrimaryDetailPipAction())"));
+        assertTrue(source.contains("super.setOnClickListener(listener)"));
+        assertTrue(source.contains("super.setOnLongClickListener(listener)"));
+        assertTrue(source.contains("super.setOnTouchListener(listener)"));
+    }
+}


### PR DESCRIPTION
- Route the primary PiP-looking player action through Android native picture-in-picture
- Enter PiP without pre-transition fullscreen layout changes so the animation stays smooth
- Keep the legacy floating Popup player as a separate secondary action
- Fall back to Popup when native PiP is unavailable
- Preserve long-press enqueue behavior on the legacy Popup action
- Add regression coverage for the dedicated PiP path
- Fixes #369