### PR TITLE
Prevent queue navigation from triggering PiP

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
@@ -1,6 +1,8 @@
 package org.schabi.newpipe.player.pip;
 
+import android.app.ActivityManager;
 import android.app.PictureInPictureParams;
+import android.content.ComponentName;
 import android.content.pm.PackageManager;
 import android.graphics.Rect;
 import android.os.Build;
@@ -15,6 +17,7 @@ import androidx.preference.PreferenceManager;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
+import org.schabi.newpipe.player.PlayQueueActivity;
 import org.schabi.newpipe.util.DeviceUtils;
 
 import java.util.Optional;
@@ -48,6 +51,11 @@ public final class NativePipController {
         }
         final VideoDetailFragment fragment = currentFragment().orElse(null);
         if (fragment == null || !fragment.isNativePipEligible()) {
+            return;
+        }
+
+        if (isOpeningPlayQueueActivity()) {
+            disableAutoEnterForInternalNavigation(fragment);
             return;
         }
 
@@ -101,6 +109,45 @@ public final class NativePipController {
         }
     }
 
+    @SuppressWarnings("deprecation")
+    private boolean isOpeningPlayQueueActivity() {
+        final ActivityManager activityManager = activity.getSystemService(ActivityManager.class);
+        if (activityManager == null) {
+            return false;
+        }
+        try {
+            for (final ActivityManager.RunningTaskInfo taskInfo
+                    : activityManager.getRunningTasks(3)) {
+                final ComponentName topActivity = taskInfo.topActivity;
+                if (topActivity != null
+                        && activity.getPackageName().equals(topActivity.getPackageName())) {
+                    return isInternalPlayQueueTarget(
+                            activity.getPackageName(), topActivity.getPackageName(),
+                            topActivity.getClassName());
+                }
+            }
+        } catch (final SecurityException ignored) {
+            // Some vendor builds restrict task inspection more aggressively than Android itself.
+        }
+        return false;
+    }
+
+    static boolean isInternalPlayQueueTarget(@NonNull final String appPackageName,
+                                             @NonNull final String topPackageName,
+                                             @NonNull final String topClassName) {
+        return appPackageName.equals(topPackageName)
+                && PlayQueueActivity.class.getName().equals(topClassName);
+    }
+
+    private void disableAutoEnterForInternalNavigation(
+            @NonNull final VideoDetailFragment fragment) {
+        try {
+            activity.setPictureInPictureParams(buildParams(fragment, false));
+        } catch (final IllegalArgumentException | IllegalStateException ignored) {
+            // Internal navigation must continue even if a vendor build rejects the PiP update.
+        }
+    }
+
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
     private boolean isSupported() {
         // Keep this guard before evaluating any newer Activity APIs. Java evaluates method
@@ -125,6 +172,14 @@ public final class NativePipController {
                 && !isTv && !isInMultiWindowMode;
     }
 
+    static boolean shouldAutoEnter(final boolean allowAutoEnter,
+                                   final boolean enabled,
+                                   final boolean hasFragment,
+                                   final boolean eligible,
+                                   final boolean playing) {
+        return allowAutoEnter && enabled && hasFragment && eligible && playing;
+    }
+
     private boolean isEnabled() {
         return PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(
                 activity.getString(R.string.native_pip_key), false);
@@ -141,6 +196,13 @@ public final class NativePipController {
     @RequiresApi(Build.VERSION_CODES.O)
     @NonNull
     private PictureInPictureParams buildParams(final VideoDetailFragment fragment) {
+        return buildParams(fragment, true);
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    @NonNull
+    private PictureInPictureParams buildParams(final VideoDetailFragment fragment,
+                                               final boolean allowAutoEnter) {
         final PictureInPictureParams.Builder builder = new PictureInPictureParams.Builder();
         if (fragment != null) {
             final float aspectRatio = sanitizeAspectRatio(fragment.getNativePipAspectRatio());
@@ -151,8 +213,12 @@ public final class NativePipController {
             }
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            final boolean autoEnter = isEnabled() && fragment != null
-                    && fragment.isNativePipEligible() && fragment.isNativePipPlaying();
+            final boolean autoEnter = shouldAutoEnter(
+                    allowAutoEnter,
+                    isEnabled(),
+                    fragment != null,
+                    fragment != null && fragment.isNativePipEligible(),
+                    fragment != null && fragment.isNativePipPlaying());
             builder.setAutoEnterEnabled(autoEnter);
             builder.setSeamlessResizeEnabled(true);
         }

--- a/app/src/test/java/org/schabi/newpipe/player/pip/NativePipControllerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/pip/NativePipControllerTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import android.os.Build;
 
 import org.junit.Test;
+import org.schabi.newpipe.player.PlayQueueActivity;
 
 public class NativePipControllerTest {
     private static final float TOLERANCE = 0.001f;
@@ -43,5 +44,28 @@ public class NativePipControllerTest {
                 Build.VERSION_CODES.O, true, true, false));
         assertFalse(NativePipController.isSupportedEnvironment(
                 Build.VERSION_CODES.O, true, false, true));
+    }
+
+    @Test
+    public void playQueueActivityIsRecognizedAsInternalNavigation() {
+        assertTrue(NativePipController.isInternalPlayQueueTarget(
+                "org.wisso.newpipematerial",
+                "org.wisso.newpipematerial",
+                PlayQueueActivity.class.getName()));
+        assertFalse(NativePipController.isInternalPlayQueueTarget(
+                "org.wisso.newpipematerial",
+                "com.example.external",
+                PlayQueueActivity.class.getName()));
+        assertFalse(NativePipController.isInternalPlayQueueTarget(
+                "org.wisso.newpipematerial",
+                "org.wisso.newpipematerial",
+                "org.schabi.newpipe.MainActivity"));
+    }
+
+    @Test
+    public void internalNavigationCanDisableAutoEnterWithoutChangingEligibility() {
+        assertTrue(NativePipController.shouldAutoEnter(true, true, true, true, true));
+        assertFalse(NativePipController.shouldAutoEnter(false, true, true, true, true));
+        assertFalse(NativePipController.shouldAutoEnter(true, true, true, true, false));
     }
 }


### PR DESCRIPTION
- Suppress native PiP auto-entry when the minimized player opens the in-app play queue
- Detect the Play Queue activity as an internal task transition before handling the leave hint
- Disable auto-enter only for that internal transition and let MainActivity restore normal PiP parameters on return
- Keep Home/swipe-to-Home PiP and the dedicated PiP button unchanged
- Preserve playback state while opening and managing the queue
- Add regression coverage for internal queue detection and temporary auto-enter suppression
- Fixes #366