### PR TITLE
Restore orientation when minimizing fullscreen player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
@@ -1,6 +1,9 @@
 package org.schabi.newpipe.player.gesture;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.ActivityInfo;
 import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
@@ -16,6 +19,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.navigationrail.NavigationRailView;
 
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.helper.PlayerHolder;
+import org.schabi.newpipe.util.DeviceUtils;
 
 import java.util.List;
 
@@ -35,6 +40,9 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
     private final BottomSheetCallback bottomNavigationCallback = new BottomSheetCallback() {
         @Override
         public void onStateChanged(@NonNull final View bottomSheet, final int newState) {
+            if (newState == STATE_COLLAPSED) {
+                restorePhoneOrientationAfterFullscreenCollapse(bottomSheet);
+            }
             if (newState == STATE_COLLAPSED || newState == STATE_EXPANDED
                     || newState == STATE_HIDDEN) {
                 updateBottomNavigation((FrameLayout) bottomSheet, newState, null);
@@ -142,6 +150,36 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
         }
 
         return super.onInterceptTouchEvent(parent, child, event);
+    }
+
+    private void restorePhoneOrientationAfterFullscreenCollapse(@NonNull final View bottomSheet) {
+        final Activity activity = findActivity(bottomSheet.getContext());
+        if (activity == null
+                || DeviceUtils.isTablet(activity)
+                || DeviceUtils.isTv(activity)
+                || DeviceUtils.isDesktopMode(activity)) {
+            return;
+        }
+
+        if (PlayerHolder.getInstance().exitMainPlayerFullscreenForMiniPlayer()) {
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        }
+    }
+
+    @Nullable
+    private static Activity findActivity(@NonNull final Context context) {
+        Context current = context;
+        while (current instanceof ContextWrapper) {
+            if (current instanceof Activity) {
+                return (Activity) current;
+            }
+            final Context base = ((ContextWrapper) current).getBaseContext();
+            if (base == current) {
+                break;
+            }
+            current = base;
+        }
+        return null;
     }
 
     private void updateBottomNavigation(@NonNull final FrameLayout bottomSheet,

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -23,6 +23,7 @@ import org.schabi.newpipe.player.event.PlayerServiceEventListener;
 import org.schabi.newpipe.player.event.PlayerServiceExtendedEventListener;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
+import org.schabi.newpipe.player.ui.MainPlayerUi;
 import org.schabi.newpipe.util.NavigationHelper;
 
 import java.util.Optional;
@@ -84,6 +85,24 @@ public final class PlayerHolder {
         return getPlayer()
                 .map(player -> player.consumeMainPlayerFullscreenBeforePopup(fallback))
                 .orElse(fallback);
+    }
+
+    /**
+     * Exits the main player's fullscreen UI without touching playback state.
+     *
+     * @return whether a fullscreen main player was actually changed to non-fullscreen
+     */
+    public boolean exitMainPlayerFullscreenForMiniPlayer() {
+        return getPlayer()
+                .flatMap(player -> player.UIs().get(MainPlayerUi.class))
+                .map(playerUi -> {
+                    if (!playerUi.isFullscreen()) {
+                        return false;
+                    }
+                    playerUi.setFullscreen(false);
+                    return !playerUi.isFullscreen();
+                })
+                .orElse(false);
     }
 
     public boolean isPlayerOpen() {

--- a/app/src/test/java/org/schabi/newpipe/player/gesture/PlayerCollapseOrientationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/gesture/PlayerCollapseOrientationTest.java
@@ -1,0 +1,63 @@
+package org.schabi.newpipe.player.gesture;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class PlayerCollapseOrientationTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void collapsedPhonePlayerReleasesFullscreenOrientation() throws Exception {
+        final String behavior = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java"));
+        final String stateChanged = methodBody(behavior, "public void onStateChanged(");
+        final String restoreMethod = methodBody(
+                behavior, "private void restorePhoneOrientationAfterFullscreenCollapse(");
+
+        assertTrue(stateChanged.contains("newState == STATE_COLLAPSED"));
+        assertTrue(stateChanged.contains("restorePhoneOrientationAfterFullscreenCollapse"));
+        assertTrue(restoreMethod.contains("DeviceUtils.isTablet(activity)"));
+        assertTrue(restoreMethod.contains("DeviceUtils.isTv(activity)"));
+        assertTrue(restoreMethod.contains("DeviceUtils.isDesktopMode(activity)"));
+        assertTrue(restoreMethod.contains("exitMainPlayerFullscreenForMiniPlayer()"));
+        assertTrue(restoreMethod.contains("SCREEN_ORIENTATION_UNSPECIFIED"));
+    }
+
+    @Test
+    public void miniPlayerFullscreenExitDoesNotChangePlayback() throws Exception {
+        final String holder = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/helper/PlayerHolder.java"));
+        final String method = methodBody(
+                holder, "public boolean exitMainPlayerFullscreenForMiniPlayer()");
+
+        assertTrue(method.contains("playerUi.isFullscreen()"));
+        assertTrue(method.contains("playerUi.setFullscreen(false)"));
+        assertFalse(method.contains(".play("));
+        assertFalse(method.contains(".pause("));
+        assertFalse(method.contains("seekTo("));
+    }
+
+    private static String methodBody(final String source, final String signature) {
+        final int signatureIndex = source.indexOf(signature);
+        assertTrue("Missing method: " + signature, signatureIndex >= 0);
+
+        final int bodyStart = source.indexOf('{', signatureIndex);
+        assertTrue("Missing method body: " + signature, bodyStart >= 0);
+
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unclosed method body: " + signature);
+    }
+}


### PR DESCRIPTION
- Exit the main player’s fullscreen UI when the bottom sheet reaches the minimized state on phones
- Release WizeStream’s forced landscape orientation so the device’s normal orientation lock takes over
- Keep tablet, TV, and desktop-mode behavior unchanged
- Preserve playback state, position, queue, and the existing fullscreen gesture behavior
- Add regression coverage for collapsed-player orientation restoration and playback-state preservation
- Fixes #367