### PR TITLE
Enter fullscreen when rotating with orientation lock

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java
@@ -39,6 +39,8 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
             R.id.detail_content_root_layout, R.id.relatedItemsLayout,
             R.id.itemsListPanel, R.id.view_pager, R.id.tab_layout, R.id.bottomControls,
             R.id.playPauseButton, R.id.playPreviousButton, R.id.playNextButton);
+    private final LockedOrientationFullscreenController lockedOrientationFullscreenController =
+            new LockedOrientationFullscreenController();
 
     private boolean playerTransitionActive;
     private int playerTransitionGeneration;
@@ -52,6 +54,8 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
     private final BottomSheetCallback bottomNavigationCallback = new BottomSheetCallback() {
         @Override
         public void onStateChanged(@NonNull final View bottomSheet, final int newState) {
+            lockedOrientationFullscreenController.onPlayerSheetStateChanged(newState);
+
             if (PlayerSheetTransitionCalculator.isActiveTransitionState(newState)) {
                 beginPlayerTransition(bottomSheet);
             } else if (newState == STATE_COLLAPSED || newState == STATE_EXPANDED
@@ -88,6 +92,7 @@ public class CustomBottomSheetBehavior extends BottomSheetBehavior<FrameLayout> 
         bottomSheetView = child;
         applyPlayerPeekHeight(child, isBottomNavigationRequested(child));
         final boolean handled = super.onLayoutChild(parent, child, layoutDirection);
+        lockedOrientationFullscreenController.attach(child, getState());
         updateBottomNavigation(child, getState(), null);
         if (!playerTransitionActive) {
             resetMiniPlayerChrome(child);

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenController.java
@@ -1,0 +1,333 @@
+package org.schabi.newpipe.player.gesture;
+
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED;
+import static com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.ActivityInfo;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.OrientationEventListener;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.preference.PreferenceManager;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.helper.PlayerHolder;
+import org.schabi.newpipe.util.DeviceUtils;
+
+/**
+ * Allows the main video player to follow the physical phone orientation even while Android's
+ * system rotation is locked. The controller only claims fullscreen transitions that it initiated,
+ * so manually-entered fullscreen remains entirely under the user's control.
+ */
+final class LockedOrientationFullscreenController {
+    static final int ORIENTATION_ZONE_OTHER = 0;
+    static final int ORIENTATION_ZONE_PORTRAIT = 1;
+    static final int ORIENTATION_ZONE_LANDSCAPE = 2;
+
+    private static final int ORIENTATION_TOLERANCE_DEGREES = 30;
+    private static final long STABLE_ORIENTATION_DELAY_MILLIS = 250L;
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private int sheetState = STATE_HIDDEN;
+    private int pendingOrientationZone = ORIENTATION_ZONE_OTHER;
+    private int stableOrientationZone = ORIENTATION_ZONE_OTHER;
+    private boolean autoEnteredFullscreen;
+    private boolean listening;
+
+    @Nullable
+    private View bottomSheet;
+    @Nullable
+    private Activity activity;
+    @Nullable
+    private LifecycleOwner lifecycleOwner;
+    @Nullable
+    private OrientationEventListener orientationEventListener;
+
+    private final Runnable commitPendingOrientation = () -> {
+        if (pendingOrientationZone == ORIENTATION_ZONE_OTHER) {
+            return;
+        }
+        final int committedZone = pendingOrientationZone;
+        pendingOrientationZone = ORIENTATION_ZONE_OTHER;
+        if (handleStableOrientation(committedZone)) {
+            stableOrientationZone = committedZone;
+        }
+    };
+
+    private final LifecycleEventObserver lifecycleObserver = (source, event) -> {
+        if (event == Lifecycle.Event.ON_START) {
+            startListening();
+        } else if (event == Lifecycle.Event.ON_STOP) {
+            stopListening();
+        } else if (event == Lifecycle.Event.ON_DESTROY) {
+            detach();
+        }
+    };
+
+    private final View.OnAttachStateChangeListener attachStateChangeListener =
+            new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(final View view) {
+                    if (lifecycleOwner == null) {
+                        startListening();
+                    }
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(final View view) {
+                    if (view == bottomSheet) {
+                        detach();
+                    }
+                }
+            };
+
+    void attach(@NonNull final View playerSheet, final int currentSheetState) {
+        sheetState = currentSheetState;
+        if (bottomSheet == playerSheet) {
+            return;
+        }
+
+        detach();
+        bottomSheet = playerSheet;
+        sheetState = currentSheetState;
+        activity = findActivity(playerSheet.getContext());
+        if (activity == null) {
+            return;
+        }
+
+        orientationEventListener = new OrientationEventListener(activity) {
+            @Override
+            public void onOrientationChanged(final int orientation) {
+                handleOrientationChanged(orientation);
+            }
+        };
+        playerSheet.addOnAttachStateChangeListener(attachStateChangeListener);
+
+        if (activity instanceof LifecycleOwner owner) {
+            lifecycleOwner = owner;
+            owner.getLifecycle().addObserver(lifecycleObserver);
+            if (owner.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
+                startListening();
+            }
+        } else if (playerSheet.isAttachedToWindow()) {
+            startListening();
+        }
+    }
+
+    void onPlayerSheetStateChanged(final int newState) {
+        sheetState = newState;
+        if (newState == STATE_EXPANDED) {
+            cancelPendingOrientation();
+            stableOrientationZone = ORIENTATION_ZONE_OTHER;
+        } else if (newState == STATE_COLLAPSED || newState == STATE_HIDDEN) {
+            cancelPendingOrientation();
+            stableOrientationZone = ORIENTATION_ZONE_OTHER;
+            // The normal collapsed-player path restores orientation/fullscreen. Do not let a
+            // previous automatic entry claim a later manual fullscreen session.
+            autoEnteredFullscreen = false;
+        }
+    }
+
+    private void detach() {
+        stopListening();
+        if (bottomSheet != null) {
+            bottomSheet.removeOnAttachStateChangeListener(attachStateChangeListener);
+        }
+        if (lifecycleOwner != null) {
+            lifecycleOwner.getLifecycle().removeObserver(lifecycleObserver);
+        }
+        bottomSheet = null;
+        activity = null;
+        lifecycleOwner = null;
+        orientationEventListener = null;
+        sheetState = STATE_HIDDEN;
+        autoEnteredFullscreen = false;
+    }
+
+    private void startListening() {
+        if (listening || activity == null || orientationEventListener == null
+                || !isFeatureEnabled(activity)
+                || isLargeScreenDevice(activity)
+                || !orientationEventListener.canDetectOrientation()) {
+            return;
+        }
+        orientationEventListener.enable();
+        listening = true;
+    }
+
+    private void stopListening() {
+        if (orientationEventListener != null && listening) {
+            orientationEventListener.disable();
+        }
+        listening = false;
+        cancelPendingOrientation();
+        stableOrientationZone = ORIENTATION_ZONE_OTHER;
+    }
+
+    private void handleOrientationChanged(final int orientation) {
+        if (orientation == OrientationEventListener.ORIENTATION_UNKNOWN) {
+            cancelPendingOrientation();
+            return;
+        }
+
+        final int orientationZone = orientationZone(orientation);
+        if (orientationZone == ORIENTATION_ZONE_OTHER) {
+            cancelPendingOrientation();
+            return;
+        }
+        if (orientationZone == ORIENTATION_ZONE_LANDSCAPE && sheetState != STATE_EXPANDED) {
+            cancelPendingOrientation();
+            return;
+        }
+        if (orientationZone == stableOrientationZone
+                || orientationZone == pendingOrientationZone) {
+            return;
+        }
+
+        handler.removeCallbacks(commitPendingOrientation);
+        pendingOrientationZone = orientationZone;
+        handler.postDelayed(commitPendingOrientation, STABLE_ORIENTATION_DELAY_MILLIS);
+    }
+
+    private void cancelPendingOrientation() {
+        handler.removeCallbacks(commitPendingOrientation);
+        pendingOrientationZone = ORIENTATION_ZONE_OTHER;
+    }
+
+    private boolean handleStableOrientation(final int orientationZone) {
+        final Activity currentActivity = activity;
+        if (currentActivity == null) {
+            return false;
+        }
+
+        if (orientationZone == ORIENTATION_ZONE_LANDSCAPE) {
+            final PlayerHolder playerHolder = PlayerHolder.getInstance();
+            final boolean featureEnabled = isFeatureEnabled(currentActivity);
+            final boolean systemRotationLocked =
+                    PlayerHelper.globalScreenOrientationLocked(currentActivity);
+            final boolean playerExpanded = sheetState == STATE_EXPANDED;
+            final boolean videoPlayerEligible =
+                    playerHolder.isMainVideoPlayerOrientationEligible();
+            final boolean alreadyFullscreen = playerHolder.isMainPlayerFullscreen();
+            final boolean explicitLandscapeRequest = isExplicitLandscapeOrientation(
+                    currentActivity.getRequestedOrientation());
+            final boolean inPictureInPicture = isInPictureInPicture(currentActivity);
+            final boolean largeScreenDevice = isLargeScreenDevice(currentActivity);
+
+            if (shouldAutoEnterFullscreen(
+                    featureEnabled,
+                    systemRotationLocked,
+                    playerExpanded,
+                    videoPlayerEligible,
+                    alreadyFullscreen,
+                    explicitLandscapeRequest,
+                    inPictureInPicture,
+                    largeScreenDevice)) {
+                autoEnteredFullscreen = true;
+                currentActivity.setRequestedOrientation(
+                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+                return true;
+            }
+
+            // Keep checking while the expanded player is still becoming eligible or PiP is
+            // finishing. Permanent/manual blocks can be treated as a stable landscape state.
+            return playerExpanded && videoPlayerEligible && !inPictureInPicture;
+        }
+
+        if (shouldAutoExitFullscreen(autoEnteredFullscreen, orientationZone)) {
+            autoEnteredFullscreen = false;
+            currentActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        }
+        return true;
+    }
+
+    private static boolean isFeatureEnabled(@NonNull final Activity activity) {
+        return PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(
+                activity.getString(R.string.rotate_to_fullscreen_key), true);
+    }
+
+    private static boolean isInPictureInPicture(@NonNull final Activity activity) {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && activity.isInPictureInPictureMode();
+    }
+
+    private static boolean isLargeScreenDevice(@NonNull final Activity activity) {
+        return DeviceUtils.isTablet(activity)
+                || DeviceUtils.isTv(activity)
+                || DeviceUtils.isDesktopMode(activity);
+    }
+
+    static int orientationZone(final int orientation) {
+        if (orientation < 0) {
+            return ORIENTATION_ZONE_OTHER;
+        }
+        final int normalized = orientation % 360;
+        if (normalized <= ORIENTATION_TOLERANCE_DEGREES
+                || normalized >= 360 - ORIENTATION_TOLERANCE_DEGREES) {
+            return ORIENTATION_ZONE_PORTRAIT;
+        }
+        if (Math.abs(normalized - 90) <= ORIENTATION_TOLERANCE_DEGREES
+                || Math.abs(normalized - 270) <= ORIENTATION_TOLERANCE_DEGREES) {
+            return ORIENTATION_ZONE_LANDSCAPE;
+        }
+        return ORIENTATION_ZONE_OTHER;
+    }
+
+    static boolean shouldAutoEnterFullscreen(final boolean featureEnabled,
+                                             final boolean systemRotationLocked,
+                                             final boolean playerExpanded,
+                                             final boolean videoPlayerEligible,
+                                             final boolean alreadyFullscreen,
+                                             final boolean explicitLandscapeRequest,
+                                             final boolean inPictureInPicture,
+                                             final boolean largeScreenDevice) {
+        return featureEnabled
+                && systemRotationLocked
+                && playerExpanded
+                && videoPlayerEligible
+                && !alreadyFullscreen
+                && !explicitLandscapeRequest
+                && !inPictureInPicture
+                && !largeScreenDevice;
+    }
+
+    static boolean shouldAutoExitFullscreen(final boolean autoEnteredFullscreen,
+                                            final int orientationZone) {
+        return autoEnteredFullscreen && orientationZone == ORIENTATION_ZONE_PORTRAIT;
+    }
+
+    static boolean isExplicitLandscapeOrientation(final int requestedOrientation) {
+        return requestedOrientation == ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                || requestedOrientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                || requestedOrientation == ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+                || requestedOrientation == ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE;
+    }
+
+    @Nullable
+    private static Activity findActivity(@NonNull final Context context) {
+        Context current = context;
+        while (current instanceof ContextWrapper) {
+            if (current instanceof Activity) {
+                return (Activity) current;
+            }
+            final Context base = ((ContextWrapper) current).getBaseContext();
+            if (base == current) {
+                break;
+            }
+            current = base;
+        }
+        return current instanceof Activity ? (Activity) current : null;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -76,6 +76,31 @@ public final class PlayerHolder {
         return getPlayer().map(Player::isPlaying).orElse(false);
     }
 
+    /**
+     * Returns whether a main video is in a state where physical rotation may control fullscreen.
+     */
+    public boolean isMainVideoPlayerOrientationEligible() {
+        return getPlayer().map(player -> {
+            if (player.getPlayerType() != PlayerType.MAIN
+                    || !player.videoPlayerSelected()
+                    || player.isAudioOnly()) {
+                return false;
+            }
+            final int state = player.getCurrentState();
+            return state == Player.STATE_PLAYING
+                    || state == Player.STATE_BUFFERING
+                    || state == Player.STATE_PAUSED
+                    || state == Player.STATE_PAUSED_SEEK;
+        }).orElse(false);
+    }
+
+    public boolean isMainPlayerFullscreen() {
+        return getPlayer()
+                .flatMap(player -> player.UIs().get(MainPlayerUi.class))
+                .map(MainPlayerUi::isFullscreen)
+                .orElse(false);
+    }
+
     public void rememberMainPlayerFullscreenBeforePopup(final boolean fullscreen) {
         getPlayer().ifPresent(player ->
                 player.rememberMainPlayerFullscreenBeforePopup(fullscreen));

--- a/app/src/main/res/values/rotate_to_fullscreen_strings.xml
+++ b/app/src/main/res/values/rotate_to_fullscreen_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="rotate_to_fullscreen_key" translatable="false">rotate_to_fullscreen</string>
+    <string name="rotate_to_fullscreen_title">Rotate device to enter fullscreen</string>
+    <string name="rotate_to_fullscreen_summary">When system rotation is locked, turn your phone sideways to enter fullscreen and return it upright to exit fullscreen.</string>
+</resources>

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -196,6 +196,14 @@
             app:iconSpaceReserved="false" />
 
         <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/rotate_to_fullscreen_key"
+            android:summary="@string/rotate_to_fullscreen_summary"
+            android:title="@string/rotate_to_fullscreen_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
+
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/pin_video_while_scrolling_key"
             android:summary="@string/pin_video_while_scrolling_summary"

--- a/app/src/test/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenControllerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenControllerTest.java
@@ -1,0 +1,103 @@
+package org.schabi.newpipe.player.gesture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.pm.ActivityInfo;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LockedOrientationFullscreenControllerTest {
+    private final Path projectDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main")
+            : Path.of("app/src/main");
+
+    @Test
+    public void orientationZonesUseHysteresisGapsAroundPortraitAndLandscape() {
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_PORTRAIT,
+                LockedOrientationFullscreenController.orientationZone(0));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_PORTRAIT,
+                LockedOrientationFullscreenController.orientationZone(25));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_PORTRAIT,
+                LockedOrientationFullscreenController.orientationZone(335));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_LANDSCAPE,
+                LockedOrientationFullscreenController.orientationZone(90));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_LANDSCAPE,
+                LockedOrientationFullscreenController.orientationZone(115));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_LANDSCAPE,
+                LockedOrientationFullscreenController.orientationZone(245));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_OTHER,
+                LockedOrientationFullscreenController.orientationZone(45));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_OTHER,
+                LockedOrientationFullscreenController.orientationZone(180));
+        assertEquals(LockedOrientationFullscreenController.ORIENTATION_ZONE_OTHER,
+                LockedOrientationFullscreenController.orientationZone(-1));
+    }
+
+    @Test
+    public void lockedExpandedVideoCanEnterFullscreenAutomatically() {
+        assertTrue(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, true, true, false, false, false, false));
+    }
+
+    @Test
+    public void automaticEntryDoesNotTakeOverManualOrUnsupportedSessions() {
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                false, true, true, true, false, false, false, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, false, true, true, false, false, false, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, false, true, false, false, false, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, true, false, false, false, false, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, true, true, true, false, false, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, true, true, false, true, false, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, true, true, false, false, true, false));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
+                true, true, true, true, false, false, false, true));
+    }
+
+    @Test
+    public void onlyAutomaticallyEnteredFullscreenExitsWhenPhoneReturnsUpright() {
+        assertTrue(LockedOrientationFullscreenController.shouldAutoExitFullscreen(
+                true, LockedOrientationFullscreenController.ORIENTATION_ZONE_PORTRAIT));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoExitFullscreen(
+                true, LockedOrientationFullscreenController.ORIENTATION_ZONE_LANDSCAPE));
+        assertFalse(LockedOrientationFullscreenController.shouldAutoExitFullscreen(
+                false, LockedOrientationFullscreenController.ORIENTATION_ZONE_PORTRAIT));
+    }
+
+    @Test
+    public void explicitLandscapeRequestsProtectManualFullscreen() {
+        assertTrue(LockedOrientationFullscreenController.isExplicitLandscapeOrientation(
+                ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE));
+        assertTrue(LockedOrientationFullscreenController.isExplicitLandscapeOrientation(
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE));
+        assertTrue(LockedOrientationFullscreenController.isExplicitLandscapeOrientation(
+                ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE));
+        assertFalse(LockedOrientationFullscreenController.isExplicitLandscapeOrientation(
+                ActivityInfo.SCREEN_ORIENTATION_PORTRAIT));
+    }
+
+    @Test
+    public void rotateToFullscreenIsEnabledByDefaultAndWiredToPlayerSheet() throws Exception {
+        final String settings = Files.readString(projectDirectory.resolve(
+                "res/xml/video_audio_settings.xml"));
+        final String behavior = Files.readString(projectDirectory.resolve(
+                "java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java"));
+
+        final int preference = settings.indexOf("android:key=\"@string/rotate_to_fullscreen_key\"");
+        final int defaultValue = settings.lastIndexOf("android:defaultValue=\"true\"", preference);
+        assertTrue(preference >= 0 && defaultValue >= 0 && preference - defaultValue < 100);
+        assertTrue(behavior.contains("lockedOrientationFullscreenController.attach(child, getState())"));
+        assertTrue(behavior.contains(
+                "lockedOrientationFullscreenController.onPlayerSheetStateChanged(newState)"));
+    }
+}


### PR DESCRIPTION
- Add a Rotate device to enter fullscreen setting under Video & Audio → Player behavior, enabled by default
- Detect physical phone orientation with a lifecycle-bound OrientationEventListener even when Android rotation is locked
- Enter sensor-landscape fullscreen only for the expanded main video player on phones
- Return to the normal locked orientation when the phone is upright only when fullscreen was entered automatically
- Protect manually entered fullscreen, PiP, mini-player, audio-only, tablet, TV, and desktop-mode sessions
- Use stable angle thresholds and a short hold delay to avoid accidental rotation from small device movements
- Preserve playback state, position, queue, zoom, captions, and the recent fullscreen transition fixes
- Add regression coverage for orientation zones, eligibility, manual-fullscreen protection, and preference wiring
- Fixes #364