### PR TITLE
Fix rotate-to-fullscreen CI checks

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenController.java
@@ -225,16 +225,17 @@ final class LockedOrientationFullscreenController {
                     currentActivity.getRequestedOrientation());
             final boolean inPictureInPicture = isInPictureInPicture(currentActivity);
             final boolean largeScreenDevice = isLargeScreenDevice(currentActivity);
+            final boolean playerStateBlocksEntry = alreadyFullscreen
+                    || explicitLandscapeRequest
+                    || inPictureInPicture
+                    || largeScreenDevice;
 
             if (shouldAutoEnterFullscreen(
                     featureEnabled,
                     systemRotationLocked,
                     playerExpanded,
                     videoPlayerEligible,
-                    alreadyFullscreen,
-                    explicitLandscapeRequest,
-                    inPictureInPicture,
-                    largeScreenDevice)) {
+                    playerStateBlocksEntry)) {
                 autoEnteredFullscreen = true;
                 currentActivity.setRequestedOrientation(
                         ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
@@ -289,18 +290,12 @@ final class LockedOrientationFullscreenController {
                                              final boolean systemRotationLocked,
                                              final boolean playerExpanded,
                                              final boolean videoPlayerEligible,
-                                             final boolean alreadyFullscreen,
-                                             final boolean explicitLandscapeRequest,
-                                             final boolean inPictureInPicture,
-                                             final boolean largeScreenDevice) {
+                                             final boolean playerStateBlocksEntry) {
         return featureEnabled
                 && systemRotationLocked
                 && playerExpanded
                 && videoPlayerEligible
-                && !alreadyFullscreen
-                && !explicitLandscapeRequest
-                && !inPictureInPicture
-                && !largeScreenDevice;
+                && !playerStateBlocksEntry;
     }
 
     static boolean shouldAutoExitFullscreen(final boolean autoEnteredFullscreen,

--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHolder.java
@@ -78,6 +78,8 @@ public final class PlayerHolder {
 
     /**
      * Returns whether a main video is in a state where physical rotation may control fullscreen.
+     *
+     * @return true when the main video player is eligible for orientation-driven fullscreen
      */
     public boolean isMainVideoPlayerOrientationEligible() {
         return getPlayer().map(player -> {

--- a/app/src/test/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenControllerTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/gesture/LockedOrientationFullscreenControllerTest.java
@@ -41,27 +41,21 @@ public class LockedOrientationFullscreenControllerTest {
     @Test
     public void lockedExpandedVideoCanEnterFullscreenAutomatically() {
         assertTrue(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, true, true, false, false, false, false));
+                true, true, true, true, false));
     }
 
     @Test
-    public void automaticEntryDoesNotTakeOverManualOrUnsupportedSessions() {
+    public void automaticEntryHonorsEligibilityAndProtectedPlayerState() {
         assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                false, true, true, true, false, false, false, false));
+                false, true, true, true, false));
         assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, false, true, true, false, false, false, false));
+                true, false, true, true, false));
         assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, false, true, false, false, false, false));
+                true, true, false, true, false));
         assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, true, false, false, false, false, false));
+                true, true, true, false, false));
         assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, true, true, true, false, false, false));
-        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, true, true, false, true, false, false));
-        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, true, true, false, false, true, false));
-        assertFalse(LockedOrientationFullscreenController.shouldAutoEnterFullscreen(
-                true, true, true, true, false, false, false, true));
+                true, true, true, true, true));
     }
 
     @Test
@@ -93,10 +87,13 @@ public class LockedOrientationFullscreenControllerTest {
         final String behavior = Files.readString(projectDirectory.resolve(
                 "java/org/schabi/newpipe/player/gesture/CustomBottomSheetBehavior.java"));
 
-        final int preference = settings.indexOf("android:key=\"@string/rotate_to_fullscreen_key\"");
-        final int defaultValue = settings.lastIndexOf("android:defaultValue=\"true\"", preference);
+        final int preference = settings.indexOf(
+                "android:key=\"@string/rotate_to_fullscreen_key\"");
+        final int defaultValue = settings.lastIndexOf(
+                "android:defaultValue=\"true\"", preference);
         assertTrue(preference >= 0 && defaultValue >= 0 && preference - defaultValue < 100);
-        assertTrue(behavior.contains("lockedOrientationFullscreenController.attach(child, getState())"));
+        assertTrue(behavior.contains(
+                "lockedOrientationFullscreenController.attach(child, getState())"));
         assertTrue(behavior.contains(
                 "lockedOrientationFullscreenController.onPlayerSheetStateChanged(newState)"));
     }


### PR DESCRIPTION
- Add the missing Javadoc return description for the orientation-eligibility helper
- Refactor the rotate-to-fullscreen eligibility check to avoid the new excessive-parameter warning
- Keep manual fullscreen, PiP, large-screen, and existing eligibility protections unchanged
- Reformat the regression test to satisfy the project line-length rule
- Preserve the merged #364 behavior while making the JVM and Android CI lanes reach their real checks