### PR TITLE
Align Local Media toolbar and refresh

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt
@@ -74,6 +74,16 @@ class LocalMediaBrowserViewModel(application: Application) : AndroidViewModel(ap
         showRoots()
     }
 
+    fun refresh() {
+        val current = mutableState.value ?: LocalMediaBrowserState()
+        val location = current.location
+        if (location == null) {
+            showRoots()
+        } else {
+            load(location, current.title) { browser.list(location) }
+        }
+    }
+
     fun mediaItem(entry: LocalMediaDocumentEntry): LocalMediaItem? = browser.mediaItem(entry)
 
     fun collect(

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -3,13 +3,18 @@
  */
 package org.schabi.newpipe.local.media
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
@@ -43,6 +48,11 @@ internal fun localMediaItemLayout(itemViewMode: ItemViewMode): Int = when (itemV
 }
 
 class LocalMediaFragment : Fragment() {
+    private companion object {
+        const val STATE_QUERY = "local_media_query"
+        const val STATE_SEARCH_EXPANDED = "local_media_search_expanded"
+    }
+
     private enum class Filter { ALL, AUDIO, VIDEO, BROWSE }
     private enum class Sort { TITLE, ARTIST, ALBUM, FOLDER, RECENT }
 
@@ -52,6 +62,7 @@ class LocalMediaFragment : Fragment() {
     private var filter = Filter.ALL
     private var sort = Sort.TITLE
     private var query = ""
+    private var searchExpanded = false
     private var audioCategory = LocalMediaAudioCategory.TRACKS
     private var videoCategory = LocalMediaVideoCategory.VIDEOS
     private var activeGroup: LocalMediaGroup? = null
@@ -62,6 +73,7 @@ class LocalMediaFragment : Fragment() {
     private lateinit var viewModel: LocalMediaViewModel
     private lateinit var browserViewModel: LocalMediaBrowserViewModel
     private var browserState = LocalMediaBrowserState()
+    private var searchField: TextInputEditText? = null
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
@@ -82,6 +94,13 @@ class LocalMediaFragment : Fragment() {
         }
     }
 
+    override fun onCreate(state: Bundle?) {
+        super.onCreate(state)
+        setHasOptionsMenu(true)
+        query = state?.getString(STATE_QUERY).orEmpty()
+        searchExpanded = state?.getBoolean(STATE_SEARCH_EXPANDED) ?: false
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -98,6 +117,7 @@ class LocalMediaFragment : Fragment() {
         adapter = LocalMediaAdapter(::play, ::showActions)
         groupAdapter = LocalMediaGroupAdapter(::openGroup)
         documentAdapter = LocalMediaDocumentAdapter(::openDocument, ::showDocumentActions)
+        searchField = view.findViewById(R.id.localMediaSearch)
         list.adapter = adapter
         applyItemViewMode()
 
@@ -160,21 +180,31 @@ class LocalMediaFragment : Fragment() {
         view.findViewById<View>(R.id.localMediaBrowseMore).setOnClickListener {
             browserState.location?.let { showFolderActions(it, browserState.title, false) }
         }
-        view.findViewById<TextInputEditText>(R.id.localMediaSearch).addTextChangedListener(
-            object : TextWatcher {
-                override fun beforeTextChanged(
-                    s: CharSequence?,
-                    start: Int,
-                    count: Int,
-                    after: Int
-                ) = Unit
-                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                    query = s?.toString().orEmpty()
-                    updateList()
+        searchField?.apply {
+            if (query.isNotEmpty()) setText(query)
+            addTextChangedListener(
+                object : TextWatcher {
+                    override fun beforeTextChanged(
+                        s: CharSequence?,
+                        start: Int,
+                        count: Int,
+                        after: Int
+                    ) = Unit
+
+                    override fun onTextChanged(
+                        s: CharSequence?,
+                        start: Int,
+                        before: Int,
+                        count: Int
+                    ) {
+                        query = s?.toString().orEmpty()
+                        updateList()
+                    }
+
+                    override fun afterTextChanged(s: Editable?) = Unit
                 }
-                override fun afterTextChanged(s: Editable?) = Unit
-            }
-        )
+            )
+        }
         viewModel.state.observe(viewLifecycleOwner, ::renderState)
         browserViewModel.state.observe(viewLifecycleOwner, ::renderBrowserState)
         requireActivity().onBackPressedDispatcher.addCallback(
@@ -188,6 +218,7 @@ class LocalMediaFragment : Fragment() {
                 }
             }
         )
+        updateSearchVisibility()
         loadOrExplainPermission()
     }
 
@@ -195,6 +226,44 @@ class LocalMediaFragment : Fragment() {
         super.onResume()
         ThemeHelper.setTitleToAppCompatActivity(activity, getString(R.string.local_media))
         if (::adapter.isInitialized) applyItemViewMode()
+        requireActivity().invalidateOptionsMenu()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(STATE_QUERY, query)
+        outState.putBoolean(STATE_SEARCH_EXPANDED, searchExpanded)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_local_media, menu)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+        menu.findItem(R.id.menu_item_search_content)?.isVisible = filter != Filter.BROWSE
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.menu_item_search_content -> {
+                toggleSearch()
+                true
+            }
+
+            R.id.menu_item_local_media_refresh -> {
+                refreshLocalMedia()
+                true
+            }
+
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onDestroyView() {
+        searchField = null
+        super.onDestroyView()
     }
 
     override fun onDestroy() {
@@ -215,6 +284,50 @@ class LocalMediaFragment : Fragment() {
         viewModel.load(access)
     }
 
+    private fun refreshLocalMedia() {
+        if (!::viewModel.isInitialized || !::browserViewModel.isInitialized) return
+        val access = LocalMediaPermissionPolicy.access(requireContext())
+        if (!access.hasAnyAccess) {
+            showMessage(R.string.local_media_permission_description, true)
+            return
+        }
+        view?.findViewById<View>(R.id.localMediaMessagePanel)?.visibility = View.GONE
+        viewModel.load(access, force = true)
+        if (filter == Filter.BROWSE) browserViewModel.refresh()
+    }
+
+    private fun toggleSearch() {
+        if (filter == Filter.BROWSE) return
+        searchExpanded = !searchExpanded
+        if (!searchExpanded) searchField?.text?.clear()
+        updateSearchVisibility(focus = searchExpanded)
+    }
+
+    private fun updateSearchVisibility(focus: Boolean = false) {
+        val shouldShow = searchExpanded && filter != Filter.BROWSE
+        view?.findViewById<View>(R.id.localMediaSearchLayout)?.visibility =
+            if (shouldShow) View.VISIBLE else View.GONE
+
+        val field = searchField ?: return
+        if (shouldShow) {
+            if (focus) {
+                field.requestFocus()
+                field.post {
+                    val inputMethodManager = requireContext().getSystemService(
+                        Context.INPUT_METHOD_SERVICE
+                    ) as InputMethodManager
+                    inputMethodManager.showSoftInput(field, InputMethodManager.SHOW_IMPLICIT)
+                }
+            }
+        } else {
+            field.clearFocus()
+            val inputMethodManager = requireContext().getSystemService(
+                Context.INPUT_METHOD_SERVICE
+            ) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(field.windowToken, 0)
+        }
+    }
+
     private fun renderState(state: LocalMediaLibraryState) {
         if (!isAdded || view == null) return
         view?.findViewById<View>(R.id.localMediaProgress)?.visibility =
@@ -232,11 +345,11 @@ class LocalMediaFragment : Fragment() {
             if (selected == Filter.VIDEO) View.VISIBLE else View.GONE
         view?.findViewById<View>(R.id.localMediaBrowseNavigation)?.visibility =
             if (selected == Filter.BROWSE) View.VISIBLE else View.GONE
-        view?.findViewById<View>(R.id.localMediaSearchLayout)?.visibility =
-            if (selected == Filter.BROWSE) View.GONE else View.VISIBLE
+        updateSearchVisibility()
         view?.findViewById<View>(R.id.localMediaSort)?.visibility =
             if (selected == Filter.BROWSE) View.GONE else View.VISIBLE
         view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility = View.GONE
+        requireActivity().invalidateOptionsMenu()
         if (selected == Filter.BROWSE) renderBrowserState(browserState) else updateList()
     }
 

--- a/app/src/main/res/layout/fragment_local_media.xml
+++ b/app/src/main/res/layout/fragment_local_media.xml
@@ -23,16 +23,29 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="16dp"
-                android:layout_marginTop="12dp"
-                android:hint="@string/local_media_search_hint"
-                app:endIconMode="clear_text">
+                android:layout_marginTop="8dp"
+                android:visibility="gone"
+                app:boxCornerRadiusBottomEnd="22dp"
+                app:boxCornerRadiusBottomStart="22dp"
+                app:boxCornerRadiusTopEnd="22dp"
+                app:boxCornerRadiusTopStart="22dp"
+                app:boxStrokeWidth="1dp"
+                app:boxStrokeWidthFocused="1dp"
+                app:endIconMode="clear_text"
+                app:hintEnabled="false">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/localMediaSearch"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="44dp"
+                    android:gravity="center_vertical"
+                    android:hint="@string/local_media_search_hint"
                     android:imeOptions="actionDone"
-                    android:inputType="text" />
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:paddingTop="0dp"
+                    android:paddingBottom="0dp"
+                    android:singleLine="true" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <HorizontalScrollView

--- a/app/src/main/res/menu/menu_local_media.xml
+++ b/app/src/main/res/menu/menu_local_media.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <item
+        android:id="@+id/menu_item_search_content"
+        android:icon="@drawable/ic_search"
+        android:title="@string/search"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
+    <item
+        android:id="@+id/menu_item_local_media_refresh"
+        android:orderInCategory="1"
+        android:title="@string/local_media_refresh"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/local_media_toolbar_strings.xml
+++ b/app/src/main/res/values/local_media_toolbar_strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="local_media_refresh">Refresh</string>
+</resources>


### PR DESCRIPTION
- Add a History-style Search action and overflow menu to Local Media
- Reveal the existing local search field only when Search is selected
- Make the search field shorter with fully rounded left and right sides
- Add Refresh to force a complete MediaStore rescan and refresh the active folder browser
- Preserve Local Media filters, audio/video categories, sorting, browsing, and restored search state