### PR TITLE
Recover local video surface after fullscreen exit

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
@@ -1,10 +1,17 @@
 package org.schabi.newpipe.player.playback;
 
+import android.content.ContentResolver;
 import android.content.Context;
+import android.net.Uri;
 import android.view.SurfaceHolder;
 
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.video.PlaceholderSurface;
+
+import org.schabi.newpipe.views.ExpandableSurfaceView;
+
+import java.util.Objects;
 
 /**
  * Prevent error message: 'Unrecoverable player error occurred'
@@ -23,10 +30,16 @@ import com.google.android.exoplayer2.video.PlaceholderSurface;
  * https://github.com/google/ExoPlayer/issues/2703#issuecomment-300599981
  */
 public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
+    private static final double FULLSCREEN_EXPANSION_FACTOR = 1.35;
+    private static final double FULLSCREEN_EXIT_SHRINK_FACTOR = 0.80;
 
     private final Context context;
     private final Player player;
     private PlaceholderSurface placeholderSurface;
+    private int previousWidth;
+    private int previousHeight;
+    private boolean expandedSurfaceSeen;
+    private String trackedMediaUri;
 
     public SurfaceHolderCallback(final Context context, final Player player) {
         this.context = context;
@@ -43,10 +56,91 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
                                final int format,
                                final int width,
                                final int height) {
+        final String currentMediaUri = currentMediaUri();
+        if (!Objects.equals(trackedMediaUri, currentMediaUri)) {
+            resetSurfaceTransitionTracking();
+            trackedMediaUri = currentMediaUri;
+        }
+
+        final boolean localMedia = isLocalMediaUri(currentMediaUri);
+        if (localMedia && isLargeSurfaceExpansion(
+                previousWidth, previousHeight, width, height)) {
+            expandedSurfaceSeen = true;
+        }
+
+        final boolean recoverSurface = shouldRecoverLocalSurface(
+                localMedia,
+                expandedSurfaceSeen,
+                previousWidth,
+                previousHeight,
+                width,
+                height);
+        previousWidth = width;
+        previousHeight = height;
+
+        if (recoverSurface) {
+            expandedSurfaceSeen = false;
+            ExpandableSurfaceView.requestSurfaceRecreation(holder);
+        }
+
         // Some devices keep the same SurfaceView across fullscreen/orientation transitions and
         // only resize its underlying surface. Rebind on every structural surface change so the
         // decoder cannot remain attached to the placeholder/stale fullscreen output.
         bindVideoSurface(holder);
+    }
+
+    private String currentMediaUri() {
+        final MediaItem mediaItem = player.getCurrentMediaItem();
+        if (mediaItem == null || mediaItem.localConfiguration == null) {
+            return null;
+        }
+        return mediaItem.localConfiguration.uri.toString();
+    }
+
+    static boolean isLocalMediaUri(final String mediaUri) {
+        if (mediaUri == null || mediaUri.isEmpty()) {
+            return false;
+        }
+        final String scheme = Uri.parse(mediaUri).getScheme();
+        return ContentResolver.SCHEME_CONTENT.equals(scheme)
+                || ContentResolver.SCHEME_FILE.equals(scheme)
+                || ContentResolver.SCHEME_ANDROID_RESOURCE.equals(scheme);
+    }
+
+    static boolean isLargeSurfaceExpansion(final int previousWidth,
+                                           final int previousHeight,
+                                           final int width,
+                                           final int height) {
+        final long previousArea = surfaceArea(previousWidth, previousHeight);
+        final long currentArea = surfaceArea(width, height);
+        return previousArea > 0L
+                && currentArea > previousArea * FULLSCREEN_EXPANSION_FACTOR;
+    }
+
+    static boolean shouldRecoverLocalSurface(final boolean localMedia,
+                                             final boolean expandedSurfaceSeen,
+                                             final int previousWidth,
+                                             final int previousHeight,
+                                             final int width,
+                                             final int height) {
+        if (!localMedia || !expandedSurfaceSeen) {
+            return false;
+        }
+        final long previousArea = surfaceArea(previousWidth, previousHeight);
+        final long currentArea = surfaceArea(width, height);
+        return previousArea > 0L
+                && currentArea > 0L
+                && currentArea < previousArea * FULLSCREEN_EXIT_SHRINK_FACTOR;
+    }
+
+    private static long surfaceArea(final int width, final int height) {
+        return width <= 0 || height <= 0 ? 0L : (long) width * height;
+    }
+
+    private void resetSurfaceTransitionTracking() {
+        previousWidth = 0;
+        previousHeight = 0;
+        expandedSurfaceSeen = false;
     }
 
     private void bindVideoSurface(final SurfaceHolder holder) {
@@ -62,6 +156,8 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
     }
 
     public void release() {
+        resetSurfaceTransitionTracking();
+        trackedMediaUri = null;
         if (placeholderSurface != null) {
             placeholderSurface.release();
             placeholderSurface = null;

--- a/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
@@ -1,8 +1,6 @@
 package org.schabi.newpipe.player.playback;
 
-import android.content.ContentResolver;
 import android.content.Context;
-import android.net.Uri;
 import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.MediaItem;
@@ -101,10 +99,14 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
         if (mediaUri == null || mediaUri.isEmpty()) {
             return false;
         }
-        final String scheme = Uri.parse(mediaUri).getScheme();
-        return ContentResolver.SCHEME_CONTENT.equals(scheme)
-                || ContentResolver.SCHEME_FILE.equals(scheme)
-                || ContentResolver.SCHEME_ANDROID_RESOURCE.equals(scheme);
+        final int schemeSeparator = mediaUri.indexOf(':');
+        if (schemeSeparator <= 0) {
+            return false;
+        }
+        final String scheme = mediaUri.substring(0, schemeSeparator);
+        return "content".equalsIgnoreCase(scheme)
+                || "file".equalsIgnoreCase(scheme)
+                || "android.resource".equalsIgnoreCase(scheme);
     }
 
     static boolean isLargeSurfaceExpansion(final int previousWidth,

--- a/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
@@ -2,9 +2,18 @@ package org.schabi.newpipe.views;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.View;
+
+import androidx.annotation.NonNull;
 
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT;
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_ZOOM;
@@ -12,6 +21,11 @@ import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MOD
 public class ExpandableSurfaceView extends SurfaceView {
     public static final float MIN_USER_ZOOM = 1.0f;
     public static final float MAX_USER_ZOOM = 4.0f;
+
+    private static final long SURFACE_RECOVERY_SETTLE_DELAY_MILLIS = 120L;
+    private static final long SURFACE_RECREATE_GAP_MILLIS = 48L;
+    private static final Map<SurfaceHolder, WeakReference<ExpandableSurfaceView>> SURFACE_VIEWS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     private int resizeMode = RESIZE_MODE_FIT;
     private int baseHeight = 0;
@@ -22,9 +36,49 @@ public class ExpandableSurfaceView extends SurfaceView {
     private float userZoomScale = MIN_USER_ZOOM;
     private float userTranslationX;
     private float userTranslationY;
+    private int surfaceRecreationGeneration;
 
     public ExpandableSurfaceView(final Context context, final AttributeSet attrs) {
         super(context, attrs);
+        SURFACE_VIEWS.put(getHolder(), new WeakReference<>(this));
+    }
+
+    /**
+     * Requests a one-shot SurfaceView lifecycle restart after the current layout transition settles.
+     * Keeping the view invisible for a short frame gap forces Android to tear down the old surface
+     * and create a fresh one without changing the player's layout parameters.
+     *
+     * @param holder holder that belongs to the player surface needing recovery
+     * @return whether a matching player SurfaceView was found
+     */
+    public static boolean requestSurfaceRecreation(@NonNull final SurfaceHolder holder) {
+        final WeakReference<ExpandableSurfaceView> reference = SURFACE_VIEWS.get(holder);
+        final ExpandableSurfaceView surfaceView = reference == null ? null : reference.get();
+        if (surfaceView == null) {
+            SURFACE_VIEWS.remove(holder);
+            return false;
+        }
+        surfaceView.scheduleSurfaceRecreation();
+        return true;
+    }
+
+    private void scheduleSurfaceRecreation() {
+        final int generation = ++surfaceRecreationGeneration;
+        postDelayed(() -> {
+            if (generation != surfaceRecreationGeneration
+                    || !isAttachedToWindow()
+                    || getVisibility() != View.VISIBLE) {
+                return;
+            }
+
+            setVisibility(View.INVISIBLE);
+            postDelayed(() -> {
+                if (generation == surfaceRecreationGeneration
+                        && getVisibility() == View.INVISIBLE) {
+                    setVisibility(View.VISIBLE);
+                }
+            }, SURFACE_RECREATE_GAP_MILLIS);
+        }, SURFACE_RECOVERY_SETTLE_DELAY_MILLIS);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
@@ -44,9 +44,9 @@ public class ExpandableSurfaceView extends SurfaceView {
     }
 
     /**
-     * Requests a one-shot SurfaceView lifecycle restart after the current layout transition settles.
-     * Keeping the view invisible for a short frame gap forces Android to tear down the old surface
-     * and create a fresh one without changing the player's layout parameters.
+     * Requests a one-shot SurfaceView lifecycle restart after the current layout transition
+     * settles. Keeping the view invisible for a short frame gap forces Android to tear down the
+     * old surface and create a fresh one without changing the player's layout parameters.
      *
      * @param holder holder that belongs to the player surface needing recovery
      * @return whether a matching player SurfaceView was found

--- a/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceHolderCallbackTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceHolderCallbackTest.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.player.playback;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,7 +14,13 @@ import com.google.android.exoplayer2.Player;
 
 import org.junit.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 public class SurfaceHolderCallbackTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
     @Test
     public void surfaceChangedRebindsCurrentVideoSurface() {
         final Context context = mock(Context.class);
@@ -39,5 +47,44 @@ public class SurfaceHolderCallbackTest {
         callback.surfaceCreated(holder);
 
         verify(player).setVideoSurface(surface);
+    }
+
+    @Test
+    public void localMediaUriDetectionRejectsRemoteStreams() {
+        assertTrue(SurfaceHolderCallback.isLocalMediaUri("content://media/video/42"));
+        assertTrue(SurfaceHolderCallback.isLocalMediaUri("file:///storage/emulated/0/video.mp4"));
+        assertTrue(SurfaceHolderCallback.isLocalMediaUri("android.resource://app/raw/video"));
+        assertFalse(SurfaceHolderCallback.isLocalMediaUri("https://example.com/video.mp4"));
+        assertFalse(SurfaceHolderCallback.isLocalMediaUri(null));
+    }
+
+    @Test
+    public void fullscreenSizedExpansionThenShrinkQualifiesForLocalRecovery() {
+        assertTrue(SurfaceHolderCallback.isLargeSurfaceExpansion(
+                1080, 607, 2400, 1080));
+        assertTrue(SurfaceHolderCallback.shouldRecoverLocalSurface(
+                true, true, 2400, 1080, 1080, 607));
+    }
+
+    @Test
+    public void recoveryDoesNotRunForRemoteOrOrdinaryResizes() {
+        assertFalse(SurfaceHolderCallback.shouldRecoverLocalSurface(
+                false, true, 2400, 1080, 1080, 607));
+        assertFalse(SurfaceHolderCallback.shouldRecoverLocalSurface(
+                true, false, 2400, 1080, 1080, 607));
+        assertFalse(SurfaceHolderCallback.shouldRecoverLocalSurface(
+                true, true, 1080, 607, 1000, 560));
+    }
+
+    @Test
+    public void recoveryRestartsSurfaceLifecycleWithoutChangingLayout() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/views/ExpandableSurfaceView.java"));
+
+        assertTrue(source.contains("requestSurfaceRecreation"));
+        assertTrue(source.contains("setVisibility(View.INVISIBLE)"));
+        assertTrue(source.contains("setVisibility(View.VISIBLE)"));
+        assertTrue(source.contains("SURFACE_RECOVERY_SETTLE_DELAY_MILLIS"));
+        assertTrue(source.contains("SURFACE_RECREATE_GAP_MILLIS"));
     }
 }


### PR DESCRIPTION
- Detect local-media SurfaceView transitions that expand into fullscreen and then shrink back to the normal player
- Keep ordinary surface changes on the existing lightweight rebind path
- Recreate the local SurfaceView once after the fullscreen layout settles so Android gets a fresh surface and compositor layer
- Preserve playback state, position, queue, decoder ownership, and the recent player transition work
- Leave remote streaming, ordinary resizes, mini-player changes, and non-local media unaffected
- Add regression coverage for local URI detection, fullscreen-size transitions, and the one-shot SurfaceView lifecycle restart
- Relates to #373