### PR TITLE
Stabilize video surface across fullscreen transitions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1835,9 +1835,11 @@ public final class VideoDetailFragment
             player.UIs().get(MainPlayerUi.class).ifPresent(playerUi -> {
                 // sometimes binding would be null here, even though getView() != null above u.u
                 if (binding != null) {
-                    // prevent from re-adding a view multiple times
-                    playerUi.removeViewFromParent();
-                    binding.playerPlaceholder.addView(playerUi.getBinding().getRoot());
+                    final View playerView = playerUi.getBinding().getRoot();
+                    if (playerView.getParent() != binding.playerPlaceholder) {
+                        playerUi.removeViewFromParent();
+                        binding.playerPlaceholder.addView(playerView);
+                    }
                     playerUi.setupVideoSurfaceIfNeeded();
                     updatePinnedPlayerLayout();
                 }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
@@ -3,13 +3,8 @@ package org.schabi.newpipe.player.playback;
 import android.content.Context;
 import android.view.SurfaceHolder;
 
-import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.video.PlaceholderSurface;
-
-import org.schabi.newpipe.views.ExpandableSurfaceView;
-
-import java.util.Objects;
 
 /**
  * Prevent error message: 'Unrecoverable player error occurred'
@@ -28,16 +23,10 @@ import java.util.Objects;
  * https://github.com/google/ExoPlayer/issues/2703#issuecomment-300599981
  */
 public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
-    private static final double FULLSCREEN_EXPANSION_FACTOR = 1.35;
-    private static final double FULLSCREEN_EXIT_SHRINK_FACTOR = 0.80;
 
     private final Context context;
     private final Player player;
     private PlaceholderSurface placeholderSurface;
-    private int previousWidth;
-    private int previousHeight;
-    private boolean expandedSurfaceSeen;
-    private String trackedMediaUri;
 
     public SurfaceHolderCallback(final Context context, final Player player) {
         this.context = context;
@@ -54,95 +43,10 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
                                final int format,
                                final int width,
                                final int height) {
-        final String currentMediaUri = currentMediaUri();
-        if (!Objects.equals(trackedMediaUri, currentMediaUri)) {
-            resetSurfaceTransitionTracking();
-            trackedMediaUri = currentMediaUri;
-        }
-
-        final boolean localMedia = isLocalMediaUri(currentMediaUri);
-        if (localMedia && isLargeSurfaceExpansion(
-                previousWidth, previousHeight, width, height)) {
-            expandedSurfaceSeen = true;
-        }
-
-        final boolean recoverSurface = shouldRecoverLocalSurface(
-                localMedia,
-                expandedSurfaceSeen,
-                previousWidth,
-                previousHeight,
-                width,
-                height);
-        previousWidth = width;
-        previousHeight = height;
-
-        if (recoverSurface) {
-            expandedSurfaceSeen = false;
-            ExpandableSurfaceView.requestSurfaceRecreation(holder);
-        }
-
         // Some devices keep the same SurfaceView across fullscreen/orientation transitions and
         // only resize its underlying surface. Rebind on every structural surface change so the
-        // decoder cannot remain attached to the placeholder/stale fullscreen output.
+        // decoder cannot remain attached to a stale fullscreen output.
         bindVideoSurface(holder);
-    }
-
-    private String currentMediaUri() {
-        final MediaItem mediaItem = player.getCurrentMediaItem();
-        if (mediaItem == null || mediaItem.localConfiguration == null) {
-            return null;
-        }
-        return mediaItem.localConfiguration.uri.toString();
-    }
-
-    static boolean isLocalMediaUri(final String mediaUri) {
-        if (mediaUri == null || mediaUri.isEmpty()) {
-            return false;
-        }
-        final int schemeSeparator = mediaUri.indexOf(':');
-        if (schemeSeparator <= 0) {
-            return false;
-        }
-        final String scheme = mediaUri.substring(0, schemeSeparator);
-        return "content".equalsIgnoreCase(scheme)
-                || "file".equalsIgnoreCase(scheme)
-                || "android.resource".equalsIgnoreCase(scheme);
-    }
-
-    static boolean isLargeSurfaceExpansion(final int previousWidth,
-                                           final int previousHeight,
-                                           final int width,
-                                           final int height) {
-        final long previousArea = surfaceArea(previousWidth, previousHeight);
-        final long currentArea = surfaceArea(width, height);
-        return previousArea > 0L
-                && currentArea > previousArea * FULLSCREEN_EXPANSION_FACTOR;
-    }
-
-    static boolean shouldRecoverLocalSurface(final boolean localMedia,
-                                             final boolean expandedSurfaceSeen,
-                                             final int previousWidth,
-                                             final int previousHeight,
-                                             final int width,
-                                             final int height) {
-        if (!localMedia || !expandedSurfaceSeen) {
-            return false;
-        }
-        final long previousArea = surfaceArea(previousWidth, previousHeight);
-        final long currentArea = surfaceArea(width, height);
-        return previousArea > 0L
-                && currentArea > 0L
-                && currentArea < previousArea * FULLSCREEN_EXIT_SHRINK_FACTOR;
-    }
-
-    private static long surfaceArea(final int width, final int height) {
-        return width <= 0 || height <= 0 ? 0L : (long) width * height;
-    }
-
-    private void resetSurfaceTransitionTracking() {
-        previousWidth = 0;
-        previousHeight = 0;
-        expandedSurfaceSeen = false;
     }
 
     private void bindVideoSurface(final SurfaceHolder holder) {
@@ -158,8 +62,6 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
     }
 
     public void release() {
-        resetSurfaceTransitionTracking();
-        trackedMediaUri = null;
         if (placeholderSurface != null) {
             placeholderSurface.release();
             placeholderSurface = null;

--- a/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
@@ -1,19 +1,11 @@
 package org.schabi.newpipe.views;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
-import android.view.SurfaceHolder;
 import android.view.SurfaceView;
-import android.view.View;
-
-import androidx.annotation.NonNull;
 
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
-
-import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_FIT;
 import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MODE_ZOOM;
@@ -21,11 +13,6 @@ import static com.google.android.exoplayer2.ui.AspectRatioFrameLayout.RESIZE_MOD
 public class ExpandableSurfaceView extends SurfaceView {
     public static final float MIN_USER_ZOOM = 1.0f;
     public static final float MAX_USER_ZOOM = 4.0f;
-
-    private static final long SURFACE_RECOVERY_SETTLE_DELAY_MILLIS = 120L;
-    private static final long SURFACE_RECREATE_GAP_MILLIS = 48L;
-    private static final Map<SurfaceHolder, WeakReference<ExpandableSurfaceView>> SURFACE_VIEWS =
-            Collections.synchronizedMap(new WeakHashMap<>());
 
     private int resizeMode = RESIZE_MODE_FIT;
     private int baseHeight = 0;
@@ -36,49 +23,15 @@ public class ExpandableSurfaceView extends SurfaceView {
     private float userZoomScale = MIN_USER_ZOOM;
     private float userTranslationX;
     private float userTranslationY;
-    private int surfaceRecreationGeneration;
 
     public ExpandableSurfaceView(final Context context, final AttributeSet attrs) {
         super(context, attrs);
-        SURFACE_VIEWS.put(getHolder(), new WeakReference<>(this));
-    }
-
-    /**
-     * Requests a one-shot SurfaceView lifecycle restart after the current layout transition
-     * settles. Keeping the view invisible for a short frame gap forces Android to tear down the
-     * old surface and create a fresh one without changing the player's layout parameters.
-     *
-     * @param holder holder that belongs to the player surface needing recovery
-     * @return whether a matching player SurfaceView was found
-     */
-    public static boolean requestSurfaceRecreation(@NonNull final SurfaceHolder holder) {
-        final WeakReference<ExpandableSurfaceView> reference = SURFACE_VIEWS.get(holder);
-        final ExpandableSurfaceView surfaceView = reference == null ? null : reference.get();
-        if (surfaceView == null) {
-            SURFACE_VIEWS.remove(holder);
-            return false;
+        // Media3's PlayerView uses this lifecycle from Android 14 onward. WizeStream uses its
+        // SurfaceView directly, so keep the decoder surface alive while the player remains attached
+        // even when visibility changes during fullscreen, PiP, or bottom-sheet transitions.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            setSurfaceLifecycle(SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT);
         }
-        surfaceView.scheduleSurfaceRecreation();
-        return true;
-    }
-
-    private void scheduleSurfaceRecreation() {
-        final int generation = ++surfaceRecreationGeneration;
-        postDelayed(() -> {
-            if (generation != surfaceRecreationGeneration
-                    || !isAttachedToWindow()
-                    || getVisibility() != View.VISIBLE) {
-                return;
-            }
-
-            setVisibility(View.INVISIBLE);
-            postDelayed(() -> {
-                if (generation == surfaceRecreationGeneration
-                        && getVisibility() == View.INVISIBLE) {
-                    setVisibility(View.VISIBLE);
-                }
-            }, SURFACE_RECREATE_GAP_MILLIS);
-        }, SURFACE_RECOVERY_SETTLE_DELAY_MILLIS);
     }
 
     @Override

--- a/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceHolderCallbackTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceHolderCallbackTest.java
@@ -50,41 +50,32 @@ public class SurfaceHolderCallbackTest {
     }
 
     @Test
-    public void localMediaUriDetectionRejectsRemoteStreams() {
-        assertTrue(SurfaceHolderCallback.isLocalMediaUri("content://media/video/42"));
-        assertTrue(SurfaceHolderCallback.isLocalMediaUri("file:///storage/emulated/0/video.mp4"));
-        assertTrue(SurfaceHolderCallback.isLocalMediaUri("android.resource://app/raw/video"));
-        assertFalse(SurfaceHolderCallback.isLocalMediaUri("https://example.com/video.mp4"));
-        assertFalse(SurfaceHolderCallback.isLocalMediaUri(null));
+    public void surfaceRecoveryIsNotRestrictedToLocalMedia() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/playback/SurfaceHolderCallback.java"));
+
+        assertFalse(source.contains("isLocalMediaUri"));
+        assertFalse(source.contains("requestSurfaceRecreation"));
     }
 
     @Test
-    public void fullscreenSizedExpansionThenShrinkQualifiesForLocalRecovery() {
-        assertTrue(SurfaceHolderCallback.isLargeSurfaceExpansion(
-                1080, 607, 2400, 1080));
-        assertTrue(SurfaceHolderCallback.shouldRecoverLocalSurface(
-                true, true, 2400, 1080, 1080, 607));
-    }
-
-    @Test
-    public void recoveryDoesNotRunForRemoteOrOrdinaryResizes() {
-        assertFalse(SurfaceHolderCallback.shouldRecoverLocalSurface(
-                false, true, 2400, 1080, 1080, 607));
-        assertFalse(SurfaceHolderCallback.shouldRecoverLocalSurface(
-                true, false, 2400, 1080, 1080, 607));
-        assertFalse(SurfaceHolderCallback.shouldRecoverLocalSurface(
-                true, true, 1080, 607, 1000, 560));
-    }
-
-    @Test
-    public void recoveryRestartsSurfaceLifecycleWithoutChangingLayout() throws Exception {
+    public void expandableSurfaceFollowsAttachmentLifecycleOnAndroid14Plus() throws Exception {
         final String source = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/views/ExpandableSurfaceView.java"));
 
-        assertTrue(source.contains("requestSurfaceRecreation"));
-        assertTrue(source.contains("setVisibility(View.INVISIBLE)"));
-        assertTrue(source.contains("setVisibility(View.VISIBLE)"));
-        assertTrue(source.contains("SURFACE_RECOVERY_SETTLE_DELAY_MILLIS"));
-        assertTrue(source.contains("SURFACE_RECREATE_GAP_MILLIS"));
+        assertTrue(source.contains("SURFACE_LIFECYCLE_FOLLOWS_ATTACHMENT"));
+        assertFalse(source.contains("requestSurfaceRecreation"));
+        assertFalse(source.contains("setVisibility(View.INVISIBLE)"));
+    }
+
+    @Test
+    public void detailFragmentKeepsPlayerAttachedToTheCorrectPlaceholder() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));
+
+        assertTrue(source.contains("final View playerView = playerUi.getBinding().getRoot();"));
+        assertTrue(source.contains(
+                "if (playerView.getParent() != binding.playerPlaceholder)"));
+        assertTrue(source.contains("binding.playerPlaceholder.addView(playerView);"));
     }
 }


### PR DESCRIPTION
- Keep the main player attached when it is already in the correct placeholder instead of tearing down and recreating the SurfaceView on every fullscreen state change.
- Remove the local-media-only forced SurfaceView visibility recreation and keep surface rebinding media-agnostic for local files and streaming services.
- Use Android 14+ attachment-based SurfaceView lifecycle so visibility changes during fullscreen, PiP, and bottom-sheet transitions do not unnecessarily destroy the decoder surface.
- Add regression coverage for stable player attachment and media-agnostic surface handling.
- Fixes #373