### PR TITLE
Fix portrait fullscreen re-entry after rotation

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -518,7 +518,7 @@ public final class VideoDetailFragment
         }
     }
 
-    static boolean fullscreenStateForOrientation(final int orientation,
+    public static boolean fullscreenStateForOrientation(final int orientation,
                                                  final boolean fullscreen,
                                                  final boolean verticalVideo,
                                                  final boolean tablet,
@@ -3317,7 +3317,8 @@ public final class VideoDetailFragment
                         setOverlayElementsClickable(false);
                         hideSystemUiIfNeeded();
                         // Conditions when the player should be expanded to fullscreen
-                        if (DeviceUtils.isLandscape(requireContext())
+                        if (getResources().getConfiguration().orientation
+                                == Configuration.ORIENTATION_LANDSCAPE
                                 && isPlayerAvailable()
                                 && player.isPlaying()
                                 && !isFullscreen()

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -421,6 +421,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
             // Close it because when changing orientation from portrait
             // (in fullscreen mode) the size of queue layout can be larger than the screen size
             closeItemsList();
+            syncFullscreenWithCurrentOrientation();
         } else if (ACTION_PLAY_PAUSE.equals(intent.getAction())) {
             // Ensure that we have audio-only stream playing when a user
             // started to play from notification's play button from outside of the app
@@ -1116,6 +1117,15 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
                 && !DeviceUtils.isTablet(context)) {
             setFullscreen(true);
         }
+    }
+
+    private void syncFullscreenWithCurrentOrientation() {
+        setFullscreen(VideoDetailFragment.fullscreenStateForOrientation(
+                context.getResources().getConfiguration().orientation,
+                isFullscreen,
+                isVerticalVideo,
+                DeviceUtils.isTablet(context),
+                player.isAudioOnly()));
     }
     //endregion
 

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -119,4 +119,20 @@ public class VideoDetailOrientationHandlingTest {
         assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
                 Configuration.ORIENTATION_LANDSCAPE, true, true));
     }
+
+    @Test
+    public void fullscreenReentryUsesAuthoritativeConfigurationOrientation() throws Exception {
+        final String fragment = Files.readString(projectDirectory.resolve(
+                "java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));
+        final String playerUi = Files.readString(projectDirectory.resolve(
+                "java/org/schabi/newpipe/player/ui/MainPlayerUi.java"));
+
+        assertTrue(fragment.contains("getResources().getConfiguration().orientation\n"
+                + "                                == Configuration.ORIENTATION_LANDSCAPE"));
+        assertFalse(fragment.contains("if (DeviceUtils.isLandscape(requireContext())\n"
+                + "                                && isPlayerAvailable()"));
+        assertTrue(playerUi.contains("syncFullscreenWithCurrentOrientation();"));
+        assertTrue(playerUi.contains(
+                "VideoDetailFragment.fullscreenStateForOrientation("));
+    }
 }


### PR DESCRIPTION
- Use `Configuration.orientation` instead of transient display metrics when the expanded player decides whether landscape should re-enter fullscreen.
- Reconcile `MainPlayerUi` fullscreen state directly on configuration-change broadcasts so the object that owns the fullscreen flag cannot remain stale after rotation.
- Reuse the existing orientation policy so horizontal video exits fullscreen in portrait while tablet and audio-only behavior remain unchanged.
- Remove the unsuccessful TextureView experiment and keep the existing SurfaceView playback path from `pipe`.
- Add regression coverage for the stale-landscape re-entry path and player-owned configuration reconciliation.
- Follow-up for #373