### PR TITLE
Remember feed filters per group

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -143,6 +143,9 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         groupId = arguments?.getLong(KEY_GROUP_ID, FeedGroupEntity.GROUP_ALL_ID)
             ?: FeedGroupEntity.GROUP_ALL_ID
         groupName = arguments?.getString(KEY_GROUP_NAME) ?: ""
+        val storedFilter = PreferenceManager.getDefaultSharedPreferences(requireContext())
+            .getString(streamFilterPreferenceKey(groupId), StreamListFilter.NONE.name)
+        selectedStreamFilter = restoreStreamFilter(storedFilter)
 
         onSettingsChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (getString(R.string.list_view_mode_key).equals(key) ||
@@ -265,6 +268,9 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
                 selectedStreamFilter = StreamListFilter.fromChipId(
                     checkedIds.firstOrNull() ?: View.NO_ID
                 )
+                PreferenceManager.getDefaultSharedPreferences(requireContext()).edit {
+                    putString(streamFilterPreferenceKey(groupId), selectedStreamFilter.name)
+                }
                 latestLoadedState?.let { showFilteredFeedItems(it, false) }
             }
     }
@@ -876,6 +882,13 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     companion object {
         const val KEY_GROUP_ID = "ARG_GROUP_ID"
         const val KEY_GROUP_NAME = "ARG_GROUP_NAME"
+        private const val STREAM_FILTER_PREF_PREFIX = "feed_stream_filter_"
+
+        internal fun streamFilterPreferenceKey(groupId: Long): String = "$STREAM_FILTER_PREF_PREFIX$groupId"
+
+        internal fun restoreStreamFilter(storedValue: String?): StreamListFilter = storedValue?.let { value ->
+            runCatching { StreamListFilter.valueOf(value) }.getOrDefault(StreamListFilter.NONE)
+        } ?: StreamListFilter.NONE
 
         @JvmStatic
         fun newInstance(groupId: Long = FeedGroupEntity.GROUP_ALL_ID, groupName: String? = null): FeedFragment {

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedFilterPersistenceTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedFilterPersistenceTest.kt
@@ -1,0 +1,21 @@
+package org.schabi.newpipe.local.feed
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.schabi.newpipe.util.StreamListFilter
+
+class FeedFilterPersistenceTest {
+    @Test
+    fun filterPreferenceIsScopedPerFeedGroup() {
+        assertEquals("feed_stream_filter_-1", FeedFragment.streamFilterPreferenceKey(-1L))
+        assertEquals("feed_stream_filter_42", FeedFragment.streamFilterPreferenceKey(42L))
+    }
+
+    @Test
+    fun storedFilterRestoresAndUnknownValuesFallBackSafely() {
+        assertEquals(StreamListFilter.LIVE, FeedFragment.restoreStreamFilter("LIVE"))
+        assertEquals(StreamListFilter.SHORTS, FeedFragment.restoreStreamFilter("SHORTS"))
+        assertEquals(StreamListFilter.NONE, FeedFragment.restoreStreamFilter("REMOVED_FILTER"))
+        assertEquals(StreamListFilter.NONE, FeedFragment.restoreStreamFilter(null))
+    }
+}


### PR DESCRIPTION
- Persist the selected What's New/feed stream filter across app restarts.
- Scope the saved filter by feed group so different groups can remember different choices.
- Restore invalid or removed stored filter values safely to the unfiltered state.
- Add regression coverage for per-group preference keys and safe filter restoration.
- Fixes #392