### PR TITLE
Add configurable global search default

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -323,7 +323,7 @@ public class MainFragment extends BaseFragment
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == R.id.action_search) {
             final ContextualSearchable searchable = getCurrentContextualSearchable();
-            if (searchable != null) {
+            if (shouldUseContextualSearch(prefersGlobalSearch(), searchable != null)) {
                 openContextualSearch(searchable);
                 return true;
             }
@@ -336,6 +336,19 @@ public class MainFragment extends BaseFragment
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private boolean prefersGlobalSearch() {
+        final String defaultValue = getString(R.string.search_button_behavior_current_tab_value);
+        final String configuredValue = prefs.getString(
+                getString(R.string.search_button_behavior_key), defaultValue);
+        return getString(R.string.search_button_behavior_current_service_value)
+                .equals(configuredValue);
+    }
+
+    static boolean shouldUseContextualSearch(final boolean preferGlobalSearch,
+                                             final boolean contextualSearchAvailable) {
+        return !preferGlobalSearch && contextualSearchAvailable;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1745,4 +1745,17 @@
     <string name="sponsor_block_category_non_music_key">sponsor_block_category_non_music</string>
     <string name="sponsor_block_category_preview_key">sponsor_block_category_preview</string>
     <string name="sponsor_block_category_filler_key">sponsor_block_category_filler</string>
+
+    <!-- Search behavior -->
+    <string name="search_button_behavior_key">search_button_behavior</string>
+    <string name="search_button_behavior_current_tab_value">current_tab</string>
+    <string name="search_button_behavior_current_service_value">current_service</string>
+    <string-array name="search_button_behavior_values">
+        <item>@string/search_button_behavior_current_tab_value</item>
+        <item>@string/search_button_behavior_current_service_value</item>
+    </string-array>
+    <string-array name="search_button_behavior_entries">
+        <item>@string/search_button_behavior_current_tab</item>
+        <item>@string/search_button_behavior_current_service</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1579,4 +1579,9 @@
     <string name="delete_saved_search_feed">Delete saved search feed</string>
     <string name="delete_saved_search_feed_confirmation">Delete this saved search feed and its cached results?</string>
     <string name="saved_search_feed_delete_failed">Could not delete this saved search feed</string>
+
+    <string name="search_button_behavior_title">Search button behavior</string>
+    <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
+    <string name="search_button_behavior_current_tab">Search current tab</string>
+    <string name="search_button_behavior_current_service">Search current service</string>
 </resources>

--- a/app/src/main/res/xml/content_settings.xml
+++ b/app/src/main/res/xml/content_settings.xml
@@ -117,6 +117,17 @@
         app:iconSpaceReserved="false" />
 
     <ListPreference
+        android:defaultValue="@string/search_button_behavior_current_tab_value"
+        android:entries="@array/search_button_behavior_entries"
+        android:entryValues="@array/search_button_behavior_values"
+        android:key="@string/search_button_behavior_key"
+        android:summary="@string/search_button_behavior_summary"
+        android:title="@string/search_button_behavior_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false"
+        app:useSimpleSummaryProvider="true" />
+
+    <ListPreference
         android:defaultValue="@string/image_quality_default"
         android:entries="@array/image_quality_description"
         android:entryValues="@array/image_quality_values"

--- a/app/src/test/java/org/schabi/newpipe/fragments/MainFragmentSearchBehaviorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/MainFragmentSearchBehaviorTest.java
@@ -1,0 +1,35 @@
+package org.schabi.newpipe.fragments;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MainFragmentSearchBehaviorTest {
+    private final Path resourcesDirectory = Files.exists(Path.of("src/main/res"))
+            ? Path.of("src/main/res") : Path.of("app/src/main/res");
+
+    @Test
+    public void currentTabRemainsDefaultWhenContextualSearchIsAvailable() {
+        assertTrue(MainFragment.shouldUseContextualSearch(false, true));
+        assertFalse(MainFragment.shouldUseContextualSearch(false, false));
+    }
+
+    @Test
+    public void globalSearchPreferenceSkipsContextualSearch() {
+        assertFalse(MainFragment.shouldUseContextualSearch(true, true));
+        assertFalse(MainFragment.shouldUseContextualSearch(true, false));
+    }
+
+    @Test
+    public void contentSettingsExposeSearchButtonBehavior() throws Exception {
+        final String settings = Files.readString(
+                resourcesDirectory.resolve("xml/content_settings.xml"));
+        assertTrue(settings.contains("@string/search_button_behavior_key"));
+        assertTrue(settings.contains("@array/search_button_behavior_entries"));
+        assertTrue(settings.contains("@array/search_button_behavior_values"));
+    }
+}


### PR DESCRIPTION
- Add a Search button behavior preference with Current tab and Current service choices.
- Preserve contextual current-tab search as the default behavior.
- Allow users to skip contextual filtering and open the selected service's global search directly.
- Keep the behavior service-generic instead of hardcoding YouTube.
- Add regression coverage for search routing and the new preference entry.
- Fixes #390