### PR TITLE
Keep main navigation available in search

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -53,6 +53,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
+import androidx.core.view.MenuItemCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
@@ -60,6 +61,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.navigation.NavigationBarView;
 
 import org.schabi.newpipe.databinding.ActivityMainBinding;
 import org.schabi.newpipe.databinding.DrawerHeaderBinding;
@@ -81,6 +83,7 @@ import org.schabi.newpipe.fragments.list.search.SearchFragment;
 import org.schabi.newpipe.local.feed.notifications.NotificationWorker;
 import org.schabi.newpipe.learning.LearningMode;
 import org.schabi.newpipe.player.Player;
+import org.schabi.newpipe.player.gesture.CustomBottomSheetBehavior;
 import org.schabi.newpipe.player.event.OnKeyDownListener;
 import org.schabi.newpipe.player.helper.PlayerHolder;
 import org.schabi.newpipe.player.pip.NativePipController;
@@ -90,6 +93,10 @@ import org.schabi.newpipe.settings.tabs.DrawerServiceSectionsPolicy;
 import org.schabi.newpipe.settings.tabs.HomeDestinationKey;
 import org.schabi.newpipe.settings.tabs.HomeDestinationResolver;
 import org.schabi.newpipe.settings.tabs.HomeDrawerPolicy;
+import org.schabi.newpipe.settings.tabs.HomeNavigationMode;
+import org.schabi.newpipe.settings.tabs.HomeNavigationModeResolver;
+import org.schabi.newpipe.settings.tabs.Tab;
+import org.schabi.newpipe.settings.tabs.TabletNavigationPositionResolver;
 import org.schabi.newpipe.settings.tabs.TabsManager;
 import org.schabi.newpipe.settings.migration.MigrationManager;
 import org.schabi.newpipe.util.Constants;
@@ -149,11 +156,17 @@ public class MainActivity extends AppCompatActivity {
     private static final int ITEM_ID_YOUTUBE_MUSIC = 10_000;
 
     private static final int ORDER = 0;
+    private static final int SEARCH_BOTTOM_NAVIGATION_MAX_ITEM_COUNT = 5;
+    private static final int SEARCH_NAVIGATION_RAIL_MAX_ITEM_COUNT = 7;
+    private static final int SEARCH_NAVIGATION_ITEM_ID_BASE = 20_000;
     public static final String KEY_IS_IN_BACKGROUND = "is_in_background";
 
     private SharedPreferences sharedPreferences;
     private SharedPreferences.Editor sharedPrefEditor;
     private NativePipController nativePipController;
+    private boolean searchNavigationActive;
+    private int lastMainTabPosition;
+    private int pendingMainTabPosition = -1;
     /*//////////////////////////////////////////////////////////////////////////
     // Activity's LifeCycle
     //////////////////////////////////////////////////////////////////////////*/
@@ -956,6 +969,242 @@ public class MainActivity extends AppCompatActivity {
     public void setContextualSearchToolbarActive(final boolean active) {
         contextualSearchToolbarActive = active;
         updateDrawerNavigation();
+    }
+
+    public void rememberMainTabPosition(final int position) {
+        if (position >= 0) {
+            lastMainTabPosition = position;
+        }
+    }
+
+    public int consumePendingMainTabPosition() {
+        final int pendingPosition = pendingMainTabPosition;
+        pendingMainTabPosition = -1;
+        return pendingPosition;
+    }
+
+    public void showMainNavigationForSearch() {
+        searchNavigationActive = true;
+        final List<Tab> tabs = TabsManager.getManager(this).getTabs();
+        if (tabs.isEmpty()) {
+            hideSearchNavigationViews();
+            return;
+        }
+
+        final int orientation = getResources().getConfiguration().orientation;
+        final int positionKey = orientation == Configuration.ORIENTATION_LANDSCAPE
+                ? R.string.tablet_navigation_landscape_position_key
+                : R.string.tablet_navigation_portrait_position_key;
+        final String defaultPosition = getString(R.string.tablet_navigation_position_default_value);
+        final String configuredPosition = sharedPreferences.getString(
+                getString(positionKey), defaultPosition);
+        final boolean tablet = DeviceUtils.isTablet(this);
+        final boolean useNavigationRail = TabletNavigationPositionResolver.useNavigationRail(
+                tablet, orientation, configuredPosition);
+        final NavigationBarView navigation = useNavigationRail
+                ? mainBinding.mainNavigationRail : mainBinding.mainBottomNavigation;
+        final NavigationBarView otherNavigation = useNavigationRail
+                ? mainBinding.mainBottomNavigation : mainBinding.mainNavigationRail;
+        clearSearchNavigationView(otherNavigation);
+
+        final int itemLimit = useNavigationRail
+                ? SEARCH_NAVIGATION_RAIL_MAX_ITEM_COUNT
+                : SEARCH_BOTTOM_NAVIGATION_MAX_ITEM_COUNT;
+        final boolean mainTabsAtBottom = sharedPreferences.getBoolean(
+                getString(R.string.main_tabs_position_key), true);
+        final HomeNavigationMode navigationMode = HomeNavigationModeResolver
+                .resolveNavigationMode(tabs.size(), mainTabsAtBottom);
+        final boolean showNavigation = shouldShowSearchNavigation(
+                tablet,
+                tabs.size(),
+                itemLimit,
+                navigationMode == HomeNavigationMode.BOTTOM_NAVIGATION);
+        if (!showNavigation) {
+            clearSearchNavigationView(navigation);
+            resetSearchNavigationContentInsets();
+            notifySearchNavigationVisibilityChanged();
+            return;
+        }
+
+        populateSearchNavigation(navigation, tabs);
+        applySearchNavigationContentInsets(useNavigationRail);
+        navigation.setTag(Boolean.TRUE);
+        if (playerCoversMainNavigation()) {
+            navigation.setVisibility(View.INVISIBLE);
+        } else {
+            navigation.setVisibility(View.VISIBLE);
+        }
+        navigation.bringToFront();
+        notifySearchNavigationVisibilityChanged();
+    }
+
+    public void hideMainNavigationForSearch() {
+        if (!searchNavigationActive) {
+            return;
+        }
+        searchNavigationActive = false;
+        hideSearchNavigationViews();
+    }
+
+    private void hideSearchNavigationViews() {
+        clearSearchNavigationView(mainBinding.mainBottomNavigation);
+        clearSearchNavigationView(mainBinding.mainNavigationRail);
+        resetSearchNavigationContentInsets();
+        notifySearchNavigationVisibilityChanged();
+    }
+
+    private void populateSearchNavigation(@NonNull final NavigationBarView navigation,
+                                          @NonNull final List<Tab> tabs) {
+        navigation.setOnItemSelectedListener(null);
+        navigation.setOnItemReselectedListener(null);
+        final Menu menu = navigation.getMenu();
+        menu.clear();
+
+        final int selectedPosition = normalizeSearchNavigationTabPosition(
+                lastMainTabPosition, tabs.size());
+        lastMainTabPosition = selectedPosition;
+        for (int index = 0; index < tabs.size(); index++) {
+            final Tab tab = tabs.get(index);
+            final String tabName = tab.getTabName(this);
+            final MenuItem item = menu.add(Menu.NONE,
+                    SEARCH_NAVIGATION_ITEM_ID_BASE + index,
+                    index,
+                    getSearchNavigationDisplayLabel(tab, tabName));
+            final int iconRes = tab.getTabIconRes(this);
+            item.setIcon(iconRes > 0 ? iconRes : R.drawable.ic_asterisk);
+            item.setCheckable(true);
+            item.setChecked(index == selectedPosition);
+            MenuItemCompat.setContentDescription(item, tabName);
+        }
+        applySearchNavigationLabelVisibility(navigation);
+        navigation.setAlpha(1.0f);
+        navigation.setTranslationX(0.0f);
+        navigation.setTranslationY(0.0f);
+        navigation.setOnItemSelectedListener(item -> {
+            final int position = item.getItemId() - SEARCH_NAVIGATION_ITEM_ID_BASE;
+            if (position < 0 || position >= tabs.size()) {
+                return false;
+            }
+            lastMainTabPosition = position;
+            pendingMainTabPosition = position;
+            NavigationHelper.gotoMainFragment(getSupportFragmentManager());
+            return true;
+        });
+    }
+
+    private String getSearchNavigationDisplayLabel(@NonNull final Tab tab,
+                                                   @NonNull final String tabName) {
+        if (tab instanceof Tab.KioskTab
+                && "live".equals(((Tab.KioskTab) tab).getKioskId())) {
+            return getString(R.string.duration_live);
+        }
+        if (tab instanceof Tab.DefaultKioskTab
+                && getString(R.string.recommended_lives).equals(tabName)) {
+            return getString(R.string.duration_live);
+        }
+        if (tab.getTabId() == Tab.BookmarksTab.ID) {
+            return getString(R.string.bottom_navigation_tab_bookmarks);
+        }
+        return tabName;
+    }
+
+    private void applySearchNavigationLabelVisibility(@NonNull final NavigationBarView navigation) {
+        final String defaultValue = getString(R.string.bottom_navigation_labels_default_value);
+        final String configuredValue = sharedPreferences.getString(
+                getString(R.string.bottom_navigation_labels_key), defaultValue);
+        final int labelVisibilityMode;
+        if (getString(R.string.bottom_navigation_labels_always_value)
+                .equals(configuredValue)) {
+            labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_LABELED;
+        } else if (getString(R.string.bottom_navigation_labels_hidden_value)
+                .equals(configuredValue)) {
+            labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_UNLABELED;
+        } else {
+            labelVisibilityMode = NavigationBarView.LABEL_VISIBILITY_SELECTED;
+        }
+        navigation.setLabelVisibilityMode(labelVisibilityMode);
+    }
+
+    private void clearSearchNavigationView(@NonNull final NavigationBarView navigation) {
+        navigation.setOnItemSelectedListener(null);
+        navigation.setOnItemReselectedListener(null);
+        navigation.getMenu().clear();
+        navigation.setTag(Boolean.FALSE);
+        navigation.setAlpha(1.0f);
+        navigation.setTranslationX(0.0f);
+        navigation.setTranslationY(0.0f);
+        navigation.setVisibility(View.GONE);
+    }
+
+    private boolean playerCoversMainNavigation() {
+        final BottomSheetBehavior<?> behavior = BottomSheetBehavior.from(
+                mainBinding.fragmentPlayerHolder);
+        final int state = behavior.getState();
+        return state == BottomSheetBehavior.STATE_EXPANDED
+                || state == BottomSheetBehavior.STATE_DRAGGING
+                || state == BottomSheetBehavior.STATE_SETTLING
+                || state == BottomSheetBehavior.STATE_HALF_EXPANDED;
+    }
+
+    private void applySearchNavigationContentInsets(final boolean navigationRail) {
+        final int startInset = navigationRail
+                ? getResources().getDimensionPixelSize(R.dimen.main_navigation_rail_width) : 0;
+        final int bottomInset = navigationRail
+                ? 0 : getResources().getDimensionPixelSize(R.dimen.main_bottom_navigation_height);
+        setSearchNavigationStartMargin(mainBinding.fragmentHolder, startInset);
+        setSearchNavigationStartMargin(mainBinding.toolbarLayout.getRoot(), startInset);
+        setSearchNavigationBottomMargin(mainBinding.fragmentHolder, bottomInset);
+    }
+
+    private void resetSearchNavigationContentInsets() {
+        setSearchNavigationStartMargin(mainBinding.fragmentHolder, 0);
+        setSearchNavigationStartMargin(mainBinding.toolbarLayout.getRoot(), 0);
+        setSearchNavigationBottomMargin(mainBinding.fragmentHolder, 0);
+    }
+
+    private static void setSearchNavigationStartMargin(@NonNull final View view,
+                                                       final int margin) {
+        if (!(view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams)) {
+            return;
+        }
+        final ViewGroup.MarginLayoutParams params =
+                (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        if (params.getMarginStart() != margin) {
+            params.setMarginStart(margin);
+            view.setLayoutParams(params);
+        }
+    }
+
+    private static void setSearchNavigationBottomMargin(@NonNull final View view,
+                                                        final int margin) {
+        if (!(view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams)) {
+            return;
+        }
+        final ViewGroup.MarginLayoutParams params =
+                (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        if (params.bottomMargin != margin) {
+            params.bottomMargin = margin;
+            view.setLayoutParams(params);
+        }
+    }
+
+    private void notifySearchNavigationVisibilityChanged() {
+        final BottomSheetBehavior<?> behavior = BottomSheetBehavior.from(
+                mainBinding.fragmentPlayerHolder);
+        if (behavior instanceof CustomBottomSheetBehavior customBehavior) {
+            customBehavior.onBottomNavigationVisibilityChanged();
+        }
+    }
+
+    static boolean shouldShowSearchNavigation(final boolean tablet,
+                                              final int tabCount,
+                                              final int itemLimit,
+                                              final boolean phoneUsesBottomNavigation) {
+        return tablet ? tabCount <= itemLimit : phoneUsesBottomNavigation;
+    }
+
+    static int normalizeSearchNavigationTabPosition(final int position, final int tabCount) {
+        return position >= 0 && position < tabCount ? position : 0;
     }
 
     private void handleIntent(final Intent intent) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -179,10 +179,13 @@ public class MainFragment extends BaseFragment
                 }
                 updateTitleForTab(position);
                 updateBottomNavigationSelection(position);
+                rememberMainTabPosition(position);
                 requireActivity().invalidateOptionsMenu();
             }
         });
         setupTabs();
+        restorePendingMainTabSelection();
+        rememberMainTabPosition(binding.pager.getCurrentItem());
         initContextualSearchToolbar();
         initContextualSearchInsets();
         if (contextualSearchOpen) {
@@ -290,6 +293,22 @@ public class MainFragment extends BaseFragment
         navigationRailView = null;
         super.onDestroyView();
         binding = null;
+    }
+
+    private void rememberMainTabPosition(final int position) {
+        if (activity instanceof MainActivity) {
+            ((MainActivity) activity).rememberMainTabPosition(position);
+        }
+    }
+
+    private void restorePendingMainTabSelection() {
+        if (!(activity instanceof MainActivity) || binding == null) {
+            return;
+        }
+        final int position = ((MainActivity) activity).consumePendingMainTabPosition();
+        if (position >= 0 && position < tabsList.size()) {
+            binding.pager.setCurrentItem(position, false);
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -44,6 +44,7 @@ import com.evernote.android.state.State;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
 
+import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.feed.model.SavedSearchFeedEntity;
 import org.schabi.newpipe.databinding.FragmentSearchBinding;
@@ -377,6 +378,9 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
 
     @Override
     public void onPause() {
+        if (activity instanceof MainActivity) {
+            ((MainActivity) activity).hideMainNavigationForSearch();
+        }
         super.onPause();
 
         wasSearchFocused = searchEditText.hasFocus();
@@ -397,6 +401,9 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
             Log.d(TAG, "onResume() called");
         }
         super.onResume();
+        if (activity instanceof MainActivity) {
+            ((MainActivity) activity).showMainNavigationForSearch();
+        }
 
         if (suggestionDisposable == null || suggestionDisposable.isDisposed()) {
             initSuggestionObserver();

--- a/app/src/test/java/org/schabi/newpipe/MainSearchNavigationPersistenceTest.java
+++ b/app/src/test/java/org/schabi/newpipe/MainSearchNavigationPersistenceTest.java
@@ -1,0 +1,46 @@
+package org.schabi.newpipe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MainSearchNavigationPersistenceTest {
+    private final Path mainDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main") : Path.of("app/src/main");
+
+    @Test
+    public void searchNavigationMatchesTheMainNavigationMode() {
+        assertTrue(MainActivity.shouldShowSearchNavigation(false, 4, 5, true));
+        assertFalse(MainActivity.shouldShowSearchNavigation(false, 4, 5, false));
+        assertTrue(MainActivity.shouldShowSearchNavigation(true, 7, 7, false));
+        assertFalse(MainActivity.shouldShowSearchNavigation(true, 8, 7, true));
+    }
+
+    @Test
+    public void invalidRememberedTabFallsBackToTheFirstTab() {
+        assertEquals(0, MainActivity.normalizeSearchNavigationTabPosition(-1, 4));
+        assertEquals(0, MainActivity.normalizeSearchNavigationTabPosition(5, 4));
+        assertEquals(2, MainActivity.normalizeSearchNavigationTabPosition(2, 4));
+    }
+
+    @Test
+    public void searchFragmentHandsNavigationVisibilityToTheActivity() throws Exception {
+        final String source = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/fragments/list/search/SearchFragment.java"));
+        assertTrue(source.contains("showMainNavigationForSearch()"));
+        assertTrue(source.contains("hideMainNavigationForSearch()"));
+    }
+
+    @Test
+    public void mainFragmentConsumesTheDestinationSelectedFromSearch() throws Exception {
+        final String source = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/fragments/MainFragment.java"));
+        assertTrue(source.contains("consumePendingMainTabPosition()"));
+        assertTrue(source.contains("rememberMainTabPosition(position)"));
+    }
+}


### PR DESCRIPTION
- Keep the activity-owned bottom navigation visible while global Search is open when the main screen normally uses bottom navigation.
- Preserve the equivalent navigation rail on supported tablet layouts.
- Restore the originating tab selection and allow a Search navigation tap to pop Search and open the selected main destination directly.
- Reserve bottom or start content space so search results and the toolbar do not render underneath persistent navigation.
- Hide the persistent navigation when the player covers it and restore normal main-screen ownership after leaving Search.
- Add regression coverage for navigation visibility rules, tab restoration, and Search/MainFragment handoff.
- Fixes #391