### PR TITLE
Scroll What's New to top on navigation reselection

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -52,6 +52,7 @@ import org.schabi.newpipe.databinding.FragmentMainBinding;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.local.feed.FeedFragment;
 import org.schabi.newpipe.local.playlist.LocalPlaylistFragment;
 import org.schabi.newpipe.local.search.ContextualSearchHelper;
 import org.schabi.newpipe.local.search.ContextualSearchable;
@@ -473,6 +474,7 @@ public class MainFragment extends BaseFragment
             final int position = getBottomNavigationItemPosition(item.getItemId());
             if (position >= 0 && position < tabsList.size()) {
                 updateTitleForTab(position);
+                scrollCurrentFeedToTop(position);
             }
         });
     }
@@ -496,6 +498,17 @@ public class MainFragment extends BaseFragment
             return;
         }
         setTitle(tabsList.get(tabPosition).getTabName(requireContext()));
+    }
+
+    private void scrollCurrentFeedToTop(final int position) {
+        if (pagerAdapter == null || position < 0 || position >= tabsList.size()
+                || tabsList.get(position).getTabId() != Tab.FeedTab.ID) {
+            return;
+        }
+        final Fragment primaryFragment = pagerAdapter.getPrimaryFragment();
+        if (primaryFragment instanceof FeedFragment feedFragment) {
+            feedFragment.scrollToTop();
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1020,6 +1033,7 @@ public class MainFragment extends BaseFragment
             Log.d(TAG, "onTabReselected() called with: tab = [" + tab + "]");
         }
         updateTitleForTab(tab.getPosition());
+        scrollCurrentFeedToTop(tab.getPosition());
     }
 
     public static final class SelectedTabsPagerAdapter

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -259,9 +259,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             !feedHeaderExpanded || feedBinding.itemsList.canScrollVertically(-1)
         }
         feedBinding.newItemsLoadedButton.setOnClickListener {
-            hideNewItemsLoaded(true)
-            feedBinding.itemsList.scrollToPosition(0)
-            feedBinding.feedHeader.setExpanded(true, true)
+            scrollToTop()
         }
         feedBinding.streamFilterChips.streamFilterChipGroup
             .setOnCheckedStateChangeListener { _, checkedIds ->
@@ -273,6 +271,16 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
                 }
                 latestLoadedState?.let { showFilteredFeedItems(it, false) }
             }
+    }
+
+    fun scrollToTop() {
+        val binding = _feedBinding ?: return
+        if (tryGetNewItemsLoadedButton()?.isVisible == true) {
+            hideNewItemsLoaded(true)
+        }
+        binding.itemsList.stopScroll()
+        binding.itemsList.scrollToPosition(0)
+        binding.feedHeader.setExpanded(true, true)
     }
 
     // /////////////////////////////////////////////////////////////////////////

--- a/app/src/test/java/org/schabi/newpipe/fragments/MainFragmentFeedReselectionTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/MainFragmentFeedReselectionTest.java
@@ -1,0 +1,39 @@
+package org.schabi.newpipe.fragments;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MainFragmentFeedReselectionTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void navigationReselectionScrollsWhatsNewFeedToTop() throws Exception {
+        final String main = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/fragments/MainFragment.java"));
+        final String feed = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/local/feed/FeedFragment.kt"));
+
+        assertTrue(main.contains("scrollCurrentFeedToTop(position);"));
+        assertTrue(main.contains("scrollCurrentFeedToTop(tab.getPosition());"));
+        assertTrue(main.contains("tabsList.get(position).getTabId() != Tab.FeedTab.ID"));
+        assertTrue(main.contains("feedFragment.scrollToTop();"));
+        assertTrue(feed.contains("fun scrollToTop()"));
+        assertTrue(feed.contains("binding.itemsList.stopScroll()"));
+        assertTrue(feed.contains("binding.itemsList.scrollToPosition(0)"));
+        assertTrue(feed.contains("binding.feedHeader.setExpanded(true, true)"));
+    }
+
+    @Test
+    public void newItemsButtonReusesTheSameScrollToTopPath() throws Exception {
+        final String feed = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/local/feed/FeedFragment.kt"));
+
+        assertTrue(feed.contains("newItemsLoadedButton.setOnClickListener {\n"
+                + "            scrollToTop()"));
+    }
+}


### PR DESCRIPTION
- Reselecting What's New from bottom navigation or the navigation rail jumps directly to the top of the feed.
- Reselecting What's New from the scrollable tab layout uses the same behavior.
- Stop active list scrolling and expand the feed header before returning to the first item.
- Reuse the same scroll-to-top path for the existing new-items button.
- Add regression coverage for both navigation reselection paths and feed scrolling.
- Fixes #398