### PR TITLE
Fix fullscreen orientation regression

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -269,7 +269,6 @@ public final class VideoDetailFragment
     private int viewPagerBaseBottomMargin;
     private boolean detailLayoutRecreationPending;
     private boolean detailLayoutRecreationRequested;
-    private int pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
 
     private ContentObserver settingsContentObserver;
     @Nullable
@@ -441,34 +440,18 @@ public final class VideoDetailFragment
             return;
         }
         final int orientation = newConfig.orientation;
-        if (shouldRecreateDetailLayout(binding.relatedItemsLayout != null,
-                orientation, newConfig.screenWidthDp)) {
-            pendingFullscreenOrientation = orientation;
-            final Optional<MainPlayerUi> playerUi = player == null
-                    ? Optional.empty() : player.UIs().get(MainPlayerUi.class);
-            if (player != null) {
-                // The new configuration is already authoritative here. Apply fullscreen before
-                // detaching the detail layout so the transition cannot be lost while the player
-                // reconnects; the restored layout will recalculate the surface dimensions.
-                syncFullscreenWithOrientation(playerUi, orientation);
-            }
-            if (shouldKeepDetailLayoutWhileFullscreen(
-                    orientation,
-                    playerUi.map(MainPlayerUi::isFullscreen).orElse(false),
-                    DeviceUtils.isTablet(activity)
-                            || DeviceUtils.isTv(activity)
-                            || DeviceUtils.isDesktopMode(activity))) {
-                // Phone details are hidden in fullscreen, so replacing them with the wide layout
-                // only creates a detach/reconnect race when the device returns to portrait.
-                pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
-                detailLayoutRecreationRequested = false;
-                binding.getRoot().post(() -> {
-                    if (binding != null && player != null && isAdded()) {
-                        tryAddVideoPlayerView();
-                    }
-                });
-                return;
-            }
+        final boolean keepPhonePlayerLayout = shouldKeepPhonePlayerLayoutForLandscape(
+                orientation,
+                player != null,
+                player != null && player.videoPlayerSelected(),
+                player != null && player.isAudioOnly(),
+                lastStableBottomSheetState,
+                DeviceUtils.isTablet(activity)
+                        || DeviceUtils.isTv(activity)
+                        || DeviceUtils.isDesktopMode(activity));
+        if (!keepPhonePlayerLayout
+                && shouldRecreateDetailLayout(binding.relatedItemsLayout != null,
+                        orientation, newConfig.screenWidthDp)) {
             detailLayoutRecreationRequested = true;
             recreateDetailLayoutForConfigurationChange();
             return;
@@ -476,63 +459,54 @@ public final class VideoDetailFragment
         if (player == null) {
             return;
         }
-        // MainActivity handles orientation changes for native PiP, so the fragment is no longer
-        // recreated. Wait until the updated layout is applied, then restore the same fullscreen
-        // transition that previously ran when the player reconnected after rotation.
+        // Apply fullscreen only after Android has installed the new configuration.
+        // Re-read the current orientation in the posted callback so rapid rotations
+        // cannot apply a stale landscape/portrait state.
         binding.getRoot().post(() -> {
             if (binding != null && player != null && isAdded()) {
                 syncFullscreenWithOrientation(
-                        player.UIs().get(MainPlayerUi.class), orientation);
+                        player.UIs().get(MainPlayerUi.class),
+                        getResources().getConfiguration().orientation);
             }
         });
     }
 
     private void syncFullscreenWithOrientation(
             @NonNull final Optional<MainPlayerUi> playerUi) {
-        final int orientation = pendingFullscreenOrientation
-                != Configuration.ORIENTATION_UNDEFINED
-                ? pendingFullscreenOrientation
-                : getResources().getConfiguration().orientation;
-        pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
-        syncFullscreenWithOrientation(playerUi, orientation);
+        syncFullscreenWithOrientation(
+                playerUi, getResources().getConfiguration().orientation);
     }
 
     private void syncFullscreenWithOrientation(
             @NonNull final Optional<MainPlayerUi> playerUi,
             final int orientation) {
-        if (player == null) {
+        if (player == null || DeviceUtils.isTablet(activity)
+                || DeviceUtils.isTv(activity) || DeviceUtils.isDesktopMode(activity)
+                || player.isAudioOnly()) {
             return;
         }
 
-        playerUi.ifPresent(ui -> ui.setFullscreen(fullscreenStateForOrientation(
-                orientation,
-                ui.isFullscreen(),
-                ui.isVerticalVideo(),
-                DeviceUtils.isTablet(activity),
-                player.isAudioOnly())));
-
         if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            // Preserve the existing landscape playback preparation after applying the
-            // fullscreen state independently from the player's current state.
-            checkLandscape();
+            playerUi.ifPresent(ui -> ui.setFullscreen(true));
+        } else if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+            playerUi.filter(ui -> ui.isFullscreen() && !ui.isVerticalVideo())
+                    .ifPresent(ui -> ui.setFullscreen(false));
         }
     }
 
-    static boolean fullscreenStateForOrientation(final int orientation,
-                                                 final boolean fullscreen,
-                                                 final boolean verticalVideo,
-                                                 final boolean tablet,
-                                                 final boolean audioOnly) {
-        if (tablet || audioOnly) {
-            return fullscreen;
-        }
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            return true;
-        }
-        if (orientation == Configuration.ORIENTATION_PORTRAIT && !verticalVideo) {
-            return false;
-        }
-        return fullscreen;
+    static boolean shouldKeepPhonePlayerLayoutForLandscape(
+            final int orientation,
+            final boolean playerAvailable,
+            final boolean videoPlayerSelected,
+            final boolean audioOnly,
+            final int bottomSheetState,
+            final boolean largeScreenDevice) {
+        return orientation == Configuration.ORIENTATION_LANDSCAPE
+                && playerAvailable
+                && videoPlayerSelected
+                && !audioOnly
+                && bottomSheetState == BottomSheetBehavior.STATE_EXPANDED
+                && !largeScreenDevice;
     }
 
     static boolean shouldUseWideLandscapeDetailLayout(final int orientation,
@@ -546,14 +520,6 @@ public final class VideoDetailFragment
                                               final int screenWidthDp) {
         return wideLandscapeLayout
                 != shouldUseWideLandscapeDetailLayout(orientation, screenWidthDp);
-    }
-
-    static boolean shouldKeepDetailLayoutWhileFullscreen(final int orientation,
-                                                         final boolean fullscreen,
-                                                         final boolean largeScreenDevice) {
-        return orientation == Configuration.ORIENTATION_LANDSCAPE
-                && fullscreen
-                && !largeScreenDevice;
     }
 
     private void recreateDetailLayoutForConfigurationChange() {
@@ -2777,47 +2743,19 @@ public final class VideoDetailFragment
         // from landscape to portrait every time.
         // Just turn on fullscreen mode in landscape orientation
         // or portrait & unlocked global orientation
-        final int currentOrientation = getResources().getConfiguration().orientation;
-        final boolean isLandscape = currentOrientation == Configuration.ORIENTATION_LANDSCAPE;
-        if (!isPlayerAvailable()) {
-            // The initial start-fullscreen path runs before the player service connects. Rotate
-            // now and let the connection/configuration callbacks apply fullscreen afterward.
-            if (!DeviceUtils.isTv(activity) && !isLandscape) {
-                activity.setRequestedOrientation(
-                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
-            }
-            return;
-        }
-
-        final Optional<MainPlayerUi> playerUi = player.UIs().get(MainPlayerUi.class);
+        final boolean isLandscape = DeviceUtils.isLandscape(requireContext());
         if (DeviceUtils.isTv(activity) || DeviceUtils.isTablet(activity)
                 && (!globalScreenOrientationLocked(activity) || isLandscape)) {
-            playerUi.ifPresent(ui -> ui.setFullscreen(!ui.isFullscreen()));
+            player.UIs().get(MainPlayerUi.class)
+                    .ifPresent(MainPlayerUi::toggleFullscreen);
             return;
         }
 
-        playerUi.ifPresent(ui -> {
-            final boolean fullscreen = !ui.isFullscreen();
-            final int newOrientation = fullscreen
-                    ? ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-                    : ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+        final int newOrientation = isLandscape
+                ? ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                : ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
 
-            // Applying fullscreen while the old orientation is still laid out makes the
-            // surface cache the old window height and can stretch the video after rotation.
-            // Normally onConfigurationChanged() applies the state after the target layout.
-            // Apply it here only when no orientation change (and thus no callback) is needed.
-            if (isTargetFullscreenOrientation(currentOrientation, fullscreen)) {
-                ui.setFullscreen(fullscreen);
-            }
-            activity.setRequestedOrientation(newOrientation);
-        });
-    }
-
-    static boolean isTargetFullscreenOrientation(final int orientation,
-                                                 final boolean fullscreen) {
-        return fullscreen
-                ? orientation == Configuration.ORIENTATION_LANDSCAPE
-                : orientation == Configuration.ORIENTATION_PORTRAIT;
+        activity.setRequestedOrientation(newOrientation);
     }
 
     /*
@@ -3317,7 +3255,8 @@ public final class VideoDetailFragment
                         setOverlayElementsClickable(false);
                         hideSystemUiIfNeeded();
                         // Conditions when the player should be expanded to fullscreen
-                        if (DeviceUtils.isLandscape(requireContext())
+                        if (getResources().getConfiguration().orientation
+                                == Configuration.ORIENTATION_LANDSCAPE
                                 && isPlayerAvailable()
                                 && player.isPlaying()
                                 && !isFullscreen()

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -1106,6 +1106,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         return !verticalVideo || landscape && screenOrientationLocked;
     }
 
+
     public void checkLandscape() {
         // check if landscape is correct
         final boolean videoInLandscapeButNotInFullscreen = isLandscape()
@@ -1117,6 +1118,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
             setFullscreen(true);
         }
     }
+
     //endregion
 
 

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertTrue;
 
 import android.content.res.Configuration;
 
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+
 import org.junit.Test;
 
 import java.nio.file.Files;
@@ -12,111 +14,105 @@ import java.nio.file.Path;
 
 public class VideoDetailOrientationHandlingTest {
     private final Path projectDirectory = Files.exists(Path.of("src/main"))
-            ? Path.of("src/main")
-            : Path.of("app/src/main");
+            ? Path.of("src/main") : Path.of("app/src/main");
 
     @Test
-    public void handledConfigurationChangesResyncPlayerFullscreen() throws Exception {
-        final String manifest = Files.readString(projectDirectory.resolve("AndroidManifest.xml"));
-        final String fragment = Files.readString(projectDirectory.resolve(
+    public void configurationOwnsFullscreenWithoutDeferredOrientationState()
+            throws Exception {
+        final String fragment = readFragment();
+        assertTrue(fragment.contains("final int orientation = newConfig.orientation;"));
+        assertTrue(fragment.contains("ui.setFullscreen(true)"));
+        assertTrue(fragment.contains("ui.setFullscreen(false)"));
+        assertFalse(fragment.contains("pendingFullscreenOrientation"));
+        assertFalse(fragment.contains("fullscreenStateForOrientation("));
+    }
+
+    @Test
+    public void expandedPhoneVideoKeepsCurrentLayoutForLandscapeFullscreen() {
+        assertTrue(VideoDetailFragment.shouldKeepPhonePlayerLayoutForLandscape(
+                Configuration.ORIENTATION_LANDSCAPE,
+                true, true, false,
+                BottomSheetBehavior.STATE_EXPANDED, false));
+        assertFalse(VideoDetailFragment.shouldKeepPhonePlayerLayoutForLandscape(
+                Configuration.ORIENTATION_PORTRAIT,
+                true, true, false,
+                BottomSheetBehavior.STATE_EXPANDED, false));
+        assertFalse(VideoDetailFragment.shouldKeepPhonePlayerLayoutForLandscape(
+                Configuration.ORIENTATION_LANDSCAPE,
+                true, true, true,
+                BottomSheetBehavior.STATE_EXPANDED, false));
+        assertFalse(VideoDetailFragment.shouldKeepPhonePlayerLayoutForLandscape(
+                Configuration.ORIENTATION_LANDSCAPE,
+                true, true, false,
+                BottomSheetBehavior.STATE_COLLAPSED, false));
+        assertFalse(VideoDetailFragment.shouldKeepPhonePlayerLayoutForLandscape(
+                Configuration.ORIENTATION_LANDSCAPE,
+                true, true, false,
+                BottomSheetBehavior.STATE_EXPANDED, true));
+    }
+
+    @Test
+    public void fullscreenLayoutGuardRunsBeforeWideLayoutRecreation()
+            throws Exception {
+        final String configuration = methodBody(
+                readFragment(), "public void onConfigurationChanged(");
+        final int keepLayout = configuration.indexOf(
+                "shouldKeepPhonePlayerLayoutForLandscape(");
+        final int recreate = configuration.indexOf("shouldRecreateDetailLayout(");
+        final int postedSync = configuration.indexOf("binding.getRoot().post(");
+        assertTrue(keepLayout >= 0);
+        assertTrue(recreate > keepLayout);
+        assertTrue(postedSync > recreate);
+        assertTrue(configuration.contains(
+                "getResources().getConfiguration().orientation"));
+    }
+
+    @Test
+    public void expandedPlayerUsesConfigurationOrientation() throws Exception {
+        final String fragment = readFragment();
+        final String marker =
+                "// Conditions when the player should be expanded to fullscreen";
+        final int markerIndex = fragment.indexOf(marker);
+        assertTrue(markerIndex >= 0);
+
+        final int blockEnd = Math.min(fragment.length(), markerIndex + 700);
+        final String expandedPlayerBlock = fragment.substring(markerIndex, blockEnd);
+        assertTrue(expandedPlayerBlock.contains(
+                "getResources().getConfiguration().orientation"));
+        assertTrue(expandedPlayerBlock.contains(
+                "Configuration.ORIENTATION_LANDSCAPE"));
+        assertFalse(expandedPlayerBlock.contains(
+                "DeviceUtils.isLandscape(requireContext())"));
+    }
+
+    @Test
+    public void detailLayoutRestorationStillRebindsPlayer() throws Exception {
+        final String restore = methodBody(
+                readFragment(),
+                "private void restoreDetailLayoutAfterConfigurationChange()");
+        assertTrue(restore.contains("tryAddVideoPlayerView();"));
+        assertTrue(restore.contains("updatePinnedPlayerLayout();"));
+        assertTrue(restore.contains("syncFullscreenWithOrientation("));
+    }
+
+    private String readFragment() throws Exception {
+        return Files.readString(projectDirectory.resolve(
                 "java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));
-
-        assertTrue(manifest.contains("android:configChanges="
-                + "\"screenSize|smallestScreenSize|screenLayout|orientation\""));
-        assertTrue(fragment.contains("public void onConfigurationChanged("));
-        assertTrue(fragment.contains("syncFullscreenWithOrientation("));
-        assertTrue(fragment.contains("newConfig.orientation"));
-        assertTrue(fragment.contains("ui.setFullscreen(fullscreenStateForOrientation("));
-        assertTrue(fragment.contains("binding.getRoot().post("));
-        assertTrue(fragment.contains("detailLayoutRecreationRequested"));
-        assertTrue(fragment.contains("pendingFullscreenOrientation = orientation"));
-        assertTrue(fragment.contains("pendingFullscreenOrientation\n"
-                + "                != Configuration.ORIENTATION_UNDEFINED"));
-        assertTrue(fragment.contains("reconcileDetailLayoutAfterConfigurationChange"));
-        assertTrue(fragment.contains("restoreDetailLayoutAfterConfigurationChange"));
-        assertTrue(fragment.contains(
-                "syncFullscreenWithOrientation(player.UIs().get(MainPlayerUi.class));"));
-        assertTrue(fragment.contains("prepareAndHandleInfo(currentInfo, false)"));
-        assertTrue(fragment.contains("fullscreen ? View.GONE : View.VISIBLE"));
-
-        final int pendingOrientation = fragment.indexOf(
-                "pendingFullscreenOrientation = orientation");
-        final int immediateSync = fragment.indexOf(
-                "syncFullscreenWithOrientation(", pendingOrientation);
-        final int layoutRecreation = fragment.indexOf(
-                "recreateDetailLayoutForConfigurationChange();", pendingOrientation);
-        assertTrue(pendingOrientation >= 0
-                && pendingOrientation < immediateSync
-                && immediateSync < layoutRecreation);
     }
 
-    @Test
-    public void landscapePhoneVideoEntersFullscreenRegardlessOfPlaybackState() {
-        assertTrue(VideoDetailFragment.fullscreenStateForOrientation(
-                Configuration.ORIENTATION_LANDSCAPE,
-                false,
-                false,
-                false,
-                false));
-    }
-
-    @Test
-    public void portraitHorizontalVideoExitsFullscreen() {
-        assertFalse(VideoDetailFragment.fullscreenStateForOrientation(
-                Configuration.ORIENTATION_PORTRAIT,
-                true,
-                false,
-                false,
-                false));
-    }
-
-    @Test
-    public void portraitVerticalVideoKeepsDirectFullscreenState() {
-        assertTrue(VideoDetailFragment.fullscreenStateForOrientation(
-                Configuration.ORIENTATION_PORTRAIT,
-                true,
-                true,
-                false,
-                false));
-    }
-
-    @Test
-    public void tabletAndAudioOnlyPlaybackIgnoreOrientationChanges() {
-        assertFalse(VideoDetailFragment.fullscreenStateForOrientation(
-                Configuration.ORIENTATION_LANDSCAPE,
-                false,
-                false,
-                true,
-                false));
-        assertFalse(VideoDetailFragment.fullscreenStateForOrientation(
-                Configuration.ORIENTATION_LANDSCAPE,
-                false,
-                false,
-                false,
-                true));
-    }
-
-    @Test
-    public void manualFullscreenWaitsForItsTargetOrientation() {
-        assertFalse(VideoDetailFragment.isTargetFullscreenOrientation(
-                Configuration.ORIENTATION_PORTRAIT, true));
-        assertTrue(VideoDetailFragment.isTargetFullscreenOrientation(
-                Configuration.ORIENTATION_LANDSCAPE, true));
-        assertFalse(VideoDetailFragment.isTargetFullscreenOrientation(
-                Configuration.ORIENTATION_LANDSCAPE, false));
-        assertTrue(VideoDetailFragment.isTargetFullscreenOrientation(
-                Configuration.ORIENTATION_PORTRAIT, false));
-    }
-
-    @Test
-    public void phoneFullscreenKeepsCurrentDetailLayoutDuringLandscapeRotation() {
-        assertTrue(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
-                Configuration.ORIENTATION_LANDSCAPE, true, false));
-        assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
-                Configuration.ORIENTATION_PORTRAIT, true, false));
-        assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
-                Configuration.ORIENTATION_LANDSCAPE, false, false));
-        assertFalse(VideoDetailFragment.shouldKeepDetailLayoutWhileFullscreen(
-                Configuration.ORIENTATION_LANDSCAPE, true, true));
+    private static String methodBody(final String source, final String signature) {
+        final int signatureIndex = source.indexOf(signature);
+        assertTrue("Missing method: " + signature, signatureIndex >= 0);
+        final int bodyStart = source.indexOf('{', signatureIndex);
+        assertTrue("Missing method body: " + signature, bodyStart >= 0);
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unclosed method body: " + signature);
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/FullscreenExitIntegrationTest.java
@@ -18,52 +18,54 @@ public class FullscreenExitIntegrationTest {
                 "org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt");
         final String onScrollEnd = methodBody(source, "override fun onScrollEnd");
 
-        assertTrue(onScrollEnd.contains("playerUi.toggleFullscreenWithOrientation()"));
+        assertTrue(onScrollEnd.contains(
+                "playerUi.toggleFullscreenWithOrientation()"));
         assertFalse(onScrollEnd.contains("playerUi.toggleFullscreen()"));
     }
 
     @Test
-    public void orientationAwareActionUsesRotationCallbackWithDirectFallback() throws Exception {
+    public void orientationAwareActionUsesRotationCallbackWithDirectFallback()
+            throws Exception {
         final String source = read("org/schabi/newpipe/player/ui/MainPlayerUi.java");
-        final String toggle = methodBody(source, "public void toggleFullscreenWithOrientation()");
+        final String toggle = methodBody(
+                source, "public void toggleFullscreenWithOrientation()");
 
-        assertTrue(toggle.contains("PlayerServiceEventListener::onScreenRotationButtonClicked"));
+        assertTrue(toggle.contains(
+                "PlayerServiceEventListener::onScreenRotationButtonClicked"));
         assertTrue(toggle.contains("toggleFullscreen();"));
     }
 
     @Test
-    public void rotationButtonDefersFullscreenUntilTargetOrientation() throws Exception {
+    public void rotationButtonLetsConfigurationCallbackOwnFullscreenState()
+            throws Exception {
         final String source = read(
                 "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
-        final String rotation = methodBody(source,
-                "public void onScreenRotationButtonClicked()");
+        final String rotation = methodBody(
+                source, "public void onScreenRotationButtonClicked()");
 
-        assertTrue(rotation.contains(
-                "if (isTargetFullscreenOrientation(currentOrientation, fullscreen))"));
-        assertTrue(rotation.contains("ui.setFullscreen(fullscreen);"));
+        assertTrue(rotation.contains("DeviceUtils.isLandscape(requireContext())"));
         assertTrue(rotation.contains("SCREEN_ORIENTATION_SENSOR_LANDSCAPE"));
         assertTrue(rotation.contains("SCREEN_ORIENTATION_PORTRAIT"));
-        assertFalse(rotation.contains("DeviceUtils.isLandscape(requireContext())"));
+        assertTrue(rotation.contains(
+                "activity.setRequestedOrientation(newOrientation)"));
+        assertFalse(rotation.contains("isTargetFullscreenOrientation"));
+        assertFalse(rotation.contains("ui.setFullscreen(fullscreen)"));
+    }
+
+
+    @Test
+    public void landscapeAutoFullscreenDoesNotDependOnTransientPlaybackState()
+            throws Exception {
+        final String playerUi = read("org/schabi/newpipe/player/ui/MainPlayerUi.java");
+        final String checkLandscape = methodBody(
+                playerUi, "public void checkLandscape()");
+        assertTrue(checkLandscape.contains("setFullscreen(true);"));
+        assertFalse(checkLandscape.contains("STATE_COMPLETED"));
+        assertFalse(checkLandscape.contains("STATE_PAUSED"));
     }
 
     @Test
-    public void initialFullscreenRotationDoesNotRequireABoundPlayer() throws Exception {
-        final String source = read(
-                "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
-        final String rotation = methodBody(source,
-                "public void onScreenRotationButtonClicked()");
-
-        final int missingPlayerGuard = rotation.indexOf("if (!isPlayerAvailable())");
-        final int playerAccess = rotation.indexOf("player.UIs().get(MainPlayerUi.class)");
-        assertTrue("Missing-player guard must exist", missingPlayerGuard >= 0);
-        assertTrue("Missing-player guard must run before player access",
-                missingPlayerGuard < playerAccess);
-        assertTrue(rotation.substring(missingPlayerGuard, playerAccess).contains(
-                "SCREEN_ORIENTATION_SENSOR_LANDSCAPE"));
-    }
-
-    @Test
-    public void explicitFullscreenSetterIsIdempotent() throws Exception {
+    public void explicitFullscreenSetterRemainsIdempotent() throws Exception {
         final String source = read("org/schabi/newpipe/player/ui/MainPlayerUi.java");
         final String setter = methodBody(source, "public void setFullscreen(");
 
@@ -76,7 +78,8 @@ public class FullscreenExitIntegrationTest {
     public void backExitsFullscreenWithoutPausingPlayback() throws Exception {
         final String source = read(
                 "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java");
-        final String onBackPressed = methodBody(source, "public boolean onBackPressed()");
+        final String onBackPressed = methodBody(
+                source, "public boolean onBackPressed()");
 
         assertTrue(onBackPressed.contains("restoreDefaultOrientation();"));
         assertFalse(onBackPressed.contains("player.pause();"));


### PR DESCRIPTION
- Restore configuration-owned fullscreen/orientation transitions without carrying deferred orientation state across layout changes.
- Remove `pendingFullscreenOrientation` and let the final Android configuration own landscape/portrait fullscreen reconciliation.
- Keep an expanded phone video on its current detail layout during landscape rotation instead of switching to the 840dp wide-detail layout before fullscreen can be applied.
- Apply fullscreen after the new configuration is active and re-read the current orientation in the posted callback so rapid rotations cannot apply stale state.
- Enter fullscreen reliably in landscape and exit fullscreen for horizontal video in portrait.
- Keep the rotation button focused on requesting orientation instead of changing fullscreen against the previous layout.
- Preserve the wide-detail layout on tablets, TV, desktop-mode devices, and non-expanded/non-video states.
- Preserve later PiP handling, SurfaceView playback, local-media support, and other player UI improvements.
- Add regression coverage for the phone landscape layout guard, fullscreen reconciliation ordering, and stable orientation checks.
- Keep #373 open for real-device verification.