### PR TITLE
Use Material 3 live stream dialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -63,6 +63,7 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.navigation.NavigationBarView;
 
 import org.schabi.newpipe.App;
@@ -1354,7 +1355,7 @@ public final class VideoDetailFragment
             return;
         }
 
-        liveNotStartedDialog = new AlertDialog.Builder(activity)
+        liveNotStartedDialog = new MaterialAlertDialogBuilder(activity)
                 .setTitle(R.string.live_stream_not_started_title)
                 .setMessage(R.string.live_stream_not_started_message)
                 .setNegativeButton(R.string.close, null)

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLiveStreamErrorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLiveStreamErrorTest.java
@@ -43,6 +43,11 @@ public class VideoDetailLiveStreamErrorTest {
 
         final String dialog = source.substring(dialogStart, dialogEnd);
         assertTrue(dialog.contains("handleError();"));
+        assertTrue(source.contains(
+                "import com.google.android.material.dialog."
+                        + "MaterialAlertDialogBuilder;"));
+        assertTrue(dialog.contains(
+                "new MaterialAlertDialogBuilder(activity)"));
         assertTrue(dialog.contains(
                 ".setTitle(R.string.live_stream_not_started_title)"));
         assertTrue(dialog.contains(


### PR DESCRIPTION
- Replace the AppCompat live-not-started alert with `MaterialAlertDialogBuilder` so the dialog uses WizeStream's Material 3 theme, shape, spacing, typography, and button treatment.
- Keep the existing Live stream has not started title, explanatory message, Close action, and Retry behavior unchanged.
- Preserve the existing dialog lifecycle and duplicate-dialog guard.
- Add regression coverage ensuring the live-not-started path uses the Material 3 dialog builder.