### PR TITLE
Handle unreleased YouTube premieres as scheduled streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -83,6 +83,7 @@ import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.LiveNotStartException;
+import org.schabi.newpipe.extractor.exceptions.VideoNotReleaseException;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
@@ -1337,7 +1338,8 @@ public final class VideoDetailFragment
                         }
                     }
                 }, throwable -> {
-                    if (throwable instanceof LiveNotStartException) {
+                    if (throwable instanceof LiveNotStartException
+                            || throwable instanceof VideoNotReleaseException) {
                         showLiveNotStartedDialog();
                     } else {
                         showError(new ErrorInfo(throwable, UserAction.REQUESTED_STREAM,

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLiveStreamErrorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailLiveStreamErrorTest.java
@@ -21,11 +21,15 @@ public class VideoDetailLiveStreamErrorTest {
 
         final String workerFlow = source.substring(workerStart, dialogStart);
         final int liveCheck = workerFlow.indexOf(
-                "if (throwable instanceof LiveNotStartException)");
+                "if (throwable instanceof LiveNotStartException");
+        final int unreleasedCheck = workerFlow.indexOf(
+                "throwable instanceof VideoNotReleaseException", liveCheck);
         final int liveDialog = workerFlow.indexOf("showLiveNotStartedDialog()", liveCheck);
         final int genericError = workerFlow.indexOf("showError(new ErrorInfo(", liveDialog);
 
         assertTrue(liveCheck >= 0);
+        assertTrue(unreleasedCheck > liveCheck);
+        assertTrue(unreleasedCheck < liveDialog);
         assertTrue(liveDialog > liveCheck);
         assertTrue(genericError > liveDialog);
     }


### PR DESCRIPTION
- Route `VideoNotReleaseException` through the existing live-not-started dialog instead of generic error reporting
- Preserve the existing Close and Retry behavior for scheduled livestreams and premieres
- Extend regression coverage to require both scheduled-stream exception types before the generic error path