### PR TITLE
Honor full titles in wide related videos

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -11,7 +11,6 @@ import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.PignateFooterBinding;
 import org.schabi.newpipe.dearrow.DeArrowService;
 import org.schabi.newpipe.extractor.InfoItem;
@@ -34,6 +33,7 @@ import org.schabi.newpipe.info_list.holder.StreamCardInfoItemHolder;
 import org.schabi.newpipe.info_list.holder.StreamGridInfoItemHolder;
 import org.schabi.newpipe.info_list.holder.StreamInfoItemHolder;
 import org.schabi.newpipe.info_list.holder.StreamMiniInfoItemHolder;
+import org.schabi.newpipe.info_list.holder.StreamWideRelatedInfoItemHolder;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.FallbackViewHolder;
@@ -354,8 +354,7 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             case STREAM_HOLDER_TYPE:
                 return new StreamInfoItemHolder(infoItemBuilder, parent);
             case WIDE_RELATED_STREAM_HOLDER_TYPE:
-                return new StreamInfoItemHolder(
-                        infoItemBuilder, R.layout.list_stream_related_wide_item, parent);
+                return new StreamWideRelatedInfoItemHolder(infoItemBuilder, parent);
             case GRID_STREAM_HOLDER_TYPE:
                 return new StreamGridInfoItemHolder(infoItemBuilder, parent);
             case CARD_STREAM_HOLDER_TYPE:

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamWideRelatedInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/StreamWideRelatedInfoItemHolder.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.info_list.holder;
+
+import android.view.ViewGroup;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.extractor.InfoItem;
+import org.schabi.newpipe.info_list.InfoItemBuilder;
+import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.util.GridTitleDisplayPolicy;
+
+/** Stream holder for the wide related-video column shown beside the player. */
+public final class StreamWideRelatedInfoItemHolder extends StreamInfoItemHolder {
+    public StreamWideRelatedInfoItemHolder(final InfoItemBuilder infoItemBuilder,
+                                           final ViewGroup parent) {
+        super(infoItemBuilder, R.layout.list_stream_related_wide_item, parent);
+    }
+
+    @Override
+    public void updateFromItem(final InfoItem infoItem,
+                               final HistoryRecordManager historyRecordManager) {
+        GridTitleDisplayPolicy.apply(itemVideoTitleView);
+        super.updateFromItem(infoItem, historyRecordManager);
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/WideRelatedItemsIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/WideRelatedItemsIntegrationTest.java
@@ -19,11 +19,16 @@ public class WideRelatedItemsIntegrationTest {
         final String relatedItems = read("org/schabi/newpipe/fragments/list/videos/"
                 + "RelatedItemsFragment.java");
         final String adapter = read("org/schabi/newpipe/info_list/InfoListAdapter.java");
+        final String wideRelatedHolder = read("org/schabi/newpipe/info_list/holder/"
+                + "StreamWideRelatedInfoItemHolder.java");
 
         assertTrue(videoDetail.contains("RelatedItemsFragment.getInstance(info, true)"));
         assertTrue(videoDetail.contains("RelatedItemsFragment.getInstance(info)"));
         assertTrue(relatedItems.contains("setUseWideRelatedVariant("));
-        assertTrue(adapter.contains("R.layout.list_stream_related_wide_item"));
+        assertTrue(adapter.contains("case WIDE_RELATED_STREAM_HOLDER_TYPE:"));
+        assertTrue(adapter.contains(
+                "return new StreamWideRelatedInfoItemHolder(infoItemBuilder, parent);"));
+        assertTrue(wideRelatedHolder.contains("R.layout.list_stream_related_wide_item"));
     }
 
     private String read(final String relativePath) throws Exception {

--- a/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/GridTitleDisplayPolicyTest.java
@@ -67,12 +67,14 @@ public class GridTitleDisplayPolicyTest {
     }
 
     @Test
-    public void everyStreamGridOrCardHolderAppliesTheDisplayPolicy() throws Exception {
+    public void everyFullTitleStreamHolderAppliesTheDisplayPolicy() throws Exception {
         final List<String> streamHolders = List.of(
                 "app/src/main/java/org/schabi/newpipe/info_list/holder/"
                         + "StreamGridInfoItemHolder.java",
                 "app/src/main/java/org/schabi/newpipe/info_list/holder/"
                         + "StreamCardInfoItemHolder.java",
+                "app/src/main/java/org/schabi/newpipe/info_list/holder/"
+                        + "StreamWideRelatedInfoItemHolder.java",
                 "app/src/main/java/org/schabi/newpipe/local/holder/"
                         + "LocalPlaylistStreamGridItemHolder.java",
                 "app/src/main/java/org/schabi/newpipe/local/holder/"
@@ -82,6 +84,18 @@ public class GridTitleDisplayPolicyTest {
             assertTrue(read(streamHolder).contains(
                     "GridTitleDisplayPolicy.apply(itemVideoTitleView);"));
         }
+    }
+
+    @Test
+    public void wideRelatedVideosUseTheFullTitleAwareHolder() throws Exception {
+        final String adapter = read(
+                "app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java");
+
+        assertTrue(adapter.contains("case WIDE_RELATED_STREAM_HOLDER_TYPE:"));
+        assertTrue(adapter.contains(
+                "return new StreamWideRelatedInfoItemHolder(infoItemBuilder, parent);"));
+        assertFalse(adapter.contains(
+                "R.layout.list_stream_related_wide_item, parent"));
     }
 
     @Test


### PR DESCRIPTION
- Route the dedicated wide related-video layout through a full-title-aware stream holder.
- Reapply the existing Show full video titles policy on every wide related-video bind.
- Preserve the current two-line ellipsized presentation when the preference is disabled.
- Keep the existing related-video layout, metadata, thumbnails, and interaction behavior unchanged.
- Add regression coverage so the wide related-video path cannot bypass the title-display preference again.
- Follow-up for #305