### PR TITLE
Add feed group subscription back action

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt
@@ -256,7 +256,12 @@ class FeedGroupDialog : DialogFragment(), BackPressable {
             showScreen(SubscriptionsPickerScreen)
         }
 
-        val headerMenu = feedGroupCreateBinding.subscriptionsHeaderToolbar.menu
+        val headerToolbar = feedGroupCreateBinding.subscriptionsHeaderToolbar
+        headerToolbar.setNavigationIcon(R.drawable.ic_arrow_back)
+        headerToolbar.setNavigationContentDescription(R.string.back)
+        headerToolbar.setNavigationOnClickListener { onBackPressed() }
+
+        val headerMenu = headerToolbar.menu
         requireActivity().menuInflater.inflate(R.menu.menu_feed_group_dialog, headerMenu)
 
         headerMenu.findItem(R.id.action_search).setOnMenuItemClickListener {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -683,6 +683,7 @@
     <string name="recaptcha_request_toast">reCAPTCHA challenge requested</string>
     <string name="recaptcha_solve">Solve</string>
     <string name="done">Done</string>
+    <string name="back">Back</string>
     <!-- Downloads -->
     <string name="settings_category_downloads_title">Download</string>
     <string name="settings_file_charset_title">Allowed characters in filenames</string>

--- a/app/src/test/java/org/schabi/newpipe/local/subscription/FeedGroupDialogNavigationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/subscription/FeedGroupDialogNavigationTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.subscription;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class FeedGroupDialogNavigationTest {
+    private final Path mainDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main") : Path.of("app/src/main");
+
+    @Test
+    public void subscriptionPickerProvidesAnAccessibleBackAction() throws Exception {
+        final String source = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/local/subscription/dialog/FeedGroupDialog.kt"));
+
+        assertTrue(source.contains("setNavigationIcon(R.drawable.ic_arrow_back)"));
+        assertTrue(source.contains("setNavigationContentDescription(R.string.back)"));
+        assertTrue(source.contains("setNavigationOnClickListener { onBackPressed() }"));
+    }
+}


### PR DESCRIPTION
- Add an accessible Back icon to the Select subscriptions toolbar.
- Reuse the existing dialog back flow so search closes first and selected subscriptions remain intact.
- Keep the existing Done and final Create/Save actions unchanged.
- Add regression coverage for the toolbar icon, label, and click handler.
- Closes #406