### PR TITLE
Add one-tap local playlist shuffle

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java
@@ -432,6 +432,10 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             createShareConfirmationDialog();
         } else if (item.getItemId() == R.id.menu_item_download_playlist) {
             showBulkDownloadDialog();
+        } else if (item.getItemId() == R.id.menu_item_shuffle_playlist) {
+            final PlayQueue playQueue = getCompletePlaylistPlayQueue();
+            playQueue.shuffleFromStart();
+            NavigationHelper.playOnMainPlayer(requireContext(), playQueue, false);
         } else if (item.getItemId() == R.id.menu_item_rename_playlist) {
             createRenameDialog();
         } else if (item.getItemId() == R.id.menu_item_remove_watched) {
@@ -1216,7 +1220,20 @@ public class LocalPlaylistFragment extends BaseLocalListFragment<List<PlaylistSt
             return new SinglePlayQueue(Collections.emptyList(), 0);
         }
 
-        final List<LocalItem> infoItems = itemListAdapter.getItemsList();
+        return getPlayQueue(itemListAdapter.getItemsList(), index);
+    }
+
+    private PlayQueue getCompletePlaylistPlayQueue() {
+        if (itemListAdapter == null) {
+            return new SinglePlayQueue(Collections.emptyList(), 0);
+        }
+
+        final List<? extends LocalItem> infoItems = ContextualSearchHelper.isActive(
+                contextualSearchQuery) ? unfilteredItems : itemListAdapter.getItemsList();
+        return getPlayQueue(infoItems, 0);
+    }
+
+    private PlayQueue getPlayQueue(final List<? extends LocalItem> infoItems, final int index) {
         final List<PlayQueueItem> queueItems = new ArrayList<>(infoItems.size());
         for (final LocalItem item : infoItems) {
             if (item instanceof PlaylistStreamEntry) {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -706,6 +706,7 @@ public final class Player implements PlaybackListener, Listener {
 
         playQueue = queue;
         playQueue.init();
+        simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled());
         retargetSleepTimerForNewQueue();
         reloadPlayQueueManager();
 
@@ -1715,9 +1716,9 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         if (playQueue != null) {
-            if (shuffleModeEnabled) {
+            if (shuffleModeEnabled && !playQueue.isShuffled()) {
                 playQueue.shuffle();
-            } else {
+            } else if (!shuffleModeEnabled && playQueue.isShuffled()) {
                 playQueue.unshuffle();
             }
             if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE) {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueue.java
@@ -474,6 +474,29 @@ public abstract class PlayQueue implements Serializable {
     }
 
     /**
+     * Shuffles the entire queue before playback starts, including the item at the current index.
+     * The original order is retained so {@link #unshuffle()} can restore it.
+     */
+    public synchronized void shuffleFromStart() {
+        if (size() <= 1) {
+            return;
+        }
+
+        if (backup == null) {
+            backup = new ArrayList<>(streams);
+        }
+
+        final int originalIndex = getIndex();
+        Collections.shuffle(streams);
+        queueIndex.set(0);
+
+        history.clear();
+        history.add(streams.get(0));
+
+        broadcast(new ReorderEvent(originalIndex, 0));
+    }
+
+    /**
      * Unshuffles the current play queue if a backup play queue exists.
      * <p>
      * This method undoes shuffling and index will be set to the previously playing item if found,
@@ -572,4 +595,3 @@ public abstract class PlayQueue implements Serializable {
         }
     }
 }
-

--- a/app/src/main/res/menu/menu_local_playlist.xml
+++ b/app/src/main/res/menu/menu_local_playlist.xml
@@ -24,6 +24,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_item_shuffle_playlist"
+        android:icon="@drawable/ic_shuffle"
+        android:title="@string/shuffle_playlist"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_item_rename_playlist"
         android:title="@string/rename_playlist"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="download">Download</string>
     <string name="bulk_download_title">Bulk download</string>
     <string name="download_playlist">Download playlist</string>
+    <string name="shuffle_playlist">Shuffle playlist</string>
     <string name="download_queue">Download loaded queue</string>
     <string name="bulk_download_number_files">Add track numbers to filenames</string>
     <plurals name="bulk_download_summary">

--- a/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistShuffleIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistShuffleIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.playlist;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LocalPlaylistShuffleIntegrationTest {
+    private final Path mainDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main") : Path.of("app/src/main");
+
+    @Test
+    public void localPlaylistMenuStartsTheCompletePlaylistShuffled() throws Exception {
+        final String fragment = read(
+                "java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java");
+        final String menu = read("res/menu/menu_local_playlist.xml");
+
+        assertTrue(menu.contains("@+id/menu_item_shuffle_playlist"));
+        assertTrue(fragment.contains("getCompletePlaylistPlayQueue()"));
+        assertTrue(fragment.contains("playQueue.shuffleFromStart()"));
+        assertTrue(fragment.contains("contextualSearchQuery) ? unfilteredItems"));
+    }
+
+    @Test
+    public void playerRestoresTheQueueShuffleState() throws Exception {
+        final String player = read("java/org/schabi/newpipe/player/Player.java");
+
+        assertTrue(player.contains(
+                "simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled())"));
+        assertTrue(player.contains("shuffleModeEnabled && !playQueue.isShuffled()"));
+        assertTrue(player.contains("!shuffleModeEnabled && playQueue.isShuffled()"));
+    }
+
+    private String read(final String relativePath) throws Exception {
+        return Files.readString(mainDirectory.resolve(relativePath));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueTest.java
@@ -199,4 +199,54 @@ public class PlayQueueTest {
             assertFalse(queue1.equalStreams(queue2));
         }
     }
+
+    public static class ShuffleFromStartTests {
+        private final List<PlayQueueItem> items = List.of(
+                makeItemWithUrl("URL_1"),
+                makeItemWithUrl("URL_2"),
+                makeItemWithUrl("URL_3"),
+                makeItemWithUrl("URL_4")
+        );
+
+        @Test
+        public void shufflesTheWholeQueueAndCanRestoreTheOriginalOrder() {
+            final PlayQueue queue = makePlayQueue(2, items);
+
+            queue.shuffleFromStart();
+
+            assertTrue(queue.isShuffled());
+            assertEquals(0, queue.getIndex());
+            assertEquals(items.size(), queue.getStreams().size());
+            assertTrue(queue.getStreams().containsAll(items));
+            assertFalse(queue.previous());
+
+            queue.unshuffle();
+
+            assertFalse(queue.isShuffled());
+            assertEquals(items, queue.getStreams());
+        }
+
+        @Test
+        public void twoItemQueueStartsAtTheBeginningWithoutDroppingAnItem() {
+            final List<PlayQueueItem> twoItems = items.subList(0, 2);
+            final PlayQueue queue = makePlayQueue(0, twoItems);
+
+            queue.shuffleFromStart();
+
+            assertTrue(queue.isShuffled());
+            assertEquals(0, queue.getIndex());
+            assertEquals(2, queue.getStreams().size());
+            assertTrue(queue.getStreams().containsAll(twoItems));
+        }
+
+        @Test
+        public void singleItemQueueRemainsUnshuffled() {
+            final PlayQueue queue = makePlayQueue(0, items.subList(0, 1));
+
+            queue.shuffleFromStart();
+
+            assertFalse(queue.isShuffled());
+            assertEquals(items.subList(0, 1), queue.getStreams());
+        }
+    }
 }


### PR DESCRIPTION
- Add a Shuffle playlist action to the local playlist overflow menu.
- Shuffle the complete underlying playlist, including the first item, even while contextual search is active.
- Support two-item playlists and preserve the original order for Unshuffle.
- Restore the queue shuffle state in ExoPlayer so player controls and notifications stay consistent.
- Add focused queue and local-playlist integration regression coverage.
- Closes #407