### PR TITLE
Display embedded artwork for local audio

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentAdapter.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentAdapter.kt
@@ -34,19 +34,23 @@ class LocalMediaDocumentAdapter(
 
     override fun onBindViewHolder(holder: Holder, position: Int) = holder.bind(entries[position])
 
+    override fun onViewRecycled(holder: Holder) {
+        holder.recycle()
+        super.onViewRecycled(holder)
+    }
+
     inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
         private val icon = view.findViewById<ImageView>(R.id.localMediaDocumentIcon)
         private val title = view.findViewById<TextView>(R.id.localMediaDocumentTitle)
         private val subtitle = view.findViewById<TextView>(R.id.localMediaDocumentSubtitle)
 
         fun bind(entry: LocalMediaDocumentEntry) {
-            icon.setImageResource(
-                when {
-                    entry.isDirectory -> R.drawable.ic_create_new_folder
-                    entry.isVideo -> R.drawable.ic_movie
-                    else -> R.drawable.ic_music_note
-                }
-            )
+            if (entry.isDirectory) {
+                LocalMediaThumbnailLoader.clear(icon)
+                icon.setImageResource(R.drawable.ic_create_new_folder)
+            } else {
+                LocalMediaThumbnailLoader.load(icon, entry)
+            }
             title.text = entry.name
             subtitle.text = when {
                 !entry.isAvailable -> itemView.context.getString(
@@ -70,6 +74,10 @@ class LocalMediaDocumentAdapter(
                 if (entry.isAvailable) onLongClick(entry)
                 entry.isAvailable
             }
+        }
+
+        fun recycle() {
+            LocalMediaThumbnailLoader.clear(icon)
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -758,6 +758,11 @@ private class LocalMediaGroupAdapter(
 
     override fun onBindViewHolder(holder: Holder, position: Int) = holder.bind(items[position])
 
+    override fun onViewRecycled(holder: Holder) {
+        holder.recycle()
+        super.onViewRecycled(holder)
+    }
+
     inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
         private val icon = view.findViewById<ImageView>(R.id.localMediaGroupIcon)
         private val title = view.findViewById<TextView>(R.id.localMediaGroupItemTitle)
@@ -774,18 +779,17 @@ private class LocalMediaGroupAdapter(
                 group.items.size,
                 group.items.size
             )
-            icon.setImageResource(
-                when (group.kind) {
-                    LocalMediaGroupKind.ARTIST -> R.drawable.ic_person
-                    LocalMediaGroupKind.VIDEO_FOLDER -> R.drawable.ic_movie
-                    else -> R.drawable.ic_music_note
-                }
-            )
+            group.items.firstOrNull()?.let { LocalMediaThumbnailLoader.load(icon, it) }
+                ?: icon.setImageResource(R.drawable.ic_music_note)
             title.text = group.title
             subtitle.text = listOf(group.subtitle, count)
                 .filter(String::isNotBlank)
                 .joinToString(" • ")
             itemView.setOnClickListener { onClick(group) }
+        }
+
+        fun recycle() {
+            LocalMediaThumbnailLoader.clear(icon)
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt
@@ -4,7 +4,12 @@
 package org.schabi.newpipe.local.media
 
 import android.content.ContentResolver
+import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -13,23 +18,45 @@ import android.util.LruCache
 import android.util.Size
 import android.widget.ImageView
 import androidx.annotation.WorkerThread
+import androidx.core.content.ContextCompat
 import coil3.util.CoilUtils
+import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 import org.schabi.newpipe.R
+import org.schabi.newpipe.extractor.stream.StreamType
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
-import org.schabi.newpipe.util.image.CoilHelper
 import org.schabi.newpipe.util.image.ImageStrategy
 
-/** Loads device-local artwork without treating a video content URI as an online image URL. */
+/** Loads thumbnails and embedded artwork from device-local media. */
 object LocalMediaThumbnailLoader {
     private const val THUMBNAIL_WIDTH = 512
     private const val THUMBNAIL_HEIGHT = 288
+    private const val ARTWORK_MAX_DIMENSION = 512
     private const val CACHE_SIZE_BYTES = 16 * 1024 * 1024
+    private const val MAXIMUM_PENDING_THUMBNAILS = 64
 
-    private val executor = Executors.newFixedThreadPool(2)
+    private val thumbnailExecutor = ThreadPoolExecutor(
+        2,
+        2,
+        0L,
+        TimeUnit.MILLISECONDS,
+        ArrayBlockingQueue(MAXIMUM_PENDING_THUMBNAILS),
+        ThreadPoolExecutor.DiscardOldestPolicy()
+    )
+    private val playerExecutor = Executors.newSingleThreadExecutor()
     private val mainHandler = Handler(Looper.getMainLooper())
     private val cache = object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.allocationByteCount
+    }
+
+    @Volatile
+    private var audioPlaceholder: Bitmap? = null
+
+    fun interface BitmapCallback {
+        fun onLoaded(bitmap: Bitmap?)
     }
 
     fun load(target: ImageView, item: LocalMediaItem) {
@@ -41,9 +68,62 @@ object LocalMediaThumbnailLoader {
             target,
             item.url,
             item.localMediaId,
-            item.streamType == org.schabi.newpipe.extractor.stream.StreamType.VIDEO_STREAM,
+            item.streamType == StreamType.VIDEO_STREAM,
             item.localThumbnailUrl
         )
+    }
+
+    fun load(target: ImageView, entry: LocalMediaDocumentEntry) {
+        load(
+            target,
+            entry.contentUri,
+            -1L,
+            entry.isVideo,
+            entry.contentUri.takeIf { entry.isVideo }
+        )
+    }
+
+    /**
+     * Loads artwork for the player without retaining an Activity or View reference.
+     * The callback is always dispatched on the main thread.
+     */
+    fun loadBitmap(
+        context: Context,
+        item: PlayQueueItem,
+        callback: BitmapCallback
+    ): Future<*> = playerExecutor.submit {
+        val bitmap = if (ImageStrategy.shouldLoadImages()) {
+            loadBitmap(
+                context.applicationContext.contentResolver,
+                item.url,
+                item.localMediaId,
+                item.streamType == StreamType.VIDEO_STREAM,
+                item.localThumbnailUrl
+            )
+        } else {
+            null
+        }
+        if (!Thread.currentThread().isInterrupted) {
+            mainHandler.post { callback.onLoaded(bitmap) }
+        }
+    }
+
+    @Synchronized
+    fun audioPlaceholderBitmap(context: Context): Bitmap? {
+        audioPlaceholder?.let { return it }
+        val drawable = ContextCompat.getDrawable(
+            context.applicationContext,
+            R.drawable.placeholder_thumbnail_audio
+        ) ?: return null
+        val bitmap = Bitmap.createBitmap(
+            THUMBNAIL_WIDTH,
+            THUMBNAIL_HEIGHT,
+            Bitmap.Config.ARGB_8888
+        )
+        drawable.setBounds(0, 0, bitmap.width, bitmap.height)
+        drawable.draw(Canvas(bitmap))
+        audioPlaceholder = bitmap
+        return bitmap
     }
 
     private fun load(
@@ -54,14 +134,17 @@ object LocalMediaThumbnailLoader {
         thumbnailUri: String?
     ) {
         clear(target)
-        val requestKey = contentUri
+        target.setImageResource(
+            if (isVideo) {
+                R.drawable.placeholder_thumbnail_video
+            } else {
+                R.drawable.placeholder_thumbnail_audio
+            }
+        )
+        val requestKey = "$isVideo:$contentUri"
         target.tag = requestKey
 
         if (!ImageStrategy.shouldLoadImages()) return
-        if (!isVideo) {
-            CoilHelper.loadThumbnail(target, thumbnailUri)
-            return
-        }
 
         cache[requestKey]?.let {
             target.setImageBitmap(it)
@@ -69,8 +152,14 @@ object LocalMediaThumbnailLoader {
         }
 
         val resolver = target.context.applicationContext.contentResolver
-        executor.execute {
-            val bitmap = loadVideoThumbnail(resolver, contentUri, mediaStoreId)
+        thumbnailExecutor.execute {
+            val bitmap = loadBitmap(
+                resolver,
+                contentUri,
+                mediaStoreId,
+                isVideo,
+                thumbnailUri
+            )
             if (bitmap != null) cache.put(requestKey, bitmap)
             mainHandler.post {
                 if (target.tag == requestKey && bitmap != null) target.setImageBitmap(bitmap)
@@ -82,6 +171,83 @@ object LocalMediaThumbnailLoader {
         target.tag = null
         CoilUtils.dispose(target)
         target.setImageResource(R.drawable.placeholder_thumbnail_video)
+    }
+
+    @WorkerThread
+    private fun loadBitmap(
+        resolver: ContentResolver,
+        contentUri: String,
+        mediaStoreId: Long,
+        isVideo: Boolean,
+        thumbnailUri: String?
+    ): Bitmap? {
+        val requestKey = "$isVideo:$contentUri"
+        cache[requestKey]?.let { return it }
+        val bitmap = if (isVideo) {
+            loadVideoThumbnail(resolver, contentUri, mediaStoreId)
+        } else {
+            loadEmbeddedArtwork(resolver, contentUri)
+                ?: loadArtworkUri(resolver, thumbnailUri)
+        }
+        if (bitmap != null) cache.put(requestKey, bitmap)
+        return bitmap
+    }
+
+    @WorkerThread
+    private fun loadEmbeddedArtwork(
+        resolver: ContentResolver,
+        contentUri: String
+    ): Bitmap? {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            resolver.openFileDescriptor(Uri.parse(contentUri), "r")?.use {
+                retriever.setDataSource(it.fileDescriptor)
+            } ?: return null
+            retriever.embeddedPicture?.let(::decodeArtwork)
+        } catch (_: Exception) {
+            null
+        } finally {
+            retriever.release()
+        }
+    }
+
+    @WorkerThread
+    private fun loadArtworkUri(resolver: ContentResolver, artworkUri: String?): Bitmap? {
+        if (artworkUri.isNullOrBlank()) return null
+        return try {
+            val uri = Uri.parse(artworkUri)
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            resolver.openInputStream(uri)?.use {
+                BitmapFactory.decodeStream(it, null, bounds)
+            }
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+            val options = BitmapFactory.Options().apply {
+                inSampleSize = calculateArtworkSampleSize(
+                    bounds.outWidth,
+                    bounds.outHeight,
+                    ARTWORK_MAX_DIMENSION
+                )
+            }
+            resolver.openInputStream(uri)?.use {
+                BitmapFactory.decodeStream(it, null, options)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun decodeArtwork(bytes: ByteArray): Bitmap? {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+        val options = BitmapFactory.Options().apply {
+            inSampleSize = calculateArtworkSampleSize(
+                bounds.outWidth,
+                bounds.outHeight,
+                ARTWORK_MAX_DIMENSION
+            )
+        }
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
     }
 
     @WorkerThread
@@ -110,4 +276,14 @@ object LocalMediaThumbnailLoader {
             null
         }
     }
+}
+
+internal fun calculateArtworkSampleSize(width: Int, height: Int, maximumDimension: Int): Int {
+    if (width <= 0 || height <= 0 || maximumDimension <= 0) return 1
+    var sampleSize = 1
+    val largestDimension = maxOf(width, height)
+    while (largestDimension / (sampleSize * 2) >= maximumDimension) {
+        sampleSize *= 2
+    }
+    return sampleSize
 }

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -105,6 +105,7 @@ import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.learning.LearningSessionTracker;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.local.media.LocalMediaThumbnailLoader;
 import org.schabi.newpipe.player.equalizer.EqualizerController;
 import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.event.PlayerEventListener;
@@ -153,6 +154,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
@@ -227,6 +229,8 @@ public final class Player implements PlaybackListener, Listener {
     private Bitmap currentThumbnail;
     @Nullable
     private coil3.request.Disposable thumbnailDisposable;
+    @Nullable
+    private Future<?> localThumbnailFuture;
     @NonNull
     private final PlayerHttpErrorRecovery.RecoveryGuard mediaUrlRecoveryGuard =
         new PlayerHttpErrorRecovery.RecoveryGuard();
@@ -786,6 +790,7 @@ public final class Player implements PlaybackListener, Listener {
             Log.d(TAG, "destroy() called");
         }
 
+        cancelThumbnailLoading();
         clearSleepTimer();
         saveStreamProgressState();
         setRecovery();
@@ -982,10 +987,7 @@ public final class Player implements PlaybackListener, Listener {
                     + thumbnails.size() + "]");
         }
 
-        // Cancel any ongoing image loading
-        if (thumbnailDisposable != null) {
-            thumbnailDisposable.dispose();
-        }
+        cancelThumbnailLoading();
 
         // Unset currentThumbnail, since it is now outdated. This ensures it is not used in media
         // session metadata while the new thumbnail is being loaded by Coil.
@@ -1021,6 +1023,17 @@ public final class Player implements PlaybackListener, Listener {
         };
         thumbnailDisposable = CoilHelper.INSTANCE
                 .loadScaledDownThumbnail(context, thumbnails, thumbnailTarget);
+    }
+
+    private void cancelThumbnailLoading() {
+        if (thumbnailDisposable != null) {
+            thumbnailDisposable.dispose();
+            thumbnailDisposable = null;
+        }
+        if (localThumbnailFuture != null) {
+            localThumbnailFuture.cancel(true);
+            localThumbnailFuture = null;
+        }
     }
 
 
@@ -2874,7 +2887,22 @@ public final class Player implements PlaybackListener, Listener {
         sponsorBlockSegments = Collections.emptyList();
         hideSponsorBlockManualSkipButton();
         clearSponsorBlockSeekBarMarkers();
+        cancelThumbnailLoading();
         onThumbnailLoaded(null);
+        localThumbnailFuture = LocalMediaThumbnailLoader.INSTANCE.loadBitmap(
+                context,
+                item,
+                bitmap -> {
+                    if (currentMetadata instanceof LocalMediaItemTag
+                            && ((LocalMediaItemTag) currentMetadata).getItem().isSameItem(item)) {
+                        final Bitmap displayedBitmap = bitmap != null || item.getStreamType()
+                                != StreamType.AUDIO_STREAM
+                                ? bitmap
+                                : LocalMediaThumbnailLoader.INSTANCE
+                                        .audioPlaceholderBitmap(context);
+                        onThumbnailLoaded(displayedBitmap);
+                    }
+                });
         databaseUpdateDisposable.add(recordManager.onViewed(item)
                 .onErrorComplete().subscribe());
         notifyMetadataUpdateToListeners();

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
 
+import org.schabi.newpipe.local.media.LocalMediaThumbnailLoader;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.image.CoilHelper;
@@ -39,9 +40,9 @@ public class PlayQueueItemBuilder {
         }
 
         if (item.isLocalMedia()) {
-            CoilHelper.INSTANCE.loadThumbnail(holder.itemThumbnailView,
-                    item.getLocalThumbnailUrl());
+            LocalMediaThumbnailLoader.INSTANCE.load(holder.itemThumbnailView, item);
         } else {
+            LocalMediaThumbnailLoader.INSTANCE.clear(holder.itemThumbnailView);
             CoilHelper.INSTANCE.loadThumbnail(holder.itemThumbnailView,
                     ExtractorImageCompat.thumbnailImages(item));
         }

--- a/app/src/main/res/drawable/placeholder_thumbnail_audio.xml
+++ b/app/src/main/res/drawable/placeholder_thumbnail_audio.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="9dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/placeholder_background"
+        android:pathData="M0,0h24v24h-24z" />
+    <path
+        android:fillColor="@color/placeholder_foreground"
+        android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4V7h4V3h-6z" />
+</vector>

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaArtworkTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaArtworkTest.kt
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.local.media
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalMediaArtworkTest {
+    private val projectDirectory = if (Files.exists(Path.of("src/main"))) {
+        Path.of("src/main")
+    } else {
+        Path.of("app/src/main")
+    }
+
+    @Test
+    fun `artwork sampling keeps decoded images bounded`() {
+        assertEquals(1, calculateArtworkSampleSize(512, 512, 512))
+        assertEquals(2, calculateArtworkSampleSize(1_024, 1_024, 512))
+        assertEquals(8, calculateArtworkSampleSize(4_096, 4_096, 512))
+        assertEquals(8, calculateArtworkSampleSize(4_096, 500, 512))
+    }
+
+    @Test
+    fun `local audio prefers embedded artwork and updates player surfaces`() {
+        val loader = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt"
+            )
+        )
+        val player = Files.readString(
+            projectDirectory.resolve("java/org/schabi/newpipe/player/Player.java")
+        )
+        val queue = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/player/playqueue/PlayQueueItemBuilder.java"
+            )
+        )
+
+        assertTrue(loader.contains("retriever.embeddedPicture"))
+        assertTrue(loader.indexOf("loadEmbeddedArtwork") < loader.indexOf("loadArtworkUri"))
+        assertTrue(loader.contains("ArrayBlockingQueue(MAXIMUM_PENDING_THUMBNAILS)"))
+        assertTrue(player.contains("LocalMediaThumbnailLoader.INSTANCE.loadBitmap"))
+        assertTrue(queue.contains("LocalMediaThumbnailLoader.INSTANCE.load"))
+    }
+}


### PR DESCRIPTION
- Prefer embedded audio artwork with MediaStore album art as a fallback
- Downsample and cache local artwork to keep decoding and memory use bounded
- Show artwork consistently in local media lists, groups, folder browsing, queues, the player, notifications, lock screen, and media-session surfaces
- Add a dedicated music placeholder for files without usable artwork
- Prevent recycled rows and rapid track changes from displaying stale artwork
- Add focused artwork sampling and integration regression tests
- Fixes #412