### PR TITLE
Add local library navigation from play queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -159,6 +159,7 @@ public class MainActivity extends AppCompatActivity {
     private static final int SEARCH_NAVIGATION_RAIL_MAX_ITEM_COUNT = 7;
     private static final int SEARCH_NAVIGATION_ITEM_ID_BASE = 20_000;
     public static final String KEY_IS_IN_BACKGROUND = "is_in_background";
+    public static final String KEY_OPEN_LOCAL_MEDIA_AUDIO = "open_local_media_audio";
 
     private SharedPreferences sharedPreferences;
     private SharedPreferences.Editor sharedPrefEditor;
@@ -915,7 +916,8 @@ public class MainActivity extends AppCompatActivity {
             Log.d(TAG, "initFragments() called");
         }
         StateSaver.clearStateFiles();
-        if (getIntent() != null && getIntent().hasExtra(Constants.KEY_LINK_TYPE)) {
+        if (getIntent() != null && (getIntent().hasExtra(Constants.KEY_LINK_TYPE)
+                || getIntent().getBooleanExtra(KEY_OPEN_LOCAL_MEDIA_AUDIO, false))) {
             // When user watch a video inside popup and then tries to open the video in main player
             // while the app is closed he will see a blank fragment on place of kiosk.
             // Let's open it first
@@ -1253,6 +1255,9 @@ public class MainActivity extends AppCompatActivity {
                         getSupportFragmentManager(),
                         serviceId,
                         searchString);
+
+            } else if (intent.getBooleanExtra(KEY_OPEN_LOCAL_MEDIA_AUDIO, false)) {
+                NavigationHelper.openLocalMediaAudioFragment(getSupportFragmentManager());
 
             } else {
                 NavigationHelper.gotoMainFragment(getSupportFragmentManager());

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -49,8 +49,15 @@ internal fun localMediaItemLayout(itemViewMode: ItemViewMode): Int = when (itemV
 
 class LocalMediaFragment : Fragment() {
     private companion object {
+        const val ARG_OPEN_AUDIO_TRACKS = "open_audio_tracks"
         const val STATE_QUERY = "local_media_query"
         const val STATE_SEARCH_EXPANDED = "local_media_search_expanded"
+        const val STATE_FILTER = "local_media_filter"
+
+        @JvmStatic
+        fun newAudioTracksInstance() = LocalMediaFragment().apply {
+            arguments = Bundle().apply { putBoolean(ARG_OPEN_AUDIO_TRACKS, true) }
+        }
     }
 
     private enum class Filter { ALL, AUDIO, VIDEO, BROWSE }
@@ -99,6 +106,13 @@ class LocalMediaFragment : Fragment() {
         setHasOptionsMenu(true)
         query = state?.getString(STATE_QUERY).orEmpty()
         searchExpanded = state?.getBoolean(STATE_SEARCH_EXPANDED) ?: false
+        filter = state?.getString(STATE_FILTER)
+            ?.let { saved -> Filter.entries.firstOrNull { it.name == saved } }
+            ?: if (arguments?.getBoolean(ARG_OPEN_AUDIO_TRACKS) == true) {
+                Filter.AUDIO
+            } else {
+                Filter.ALL
+            }
     }
 
     override fun onCreateView(
@@ -218,6 +232,8 @@ class LocalMediaFragment : Fragment() {
                 }
             }
         )
+        view.findViewById<Chip>(filterChipId(filter)).isChecked = true
+        selectFilter(filter)
         updateSearchVisibility()
         loadOrExplainPermission()
     }
@@ -233,6 +249,7 @@ class LocalMediaFragment : Fragment() {
         super.onSaveInstanceState(outState)
         outState.putString(STATE_QUERY, query)
         outState.putBoolean(STATE_SEARCH_EXPANDED, searchExpanded)
+        outState.putString(STATE_FILTER, filter.name)
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -351,6 +368,13 @@ class LocalMediaFragment : Fragment() {
         view?.findViewById<View>(R.id.localMediaGroupHeader)?.visibility = View.GONE
         requireActivity().invalidateOptionsMenu()
         if (selected == Filter.BROWSE) renderBrowserState(browserState) else updateList()
+    }
+
+    private fun filterChipId(selected: Filter): Int = when (selected) {
+        Filter.ALL -> R.id.localMediaAll
+        Filter.AUDIO -> R.id.localMediaAudio
+        Filter.VIDEO -> R.id.localMediaVideo
+        Filter.BROWSE -> R.id.localMediaBrowse
     }
 
     private fun selectAudioCategory(selected: LocalMediaAudioCategory) {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -28,6 +28,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.exoplayer2.PlaybackParameters;
 
+import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.ActivityPlayerQueueControlBinding;
 import org.schabi.newpipe.download.BulkDownloadDialog;
@@ -160,6 +161,10 @@ public final class PlayQueueActivity extends AppCompatActivity
                     .setChecked(player.getEqualizerState().isEnabled());
             menu.findItem(R.id.action_visualizer)
                     .setVisible(player.audioPlayerSelected());
+            final PlayQueueItem currentItem = player.getPlayQueue() == null
+                    ? null : player.getPlayQueue().getItem();
+            menu.findItem(R.id.action_browse_local_media)
+                    .setVisible(shouldShowLocalMediaBrowser(currentItem));
             updateVisualizerMenuItem();
         }
         return super.onPrepareOptionsMenu(m);
@@ -203,6 +208,9 @@ public final class PlayQueueActivity extends AppCompatActivity
         } else if (itemId == R.id.action_download_queue) {
             showBulkDownloadDialog();
             return true;
+        } else if (itemId == R.id.action_browse_local_media) {
+            openLocalMediaBrowser();
+            return true;
         } else if (itemId == R.id.action_switch_main) {
             this.player.setRecovery();
             NavigationHelper.playOnMainPlayer(this, player.getPlayQueue(), true);
@@ -225,6 +233,17 @@ public final class PlayQueueActivity extends AppCompatActivity
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    static boolean shouldShowLocalMediaBrowser(@Nullable final PlayQueueItem item) {
+        return item != null && item.isLocalMedia();
+    }
+
+    private void openLocalMediaBrowser() {
+        final Intent intent = new Intent(this, MainActivity.class)
+                .putExtra(MainActivity.KEY_OPEN_LOCAL_MEDIA_AUDIO, true)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        startActivity(intent);
     }
 
     private void showBulkDownloadDialog() {
@@ -589,6 +608,7 @@ public final class PlayQueueActivity extends AppCompatActivity
             adapter.setSelectedListener(getOnSelectedListener());
             queueControlBinding.playQueue.setAdapter(adapter);
         }
+        invalidateOptionsMenu();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -624,6 +624,13 @@ public final class NavigationHelper {
                 .commit();
     }
 
+    public static void openLocalMediaAudioFragment(final FragmentManager fragmentManager) {
+        defaultTransaction(fragmentManager)
+                .replace(R.id.fragment_holder, LocalMediaFragment.newAudioTracksInstance())
+                .addToBackStack(null)
+                .commit();
+    }
+
     public static void openSubscriptionFragment(final FragmentManager fragmentManager) {
         defaultTransaction(fragmentManager)
                 .replace(R.id.fragment_holder, new SubscriptionFragment())

--- a/app/src/main/res/menu/menu_play_queue.xml
+++ b/app/src/main/res/menu/menu_play_queue.xml
@@ -4,6 +4,13 @@
     tools:context=".player.PlayQueueActivity">
 
     <item
+        android:id="@+id/action_browse_local_media"
+        android:orderInCategory="0"
+        android:title="@string/local_media_browse_all_songs"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_append_playlist"
         android:icon="@drawable/ic_playlist_add"
         android:title="@string/add_to_playlist"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1517,6 +1517,7 @@
     <string name="equalizer_settings_summary_enabled">On · %1$s</string>
     <!-- Local media -->
     <string name="local_media">Local media</string>
+    <string name="local_media_browse_all_songs">Browse all songs</string>
     <string name="local_media_on_device">On this device</string>
     <string name="local_media_permission_description">Allow WizeStream to find music and videos stored on this device. Access is requested only when you open Local media.</string>
     <string name="local_media_grant_access">Allow media access</string>

--- a/app/src/test/java/org/schabi/newpipe/player/LocalMediaLibraryNavigationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/LocalMediaLibraryNavigationTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.schabi.newpipe.player.playqueue.PlayQueueItem;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LocalMediaLibraryNavigationTest {
+    private final Path mainDirectory = Files.exists(Path.of("src/main"))
+            ? Path.of("src/main") : Path.of("app/src/main");
+
+    @Test
+    public void browseAllSongsIsOnlyAvailableForLocalMedia() {
+        final PlayQueueItem localItem = mock(PlayQueueItem.class);
+        final PlayQueueItem remoteItem = mock(PlayQueueItem.class);
+        when(localItem.isLocalMedia()).thenReturn(true);
+        when(remoteItem.isLocalMedia()).thenReturn(false);
+
+        assertTrue(PlayQueueActivity.shouldShowLocalMediaBrowser(localItem));
+        assertFalse(PlayQueueActivity.shouldShowLocalMediaBrowser(remoteItem));
+        assertFalse(PlayQueueActivity.shouldShowLocalMediaBrowser(null));
+    }
+
+    @Test
+    public void playQueueRoutesBrowseActionToAudioTracksWithoutReplacingTheQueue()
+            throws Exception {
+        final String queueActivity = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/player/PlayQueueActivity.java"));
+        final String mainActivity = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/MainActivity.java"));
+        final String navigation = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/util/NavigationHelper.java"));
+        final String localMedia = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaFragment.kt"));
+
+        assertTrue(queueActivity.contains("MainActivity.KEY_OPEN_LOCAL_MEDIA_AUDIO"));
+        assertTrue(mainActivity.contains("openLocalMediaAudioFragment"));
+        assertTrue(navigation.contains("LocalMediaFragment.newAudioTracksInstance()"));
+        assertTrue(localMedia.contains("ARG_OPEN_AUDIO_TRACKS"));
+        assertFalse(queueActivity.contains("new LocalMediaPlayQueue"));
+    }
+}


### PR DESCRIPTION
- Add a Browse all songs action to the Play queue for local media
- Open Local media directly on Audio → Tracks without rebuilding or replacing the active queue
- Keep the action hidden for online playback queues
- Preserve the selected local-media filter across recreation
- Add focused navigation and visibility tests
- Fixes #416