### PR TITLE
Read embedded metadata for local playback

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaMetadataLoader.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaMetadataLoader.kt
@@ -1,0 +1,277 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.media
+
+import android.content.ContentResolver
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.WorkerThread
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.util.LinkedHashMap
+import java.util.Locale
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+
+data class LocalMediaEmbeddedMetadata(
+    val title: String? = null,
+    val artist: String? = null,
+    val album: String? = null,
+    val durationSeconds: Long = 0L
+)
+
+/** Resolves embedded tags for only the local item being played and caches the result by URI. */
+object LocalMediaMetadataLoader {
+    private const val CACHE_ENTRY_COUNT = 128
+
+    private val executor = Executors.newSingleThreadExecutor()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val cache = object : LinkedHashMap<String, LocalMediaEmbeddedMetadata>(
+        CACHE_ENTRY_COUNT,
+        0.75f,
+        true
+    ) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<String, LocalMediaEmbeddedMetadata>?
+        ): Boolean = size > CACHE_ENTRY_COUNT
+    }
+
+    fun interface MetadataCallback {
+        fun onLoaded(metadata: LocalMediaEmbeddedMetadata)
+    }
+
+    /** The callback is always dispatched on the main thread. */
+    fun load(
+        context: Context,
+        item: PlayQueueItem,
+        callback: MetadataCallback
+    ): Future<*> = executor.submit {
+        val cached = synchronized(cache) { cache[item.url] }
+        val metadata = cached ?: read(
+            context.applicationContext.contentResolver,
+            item.url,
+            item.mimeType
+        ).also { resolved ->
+            synchronized(cache) { cache[item.url] = resolved }
+        }
+        if (!Thread.currentThread().isInterrupted) {
+            mainHandler.post { callback.onLoaded(metadata) }
+        }
+    }
+
+    @WorkerThread
+    private fun read(
+        resolver: ContentResolver,
+        contentUri: String,
+        mimeType: String?
+    ): LocalMediaEmbeddedMetadata {
+        val retrieverMetadata = readRetrieverMetadata(resolver, contentUri)
+        if (!isOggContainer(mimeType, contentUri)) return retrieverMetadata
+
+        val oggMetadata = try {
+            resolver.openInputStream(Uri.parse(contentUri))?.use(OggVorbisCommentReader::read)
+        } catch (_: Exception) {
+            null
+        }
+        return LocalMediaEmbeddedMetadata(
+            title = oggMetadata?.title ?: retrieverMetadata.title,
+            artist = oggMetadata?.artist ?: retrieverMetadata.artist,
+            album = oggMetadata?.album ?: retrieverMetadata.album,
+            durationSeconds = retrieverMetadata.durationSeconds
+        )
+    }
+
+    @WorkerThread
+    private fun readRetrieverMetadata(
+        resolver: ContentResolver,
+        contentUri: String
+    ): LocalMediaEmbeddedMetadata {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            resolver.openFileDescriptor(Uri.parse(contentUri), "r")?.use { descriptor ->
+                retriever.setDataSource(descriptor.fileDescriptor)
+                LocalMediaEmbeddedMetadata(
+                    title = cleanTag(
+                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
+                    ),
+                    artist = cleanTag(
+                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
+                    ),
+                    album = cleanTag(
+                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)
+                    ),
+                    durationSeconds = retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                        ?.toLongOrNull()
+                        ?.takeIf { it > 0L }
+                        ?.div(1_000L)
+                        ?: 0L
+                )
+            } ?: LocalMediaEmbeddedMetadata()
+        } catch (_: Exception) {
+            LocalMediaEmbeddedMetadata()
+        } finally {
+            retriever.release()
+        }
+    }
+
+    private fun isOggContainer(mimeType: String?, contentUri: String): Boolean {
+        val normalizedMimeType = mimeType?.lowercase(Locale.ROOT)
+        val normalizedUri = contentUri.lowercase(Locale.ROOT)
+        return normalizedMimeType == "audio/ogg" ||
+            normalizedMimeType == "application/ogg" ||
+            normalizedMimeType == "audio/opus" ||
+            normalizedUri.endsWith(".ogg") ||
+            normalizedUri.endsWith(".oga") ||
+            normalizedUri.endsWith(".opus")
+    }
+}
+
+internal object OggVorbisCommentReader {
+    private const val PAGE_HEADER_SIZE = 27
+    private const val MAX_SCANNED_BYTES = 8 * 1024 * 1024
+    private const val MAX_PACKET_BYTES = 8 * 1024 * 1024
+    private const val MAX_COMMENT_COUNT = 4_096
+    private const val MAX_FIELD_BYTES = 2 * 1024 * 1024
+    private val vorbisCommentHeader = byteArrayOf(
+        3,
+        'v'.code.toByte(),
+        'o'.code.toByte(),
+        'r'.code.toByte(),
+        'b'.code.toByte(),
+        'i'.code.toByte(),
+        's'.code.toByte()
+    )
+    private val opusCommentHeader = "OpusTags".toByteArray(StandardCharsets.US_ASCII)
+
+    fun read(input: InputStream): LocalMediaEmbeddedMetadata? {
+        val packet = ByteArrayOutputStream()
+        var packetOverflowed = false
+        var scannedBytes = 0
+
+        while (scannedBytes < MAX_SCANNED_BYTES) {
+            val header = ByteArray(PAGE_HEADER_SIZE)
+            if (!input.readFully(header)) return null
+            scannedBytes += header.size
+            if (!header.copyOfRange(0, 4).contentEquals("OggS".toByteArray())) return null
+
+            val segmentCount = header[26].toInt() and 0xff
+            val lacingValues = ByteArray(segmentCount)
+            if (!input.readFully(lacingValues)) return null
+            scannedBytes += segmentCount
+
+            lacingValues.forEach { lacingValue ->
+                val segmentSize = lacingValue.toInt() and 0xff
+                val segment = ByteArray(segmentSize)
+                if (!input.readFully(segment)) return null
+                scannedBytes += segmentSize
+
+                if (!packetOverflowed && packet.size() + segmentSize <= MAX_PACKET_BYTES) {
+                    packet.write(segment)
+                } else {
+                    packetOverflowed = true
+                }
+
+                if (segmentSize < 255) {
+                    if (!packetOverflowed) {
+                        parseCommentPacket(packet.toByteArray())?.let { return it }
+                    }
+                    packet.reset()
+                    packetOverflowed = false
+                }
+            }
+        }
+        return null
+    }
+
+    private fun parseCommentPacket(packet: ByteArray): LocalMediaEmbeddedMetadata? {
+        val headerSize = when {
+            packet.startsWith(vorbisCommentHeader) -> vorbisCommentHeader.size
+            packet.startsWith(opusCommentHeader) -> opusCommentHeader.size
+            else -> return null
+        }
+        val reader = LittleEndianPacketReader(packet, headerSize)
+        val vendorLength = reader.readLength(MAX_FIELD_BYTES) ?: return null
+        if (!reader.skip(vendorLength)) return null
+        val commentCount = reader.readUnsignedInt()
+            ?.takeIf { it <= MAX_COMMENT_COUNT }
+            ?: return null
+
+        var title: String? = null
+        var artist: String? = null
+        var albumArtist: String? = null
+        var album: String? = null
+        repeat(commentCount) {
+            val fieldLength = reader.readLength(MAX_FIELD_BYTES) ?: return null
+            val field = reader.readString(fieldLength) ?: return null
+            val separator = field.indexOf('=')
+            if (separator <= 0) return@repeat
+            val key = field.substring(0, separator).uppercase(Locale.ROOT)
+            val value = cleanTag(field.substring(separator + 1)) ?: return@repeat
+            when (key) {
+                "TITLE" -> if (title == null) title = value
+                "ARTIST" -> if (artist == null) artist = value
+                "ALBUMARTIST" -> if (albumArtist == null) albumArtist = value
+                "ALBUM" -> if (album == null) album = value
+            }
+        }
+        if (title == null && artist == null && albumArtist == null && album == null) return null
+        return LocalMediaEmbeddedMetadata(title, artist ?: albumArtist, album)
+    }
+
+    private fun ByteArray.startsWith(prefix: ByteArray): Boolean = size >= prefix.size &&
+        prefix.indices.all { this[it] == prefix[it] }
+
+    private fun InputStream.readFully(target: ByteArray): Boolean {
+        var offset = 0
+        while (offset < target.size) {
+            val read = read(target, offset, target.size - offset)
+            if (read < 0) return false
+            if (read == 0) continue
+            offset += read
+        }
+        return true
+    }
+
+    private class LittleEndianPacketReader(
+        private val data: ByteArray,
+        private var position: Int
+    ) {
+        fun readUnsignedInt(): Int? {
+            if (position > data.size - Integer.BYTES) return null
+            val value = (data[position].toInt() and 0xff).toLong() or
+                ((data[position + 1].toInt() and 0xff).toLong() shl 8) or
+                ((data[position + 2].toInt() and 0xff).toLong() shl 16) or
+                ((data[position + 3].toInt() and 0xff).toLong() shl 24)
+            position += Integer.BYTES
+            return value.takeIf { it <= Int.MAX_VALUE }?.toInt()
+        }
+
+        fun readLength(maximum: Int): Int? = readUnsignedInt()?.takeIf { it <= maximum }
+
+        fun skip(length: Int): Boolean {
+            if (length < 0 || position > data.size - length) return false
+            position += length
+            return true
+        }
+
+        fun readString(length: Int): String? {
+            if (length < 0 || position > data.size - length) return null
+            return String(data, position, length, StandardCharsets.UTF_8).also {
+                position += length
+            }
+        }
+    }
+}
+
+private fun cleanTag(value: String?): String? = value
+    ?.trim { it.isWhitespace() || it == '\u0000' }
+    ?.takeIf(String::isNotEmpty)

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -105,6 +105,7 @@ import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.learning.LearningSessionTracker;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
+import org.schabi.newpipe.local.media.LocalMediaMetadataLoader;
 import org.schabi.newpipe.local.media.LocalMediaThumbnailLoader;
 import org.schabi.newpipe.player.equalizer.EqualizerController;
 import org.schabi.newpipe.player.equalizer.EqualizerState;
@@ -231,6 +232,8 @@ public final class Player implements PlaybackListener, Listener {
     private coil3.request.Disposable thumbnailDisposable;
     @Nullable
     private Future<?> localThumbnailFuture;
+    @Nullable
+    private Future<?> localMetadataFuture;
     @NonNull
     private final PlayerHttpErrorRecovery.RecoveryGuard mediaUrlRecoveryGuard =
         new PlayerHttpErrorRecovery.RecoveryGuard();
@@ -791,6 +794,7 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         cancelThumbnailLoading();
+        cancelLocalMetadataLoading();
         clearSleepTimer();
         saveStreamProgressState();
         setRecovery();
@@ -1033,6 +1037,13 @@ public final class Player implements PlaybackListener, Listener {
         if (localThumbnailFuture != null) {
             localThumbnailFuture.cancel(true);
             localThumbnailFuture = null;
+        }
+    }
+
+    private void cancelLocalMetadataLoading() {
+        if (localMetadataFuture != null) {
+            localMetadataFuture.cancel(true);
+            localMetadataFuture = null;
         }
     }
 
@@ -2869,6 +2880,8 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
+        cancelLocalMetadataLoading();
+
         applyPlaybackSpeedProfile(info);
         updateSponsorBlockSegments(info);
         maybeAutoQueueNextStream(info);
@@ -2902,6 +2915,30 @@ public final class Player implements PlaybackListener, Listener {
                                         .audioPlaceholderBitmap(context);
                         onThumbnailLoaded(displayedBitmap);
                     }
+                });
+        cancelLocalMetadataLoading();
+        localMetadataFuture = LocalMediaMetadataLoader.INSTANCE.load(
+                context,
+                item,
+                metadata -> {
+                    if (!(currentMetadata instanceof LocalMediaItemTag)
+                            || !((LocalMediaItemTag) currentMetadata)
+                                    .getItem().isSameItem(item)) {
+                        return;
+                    }
+                    if (!item.applyLocalMetadata(
+                            metadata.getTitle(),
+                            metadata.getArtist(),
+                            metadata.getAlbum(),
+                            metadata.getDurationSeconds())) {
+                        return;
+                    }
+                    if (playQueue != null) {
+                        playQueue.notifyChange();
+                    }
+                    notifyMetadataUpdateToListeners();
+                    notifyAudioTrackUpdateToListeners();
+                    UIs.call(playerUi -> playerUi.onMetadataChanged(currentMetadata));
                 });
         databaseUpdateDisposable.add(recordManager.onViewed(item)
                 .onErrorComplete().subscribe());

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/PlayQueueItem.java
@@ -28,15 +28,15 @@ public class PlayQueueItem implements Serializable {
     }
 
     @NonNull
-    private final String title;
+    private String title;
     @NonNull
     private final String url;
     private final int serviceId;
-    private final long duration;
+    private long duration;
     @NonNull
     private final List<Image> thumbnailImages;
     @NonNull
-    private final String uploader;
+    private String uploader;
     private final String uploaderUrl;
     @NonNull
     private final StreamType streamType;
@@ -46,7 +46,7 @@ public class PlayQueueItem implements Serializable {
     @Nullable
     private final String mimeType;
     @Nullable
-    private final String album;
+    private String album;
     @Nullable
     private final String folder;
     private final long localMediaId;
@@ -186,6 +186,46 @@ public class PlayQueueItem implements Serializable {
 
     public boolean isLocalMedia() {
         return sourceType == SourceType.LOCAL;
+    }
+
+    /**
+     * Applies tags read directly from a local file while preserving every existing fallback when
+     * the corresponding embedded value is absent.
+     *
+     * @param embeddedTitle title read from the file, or null when absent
+     * @param embeddedArtist artist read from the file, or null when absent
+     * @param embeddedAlbum album read from the file, or null when absent
+     * @param embeddedDuration duration read from the file in seconds, or zero when unavailable
+     * @return whether any displayed metadata changed
+     */
+    public boolean applyLocalMetadata(@Nullable final String embeddedTitle,
+                                      @Nullable final String embeddedArtist,
+                                      @Nullable final String embeddedAlbum,
+                                      final long embeddedDuration) {
+        if (!isLocalMedia()) {
+            return false;
+        }
+        boolean changed = false;
+        if (embeddedTitle != null && !embeddedTitle.isBlank()
+                && !embeddedTitle.equals(title)) {
+            title = embeddedTitle;
+            changed = true;
+        }
+        if (embeddedArtist != null && !embeddedArtist.isBlank()
+                && !embeddedArtist.equals(uploader)) {
+            uploader = embeddedArtist;
+            changed = true;
+        }
+        if (embeddedAlbum != null && !embeddedAlbum.isBlank()
+                && !embeddedAlbum.equals(album)) {
+            album = embeddedAlbum;
+            changed = true;
+        }
+        if (embeddedDuration > 0L && embeddedDuration != duration) {
+            duration = embeddedDuration;
+            changed = true;
+        }
+        return changed;
     }
 
     @Nullable

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaMetadataIntegrationTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaMetadataIntegrationTest.kt
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.media
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalMediaMetadataIntegrationTest {
+    private val projectDirectory = if (Files.exists(Path.of("src/main"))) {
+        Path.of("src/main")
+    } else {
+        Path.of("app/src/main")
+    }
+
+    @Test
+    fun `player resolves tags lazily and rejects stale asynchronous results`() {
+        val player = Files.readString(
+            projectDirectory.resolve("java/org/schabi/newpipe/player/Player.java")
+        )
+        val loaderCall = player.indexOf("LocalMediaMetadataLoader.INSTANCE.load")
+        val staleItemCheck = player.indexOf(".getItem().isSameItem(item)", loaderCall)
+        val metadataMutation = player.indexOf("item.applyLocalMetadata", staleItemCheck)
+
+        assertTrue(loaderCall >= 0)
+        assertTrue(staleItemCheck > loaderCall)
+        assertTrue(metadataMutation > staleItemCheck)
+        assertTrue(player.indexOf("playQueue.notifyChange()", metadataMutation) > metadataMutation)
+        assertTrue(
+            player.indexOf("notifyMetadataUpdateToListeners()", metadataMutation) >
+                metadataMutation
+        )
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/media/OggVorbisCommentReaderTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/OggVorbisCommentReaderTest.kt
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.media
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OggVorbisCommentReaderTest {
+    @Test
+    fun `reads title artist and album from Vorbis comments`() {
+        val metadata = OggVorbisCommentReader.read(
+            ByteArrayInputStream(
+                oggPage(
+                    vorbisCommentPacket(
+                        "TITLE=Hell on Earth",
+                        "ARTIST=Mobb Deep",
+                        "ALBUM=Hell on Earth"
+                    )
+                )
+            )
+        )
+
+        requireNotNull(metadata)
+        assertEquals("Hell on Earth", metadata.title)
+        assertEquals("Mobb Deep", metadata.artist)
+        assertEquals("Hell on Earth", metadata.album)
+    }
+
+    @Test
+    fun `uses album artist when track artist is absent`() {
+        val metadata = OggVorbisCommentReader.read(
+            ByteArrayInputStream(
+                oggPage(vorbisCommentPacket("TITLE=Song", "ALBUMARTIST=Various Artists"))
+            )
+        )
+
+        requireNotNull(metadata)
+        assertEquals("Various Artists", metadata.artist)
+    }
+
+    @Test
+    fun `reads Opus tags stored in an Ogg container`() {
+        val metadata = OggVorbisCommentReader.read(
+            ByteArrayInputStream(
+                oggPage(commentPacket("OpusTags", "TITLE=Spoken lesson", "ARTIST=Teacher"))
+            )
+        )
+
+        requireNotNull(metadata)
+        assertEquals("Spoken lesson", metadata.title)
+        assertEquals("Teacher", metadata.artist)
+    }
+
+    @Test
+    fun `rejects input that is not an Ogg stream`() {
+        assertNull(
+            OggVorbisCommentReader.read(
+                ByteArrayInputStream("not an ogg stream".toByteArray())
+            )
+        )
+    }
+
+    private fun vorbisCommentPacket(vararg comments: String): ByteArray {
+        return commentPacket("\u0003vorbis", *comments)
+    }
+
+    private fun commentPacket(header: String, vararg comments: String): ByteArray {
+        return ByteArrayOutputStream().apply {
+            write(header.toByteArray(StandardCharsets.US_ASCII))
+            writeLength(4)
+            write("test".toByteArray(StandardCharsets.UTF_8))
+            writeLength(comments.size)
+            comments.forEach { comment ->
+                val bytes = comment.toByteArray(StandardCharsets.UTF_8)
+                writeLength(bytes.size)
+                write(bytes)
+            }
+        }.toByteArray()
+    }
+
+    private fun oggPage(packet: ByteArray): ByteArray {
+        require(packet.size < 255)
+        return ByteArrayOutputStream().apply {
+            write("OggS".toByteArray(StandardCharsets.US_ASCII))
+            write(byteArrayOf(0, 0))
+            write(ByteArray(20))
+            write(byteArrayOf(1, packet.size.toByte()))
+            write(packet)
+        }.toByteArray()
+    }
+
+    private fun ByteArrayOutputStream.writeLength(value: Int) {
+        write(value and 0xff)
+        write(value ushr 8 and 0xff)
+        write(value ushr 16 and 0xff)
+        write(value ushr 24 and 0xff)
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueItemTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playqueue/PlayQueueItemTest.java
@@ -36,4 +36,25 @@ public class PlayQueueItemTest {
                 "Local", URL, 1, null, null, null, null, 1, false, null);
         assertFalse(local.isSameItem(PlayQueueTest.makeItemWithUrl(URL)));
     }
+
+    @Test
+    public void embeddedLocalMetadataReplacesScannerValuesAndPreservesMissingTags() {
+        final PlayQueueItem local = PlayQueueItem.localMedia(
+                "Music folder", URL, 0, "Scanner artist", "Scanner album",
+                "Music folder", "audio/ogg", 1, false, null);
+
+        assertTrue(local.applyLocalMetadata("Embedded title", "Embedded artist", null, 182));
+        assertEquals("Embedded title", local.getTitle());
+        assertEquals("Embedded artist", local.getUploader());
+        assertEquals("Scanner album", local.getAlbum());
+        assertEquals(182, local.getDuration());
+        assertFalse(local.applyLocalMetadata(null, "", null, 0));
+    }
+
+    @Test
+    public void remoteMetadataCannotBeMutatedByTheLocalMetadataPath() {
+        final PlayQueueItem remote = PlayQueueTest.makeItemWithUrl(URL);
+
+        assertFalse(remote.applyLocalMetadata("Changed", "Changed", "Changed", 999));
+    }
 }


### PR DESCRIPTION
- Read embedded title, artist, album, and duration tags when a local item starts playing.
- Parse bounded Vorbis comments for OGG and Opus files when Android metadata is incomplete.
- Preserve MediaStore and filename values whenever an embedded tag is missing.
- Cache resolved metadata and reject stale asynchronous results after the selected item changes.
- Refresh the queue, player, notification, lock-screen, and Android Auto metadata from the corrected queue item.
- Add coverage for tag precedence, missing values, OGG and Opus comments, and stale-result protection.
- Fixes #415