### PR TITLE
Extract download mission request factory

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -82,9 +82,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-import us.shandian.giga.get.MissionRecoveryInfo;
 import us.shandian.giga.postprocessing.Mp3OutputOptions;
-import us.shandian.giga.postprocessing.Postprocessing;
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.service.DownloadManagerService;
 import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder;
@@ -1138,103 +1136,39 @@ public class DownloadDialog extends DialogFragment
             return;
         }
 
-        final Stream selectedStream;
-        final Stream recoveryStream;
-        Stream secondaryStream = null;
-        final char kind;
-        int threads = dialogBinding.threads.getProgress() + 1;
-        final String[] urls;
-        final List<MissionRecoveryInfo> recoveryInfo;
-        String psName = null;
-        String[] psArgs = null;
-        long nearLength = 0;
+        final DownloadMissionRequest request;
+        final int threads = dialogBinding.threads.getProgress() + 1;
 
         // more download logic: select muxer, subtitle converter, etc.
         final int checkedRadioButtonId = dialogBinding.videoAudioGroup.getCheckedRadioButtonId();
         if (checkedRadioButtonId == R.id.audio_button) {
-            kind = 'a';
-            selectedStream = audioStreamsAdapter.getItem(selectedAudioIndex);
+            final AudioStream selectedStream = audioStreamsAdapter.getItem(selectedAudioIndex);
             final VideoStream muxedAudioFallbackSource = getMuxedAudioFallbackSource();
-            recoveryStream = muxedAudioFallbackSource == null
-                    ? selectedStream : muxedAudioFallbackSource;
-
-            if (Mp3DownloadPolicy.shouldTranscode(isMp3OutputSelected(),
-                    selectedStream.getFormat())) {
-                psName = Postprocessing.ALGORITHM_MP3_FROM_AUDIO;
-                psArgs = new String[] {String.valueOf(getSelectedMp3Bitrate())};
-            } else if (muxedAudioFallbackSource != null) {
-                psName = Postprocessing.ALGORITHM_M4A_FROM_MP4_DEMUXER;
-            } else if (selectedStream.getFormat() == MediaFormat.M4A) {
-                psName = Postprocessing.ALGORITHM_M4A_NO_DASH;
-            } else if (selectedStream.getFormat() == MediaFormat.WEBMA_OPUS) {
-                psName = Postprocessing.ALGORITHM_OGG_FROM_WEBM_DEMUXER;
-            }
+            request = DownloadMissionRequestFactory.forAudio(selectedStream,
+                    muxedAudioFallbackSource, isMp3OutputSelected(), getSelectedMp3Bitrate(),
+                    threads);
         } else if (checkedRadioButtonId == R.id.video_button) {
-            kind = 'v';
-            selectedStream = videoStreamsAdapter.getItem(selectedVideoIndex);
-            recoveryStream = selectedStream;
-
+            final VideoStream selectedStream = videoStreamsAdapter.getItem(selectedVideoIndex);
             final SecondaryStreamHelper<AudioStream> secondary = videoStreamsAdapter
                     .getAllSecondary()
                     .get(wrappedVideoStreams.getStreamsList().indexOf(selectedStream));
-
-            if (secondary != null) {
-                secondaryStream = secondary.getStream();
-
-                if (selectedStream.getFormat() == MediaFormat.MPEG_4) {
-                    psName = Postprocessing.ALGORITHM_MP4_FROM_DASH_MUXER;
-                } else {
-                    psName = Postprocessing.ALGORITHM_WEBM_MUXER;
-                }
-
-                final long videoSize = wrappedVideoStreams.getSizeInBytes(
-                        (VideoStream) selectedStream);
-
-                // set nearLength, only, if both sizes are fetched or known. This probably
-                // does not work on slow networks but is later updated in the downloader
-                if (secondary.getSizeInBytes() > 0 && videoSize > 0) {
-                    nearLength = secondary.getSizeInBytes() + videoSize;
-                }
-            }
+            request = DownloadMissionRequestFactory.forVideo(
+                    selectedStream,
+                    secondary == null ? null : secondary.getStream(),
+                    wrappedVideoStreams.getSizeInBytes(selectedStream),
+                    secondary == null ? 0 : secondary.getSizeInBytes(),
+                    threads);
         } else if (checkedRadioButtonId == R.id.subtitle_button) {
-            threads = 1; // use unique thread for subtitles due small file size
-            kind = 's';
-            selectedStream = subtitleStreamsAdapter.getItem(selectedSubtitleIndex);
-            recoveryStream = selectedStream;
-
-            if (selectedStream.getFormat() == MediaFormat.TTML) {
-                psName = Postprocessing.ALGORITHM_TTML_CONVERTER;
-                psArgs = new String[]{
-                        selectedStream.getFormat().getSuffix(),
-                        "false" // ignore empty frames
-                };
-            }
+            request = DownloadMissionRequestFactory.forSubtitle(
+                    subtitleStreamsAdapter.getItem(selectedSubtitleIndex));
         } else {
             return;
         }
 
-        if (secondaryStream == null) {
-            urls = new String[] {
-                    selectedStream.getContent()
-            };
-            recoveryInfo = List.of(new MissionRecoveryInfo(recoveryStream));
-        } else {
-            if (secondaryStream.getDeliveryMethod() != PROGRESSIVE_HTTP) {
-                throw new IllegalArgumentException("Unsupported stream delivery format"
-                        + secondaryStream.getDeliveryMethod());
-            }
-
-            urls = new String[] {
-                    selectedStream.getContent(), secondaryStream.getContent()
-            };
-            recoveryInfo = List.of(
-                    new MissionRecoveryInfo(selectedStream),
-                    new MissionRecoveryInfo(secondaryStream)
-            );
-        }
-
-        DownloadManagerService.startMission(context, urls, storage, kind, threads,
-                currentInfo, psName, psArgs, nearLength, new ArrayList<>(recoveryInfo));
+        DownloadManagerService.startMission(context, request.getUrls(), storage,
+                request.getKind(), request.getThreads(), currentInfo,
+                request.getPostprocessingName(), request.getPostprocessingArguments(),
+                request.getNearLength(), request.getRecoveryInfo());
 
         Toast.makeText(context, getString(R.string.download_has_started),
                 Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadMissionRequest.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadMissionRequest.kt
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import org.schabi.newpipe.extractor.MediaFormat
+import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.DeliveryMethod.PROGRESSIVE_HTTP
+import org.schabi.newpipe.extractor.stream.Stream
+import org.schabi.newpipe.extractor.stream.SubtitlesStream
+import org.schabi.newpipe.extractor.stream.VideoStream
+import us.shandian.giga.get.MissionRecoveryInfo
+import us.shandian.giga.postprocessing.Postprocessing
+
+internal class DownloadMissionRequest(
+    val urls: Array<String>,
+    val kind: Char,
+    val threads: Int,
+    val postprocessingName: String?,
+    val postprocessingArguments: Array<String>?,
+    val nearLength: Long,
+    val recoveryInfo: ArrayList<MissionRecoveryInfo>
+)
+
+/** Builds downloader inputs from the streams selected in the download dialog. */
+internal object DownloadMissionRequestFactory {
+    @JvmStatic
+    fun forAudio(
+        selectedStream: AudioStream,
+        muxedFallbackSource: VideoStream?,
+        mp3OutputSelected: Boolean,
+        mp3BitrateKbps: Int,
+        threads: Int
+    ): DownloadMissionRequest {
+        val postprocessingName: String?
+        val postprocessingArguments: Array<String>?
+        when {
+            Mp3DownloadPolicy.shouldTranscode(
+                mp3OutputSelected,
+                selectedStream.format
+            ) -> {
+                postprocessingName = Postprocessing.ALGORITHM_MP3_FROM_AUDIO
+                postprocessingArguments = arrayOf(mp3BitrateKbps.toString())
+            }
+
+            muxedFallbackSource != null -> {
+                postprocessingName = Postprocessing.ALGORITHM_M4A_FROM_MP4_DEMUXER
+                postprocessingArguments = null
+            }
+
+            selectedStream.format == MediaFormat.M4A -> {
+                postprocessingName = Postprocessing.ALGORITHM_M4A_NO_DASH
+                postprocessingArguments = null
+            }
+
+            selectedStream.format == MediaFormat.WEBMA_OPUS -> {
+                postprocessingName = Postprocessing.ALGORITHM_OGG_FROM_WEBM_DEMUXER
+                postprocessingArguments = null
+            }
+
+            else -> {
+                postprocessingName = null
+                postprocessingArguments = null
+            }
+        }
+
+        return singleStreamRequest(
+            selectedStream = selectedStream,
+            recoveryStream = muxedFallbackSource ?: selectedStream,
+            kind = 'a',
+            threads = threads,
+            postprocessingName = postprocessingName,
+            postprocessingArguments = postprocessingArguments
+        )
+    }
+
+    @JvmStatic
+    fun forVideo(
+        selectedStream: VideoStream,
+        secondaryStream: AudioStream?,
+        videoSize: Long,
+        secondarySize: Long,
+        threads: Int
+    ): DownloadMissionRequest {
+        if (secondaryStream == null) {
+            return singleStreamRequest(
+                selectedStream = selectedStream,
+                recoveryStream = selectedStream,
+                kind = 'v',
+                threads = threads
+            )
+        }
+        require(secondaryStream.deliveryMethod == PROGRESSIVE_HTTP) {
+            "Unsupported stream delivery format${secondaryStream.deliveryMethod}"
+        }
+
+        val postprocessingName = if (selectedStream.format == MediaFormat.MPEG_4) {
+            Postprocessing.ALGORITHM_MP4_FROM_DASH_MUXER
+        } else {
+            Postprocessing.ALGORITHM_WEBM_MUXER
+        }
+        val nearLength = if (secondarySize > 0 && videoSize > 0) {
+            secondarySize + videoSize
+        } else {
+            0
+        }
+        return DownloadMissionRequest(
+            urls = arrayOf(selectedStream.content, secondaryStream.content),
+            kind = 'v',
+            threads = threads,
+            postprocessingName = postprocessingName,
+            postprocessingArguments = null,
+            nearLength = nearLength,
+            recoveryInfo = arrayListOf(
+                MissionRecoveryInfo(selectedStream),
+                MissionRecoveryInfo(secondaryStream)
+            )
+        )
+    }
+
+    @JvmStatic
+    fun forSubtitle(selectedStream: SubtitlesStream): DownloadMissionRequest {
+        val format = selectedStream.format
+        val postprocessingName = if (format == MediaFormat.TTML) {
+            Postprocessing.ALGORITHM_TTML_CONVERTER
+        } else {
+            null
+        }
+        val postprocessingArguments = if (format == MediaFormat.TTML) {
+            arrayOf(format.getSuffix(), "false")
+        } else {
+            null
+        }
+        return singleStreamRequest(
+            selectedStream = selectedStream,
+            recoveryStream = selectedStream,
+            kind = 's',
+            threads = 1,
+            postprocessingName = postprocessingName,
+            postprocessingArguments = postprocessingArguments
+        )
+    }
+
+    private fun singleStreamRequest(
+        selectedStream: Stream,
+        recoveryStream: Stream,
+        kind: Char,
+        threads: Int,
+        postprocessingName: String? = null,
+        postprocessingArguments: Array<String>? = null
+    ): DownloadMissionRequest {
+        return DownloadMissionRequest(
+            urls = arrayOf(selectedStream.content),
+            kind = kind,
+            threads = threads,
+            postprocessingName = postprocessingName,
+            postprocessingArguments = postprocessingArguments,
+            nearLength = 0,
+            recoveryInfo = arrayListOf(MissionRecoveryInfo(recoveryStream))
+        )
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadMissionRequestFactoryTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadMissionRequestFactoryTest.kt
@@ -47,8 +47,10 @@ class DownloadMissionRequestFactoryTest {
             threads = 3
         )
 
-        assertEquals(Postprocessing.ALGORITHM_M4A_FROM_MP4_DEMUXER,
-            request.postprocessingName)
+        assertEquals(
+            Postprocessing.ALGORITHM_M4A_FROM_MP4_DEMUXER,
+            request.postprocessingName
+        )
         assertEquals('v', request.recoveryInfo.single().kind)
         assertEquals(MediaFormat.MPEG_4, request.recoveryInfo.single().format)
     }
@@ -67,8 +69,10 @@ class DownloadMissionRequestFactoryTest {
             arrayOf("https://example.com/video", "https://example.com/audio"),
             request.urls
         )
-        assertEquals(Postprocessing.ALGORITHM_MP4_FROM_DASH_MUXER,
-            request.postprocessingName)
+        assertEquals(
+            Postprocessing.ALGORITHM_MP4_FROM_DASH_MUXER,
+            request.postprocessingName
+        )
         assertEquals(1_200, request.nearLength)
         assertEquals(listOf('v', 'a'), request.recoveryInfo.map { it.kind })
     }
@@ -93,8 +97,10 @@ class DownloadMissionRequestFactoryTest {
 
         assertEquals('s', request.kind)
         assertEquals(1, request.threads)
-        assertEquals(Postprocessing.ALGORITHM_TTML_CONVERTER,
-            request.postprocessingName)
+        assertEquals(
+            Postprocessing.ALGORITHM_TTML_CONVERTER,
+            request.postprocessingName
+        )
         assertArrayEquals(
             arrayOf(MediaFormat.TTML.getSuffix(), "false"),
             request.postprocessingArguments

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadMissionRequestFactoryTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadMissionRequestFactoryTest.kt
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.schabi.newpipe.extractor.MediaFormat
+import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.DeliveryMethod.DASH
+import org.schabi.newpipe.extractor.stream.DeliveryMethod.PROGRESSIVE_HTTP
+import org.schabi.newpipe.extractor.stream.Stream
+import org.schabi.newpipe.extractor.stream.SubtitlesStream
+import org.schabi.newpipe.extractor.stream.VideoStream
+import us.shandian.giga.postprocessing.Postprocessing
+
+class DownloadMissionRequestFactoryTest {
+    @Test
+    fun `MP3 audio request enables transcoding`() {
+        val request = DownloadMissionRequestFactory.forAudio(
+            selectedStream = audio(MediaFormat.M4A, "audio"),
+            muxedFallbackSource = null,
+            mp3OutputSelected = true,
+            mp3BitrateKbps = 256,
+            threads = 4
+        )
+
+        assertArrayEquals(arrayOf("https://example.com/audio"), request.urls)
+        assertEquals('a', request.kind)
+        assertEquals(4, request.threads)
+        assertEquals(Postprocessing.ALGORITHM_MP3_FROM_AUDIO, request.postprocessingName)
+        assertArrayEquals(arrayOf("256"), request.postprocessingArguments)
+    }
+
+    @Test
+    fun `muxed audio fallback uses video recovery metadata`() {
+        val fallback = video(MediaFormat.MPEG_4, "fallback")
+        val request = DownloadMissionRequestFactory.forAudio(
+            selectedStream = audio(MediaFormat.M4A, "fallback"),
+            muxedFallbackSource = fallback,
+            mp3OutputSelected = false,
+            mp3BitrateKbps = 192,
+            threads = 3
+        )
+
+        assertEquals(Postprocessing.ALGORITHM_M4A_FROM_MP4_DEMUXER,
+            request.postprocessingName)
+        assertEquals('v', request.recoveryInfo.single().kind)
+        assertEquals(MediaFormat.MPEG_4, request.recoveryInfo.single().format)
+    }
+
+    @Test
+    fun `video request combines progressive secondary audio`() {
+        val request = DownloadMissionRequestFactory.forVideo(
+            selectedStream = video(MediaFormat.MPEG_4, "video"),
+            secondaryStream = audio(MediaFormat.M4A, "audio"),
+            videoSize = 1_000,
+            secondarySize = 200,
+            threads = 5
+        )
+
+        assertArrayEquals(
+            arrayOf("https://example.com/video", "https://example.com/audio"),
+            request.urls
+        )
+        assertEquals(Postprocessing.ALGORITHM_MP4_FROM_DASH_MUXER,
+            request.postprocessingName)
+        assertEquals(1_200, request.nearLength)
+        assertEquals(listOf('v', 'a'), request.recoveryInfo.map { it.kind })
+    }
+
+    @Test
+    fun `unknown video size keeps estimated length unset`() {
+        val request = DownloadMissionRequestFactory.forVideo(
+            selectedStream = video(MediaFormat.WEBM, "video"),
+            secondaryStream = audio(MediaFormat.WEBMA, "audio"),
+            videoSize = -1,
+            secondarySize = 200,
+            threads = 2
+        )
+
+        assertEquals(Postprocessing.ALGORITHM_WEBM_MUXER, request.postprocessingName)
+        assertEquals(0, request.nearLength)
+    }
+
+    @Test
+    fun `subtitle request uses one thread and TTML conversion`() {
+        val request = DownloadMissionRequestFactory.forSubtitle(subtitle(MediaFormat.TTML))
+
+        assertEquals('s', request.kind)
+        assertEquals(1, request.threads)
+        assertEquals(Postprocessing.ALGORITHM_TTML_CONVERTER,
+            request.postprocessingName)
+        assertArrayEquals(
+            arrayOf(MediaFormat.TTML.getSuffix(), "false"),
+            request.postprocessingArguments
+        )
+    }
+
+    @Test
+    fun `adaptive secondary audio is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            DownloadMissionRequestFactory.forVideo(
+                selectedStream = video(MediaFormat.MPEG_4, "video"),
+                secondaryStream = audio(MediaFormat.M4A, "audio", DASH),
+                videoSize = 1_000,
+                secondarySize = 200,
+                threads = 3
+            )
+        }
+    }
+
+    private fun audio(
+        format: MediaFormat,
+        name: String,
+        deliveryMethod: org.schabi.newpipe.extractor.stream.DeliveryMethod = PROGRESSIVE_HTTP
+    ): AudioStream {
+        return AudioStream.Builder()
+            .setId(Stream.ID_UNKNOWN)
+            .setContent("https://example.com/$name", true)
+            .setMediaFormat(format)
+            .setDeliveryMethod(deliveryMethod)
+            .setAverageBitrate(192)
+            .build()
+    }
+
+    private fun video(format: MediaFormat, name: String): VideoStream {
+        return VideoStream.Builder()
+            .setId(Stream.ID_UNKNOWN)
+            .setContent("https://example.com/$name", true)
+            .setMediaFormat(format)
+            .setDeliveryMethod(PROGRESSIVE_HTTP)
+            .setResolution("720p")
+            .setIsVideoOnly(true)
+            .build()
+    }
+
+    private fun subtitle(format: MediaFormat): SubtitlesStream {
+        return SubtitlesStream.Builder()
+            .setContent("https://example.com/subtitle", true)
+            .setMediaFormat(format)
+            .setLanguageCode("en")
+            .setAutoGenerated(false)
+            .build()
+    }
+}


### PR DESCRIPTION
- Extract audio, video and subtitle mission construction from `DownloadDialog` into a focused Kotlin factory.
- Encapsulate downloader URLs, recovery metadata, post-processing options, thread counts and estimated combined lengths in `DownloadMissionRequest`.
- Preserve MP3 transcoding, muxed-audio fallback, DASH muxing, WebM muxing and TTML conversion behavior.
- Keep storage validation, overwrite prompts and mission launching in the dialog for a later decomposition stage.
- Add JVM regression coverage for MP3 audio, muxed fallback, progressive secondary audio, unknown sizes, TTML subtitles and unsupported adaptive secondary streams.