### PR TITLE
Extract download storage conflict coordinator

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -86,7 +86,6 @@ import us.shandian.giga.postprocessing.Mp3OutputOptions;
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.service.DownloadManagerService;
 import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder;
-import us.shandian.giga.service.MissionState;
 
 public class DownloadDialog extends DialogFragment
         implements RadioGroup.OnCheckedChangeListener, AdapterView.OnItemSelectedListener {
@@ -972,151 +971,9 @@ public class DownloadDialog extends DialogFragment
                                        final Uri targetFile,
                                        final String filename,
                                        final String mime) {
-        StoredFileHelper storage;
-
-        try {
-            if (mainStorage == null) {
-                // using SAF on older android version
-                storage = new StoredFileHelper(context, null, targetFile, "");
-            } else if (targetFile == null) {
-                // the file does not exist, but it is probably used in a pending download
-                storage = new StoredFileHelper(mainStorage.getUri(), filename, mime,
-                        mainStorage.getTag());
-            } else {
-                // the target filename is already use, attempt to use it
-                storage = new StoredFileHelper(context, mainStorage.getUri(), targetFile,
-                        mainStorage.getTag());
-            }
-        } catch (final Exception e) {
-            ErrorUtil.createNotification(requireContext(),
-                    new ErrorInfo(e, UserAction.DOWNLOAD_FAILED, "Getting storage"));
-            return;
-        }
-
-        // get state of potential mission referring to the same file
-        final MissionState state = downloadManager.checkForExistingMission(storage);
-        @StringRes final int msgBtn;
-        @StringRes final int msgBody;
-
-        // this switch checks if there is already a mission referring to the same file
-        switch (state) {
-            case Finished: // there is already a finished mission
-                msgBtn = R.string.overwrite;
-                msgBody = R.string.overwrite_finished_warning;
-                break;
-            case Pending:
-                msgBtn = R.string.overwrite;
-                msgBody = R.string.download_already_pending;
-                break;
-            case PendingRunning:
-                msgBtn = R.string.generate_unique_name;
-                msgBody = R.string.download_already_running;
-                break;
-            case None: // there is no mission referring to the same file
-                if (mainStorage == null) {
-                    // This part is called if:
-                    // * using SAF on older android version
-                    // * save path not defined
-                    // * if the file exists overwrite it, is not necessary ask
-                    if (!storage.existsAsFile() && !storage.create()) {
-                        showFailedDialog(R.string.error_file_creation);
-                        return;
-                    }
-                    continueSelectedDownload(storage);
-                    return;
-                } else if (targetFile == null) {
-                    // This part is called if:
-                    // * the filename is not used in a pending/finished download
-                    // * the file does not exists, create
-
-                    if (!mainStorage.mkdirs()) {
-                        showFailedDialog(R.string.error_path_creation);
-                        return;
-                    }
-
-                    storage = mainStorage.createFile(filename, mime);
-                    if (storage == null || !storage.canWrite()) {
-                        showFailedDialog(R.string.error_file_creation);
-                        return;
-                    }
-
-                    continueSelectedDownload(storage);
-                    return;
-                }
-                msgBtn = R.string.overwrite;
-                msgBody = R.string.overwrite_unrelated_warning;
-                break;
-            default:
-                return; // unreachable
-        }
-
-        final AlertDialog.Builder askDialog = new AlertDialog.Builder(context)
-                .setTitle(R.string.download_dialog_title)
-                .setMessage(msgBody)
-                .setNegativeButton(R.string.cancel, null);
-        final StoredFileHelper finalStorage = storage;
-
-
-        if (mainStorage == null) {
-            // This part is called if:
-            // * using SAF on older android version
-            // * save path not defined
-            switch (state) {
-                case Pending:
-                case Finished:
-                    askDialog.setPositiveButton(msgBtn, (dialog, which) -> {
-                        dialog.dismiss();
-                        downloadManager.forgetMission(finalStorage);
-                        continueSelectedDownload(finalStorage);
-                    });
-                    break;
-            }
-
-            askDialog.show();
-            return;
-        }
-
-        askDialog.setPositiveButton(msgBtn, (dialog, which) -> {
-            dialog.dismiss();
-
-            StoredFileHelper storageNew;
-            switch (state) {
-                case Finished:
-                case Pending:
-                    downloadManager.forgetMission(finalStorage);
-                case None:
-                    if (targetFile == null) {
-                        storageNew = mainStorage.createFile(filename, mime);
-                    } else {
-                        try {
-                            // try take (or steal) the file
-                            storageNew = new StoredFileHelper(context, mainStorage.getUri(),
-                                    targetFile, mainStorage.getTag());
-                        } catch (final IOException e) {
-                            Log.e(TAG, "Failed to take (or steal) the file in "
-                                    + targetFile.toString());
-                            storageNew = null;
-                        }
-                    }
-
-                    if (storageNew != null && storageNew.canWrite()) {
-                        continueSelectedDownload(storageNew);
-                    } else {
-                        showFailedDialog(R.string.error_file_creation);
-                    }
-                    break;
-                case PendingRunning:
-                    storageNew = mainStorage.createUniqueFile(filename, mime);
-                    if (storageNew == null) {
-                        showFailedDialog(R.string.error_file_creation);
-                    } else {
-                        continueSelectedDownload(storageNew);
-                    }
-                    break;
-            }
-        });
-
-        askDialog.show();
+        new DownloadStorageCoordinator(requireContext(), downloadManager,
+                this::continueSelectedDownload, this::showFailedDialog)
+                .check(mainStorage, targetFile, filename, mime);
     }
 
     private void continueSelectedDownload(@NonNull final StoredFileHelper storage) {

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadStorageCoordinator.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadStorageCoordinator.kt
@@ -1,0 +1,243 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import java.io.IOException
+import org.schabi.newpipe.R
+import org.schabi.newpipe.error.ErrorInfo
+import org.schabi.newpipe.error.ErrorUtil
+import org.schabi.newpipe.error.UserAction
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper
+import org.schabi.newpipe.streams.io.StoredFileHelper
+import us.shandian.giga.service.DownloadManager
+import us.shandian.giga.service.MissionState
+
+internal fun interface DownloadReadyListener {
+    fun onDownloadReady(storage: StoredFileHelper)
+}
+
+internal fun interface DownloadFailureListener {
+    fun onDownloadFailure(@StringRes message: Int)
+}
+
+internal enum class DownloadConflictAction {
+    REPLACE,
+    UNIQUE_NAME,
+    REUSE_EXISTING
+}
+
+internal data class DownloadConflictPrompt(
+    @StringRes val positiveButton: Int,
+    @StringRes val message: Int,
+    val action: DownloadConflictAction
+)
+
+internal object DownloadStorageConflictPolicy {
+    @JvmStatic
+    fun forMissionState(state: MissionState): DownloadConflictPrompt {
+        return when (state) {
+            MissionState.Finished -> DownloadConflictPrompt(
+                positiveButton = R.string.overwrite,
+                message = R.string.overwrite_finished_warning,
+                action = DownloadConflictAction.REPLACE
+            )
+
+            MissionState.Pending -> DownloadConflictPrompt(
+                positiveButton = R.string.overwrite,
+                message = R.string.download_already_pending,
+                action = DownloadConflictAction.REPLACE
+            )
+
+            MissionState.PendingRunning -> DownloadConflictPrompt(
+                positiveButton = R.string.generate_unique_name,
+                message = R.string.download_already_running,
+                action = DownloadConflictAction.UNIQUE_NAME
+            )
+
+            MissionState.None -> DownloadConflictPrompt(
+                positiveButton = R.string.overwrite,
+                message = R.string.overwrite_unrelated_warning,
+                action = DownloadConflictAction.REUSE_EXISTING
+            )
+        }
+    }
+}
+
+/** Resolves target files and existing-mission conflicts outside the download Fragment. */
+internal class DownloadStorageCoordinator(
+    private val context: Context,
+    private val downloadManager: DownloadManager,
+    private val readyListener: DownloadReadyListener,
+    private val failureListener: DownloadFailureListener
+) {
+    fun check(
+        mainStorage: StoredDirectoryHelper?,
+        targetFile: Uri?,
+        filename: String,
+        mime: String?
+    ) {
+        val storage = try {
+            when {
+                mainStorage == null -> StoredFileHelper(
+                    context,
+                    null,
+                    requireNotNull(targetFile),
+                    ""
+                )
+
+                targetFile == null -> StoredFileHelper(
+                    mainStorage.uri,
+                    filename,
+                    mime,
+                    mainStorage.tag
+                )
+
+                else -> StoredFileHelper(
+                    context,
+                    mainStorage.uri,
+                    targetFile,
+                    mainStorage.tag
+                )
+            }
+        } catch (exception: Exception) {
+            ErrorUtil.createNotification(
+                context,
+                ErrorInfo(exception, UserAction.DOWNLOAD_FAILED, "Getting storage")
+            )
+            return
+        }
+
+        val state = downloadManager.checkForExistingMission(storage)
+        if (state == MissionState.None) {
+            if (mainStorage == null) {
+                if (!storage.existsAsFile() && !storage.create()) {
+                    failureListener.onDownloadFailure(R.string.error_file_creation)
+                    return
+                }
+                readyListener.onDownloadReady(storage)
+                return
+            }
+
+            if (targetFile == null) {
+                createNewTarget(mainStorage, filename, mime)
+                return
+            }
+        }
+
+        showConflict(
+            storage = storage,
+            mainStorage = mainStorage,
+            targetFile = targetFile,
+            filename = filename,
+            mime = mime,
+            prompt = DownloadStorageConflictPolicy.forMissionState(state)
+        )
+    }
+
+    private fun createNewTarget(
+        mainStorage: StoredDirectoryHelper,
+        filename: String,
+        mime: String?
+    ) {
+        if (!mainStorage.mkdirs()) {
+            failureListener.onDownloadFailure(R.string.error_path_creation)
+            return
+        }
+        val storage = mainStorage.createFile(filename, mime)
+        if (storage == null || !storage.canWrite()) {
+            failureListener.onDownloadFailure(R.string.error_file_creation)
+            return
+        }
+        readyListener.onDownloadReady(storage)
+    }
+
+    private fun showConflict(
+        storage: StoredFileHelper,
+        mainStorage: StoredDirectoryHelper?,
+        targetFile: Uri?,
+        filename: String,
+        mime: String?,
+        prompt: DownloadConflictPrompt
+    ) {
+        val dialog = AlertDialog.Builder(context)
+            .setTitle(R.string.download_dialog_title)
+            .setMessage(prompt.message)
+            .setNegativeButton(R.string.cancel, null)
+
+        if (mainStorage == null) {
+            if (prompt.action == DownloadConflictAction.REPLACE) {
+                dialog.setPositiveButton(prompt.positiveButton) { alert, _ ->
+                    alert.dismiss()
+                    downloadManager.forgetMission(storage)
+                    readyListener.onDownloadReady(storage)
+                }
+            }
+            dialog.show()
+            return
+        }
+
+        dialog.setPositiveButton(prompt.positiveButton) { alert, _ ->
+            alert.dismiss()
+            when (prompt.action) {
+                DownloadConflictAction.REPLACE -> {
+                    downloadManager.forgetMission(storage)
+                    createOrTakeTarget(mainStorage, targetFile, filename, mime)
+                }
+
+                DownloadConflictAction.REUSE_EXISTING ->
+                    createOrTakeTarget(mainStorage, targetFile, filename, mime)
+
+                DownloadConflictAction.UNIQUE_NAME -> {
+                    val uniqueStorage = mainStorage.createUniqueFile(filename, mime)
+                    if (uniqueStorage == null) {
+                        failureListener.onDownloadFailure(R.string.error_file_creation)
+                    } else {
+                        readyListener.onDownloadReady(uniqueStorage)
+                    }
+                }
+            }
+        }
+        dialog.show()
+    }
+
+    private fun createOrTakeTarget(
+        mainStorage: StoredDirectoryHelper,
+        targetFile: Uri?,
+        filename: String,
+        mime: String?
+    ) {
+        val replacement = if (targetFile == null) {
+            mainStorage.createFile(filename, mime)
+        } else {
+            try {
+                StoredFileHelper(
+                    context,
+                    mainStorage.uri,
+                    targetFile,
+                    mainStorage.tag
+                )
+            } catch (_: IOException) {
+                Log.e(TAG, "Failed to take (or steal) the file in $targetFile")
+                null
+            }
+        }
+
+        if (replacement != null && replacement.canWrite()) {
+            readyListener.onDownloadReady(replacement)
+        } else {
+            failureListener.onDownloadFailure(R.string.error_file_creation)
+        }
+    }
+
+    private companion object {
+        const val TAG = "DownloadStorageCoordinator"
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadStorageConflictPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadStorageConflictPolicyTest.kt
@@ -5,13 +5,13 @@
 
 package org.schabi.newpipe.download
 
+import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.schabi.newpipe.R
 import us.shandian.giga.service.MissionState
-import java.util.stream.Stream
 
 class DownloadStorageConflictPolicyTest {
     @ParameterizedTest

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadStorageConflictPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadStorageConflictPolicyTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.schabi.newpipe.R
 import us.shandian.giga.service.MissionState
 
-class DownloadStorageConflictPolicyTest {
+internal class DownloadStorageConflictPolicyTest {
     @ParameterizedTest
     @MethodSource("conflicts")
     fun `maps mission state to its conflict prompt`(

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadStorageConflictPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadStorageConflictPolicyTest.kt
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.schabi.newpipe.R
+import us.shandian.giga.service.MissionState
+import java.util.stream.Stream
+
+class DownloadStorageConflictPolicyTest {
+    @ParameterizedTest
+    @MethodSource("conflicts")
+    fun `maps mission state to its conflict prompt`(
+        state: MissionState,
+        positiveButton: Int,
+        message: Int,
+        action: DownloadConflictAction
+    ) {
+        val prompt = DownloadStorageConflictPolicy.forMissionState(state)
+
+        assertEquals(positiveButton, prompt.positiveButton)
+        assertEquals(message, prompt.message)
+        assertEquals(action, prompt.action)
+    }
+
+    private companion object {
+        @JvmStatic
+        fun conflicts(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                MissionState.Finished,
+                R.string.overwrite,
+                R.string.overwrite_finished_warning,
+                DownloadConflictAction.REPLACE
+            ),
+            Arguments.of(
+                MissionState.Pending,
+                R.string.overwrite,
+                R.string.download_already_pending,
+                DownloadConflictAction.REPLACE
+            ),
+            Arguments.of(
+                MissionState.PendingRunning,
+                R.string.generate_unique_name,
+                R.string.download_already_running,
+                DownloadConflictAction.UNIQUE_NAME
+            ),
+            Arguments.of(
+                MissionState.None,
+                R.string.overwrite,
+                R.string.overwrite_unrelated_warning,
+                DownloadConflictAction.REUSE_EXISTING
+            )
+        )
+    }
+}


### PR DESCRIPTION
- Move target-file resolution, directory creation and existing-mission conflict handling out of `DownloadDialog` into a Kotlin coordinator.
- Preserve direct-file and SAF behavior, overwrite confirmation, pending mission replacement, unique-name generation and existing-file reuse.
- Keep the Fragment responsible for selection UI, picker results, error presentation and final mission launch callbacks.
- Reduce `DownloadDialog.java` from 1,178 lines to 1,035 lines after the preceding mission-request extraction.
- Add parameterized JVM coverage for every `MissionState` conflict prompt and action.