### PR TITLE
Extract download output plan factory

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -846,61 +846,45 @@ public class DownloadDialog extends DialogFragment
 
     private void prepareSelectedDownload() {
         final StoredDirectoryHelper mainStorage;
-        final MediaFormat format;
+        final DownloadOutputPlan outputPlan;
         final String selectedMediaType;
-        long size;
 
         // first, build the filename and get the output folder (if possible)
         // later, run a very very very large file checking logic
 
-        filenameTmp = getNameEditText().concat(".");
+        final String baseFilename = getNameEditText();
 
         final int checkedRadioButtonId = dialogBinding.videoAudioGroup.getCheckedRadioButtonId();
         if (checkedRadioButtonId == R.id.audio_button) {
             selectedMediaType = getString(R.string.last_download_type_audio_key);
             mainStorage = mainStorageAudio;
-            format = audioStreamsAdapter.getItem(selectedAudioIndex).getFormat();
-            size = getWrappedAudioStreams().getSizeInBytes(selectedAudioIndex);
-            if (isMp3OutputSelected()) {
-                mimeTmp = MediaFormat.MP3.mimeType;
-                filenameTmp += MediaFormat.MP3.getSuffix();
-                if (Mp3DownloadPolicy.shouldTranscode(true, format)) {
-                    size = Mp3OutputOptions.estimateRequiredBytes(size,
-                            currentInfo.getDuration(), getSelectedMp3Bitrate());
-                }
-            } else if (format == MediaFormat.WEBMA_OPUS) {
-                mimeTmp = "audio/ogg";
-                filenameTmp += "opus";
-            } else if (format != null) {
-                mimeTmp = format.mimeType;
-                filenameTmp += format.getSuffix();
-            }
+            outputPlan = DownloadOutputPlanFactory.forAudio(
+                    baseFilename,
+                    audioStreamsAdapter.getItem(selectedAudioIndex).getFormat(),
+                    getWrappedAudioStreams().getSizeInBytes(selectedAudioIndex),
+                    currentInfo.getDuration(),
+                    isMp3OutputSelected(),
+                    getSelectedMp3Bitrate());
         } else if (checkedRadioButtonId == R.id.video_button) {
             selectedMediaType = getString(R.string.last_download_type_video_key);
             mainStorage = mainStorageVideo;
-            format = videoStreamsAdapter.getItem(selectedVideoIndex).getFormat();
-            size = wrappedVideoStreams.getSizeInBytes(selectedVideoIndex);
-            if (format != null) {
-                mimeTmp = format.mimeType;
-                filenameTmp += format.getSuffix();
-            }
+            outputPlan = DownloadOutputPlanFactory.forVideo(
+                    baseFilename,
+                    videoStreamsAdapter.getItem(selectedVideoIndex).getFormat(),
+                    wrappedVideoStreams.getSizeInBytes(selectedVideoIndex));
         } else if (checkedRadioButtonId == R.id.subtitle_button) {
             selectedMediaType = getString(R.string.last_download_type_subtitle_key);
             mainStorage = mainStorageVideo; // subtitle & video files go together
-            format = subtitleStreamsAdapter.getItem(selectedSubtitleIndex).getFormat();
-            size = wrappedSubtitleStreams.getSizeInBytes(selectedSubtitleIndex);
-            if (format != null) {
-                mimeTmp = format.mimeType;
-            }
-
-            if (format == MediaFormat.TTML) {
-                filenameTmp += MediaFormat.SRT.getSuffix();
-            } else if (format != null) {
-                filenameTmp += format.getSuffix();
-            }
+            outputPlan = DownloadOutputPlanFactory.forSubtitle(
+                    baseFilename,
+                    subtitleStreamsAdapter.getItem(selectedSubtitleIndex).getFormat(),
+                    wrappedSubtitleStreams.getSizeInBytes(selectedSubtitleIndex));
         } else {
             throw new RuntimeException("No stream selected");
         }
+
+        filenameTmp = outputPlan.getFilename();
+        mimeTmp = outputPlan.getMimeType();
 
         if (!askForSavePath && (mainStorage == null
                 || mainStorage.isDirect() == NewPipeSettings.useStorageAccessFramework(context)
@@ -945,7 +929,7 @@ public class DownloadDialog extends DialogFragment
 
         // Check for free storage space
         final long freeSpace = mainStorage.getFreeStorageSpace();
-        if (freeSpace <= size) {
+        if (freeSpace <= outputPlan.getEstimatedSize()) {
             Toast.makeText(context, getString(R.
                     string.error_insufficient_storage), Toast.LENGTH_LONG).show();
             // move the user to storage setting tab

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadOutputPlan.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadOutputPlan.kt
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import org.schabi.newpipe.extractor.MediaFormat
+import us.shandian.giga.postprocessing.Mp3OutputOptions
+
+internal data class DownloadOutputPlan(
+    val filename: String,
+    val mimeType: String?,
+    val estimatedSize: Long
+)
+
+/** Resolves the output file metadata for the stream selected in the download dialog. */
+internal object DownloadOutputPlanFactory {
+    @JvmStatic
+    fun forAudio(
+        baseFilename: String,
+        sourceFormat: MediaFormat?,
+        sourceSize: Long,
+        durationSeconds: Long,
+        mp3OutputSelected: Boolean,
+        mp3BitrateKbps: Int
+    ): DownloadOutputPlan {
+        if (mp3OutputSelected) {
+            val estimatedSize = if (Mp3DownloadPolicy.shouldTranscode(true, sourceFormat)) {
+                Mp3OutputOptions.estimateRequiredBytes(
+                    sourceSize,
+                    durationSeconds,
+                    mp3BitrateKbps
+                )
+            } else {
+                sourceSize
+            }
+            return DownloadOutputPlan(
+                filename = appendSuffix(baseFilename, MediaFormat.MP3.getSuffix()),
+                mimeType = MediaFormat.MP3.mimeType,
+                estimatedSize = estimatedSize
+            )
+        }
+
+        if (sourceFormat == MediaFormat.WEBMA_OPUS) {
+            return DownloadOutputPlan(
+                filename = appendSuffix(baseFilename, "opus"),
+                mimeType = "audio/ogg",
+                estimatedSize = sourceSize
+            )
+        }
+
+        return DownloadOutputPlan(
+            filename = appendSuffix(baseFilename, sourceFormat?.getSuffix()),
+            mimeType = sourceFormat?.mimeType,
+            estimatedSize = sourceSize
+        )
+    }
+
+    @JvmStatic
+    fun forVideo(
+        baseFilename: String,
+        format: MediaFormat?,
+        sourceSize: Long
+    ): DownloadOutputPlan {
+        return DownloadOutputPlan(
+            filename = appendSuffix(baseFilename, format?.getSuffix()),
+            mimeType = format?.mimeType,
+            estimatedSize = sourceSize
+        )
+    }
+
+    @JvmStatic
+    fun forSubtitle(
+        baseFilename: String,
+        format: MediaFormat?,
+        sourceSize: Long
+    ): DownloadOutputPlan {
+        val outputSuffix = if (format == MediaFormat.TTML) {
+            MediaFormat.SRT.getSuffix()
+        } else {
+            format?.getSuffix()
+        }
+        return DownloadOutputPlan(
+            filename = appendSuffix(baseFilename, outputSuffix),
+            mimeType = format?.mimeType,
+            estimatedSize = sourceSize
+        )
+    }
+
+    private fun appendSuffix(baseFilename: String, suffix: String?): String {
+        return "$baseFilename.${suffix.orEmpty()}"
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadOutputPlanFactoryTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadOutputPlanFactoryTest.kt
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.schabi.newpipe.extractor.MediaFormat
+import us.shandian.giga.postprocessing.Mp3OutputOptions
+
+internal class DownloadOutputPlanFactoryTest {
+    @Test
+    fun `native audio keeps its format and size`() {
+        val plan = DownloadOutputPlanFactory.forAudio(
+            baseFilename = "episode",
+            sourceFormat = MediaFormat.M4A,
+            sourceSize = 8_000,
+            durationSeconds = 120,
+            mp3OutputSelected = false,
+            mp3BitrateKbps = 192
+        )
+
+        assertEquals("episode.m4a", plan.filename)
+        assertEquals(MediaFormat.M4A.mimeType, plan.mimeType)
+        assertEquals(8_000, plan.estimatedSize)
+    }
+
+    @Test
+    fun `WebM Opus audio uses Ogg metadata`() {
+        val plan = DownloadOutputPlanFactory.forAudio(
+            baseFilename = "episode",
+            sourceFormat = MediaFormat.WEBMA_OPUS,
+            sourceSize = 7_000,
+            durationSeconds = 120,
+            mp3OutputSelected = false,
+            mp3BitrateKbps = 192
+        )
+
+        assertEquals("episode.opus", plan.filename)
+        assertEquals("audio/ogg", plan.mimeType)
+        assertEquals(7_000, plan.estimatedSize)
+    }
+
+    @Test
+    fun `MP3 output estimates transcoded size`() {
+        val plan = DownloadOutputPlanFactory.forAudio(
+            baseFilename = "episode",
+            sourceFormat = MediaFormat.M4A,
+            sourceSize = 8_000,
+            durationSeconds = 120,
+            mp3OutputSelected = true,
+            mp3BitrateKbps = 256
+        )
+
+        assertEquals("episode.mp3", plan.filename)
+        assertEquals(MediaFormat.MP3.mimeType, plan.mimeType)
+        assertEquals(
+            Mp3OutputOptions.estimateRequiredBytes(8_000, 120, 256),
+            plan.estimatedSize
+        )
+    }
+
+    @Test
+    fun `native MP3 output keeps source size`() {
+        val plan = DownloadOutputPlanFactory.forAudio(
+            baseFilename = "episode",
+            sourceFormat = MediaFormat.MP3,
+            sourceSize = 6_000,
+            durationSeconds = 120,
+            mp3OutputSelected = true,
+            mp3BitrateKbps = 320
+        )
+
+        assertEquals("episode.mp3", plan.filename)
+        assertEquals(6_000, plan.estimatedSize)
+    }
+
+    @Test
+    fun `video uses selected stream metadata`() {
+        val plan = DownloadOutputPlanFactory.forVideo(
+            baseFilename = "video",
+            format = MediaFormat.WEBM,
+            sourceSize = 42_000
+        )
+
+        assertEquals("video.webm", plan.filename)
+        assertEquals(MediaFormat.WEBM.mimeType, plan.mimeType)
+        assertEquals(42_000, plan.estimatedSize)
+    }
+
+    @Test
+    fun `TTML subtitle is saved with SRT suffix`() {
+        val plan = DownloadOutputPlanFactory.forSubtitle(
+            baseFilename = "captions-en",
+            format = MediaFormat.TTML,
+            sourceSize = 2_000
+        )
+
+        assertEquals("captions-en.srt", plan.filename)
+        assertEquals(MediaFormat.TTML.mimeType, plan.mimeType)
+        assertEquals(2_000, plan.estimatedSize)
+    }
+
+    @Test
+    fun `unknown format preserves legacy trailing separator`() {
+        val plan = DownloadOutputPlanFactory.forVideo(
+            baseFilename = "video",
+            format = null,
+            sourceSize = -1
+        )
+
+        assertEquals("video.", plan.filename)
+        assertEquals(null, plan.mimeType)
+        assertEquals(-1, plan.estimatedSize)
+    }
+}


### PR DESCRIPTION
- Move output filename, suffix, MIME type and estimated-size resolution out of `DownloadDialog` into a Kotlin factory.
- Preserve native audio and video output, WebM Opus `.opus` handling, MP3 output sizing, TTML-to-SRT conversion and unknown-format behavior.
- Keep the Fragment responsible for UI selection, destination routing, storage checks and mission launch.
- Reduce `DownloadDialog.java` from 1,035 lines to 1,019 lines after the preceding storage extraction.
- Add seven focused JVM tests for audio, video, subtitle and fallback output plans.