### PR TITLE
Extract download destination coordinator

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDestinationCoordinator.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDestinationCoordinator.kt
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Environment
+import android.provider.Settings
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import org.schabi.newpipe.R
+import org.schabi.newpipe.settings.NewPipeSettings
+import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper
+
+internal enum class DownloadDestinationAction {
+    PICK_DIRECTORY,
+    SAVE_AS,
+    INSUFFICIENT_STORAGE,
+    USE_CONFIGURED_STORAGE
+}
+
+internal object DownloadDestinationPolicy {
+    @JvmStatic
+    fun resolve(
+        askForSavePath: Boolean,
+        mainStorage: StoredDirectoryHelper?,
+        useStorageAccessFramework: Boolean,
+        estimatedSize: Long
+    ): DownloadDestinationAction {
+        if (askForSavePath) {
+            return DownloadDestinationAction.SAVE_AS
+        }
+        if (
+            mainStorage == null ||
+            mainStorage.isDirect == useStorageAccessFramework ||
+            mainStorage.isInvalidSafStorage
+        ) {
+            return DownloadDestinationAction.PICK_DIRECTORY
+        }
+        return if (mainStorage.freeStorageSpace <= estimatedSize) {
+            DownloadDestinationAction.INSUFFICIENT_STORAGE
+        } else {
+            DownloadDestinationAction.USE_CONFIGURED_STORAGE
+        }
+    }
+}
+
+internal fun interface ConfiguredDownloadTargetListener {
+    fun onConfiguredTarget(
+        mainStorage: StoredDirectoryHelper,
+        targetFile: Uri?,
+        filename: String,
+        mimeType: String?
+    )
+}
+
+internal fun interface DownloadSaveAsListener {
+    fun onSaveAsRequested(filename: String, mimeType: String?, initialPath: Uri?)
+}
+
+/** Routes an output plan to a folder picker, Save As picker, or configured storage. */
+internal class DownloadDestinationCoordinator(
+    private val context: Context,
+    private val saveAsListener: DownloadSaveAsListener,
+    private val audioFolderLauncher: ActivityResultLauncher<Intent>,
+    private val videoFolderLauncher: ActivityResultLauncher<Intent>,
+    private val targetListener: ConfiguredDownloadTargetListener
+) {
+    /** Returns true only when the configured storage path was used. */
+    fun prepare(
+        isAudio: Boolean,
+        mainStorage: StoredDirectoryHelper?,
+        outputPlan: DownloadOutputPlan,
+        askForSavePath: Boolean
+    ): Boolean {
+        val useStorageAccessFramework = NewPipeSettings.useStorageAccessFramework(context)
+        return when (
+            DownloadDestinationPolicy.resolve(
+                askForSavePath,
+                mainStorage,
+                useStorageAccessFramework,
+                outputPlan.estimatedSize
+            )
+        ) {
+            DownloadDestinationAction.PICK_DIRECTORY -> {
+                Toast.makeText(context, R.string.no_dir_yet, Toast.LENGTH_LONG).show()
+                val launcher = if (isAudio) audioFolderLauncher else videoFolderLauncher
+                NoFileManagerSafeGuard.launchSafe(
+                    launcher,
+                    StoredDirectoryHelper.getPicker(context),
+                    TAG,
+                    context
+                )
+                false
+            }
+
+            DownloadDestinationAction.SAVE_AS -> {
+                val initialPath = if (useStorageAccessFramework) {
+                    null
+                } else {
+                    val directory = if (isAudio) {
+                        Environment.DIRECTORY_MUSIC
+                    } else {
+                        Environment.DIRECTORY_MOVIES
+                    }
+                    Uri.parse(NewPipeSettings.getDir(directory).absolutePath)
+                }
+                saveAsListener.onSaveAsRequested(
+                    outputPlan.filename,
+                    outputPlan.mimeType,
+                    initialPath
+                )
+                false
+            }
+
+            DownloadDestinationAction.INSUFFICIENT_STORAGE -> {
+                Toast.makeText(
+                    context,
+                    R.string.error_insufficient_storage,
+                    Toast.LENGTH_LONG
+                ).show()
+                val intent = Intent(Settings.ACTION_INTERNAL_STORAGE_SETTINGS)
+                if (intent.resolveActivity(context.packageManager) != null) {
+                    context.startActivity(intent)
+                }
+                false
+            }
+
+            DownloadDestinationAction.USE_CONFIGURED_STORAGE -> {
+                checkNotNull(mainStorage)
+                targetListener.onConfiguredTarget(
+                    mainStorage,
+                    mainStorage.findFile(outputPlan.filename),
+                    outputPlan.filename,
+                    outputPlan.mimeType
+                )
+                true
+            }
+        }
+    }
+
+    private companion object {
+        const val TAG = "DownloadDestinationCoordinator"
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -11,9 +11,7 @@ import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.IBinder;
-import android.provider.Settings;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -57,7 +55,6 @@ import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.SubtitlesStream;
 import org.schabi.newpipe.extractor.stream.VideoStream;
-import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
@@ -839,8 +836,11 @@ public class DownloadDialog extends DialogFragment
                 .show();
     }
 
-    private void launchDirectoryPicker(final ActivityResultLauncher<Intent> launcher) {
-        NoFileManagerSafeGuard.launchSafe(launcher, StoredDirectoryHelper.getPicker(context), TAG,
+    private void launchSaveAsPicker(@NonNull final String filename,
+                                    @Nullable final String mimeType,
+                                    @Nullable final Uri initialPath) {
+        NoFileManagerSafeGuard.launchSafe(requestDownloadSaveAsLauncher,
+                StoredFileHelper.getNewPicker(context, filename, mimeType, initialPath), TAG,
                 context);
     }
 
@@ -886,65 +886,15 @@ public class DownloadDialog extends DialogFragment
         filenameTmp = outputPlan.getFilename();
         mimeTmp = outputPlan.getMimeType();
 
-        if (!askForSavePath && (mainStorage == null
-                || mainStorage.isDirect() == NewPipeSettings.useStorageAccessFramework(context)
-                || mainStorage.isInvalidSafStorage())) {
-            // Pick new download folder if one of:
-            // - Download folder is not set
-            // - Download folder uses SAF while SAF is disabled
-            // - Download folder doesn't use SAF while SAF is enabled
-            // - Download folder uses SAF but the user manually revoked access to it
-            Toast.makeText(context, getString(R.string.no_dir_yet),
-                    Toast.LENGTH_LONG).show();
-
-            if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId() == R.id.audio_button) {
-                launchDirectoryPicker(requestDownloadPickAudioFolderLauncher);
-            } else {
-                launchDirectoryPicker(requestDownloadPickVideoFolderLauncher);
-            }
-
+        final boolean usedConfiguredStorage = new DownloadDestinationCoordinator(
+                requireContext(), this::launchSaveAsPicker,
+                requestDownloadPickAudioFolderLauncher, requestDownloadPickVideoFolderLauncher,
+                this::checkSelectedDownload)
+                .prepare(checkedRadioButtonId == R.id.audio_button, mainStorage, outputPlan,
+                        askForSavePath);
+        if (!usedConfiguredStorage) {
             return;
         }
-
-        if (askForSavePath) {
-            final Uri initialPath;
-            if (NewPipeSettings.useStorageAccessFramework(context)) {
-                initialPath = null;
-            } else {
-                final File initialSavePath;
-                if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId() == R.id.audio_button) {
-                    initialSavePath = NewPipeSettings.getDir(Environment.DIRECTORY_MUSIC);
-                } else {
-                    initialSavePath = NewPipeSettings.getDir(Environment.DIRECTORY_MOVIES);
-                }
-                initialPath = Uri.parse(initialSavePath.getAbsolutePath());
-            }
-
-            NoFileManagerSafeGuard.launchSafe(requestDownloadSaveAsLauncher,
-                    StoredFileHelper.getNewPicker(context, filenameTmp, mimeTmp, initialPath), TAG,
-                    context);
-
-            return;
-        }
-
-        // Check for free storage space
-        final long freeSpace = mainStorage.getFreeStorageSpace();
-        if (freeSpace <= outputPlan.getEstimatedSize()) {
-            Toast.makeText(context, getString(R.
-                    string.error_insufficient_storage), Toast.LENGTH_LONG).show();
-            // move the user to storage setting tab
-            final Intent storageSettingsIntent = new Intent(Settings.
-                    ACTION_INTERNAL_STORAGE_SETTINGS);
-            if (storageSettingsIntent.resolveActivity(context.getPackageManager())
-                    != null) {
-                startActivity(storageSettingsIntent);
-            }
-            return;
-        }
-
-        // check for existing file with the same name
-        checkSelectedDownload(mainStorage, mainStorage.findFile(filenameTmp), filenameTmp,
-                mimeTmp);
 
         // remember the last media type downloaded by the user
         prefs.edit().putString(getString(R.string.last_used_download_type), selectedMediaType)

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadDestinationPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadDestinationPolicyTest.kt
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper
+
+internal class DownloadDestinationPolicyTest {
+    @Test
+    fun `Save As takes priority without reading configured storage`() {
+        val storage = mock(StoredDirectoryHelper::class.java)
+
+        val action = DownloadDestinationPolicy.resolve(
+            askForSavePath = true,
+            mainStorage = storage,
+            useStorageAccessFramework = true,
+            estimatedSize = 1_000
+        )
+
+        assertEquals(DownloadDestinationAction.SAVE_AS, action)
+        verifyNoInteractions(storage)
+    }
+
+    @Test
+    fun `missing configured storage requests a directory`() {
+        val action = DownloadDestinationPolicy.resolve(
+            askForSavePath = false,
+            mainStorage = null,
+            useStorageAccessFramework = false,
+            estimatedSize = 1_000
+        )
+
+        assertEquals(DownloadDestinationAction.PICK_DIRECTORY, action)
+    }
+
+    @Test
+    fun `direct storage is rejected when SAF is enabled`() {
+        val storage = storage(isDirect = true)
+
+        val action = DownloadDestinationPolicy.resolve(false, storage, true, 1_000)
+
+        assertEquals(DownloadDestinationAction.PICK_DIRECTORY, action)
+    }
+
+    @Test
+    fun `SAF storage is rejected when SAF is disabled`() {
+        val storage = storage(isDirect = false)
+
+        val action = DownloadDestinationPolicy.resolve(false, storage, false, 1_000)
+
+        assertEquals(DownloadDestinationAction.PICK_DIRECTORY, action)
+    }
+
+    @Test
+    fun `revoked SAF storage requests a new directory`() {
+        val storage = storage(isDirect = false, isInvalidSafStorage = true)
+
+        val action = DownloadDestinationPolicy.resolve(false, storage, true, 1_000)
+
+        assertEquals(DownloadDestinationAction.PICK_DIRECTORY, action)
+    }
+
+    @Test
+    fun `storage equal to estimated output size is insufficient`() {
+        val storage = storage(isDirect = true, freeStorageSpace = 1_000)
+
+        val action = DownloadDestinationPolicy.resolve(false, storage, false, 1_000)
+
+        assertEquals(DownloadDestinationAction.INSUFFICIENT_STORAGE, action)
+    }
+
+    @Test
+    fun `storage larger than estimated output uses configured directory`() {
+        val storage = storage(isDirect = true, freeStorageSpace = 1_001)
+
+        val action = DownloadDestinationPolicy.resolve(false, storage, false, 1_000)
+
+        assertEquals(DownloadDestinationAction.USE_CONFIGURED_STORAGE, action)
+    }
+
+    private fun storage(
+        isDirect: Boolean,
+        isInvalidSafStorage: Boolean = false,
+        freeStorageSpace: Long = Long.MAX_VALUE
+    ): StoredDirectoryHelper {
+        return mock(StoredDirectoryHelper::class.java).also {
+            `when`(it.isDirect).thenReturn(isDirect)
+            `when`(it.isInvalidSafStorage).thenReturn(isInvalidSafStorage)
+            `when`(it.freeStorageSpace).thenReturn(freeStorageSpace)
+        }
+    }
+}


### PR DESCRIPTION
- Move configured-folder validation, Save As routing, directory-picker routing and insufficient-storage handling out of `DownloadDialog` into a Kotlin coordinator.
- Preserve direct-storage and SAF compatibility checks, revoked SAF handling, media-specific initial folders and storage-settings fallback.
- Keep nullable unknown-format MIME behavior at the existing Java picker boundary.
- Reduce `DownloadDialog.java` from 1,019 lines to 969 lines after the output-plan extraction.
- Add seven JVM tests covering every destination-routing decision and the exact free-space boundary.