### PR TITLE
Extract download picker result handler

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -1,6 +1,5 @@
 package org.schabi.newpipe.download;
 
-import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -29,14 +28,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
-import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.PreferenceManager;
 
 import com.evernote.android.state.State;
 import com.livefront.bridge.Bridge;
-import com.nononsenseapps.filepicker.Utils;
-
 import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.databinding.DownloadDialogBinding;
@@ -56,7 +52,6 @@ import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.AudioTrackAdapter;
 import org.schabi.newpipe.util.AudioTrackAdapter.AudioTracksWrapper;
-import org.schabi.newpipe.util.FilePickerActivityHelper;
 import org.schabi.newpipe.util.FilenameUtils;
 import org.schabi.newpipe.util.ListHelper;
 import org.schabi.newpipe.util.PermissionHelper;
@@ -66,7 +61,6 @@ import org.schabi.newpipe.util.StreamItemAdapter;
 import org.schabi.newpipe.util.StreamItemAdapter.StreamInfoWrapper;
 import org.schabi.newpipe.util.ThemeHelper;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
@@ -129,9 +123,11 @@ public class DownloadDialog extends DialogFragment
 
     private SharedPreferences prefs;
 
-    // Variables for file name and MIME type when picking new folder because it's not set yet
-    private String filenameTmp;
-    private String mimeTmp;
+    // Preserve output metadata while an external picker is open.
+    @State
+    String filenameTmp;
+    @State
+    String mimeTmp;
 
     private final ActivityResultLauncher<Intent> requestDownloadSaveAsLauncher =
             registerForActivityResult(
@@ -462,74 +458,24 @@ public class DownloadDialog extends DialogFragment
     //////////////////////////////////////////////////////////////////////////*/
 
     private void requestDownloadPickAudioFolderResult(final ActivityResult result) {
-        requestDownloadPickFolderResult(
-                result, getString(R.string.download_path_audio_key), DownloadManager.TAG_AUDIO);
+        newPickerResultHandler().handleFolder(result,
+                getString(R.string.download_path_audio_key), DownloadManager.TAG_AUDIO,
+                filenameTmp, mimeTmp);
     }
 
     private void requestDownloadPickVideoFolderResult(final ActivityResult result) {
-        requestDownloadPickFolderResult(
-                result, getString(R.string.download_path_video_key), DownloadManager.TAG_VIDEO);
+        newPickerResultHandler().handleFolder(result,
+                getString(R.string.download_path_video_key), DownloadManager.TAG_VIDEO,
+                filenameTmp, mimeTmp);
     }
 
     private void requestDownloadSaveAsResult(@NonNull final ActivityResult result) {
-        if (result.getResultCode() != Activity.RESULT_OK) {
-            return;
-        }
-
-        if (result.getData() == null || result.getData().getData() == null) {
-            showFailedDialog(R.string.general_error);
-            return;
-        }
-
-        if (FilePickerActivityHelper.isOwnFileUri(context, result.getData().getData())) {
-            final File file = Utils.getFileForUri(result.getData().getData());
-            checkSelectedDownload(null, Uri.fromFile(file), file.getName(),
-                    StoredFileHelper.DEFAULT_MIME);
-            return;
-        }
-
-        final DocumentFile docFile = DocumentFile.fromSingleUri(context,
-                result.getData().getData());
-        if (docFile == null) {
-            showFailedDialog(R.string.general_error);
-            return;
-        }
-
-        // check if the selected file was previously used
-        checkSelectedDownload(null, result.getData().getData(), docFile.getName(),
-                docFile.getType());
+        newPickerResultHandler().handleSaveAs(result);
     }
 
-    private void requestDownloadPickFolderResult(@NonNull final ActivityResult result,
-                                                 final String key,
-                                                 final String tag) {
-        if (result.getResultCode() != Activity.RESULT_OK) {
-            return;
-        }
-
-        if (result.getData() == null || result.getData().getData() == null) {
-            showFailedDialog(R.string.general_error);
-            return;
-        }
-
-        Uri uri = result.getData().getData();
-        if (FilePickerActivityHelper.isOwnFileUri(context, uri)) {
-            uri = Uri.fromFile(Utils.getFileForUri(uri));
-        } else {
-            context.grantUriPermission(context.getPackageName(), uri,
-                    StoredDirectoryHelper.PERMISSION_FLAGS);
-        }
-
-        PreferenceManager.getDefaultSharedPreferences(context).edit().putString(key,
-                uri.toString()).apply();
-
-        try {
-            final StoredDirectoryHelper mainStorage = new StoredDirectoryHelper(context, uri, tag);
-            checkSelectedDownload(mainStorage, mainStorage.findFile(filenameTmp),
-                    filenameTmp, mimeTmp);
-        } catch (final IOException e) {
-            showFailedDialog(R.string.general_error);
-        }
+    private DownloadPickerResultHandler newPickerResultHandler() {
+        return new DownloadPickerResultHandler(requireContext(), downloadManager,
+                this::continueSelectedDownload, this::showFailedDialog);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadPickerResultHandler.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadPickerResultHandler.kt
@@ -52,6 +52,7 @@ internal class DownloadPickerResultHandler(
         val resolved = resolve(result)
         when (resolved.action) {
             DownloadPickerResultAction.CANCELLED -> return
+
             DownloadPickerResultAction.INVALID -> {
                 failureListener.onDownloadFailure(R.string.general_error)
                 return
@@ -95,6 +96,7 @@ internal class DownloadPickerResultHandler(
         val resolved = resolve(result)
         when (resolved.action) {
             DownloadPickerResultAction.CANCELLED -> return
+
             DownloadPickerResultAction.INVALID -> {
                 failureListener.onDownloadFailure(R.string.general_error)
                 return

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadPickerResultHandler.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadPickerResultHandler.kt
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import android.app.Activity
+import android.content.Context
+import android.net.Uri
+import androidx.activity.result.ActivityResult
+import androidx.documentfile.provider.DocumentFile
+import androidx.preference.PreferenceManager
+import com.nononsenseapps.filepicker.Utils
+import java.io.IOException
+import org.schabi.newpipe.R
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper
+import org.schabi.newpipe.streams.io.StoredFileHelper
+import org.schabi.newpipe.util.FilePickerActivityHelper
+import us.shandian.giga.service.DownloadManager
+
+internal enum class DownloadPickerResultAction {
+    CANCELLED,
+    INVALID,
+    OWN_FILE,
+    DOCUMENT
+}
+
+internal object DownloadPickerResultPolicy {
+    fun resolve(
+        resultAccepted: Boolean,
+        hasUri: Boolean,
+        isOwnFileUri: Boolean
+    ): DownloadPickerResultAction {
+        return when {
+            !resultAccepted -> DownloadPickerResultAction.CANCELLED
+            !hasUri -> DownloadPickerResultAction.INVALID
+            isOwnFileUri -> DownloadPickerResultAction.OWN_FILE
+            else -> DownloadPickerResultAction.DOCUMENT
+        }
+    }
+}
+
+/** Normalizes external picker results before handing a target to the storage coordinator. */
+internal class DownloadPickerResultHandler(
+    private val context: Context,
+    private val downloadManager: DownloadManager?,
+    private val readyListener: DownloadReadyListener,
+    private val failureListener: DownloadFailureListener
+) {
+    fun handleSaveAs(result: ActivityResult) {
+        val resolved = resolve(result)
+        when (resolved.action) {
+            DownloadPickerResultAction.CANCELLED -> return
+            DownloadPickerResultAction.INVALID -> {
+                failureListener.onDownloadFailure(R.string.general_error)
+                return
+            }
+
+            DownloadPickerResultAction.OWN_FILE -> {
+                val file = Utils.getFileForUri(checkNotNull(resolved.uri))
+                checkTarget(
+                    mainStorage = null,
+                    targetFile = Uri.fromFile(file),
+                    filename = file.name,
+                    mime = StoredFileHelper.DEFAULT_MIME
+                )
+            }
+
+            DownloadPickerResultAction.DOCUMENT -> {
+                val uri = checkNotNull(resolved.uri)
+                val document = DocumentFile.fromSingleUri(context, uri)
+                val filename = document?.name
+                if (filename == null) {
+                    failureListener.onDownloadFailure(R.string.general_error)
+                    return
+                }
+                checkTarget(
+                    mainStorage = null,
+                    targetFile = uri,
+                    filename = filename,
+                    mime = document.type
+                )
+            }
+        }
+    }
+
+    fun handleFolder(
+        result: ActivityResult,
+        preferenceKey: String,
+        storageTag: String,
+        pendingFilename: String?,
+        pendingMimeType: String?
+    ) {
+        val resolved = resolve(result)
+        when (resolved.action) {
+            DownloadPickerResultAction.CANCELLED -> return
+            DownloadPickerResultAction.INVALID -> {
+                failureListener.onDownloadFailure(R.string.general_error)
+                return
+            }
+
+            DownloadPickerResultAction.OWN_FILE,
+            DownloadPickerResultAction.DOCUMENT -> Unit
+        }
+
+        if (pendingFilename == null) {
+            failureListener.onDownloadFailure(R.string.general_error)
+            return
+        }
+
+        val selectedUri = checkNotNull(resolved.uri)
+        val directoryUri = if (resolved.action == DownloadPickerResultAction.OWN_FILE) {
+            Uri.fromFile(Utils.getFileForUri(selectedUri))
+        } else {
+            context.grantUriPermission(
+                context.packageName,
+                selectedUri,
+                StoredDirectoryHelper.PERMISSION_FLAGS
+            )
+            selectedUri
+        }
+
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .putString(preferenceKey, directoryUri.toString())
+            .apply()
+
+        try {
+            val mainStorage = StoredDirectoryHelper(context, directoryUri, storageTag)
+            checkTarget(
+                mainStorage = mainStorage,
+                targetFile = mainStorage.findFile(pendingFilename),
+                filename = pendingFilename,
+                mime = pendingMimeType
+            )
+        } catch (_: IOException) {
+            failureListener.onDownloadFailure(R.string.general_error)
+        }
+    }
+
+    private fun checkTarget(
+        mainStorage: StoredDirectoryHelper?,
+        targetFile: Uri?,
+        filename: String,
+        mime: String?
+    ) {
+        val manager = downloadManager
+        if (manager == null) {
+            failureListener.onDownloadFailure(R.string.general_error)
+            return
+        }
+        DownloadStorageCoordinator(
+            context,
+            manager,
+            readyListener,
+            failureListener
+        ).check(mainStorage, targetFile, filename, mime)
+    }
+
+    private fun resolve(result: ActivityResult): ResolvedPickerResult {
+        val resultAccepted = result.resultCode == Activity.RESULT_OK
+        val uri = if (resultAccepted) result.data?.data else null
+        val isOwnFileUri = uri != null && FilePickerActivityHelper.isOwnFileUri(context, uri)
+        return ResolvedPickerResult(
+            action = DownloadPickerResultPolicy.resolve(
+                resultAccepted,
+                uri != null,
+                isOwnFileUri
+            ),
+            uri = uri
+        )
+    }
+
+    private data class ResolvedPickerResult(
+        val action: DownloadPickerResultAction,
+        val uri: Uri?
+    )
+}

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadPickerResultPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadPickerResultPolicyTest.kt
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import java.util.stream.Stream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class DownloadPickerResultPolicyTest {
+    @ParameterizedTest
+    @MethodSource("pickerResults")
+    fun `maps picker result to handling action`(
+        resultAccepted: Boolean,
+        hasUri: Boolean,
+        isOwnFileUri: Boolean,
+        expected: DownloadPickerResultAction
+    ) {
+        assertEquals(
+            expected,
+            DownloadPickerResultPolicy.resolve(resultAccepted, hasUri, isOwnFileUri)
+        )
+    }
+
+    private companion object {
+        @JvmStatic
+        fun pickerResults(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                false,
+                true,
+                true,
+                DownloadPickerResultAction.CANCELLED
+            ),
+            Arguments.of(
+                true,
+                false,
+                true,
+                DownloadPickerResultAction.INVALID
+            ),
+            Arguments.of(
+                true,
+                true,
+                true,
+                DownloadPickerResultAction.OWN_FILE
+            ),
+            Arguments.of(
+                true,
+                true,
+                false,
+                DownloadPickerResultAction.DOCUMENT
+            )
+        )
+    }
+}


### PR DESCRIPTION
- Move Save As and download-folder result normalization, URI permission grants, folder preference persistence and storage handoff out of `DownloadDialog` into a Kotlin handler.
- Preserve cancellation, app-owned file URI conversion, SAF document handling and audio/video storage tags.
- Save the pending filename and MIME type through Bridge while an external picker is open.
- Fail safely when a picker returns no document name, pending filename or connected download manager instead of passing invalid state deeper into storage handling.
- Reduce `DownloadDialog.java` from 911 lines to 857 lines.
- Add parameterized JVM coverage for cancelled, invalid, app-owned and external document picker results.