### PR TITLE
Extract download stream size loader

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -61,7 +61,6 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.service.DownloadManagerService;
 import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder;
@@ -106,7 +105,7 @@ public class DownloadDialog extends DialogFragment
     private StreamItemAdapter<VideoStream, AudioStream> videoStreamsAdapter;
     private StreamItemAdapter<SubtitlesStream, Stream> subtitleStreamsAdapter;
 
-    private final CompositeDisposable disposables = new CompositeDisposable();
+    private DownloadStreamSizeLoader streamSizeLoader;
 
     private DownloadDialogBinding dialogBinding;
 
@@ -186,6 +185,9 @@ public class DownloadDialog extends DialogFragment
         this.audioTrackAdapter = new AudioTrackAdapter(wrappedAudioTracks);
         this.subtitleStreamsAdapter = new StreamItemAdapter<>(wrappedSubtitleStreams);
         updateSecondaryStreams();
+        streamSizeLoader = new DownloadStreamSizeLoader(wrappedVideoStreams,
+                this::getWrappedAudioStreams, wrappedSubtitleStreams,
+                this::onStreamSizeLoaded, this::onStreamSizeLoadError);
 
         final Intent intent = new Intent(context, DownloadManagerService.class);
         context.startService(intent);
@@ -309,13 +311,10 @@ public class DownloadDialog extends DialogFragment
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        disposables.clear();
-    }
-
-    @Override
     public void onDestroyView() {
+        if (streamSizeLoader != null) {
+            streamSizeLoader.clear();
+        }
         dialogBinding = null;
         super.onDestroyView();
     }
@@ -332,34 +331,21 @@ public class DownloadDialog extends DialogFragment
     //////////////////////////////////////////////////////////////////////////*/
 
     private void fetchStreamsSize() {
-        disposables.clear();
-        disposables.add(StreamInfoWrapper.fetchMoreInfoForWrapper(wrappedVideoStreams)
-                .subscribe(result -> {
-                    if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
-                            == R.id.video_button) {
-                        setupVideoSpinner();
-                    }
-                }, throwable -> ErrorUtil.showSnackbar(context,
-                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
-                                "Downloading video stream size", currentInfo))));
-        disposables.add(StreamInfoWrapper.fetchMoreInfoForWrapper(getWrappedAudioStreams())
-                .subscribe(result -> {
-                    if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
-                            == R.id.audio_button) {
-                        setupAudioSpinner();
-                    }
-                }, throwable -> ErrorUtil.showSnackbar(context,
-                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
-                                "Downloading audio stream size", currentInfo))));
-        disposables.add(StreamInfoWrapper.fetchMoreInfoForWrapper(wrappedSubtitleStreams)
-                .subscribe(result -> {
-                    if (dialogBinding.videoAudioGroup.getCheckedRadioButtonId()
-                            == R.id.subtitle_button) {
-                        setupSubtitleSpinner();
-                    }
-                }, throwable -> ErrorUtil.showSnackbar(context,
-                        new ErrorInfo(throwable, UserAction.DOWNLOAD_OPEN_DIALOG,
-                                "Downloading subtitle stream size", currentInfo))));
+        streamSizeLoader.refresh();
+    }
+
+    private void onStreamSizeLoaded(final DownloadMediaOption option) {
+        if (dialogBinding == null) {
+            return;
+        }
+        newOptionsController().refreshLoadedOption(option, selectedVideoIndex,
+                selectedAudioIndex, selectedSubtitleIndex, selectedAudioOutputIndex);
+    }
+
+    private void onStreamSizeLoadError(final DownloadMediaOption option,
+                                       final Throwable throwable) {
+        ErrorUtil.showSnackbar(context, new ErrorInfo(throwable,
+                UserAction.DOWNLOAD_OPEN_DIALOG, option.getSizeRequestDescription(), currentInfo));
     }
 
     private void setupAudioSpinner() {

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadOptionsController.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadOptionsController.kt
@@ -24,10 +24,10 @@ import org.schabi.newpipe.util.AudioTrackAdapter.AudioTracksWrapper
 import org.schabi.newpipe.util.StreamItemAdapter
 import us.shandian.giga.postprocessing.Mp3OutputOptions
 
-internal enum class DownloadMediaOption {
-    VIDEO,
-    AUDIO,
-    SUBTITLE
+internal enum class DownloadMediaOption(val sizeRequestDescription: String) {
+    VIDEO("Downloading video stream size"),
+    AUDIO("Downloading audio stream size"),
+    SUBTITLE("Downloading subtitle stream size")
 }
 
 internal object DownloadMediaOptionPolicy {
@@ -256,6 +256,28 @@ internal class DownloadOptionsController(
         )
         binding.mp3BitrateLabel.visibility = visibility(visible)
         binding.mp3BitrateSpinner.visibility = visibility(visible)
+    }
+
+    fun refreshLoadedOption(
+        option: DownloadMediaOption,
+        selectedVideoIndex: Int,
+        selectedAudioIndex: Int,
+        selectedSubtitleIndex: Int,
+        selectedAudioOutputIndex: Int
+    ) {
+        when (option) {
+            DownloadMediaOption.VIDEO -> if (binding.videoButton.isChecked) {
+                showVideo(selectedVideoIndex)
+            }
+
+            DownloadMediaOption.AUDIO -> if (binding.audioButton.isChecked) {
+                showAudio(selectedAudioIndex, selectedAudioOutputIndex)
+            }
+
+            DownloadMediaOption.SUBTITLE -> if (binding.subtitleButton.isChecked) {
+                showSubtitle(selectedSubtitleIndex)
+            }
+        }
     }
 
     private fun setRadioButtonsEnabled(enabled: Boolean) {

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadStreamSizeLoader.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadStreamSizeLoader.kt
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.Stream
+import org.schabi.newpipe.extractor.stream.SubtitlesStream
+import org.schabi.newpipe.extractor.stream.VideoStream
+import org.schabi.newpipe.util.StreamItemAdapter.StreamInfoWrapper
+
+internal fun interface DownloadAudioStreamsProvider {
+    fun get(): StreamInfoWrapper<AudioStream>
+}
+
+internal fun interface DownloadStreamSizeLoadedListener {
+    fun onLoaded(option: DownloadMediaOption)
+}
+
+internal fun interface DownloadStreamSizeErrorListener {
+    fun onError(option: DownloadMediaOption, throwable: Throwable)
+}
+
+internal fun interface DownloadStreamInfoFetcher {
+    fun fetch(streams: StreamInfoWrapper<out Stream>): Single<Boolean>
+}
+
+/** Owns the asynchronous stream metadata requests and their cancellation. */
+internal class DownloadStreamSizeLoader @JvmOverloads constructor(
+    private val videoStreams: StreamInfoWrapper<VideoStream>,
+    private val audioStreamsProvider: DownloadAudioStreamsProvider,
+    private val subtitleStreams: StreamInfoWrapper<SubtitlesStream>,
+    private val loadedListener: DownloadStreamSizeLoadedListener,
+    private val errorListener: DownloadStreamSizeErrorListener,
+    private val fetcher: DownloadStreamInfoFetcher = DownloadStreamInfoFetcher(::fetchStreamInfo)
+) {
+    private val disposables = CompositeDisposable()
+
+    fun refresh() {
+        disposables.clear()
+        load(DownloadMediaOption.VIDEO, videoStreams)
+        load(DownloadMediaOption.AUDIO, audioStreamsProvider.get())
+        load(DownloadMediaOption.SUBTITLE, subtitleStreams)
+    }
+
+    fun clear() {
+        disposables.clear()
+    }
+
+    private fun <T : Stream> load(
+        option: DownloadMediaOption,
+        streams: StreamInfoWrapper<T>
+    ) {
+        disposables.add(
+            fetcher.fetch(streams)
+                .subscribe(
+                    { loadedListener.onLoaded(option) },
+                    { errorListener.onError(option, it) }
+                )
+        )
+    }
+
+    private companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun fetchStreamInfo(streams: StreamInfoWrapper<out Stream>): Single<Boolean> {
+            return StreamInfoWrapper.fetchMoreInfoForWrapper(
+                streams as StreamInfoWrapper<Stream>
+            )
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadStreamSizeLoaderTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadStreamSizeLoaderTest.kt
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.subjects.SingleSubject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.SubtitlesStream
+import org.schabi.newpipe.extractor.stream.VideoStream
+import org.schabi.newpipe.util.StreamItemAdapter.StreamInfoWrapper
+
+internal class DownloadStreamSizeLoaderTest {
+    @Test
+    fun `refresh loads every stream group in order`() {
+        val video = StreamInfoWrapper<VideoStream>(emptyList(), null)
+        val audio = StreamInfoWrapper<AudioStream>(emptyList(), null)
+        val subtitle = StreamInfoWrapper<SubtitlesStream>(emptyList(), null)
+        val requested = mutableListOf<StreamInfoWrapper<*>>()
+        val loaded = mutableListOf<DownloadMediaOption>()
+
+        val loader = DownloadStreamSizeLoader(
+            video,
+            DownloadAudioStreamsProvider { audio },
+            subtitle,
+            DownloadStreamSizeLoadedListener { loaded += it },
+            DownloadStreamSizeErrorListener { _, _ -> },
+            DownloadStreamInfoFetcher {
+                requested += it
+                Single.just(true)
+            }
+        )
+
+        loader.refresh()
+
+        assertEquals(listOf(video, audio, subtitle), requested)
+        assertEquals(
+            listOf(
+                DownloadMediaOption.VIDEO,
+                DownloadMediaOption.AUDIO,
+                DownloadMediaOption.SUBTITLE
+            ),
+            loaded
+        )
+    }
+
+    @Test
+    fun `refresh obtains the current audio track wrapper`() {
+        val firstAudio = StreamInfoWrapper<AudioStream>(emptyList(), null)
+        val secondAudio = StreamInfoWrapper<AudioStream>(emptyList(), null)
+        var currentAudio = firstAudio
+        val requested = mutableListOf<StreamInfoWrapper<*>>()
+        val loader = loader(
+            audioProvider = DownloadAudioStreamsProvider { currentAudio },
+            fetcher = DownloadStreamInfoFetcher {
+                requested += it
+                Single.just(true)
+            }
+        )
+
+        loader.refresh()
+        currentAudio = secondAudio
+        loader.refresh()
+
+        assertSame(firstAudio, requested[1])
+        assertSame(secondAudio, requested[4])
+    }
+
+    @Test
+    fun `clear cancels pending callbacks`() {
+        val pending = SingleSubject.create<Boolean>()
+        val loaded = mutableListOf<DownloadMediaOption>()
+        val loader = loader(
+            loaded = loaded,
+            fetcher = DownloadStreamInfoFetcher { pending }
+        )
+
+        loader.refresh()
+        loader.clear()
+        pending.onSuccess(true)
+
+        assertTrue(loaded.isEmpty())
+    }
+
+    private fun loader(
+        audioProvider: DownloadAudioStreamsProvider = DownloadAudioStreamsProvider {
+            StreamInfoWrapper(emptyList(), null)
+        },
+        loaded: MutableList<DownloadMediaOption> = mutableListOf(),
+        fetcher: DownloadStreamInfoFetcher
+    ): DownloadStreamSizeLoader {
+        return DownloadStreamSizeLoader(
+            StreamInfoWrapper(emptyList(), null),
+            audioProvider,
+            StreamInfoWrapper(emptyList(), null),
+            DownloadStreamSizeLoadedListener { loaded += it },
+            DownloadStreamSizeErrorListener { _, _ -> },
+            fetcher
+        )
+    }
+}


### PR DESCRIPTION
- Move video, audio, and subtitle metadata subscriptions into a lifecycle-aware Kotlin loader
- Resolve the active audio-track wrapper on every refresh
- Cancel pending metadata callbacks when the dialog view is destroyed
- Reduce DownloadDialog.java from 702 to 688 lines
- Add tests for load order, audio-wrapper refresh, and cancellation