### PR TITLE
Extract download service connector

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -1,13 +1,10 @@
 package org.schabi.newpipe.download;
 
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.IBinder;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -63,7 +60,6 @@ import java.util.Optional;
 
 import us.shandian.giga.service.DownloadManager;
 import us.shandian.giga.service.DownloadManagerService;
-import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder;
 
 public class DownloadDialog extends DialogFragment
         implements RadioGroup.OnCheckedChangeListener, AdapterView.OnItemSelectedListener {
@@ -106,6 +102,7 @@ public class DownloadDialog extends DialogFragment
     private StreamItemAdapter<SubtitlesStream, Stream> subtitleStreamsAdapter;
 
     private DownloadStreamSizeLoader streamSizeLoader;
+    private DownloadServiceConnector serviceConnector;
 
     private DownloadDialogBinding dialogBinding;
 
@@ -189,29 +186,19 @@ public class DownloadDialog extends DialogFragment
                 this::getWrappedAudioStreams, wrappedSubtitleStreams,
                 this::onStreamSizeLoaded, this::onStreamSizeLoadError);
 
-        final Intent intent = new Intent(context, DownloadManagerService.class);
-        context.startService(intent);
+        serviceConnector = new DownloadServiceConnector(context,
+                this::onDownloadServiceConnected);
+        serviceConnector.connect();
+    }
 
-        context.bindService(intent, new ServiceConnection() {
-            @Override
-            public void onServiceConnected(final ComponentName cname, final IBinder service) {
-                final DownloadManagerBinder mgr = (DownloadManagerBinder) service;
-
-                mainStorageAudio = mgr.getMainStorageAudio();
-                mainStorageVideo = mgr.getMainStorageVideo();
-                downloadManager = mgr.getDownloadManager();
-                askForSavePath = mgr.askForSavePath();
-
-                okButton.setEnabled(true);
-
-                context.unbindService(this);
-            }
-
-            @Override
-            public void onServiceDisconnected(final ComponentName name) {
-                // nothing to do
-            }
-        }, Context.BIND_AUTO_CREATE);
+    private void onDownloadServiceConnected(final DownloadServiceState state) {
+        mainStorageAudio = state.getMainStorageAudio();
+        mainStorageVideo = state.getMainStorageVideo();
+        downloadManager = state.getDownloadManager();
+        askForSavePath = state.getAskForSavePath();
+        if (okButton != null) {
+            okButton.setEnabled(true);
+        }
     }
 
     /**
@@ -299,7 +286,7 @@ public class DownloadDialog extends DialogFragment
         toolbar.setNavigationContentDescription(R.string.cancel);
 
         okButton = toolbar.getMenu().findItem(R.id.okay);
-        okButton.setEnabled(false); // disable until the download service connection is done
+        okButton.setEnabled(downloadManager != null);
 
         toolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.okay) {
@@ -317,6 +304,14 @@ public class DownloadDialog extends DialogFragment
         }
         dialogBinding = null;
         super.onDestroyView();
+    }
+
+    @Override
+    public void onDestroy() {
+        if (serviceConnector != null) {
+            serviceConnector.disconnect();
+        }
+        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadServiceConnector.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadServiceConnector.kt
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper
+import us.shandian.giga.service.DownloadManager
+import us.shandian.giga.service.DownloadManagerService
+import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder
+
+internal data class DownloadServiceState(
+    val mainStorageAudio: StoredDirectoryHelper?,
+    val mainStorageVideo: StoredDirectoryHelper?,
+    val downloadManager: DownloadManager,
+    val askForSavePath: Boolean
+)
+
+internal fun interface DownloadServiceConnectedListener {
+    fun onConnected(state: DownloadServiceState)
+}
+
+/** Starts the download service and owns its short-lived binding. */
+internal class DownloadServiceConnector(
+    context: Context,
+    private val connectedListener: DownloadServiceConnectedListener
+) {
+    private val context = context.applicationContext ?: context
+    private var bound = false
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName, service: IBinder) {
+            val manager = service as DownloadManagerBinder
+            connectedListener.onConnected(
+                DownloadServiceState(
+                    manager.mainStorageAudio,
+                    manager.mainStorageVideo,
+                    manager.downloadManager,
+                    manager.askForSavePath()
+                )
+            )
+            disconnect()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName) = Unit
+    }
+
+    fun connect() {
+        if (bound) {
+            return
+        }
+        val intent = Intent(context, DownloadManagerService::class.java)
+        context.startService(intent)
+        bound = context.bindService(intent, connection, Context.BIND_AUTO_CREATE)
+    }
+
+    fun disconnect() {
+        if (!bound) {
+            return
+        }
+        context.unbindService(connection)
+        bound = false
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadServiceConnectorTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadServiceConnectorTest.kt
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.download
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.schabi.newpipe.streams.io.StoredDirectoryHelper
+import us.shandian.giga.service.DownloadManager
+import us.shandian.giga.service.DownloadManagerService.DownloadManagerBinder
+
+internal class DownloadServiceConnectorTest {
+    @Test
+    fun `connected service state is delivered and immediately unbound`() {
+        val context = context(bindResult = true)
+        val connection = ArgumentCaptor.forClass(ServiceConnection::class.java)
+        val audioStorage = mock(StoredDirectoryHelper::class.java)
+        val videoStorage = mock(StoredDirectoryHelper::class.java)
+        val downloadManager = mock(DownloadManager::class.java)
+        val binder = mock(DownloadManagerBinder::class.java)
+        `when`(binder.mainStorageAudio).thenReturn(audioStorage)
+        `when`(binder.mainStorageVideo).thenReturn(videoStorage)
+        `when`(binder.downloadManager).thenReturn(downloadManager)
+        `when`(binder.askForSavePath()).thenReturn(true)
+        var received: DownloadServiceState? = null
+        val connector = DownloadServiceConnector(context) { received = it }
+
+        connector.connect()
+        verify(context).bindService(
+            any(Intent::class.java),
+            connection.capture(),
+            eq(Context.BIND_AUTO_CREATE)
+        )
+        connection.value.onServiceConnected(mock(ComponentName::class.java), binder)
+
+        assertSame(audioStorage, received?.mainStorageAudio)
+        assertSame(videoStorage, received?.mainStorageVideo)
+        assertSame(downloadManager, received?.downloadManager)
+        assertTrue(received?.askForSavePath == true)
+        verify(context).unbindService(connection.value)
+
+        connector.disconnect()
+        verify(context, times(1)).unbindService(connection.value)
+    }
+
+    @Test
+    fun `pending binding is disconnected once`() {
+        val context = context(bindResult = true)
+        val connection = ArgumentCaptor.forClass(ServiceConnection::class.java)
+        val connector = DownloadServiceConnector(context) { }
+
+        connector.connect()
+        verify(context).bindService(
+            any(Intent::class.java),
+            connection.capture(),
+            eq(Context.BIND_AUTO_CREATE)
+        )
+        connector.disconnect()
+        connector.disconnect()
+
+        verify(context, times(1)).unbindService(connection.value)
+    }
+
+    @Test
+    fun `failed binding does not attempt to unbind`() {
+        val context = context(bindResult = false)
+        val connector = DownloadServiceConnector(context) { }
+
+        connector.connect()
+        connector.disconnect()
+
+        verify(context, never()).unbindService(any(ServiceConnection::class.java))
+    }
+
+    private fun context(bindResult: Boolean): Context {
+        val context = mock(Context::class.java)
+        `when`(context.applicationContext).thenReturn(context)
+        `when`(
+            context.bindService(
+                any(Intent::class.java),
+                any(ServiceConnection::class.java),
+                eq(Context.BIND_AUTO_CREATE)
+            )
+        ).thenReturn(bindResult)
+        return context
+    }
+}


### PR DESCRIPTION
- Move download-service startup and binding into a Kotlin connector
- Deliver storage and manager dependencies as an immutable service state
- Disconnect pending bindings during Fragment teardown and after successful connection
- Handle service connections that arrive before the toolbar is created
- Reduce DownloadDialog.java from 688 to 683 lines
- Add tests for state delivery, successful unbinding, pending disconnects, and failed binds