### PR TITLE
Extract sleep timer playback controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -59,7 +59,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -144,7 +143,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import coil3.target.Target;
@@ -191,7 +189,6 @@ public final class Player implements PlaybackListener, Listener {
 
     public static final int PLAY_PREV_ACTIVATION_LIMIT_MILLIS = 5000; // 5 seconds
     public static final int PROGRESS_LOOP_INTERVAL_MILLIS = 1000; // 1 second
-    private static final int SLEEP_TIMER_UPDATE_INTERVAL_MILLIS = 1000; // 1 second
 
     /*//////////////////////////////////////////////////////////////////////////
     // Other constants
@@ -268,17 +265,7 @@ public final class Player implements PlaybackListener, Listener {
             new PopupPlayerReturnState();
 
     @NonNull
-    private final SleepTimer sleepTimer = new SleepTimer();
-    @NonNull
-    private final Handler sleepTimerHandler = new Handler(Looper.getMainLooper());
-    @NonNull
-    private final Runnable sleepTimerTick = this::onSleepTimerTick;
-    @Nullable
-    private PlayQueueItem sleepTimerCurrentTarget;
-    @Nullable
-    private PlayQueueItem sleepTimerQueueTarget;
-    private boolean sleepTimerQueueTargetFollowsLoading;
-    private float sleepTimerVolumeMultiplier = 1.0f;
+    private final SleepTimerPlaybackController sleepTimerController;
     private boolean muted;
 
     // audio only mode does not mean that player type is background, but that the player was
@@ -347,6 +334,7 @@ public final class Player implements PlaybackListener, Listener {
         recordManager = new HistoryRecordManager(context);
         learningSessionTracker = new LearningSessionTracker(context);
         sponsorBlockController = new SponsorBlockPlaybackController(this);
+        sleepTimerController = new SleepTimerPlaybackController(this);
 
         setupBroadcastReceiver();
 
@@ -694,7 +682,7 @@ public final class Player implements PlaybackListener, Listener {
         playQueue = queue;
         playQueue.init();
         simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled());
-        retargetSleepTimerForNewQueue();
+        sleepTimerController.onQueueReplaced();
         reloadPlayQueueManager();
 
         UIs.call(PlayerUi::initPlayback);
@@ -775,7 +763,7 @@ public final class Player implements PlaybackListener, Listener {
 
         cancelThumbnailLoading();
         cancelLocalMetadataLoading();
-        clearSleepTimer();
+        sleepTimerController.clear();
         saveStreamProgressState();
         setRecovery();
         stopActivityBinding();
@@ -1236,7 +1224,8 @@ public final class Player implements PlaybackListener, Listener {
                 changeState(playWhenReady ? STATE_PLAYING : STATE_PAUSED);
                 break;
             case androidx.media3.common.Player.STATE_ENDED: // 4
-                maybeFinishSleepTimerAtEndOfItem(currentQueueItem(), false);
+                sleepTimerController.onItemEnded(
+                        playQueue == null ? null : playQueue.getItem(), false);
                 changeState(STATE_COMPLETED);
                 saveStreamProgressStateCompleted();
                 isPrepared = false;
@@ -1453,11 +1442,7 @@ public final class Player implements PlaybackListener, Listener {
             } else if (!shuffleModeEnabled && playQueue.isShuffled()) {
                 playQueue.unshuffle();
             }
-            if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE) {
-                sleepTimerQueueTarget = lastQueueItem();
-                sleepTimerQueueTargetFollowsLoading = !playQueue.isComplete();
-                notifySleepTimerUpdateToListeners();
-            }
+            sleepTimerController.onShuffleModeChanged();
         }
 
         UIs.call(playerUi -> playerUi.onShuffleModeEnabledChanged(shuffleModeEnabled));
@@ -1544,11 +1529,11 @@ public final class Player implements PlaybackListener, Listener {
                 .setTunnelingEnabled(tunnelingEnabled));
     }
 
-    private void applyPlayerVolume() {
+    void applyPlayerVolume() {
         if (!exoPlayerIsNull()) {
             final float equalizerHeadroom = equalizerController.getHeadroomMultiplier();
             simpleExoPlayer.setVolume(muted
-                    ? 0.0f : sleepTimerVolumeMultiplier * equalizerHeadroom);
+                    ? 0.0f : sleepTimerController.getVolumeMultiplier() * equalizerHeadroom);
         }
     }
     //endregion
@@ -1561,281 +1546,36 @@ public final class Player implements PlaybackListener, Listener {
     //region Sleep timer
 
     public void startSleepTimer(final long durationMillis, final boolean fadeOut) {
-        prepareSleepTimerStart();
-        sleepTimer.startDuration(durationMillis, fadeOut);
-        startSleepTimerUpdates();
+        sleepTimerController.startDuration(durationMillis, fadeOut);
     }
 
     public boolean startSleepTimerAtEndOfCurrent(final boolean fadeOut) {
-        final PlayQueueItem item = currentQueueItem();
-        if (item == null) {
-            return false;
-        }
-
-        prepareSleepTimerStart();
-        sleepTimerCurrentTarget = item;
-        sleepTimer.startEndOfCurrent(fadeOut);
-        startSleepTimerUpdates();
-        return true;
+        return sleepTimerController.startAtEndOfCurrent(fadeOut);
     }
 
     public boolean startSleepTimerAtEndOfQueue(final boolean fadeOut) {
-        final PlayQueueItem item = lastQueueItem();
-        if (item == null || playQueue == null) {
-            return false;
-        }
-
-        prepareSleepTimerStart();
-        sleepTimerQueueTarget = item;
-        sleepTimerQueueTargetFollowsLoading = !playQueue.isComplete();
-        sleepTimer.startEndOfQueue(fadeOut);
-        startSleepTimerUpdates();
-        return true;
-    }
-
-    private void prepareSleepTimerStart() {
-        resetSleepTimerState();
-        setSleepTimerVolumeMultiplier(1.0f);
+        return sleepTimerController.startAtEndOfQueue(fadeOut);
     }
 
     public void cancelSleepTimer() {
-        if (!sleepTimer.isActive()) {
-            return;
-        }
-        resetSleepTimerState();
-        setSleepTimerVolumeMultiplier(1.0f);
-        notifySleepTimerUpdateToListeners();
-    }
-
-    private void clearSleepTimer() {
-        resetSleepTimerState();
-        setSleepTimerVolumeMultiplier(1.0f);
-    }
-
-    private void resetSleepTimerState() {
-        sleepTimerHandler.removeCallbacks(sleepTimerTick);
-        sleepTimer.cancel();
-        sleepTimerCurrentTarget = null;
-        sleepTimerQueueTarget = null;
-        sleepTimerQueueTargetFollowsLoading = false;
-    }
-
-    private void startSleepTimerUpdates() {
-        sleepTimerHandler.removeCallbacks(sleepTimerTick);
-        sleepTimerHandler.post(sleepTimerTick);
-    }
-
-    private void onSleepTimerTick() {
-        if (!sleepTimer.isActive()) {
-            return;
-        }
-        if (sleepTimer.hasDurationExpired()) {
-            finishSleepTimer(true);
-            return;
-        }
-
-        updateSleepTimerFadeOut();
-        notifySleepTimerUpdateToListeners();
-        sleepTimerHandler.postDelayed(sleepTimerTick, SLEEP_TIMER_UPDATE_INTERVAL_MILLIS);
-    }
-
-    private void updateSleepTimerFadeOut() {
-        final float volumeMultiplier = sleepTimer.getFadeOutVolumeMultiplier(
-                getSleepTimerFadeOutRemainingMillis());
-        setSleepTimerVolumeMultiplier(volumeMultiplier);
-    }
-
-    private void setSleepTimerVolumeMultiplier(final float volumeMultiplier) {
-        final float clampedMultiplier = Math.max(0.0f, Math.min(1.0f, volumeMultiplier));
-        if (Math.abs(sleepTimerVolumeMultiplier - clampedMultiplier) < 0.001f) {
-            return;
-        }
-        sleepTimerVolumeMultiplier = clampedMultiplier;
-        applyPlayerVolume();
-    }
-
-    private void maybeFinishSleepTimerAtEndOfItem(@Nullable final PlayQueueItem endedItem,
-                                                   final boolean pausePlayback) {
-        if (endedItem == null || !sleepTimer.isActive()) {
-            return;
-        }
-
-        final boolean targetReached = (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT
-                && isSameQueueItem(endedItem, sleepTimerCurrentTarget))
-                || (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE
-                && isSameQueueItem(endedItem, sleepTimerQueueTarget));
-        if (targetReached) {
-            finishSleepTimer(pausePlayback);
-        }
-    }
-
-    private void finishSleepTimer(final boolean pausePlayback) {
-        if (!sleepTimer.isActive()) {
-            return;
-        }
-
-        resetSleepTimerState();
-        if (pausePlayback && !exoPlayerIsNull() && getPlayWhenReady()) {
-            pause();
-        }
-        setSleepTimerVolumeMultiplier(1.0f);
-        notifySleepTimerUpdateToListeners();
-        Toast.makeText(context, R.string.sleep_timer_finished, Toast.LENGTH_SHORT).show();
-    }
-
-    private void retargetSleepTimerForNewQueue() {
-        if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT) {
-            sleepTimerCurrentTarget = currentQueueItem();
-            if (sleepTimerCurrentTarget == null) {
-                clearSleepTimer();
-            }
-        } else if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE && playQueue != null) {
-            sleepTimerQueueTarget = lastQueueItem();
-            sleepTimerQueueTargetFollowsLoading = !playQueue.isComplete();
-            if (sleepTimerQueueTarget == null) {
-                clearSleepTimer();
-            }
-        }
-    }
-
-    private void retargetEndOfCurrentSleepTimer() {
-        if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT) {
-            sleepTimerCurrentTarget = currentQueueItem();
-            notifySleepTimerUpdateToListeners();
-        }
-    }
-
-    private void validateSleepTimerTargetsAfterQueueEdit() {
-        if (playQueue == null) {
-            return;
-        }
-        if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT
-                && findQueueItemIndex(sleepTimerCurrentTarget) < 0) {
-            sleepTimerCurrentTarget = currentQueueItem();
-            if (sleepTimerCurrentTarget == null) {
-                clearSleepTimer();
-            }
-        } else if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE
-                && (sleepTimerQueueTargetFollowsLoading
-                || findQueueItemIndex(sleepTimerQueueTarget) < 0)) {
-            sleepTimerQueueTarget = lastQueueItem();
-            sleepTimerQueueTargetFollowsLoading = !playQueue.isComplete();
-            if (sleepTimerQueueTarget == null) {
-                clearSleepTimer();
-            }
-        }
-    }
-
-    private long getSleepTimerFadeOutRemainingMillis() {
-        if (sleepTimer.getMode() == SleepTimer.Mode.DURATION) {
-            return sleepTimer.getDurationRemainingMillis();
-        }
-        if ((sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT
-                && isSameQueueItem(currentQueueItem(), sleepTimerCurrentTarget))
-                || (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE
-                && isSameQueueItem(currentQueueItem(), sleepTimerQueueTarget))) {
-            return getCurrentItemRemainingMillis();
-        }
-        return SleepTimer.REMAINING_TIME_UNSET;
+        sleepTimerController.cancel();
     }
 
     public long getSleepTimerRemainingMillis() {
-        if (sleepTimer.getMode() == SleepTimer.Mode.DURATION) {
-            return sleepTimer.getDurationRemainingMillis();
-        } else if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT) {
-            return isSameQueueItem(currentQueueItem(), sleepTimerCurrentTarget)
-                    ? getCurrentItemRemainingMillis() : SleepTimer.REMAINING_TIME_UNSET;
-        } else if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_QUEUE) {
-            return getQueueTargetRemainingMillis();
-        }
-        return SleepTimer.REMAINING_TIME_UNSET;
-    }
-
-    private long getQueueTargetRemainingMillis() {
-        if (playQueue == null || exoPlayerIsNull()) {
-            return SleepTimer.REMAINING_TIME_UNSET;
-        }
-        final int currentIndex = playQueue.getIndex();
-        final int targetIndex = findQueueItemIndex(sleepTimerQueueTarget);
-        if (targetIndex < currentIndex || targetIndex < 0) {
-            return SleepTimer.REMAINING_TIME_UNSET;
-        }
-
-        long remainingMillis = getCurrentItemRemainingMillis();
-        if (remainingMillis == SleepTimer.REMAINING_TIME_UNSET) {
-            return SleepTimer.REMAINING_TIME_UNSET;
-        }
-        for (int i = currentIndex + 1; i <= targetIndex; i++) {
-            final PlayQueueItem item = playQueue.getItem(i);
-            if (item == null || item.getDuration() <= 0L) {
-                return SleepTimer.REMAINING_TIME_UNSET;
-            }
-            final long itemDurationMillis = playbackTimeToWallClockMillis(
-                    TimeUnit.SECONDS.toMillis(item.getDuration()));
-            if (Long.MAX_VALUE - remainingMillis < itemDurationMillis) {
-                return SleepTimer.REMAINING_TIME_UNSET;
-            }
-            remainingMillis += itemDurationMillis;
-        }
-        return remainingMillis;
-    }
-
-    private long getCurrentItemRemainingMillis() {
-        if (exoPlayerIsNull()) {
-            return SleepTimer.REMAINING_TIME_UNSET;
-        }
-        long durationMillis = simpleExoPlayer.getDuration();
-        if (durationMillis == C.TIME_UNSET || durationMillis <= 0L) {
-            final PlayQueueItem item = currentQueueItem();
-            if (item == null || item.getDuration() <= 0L) {
-                return SleepTimer.REMAINING_TIME_UNSET;
-            }
-            durationMillis = TimeUnit.SECONDS.toMillis(item.getDuration());
-        }
-        final long mediaRemainingMillis = Math.max(0L,
-                durationMillis - Math.max(0L, simpleExoPlayer.getCurrentPosition()));
-        return playbackTimeToWallClockMillis(mediaRemainingMillis);
-    }
-
-    private long playbackTimeToWallClockMillis(final long playbackTimeMillis) {
-        final float speed = Math.max(0.01f, getPlaybackSpeed());
-        return (long) (playbackTimeMillis / speed);
-    }
-
-    @Nullable
-    private PlayQueueItem currentQueueItem() {
-        return playQueue == null ? null : playQueue.getItem();
-    }
-
-    @Nullable
-    private PlayQueueItem lastQueueItem() {
-        return playQueue == null || playQueue.isEmpty()
-                ? null : playQueue.getItem(playQueue.size() - 1);
-    }
-
-    private int findQueueItemIndex(@Nullable final PlayQueueItem target) {
-        if (playQueue == null || target == null) {
-            return -1;
-        }
-        return playQueue.indexOf(target);
-    }
-
-    private static boolean isSameQueueItem(@Nullable final PlayQueueItem first,
-                                           @Nullable final PlayQueueItem second) {
-        return first != null && first == second;
+        return sleepTimerController.remainingMillis();
     }
 
     public boolean isSleepTimerActive() {
-        return sleepTimer.isActive();
+        return sleepTimerController.isActive();
     }
 
     @NonNull
     public SleepTimer.Mode getSleepTimerMode() {
-        return sleepTimer.getMode();
+        return sleepTimerController.getMode();
     }
 
     public boolean isSleepTimerFadeOutEnabled() {
-        return sleepTimer.isFadeOutEnabled();
+        return sleepTimerController.isFadeOutEnabled();
     }
     //endregion
 
@@ -1970,7 +1710,8 @@ public final class Player implements PlaybackListener, Listener {
             mediaUrlRecoveryGuard.reset();
         }
         if (discontinuityReason == DISCONTINUITY_REASON_AUTO_TRANSITION) {
-            maybeFinishSleepTimerAtEndOfItem(playQueue.getItem(oldPosition.mediaItemIndex), true);
+            sleepTimerController.onItemEnded(
+                    playQueue.getItem(oldPosition.mediaItemIndex), true);
         }
         switch (discontinuityReason) {
             case DISCONTINUITY_REASON_AUTO_TRANSITION:
@@ -2000,10 +1741,8 @@ public final class Player implements PlaybackListener, Listener {
                 break; // only makes Android Studio linter happy, as there are no ads
         }
 
-        if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT
-                && discontinuityReason != DISCONTINUITY_REASON_AUTO_TRANSITION) {
-            sleepTimerCurrentTarget = playQueue.getItem(newIndex);
-            notifySleepTimerUpdateToListeners();
+        if (discontinuityReason != DISCONTINUITY_REASON_AUTO_TRANSITION) {
+            sleepTimerController.onPositionDiscontinuity(playQueue.getItem(newIndex));
         }
     }
 
@@ -2440,7 +2179,7 @@ public final class Player implements PlaybackListener, Listener {
             saveStreamProgressState();
             playQueue.offsetIndex(-1);
         }
-        retargetEndOfCurrentSleepTimer();
+        sleepTimerController.onCurrentItemChanged();
         triggerProgressUpdate();
     }
 
@@ -2454,7 +2193,7 @@ public final class Player implements PlaybackListener, Listener {
 
         saveStreamProgressState();
         playQueue.offsetIndex(+1);
-        retargetEndOfCurrentSleepTimer();
+        sleepTimerController.onCurrentItemChanged();
         triggerProgressUpdate();
     }
 
@@ -2706,15 +2445,12 @@ public final class Player implements PlaybackListener, Listener {
             saveStreamProgressState();
         }
         playQueue.setIndex(index);
-        if (sleepTimer.getMode() == SleepTimer.Mode.END_OF_CURRENT) {
-            sleepTimerCurrentTarget = item;
-            notifySleepTimerUpdateToListeners();
-        }
+        sleepTimerController.onQueueItemSelected(item);
     }
 
     @Override
     public void onPlayQueueEdited() {
-        validateSleepTimerTargetsAfterQueueEdit();
+        sleepTimerController.onQueueEdited();
         notifyPlaybackUpdateToListeners();
         notifySleepTimerUpdateToListeners();
         UIs.call(PlayerUi::onPlayQueueEdited);
@@ -2970,10 +2706,10 @@ public final class Player implements PlaybackListener, Listener {
         }
     }
 
-    private void notifySleepTimerUpdateToListeners() {
-        final SleepTimer.Mode mode = sleepTimer.getMode();
+    void notifySleepTimerUpdateToListeners() {
+        final SleepTimer.Mode mode = sleepTimerController.getMode();
         final long remainingMillis = getSleepTimerRemainingMillis();
-        final boolean fadeOutEnabled = sleepTimer.isFadeOutEnabled();
+        final boolean fadeOutEnabled = sleepTimerController.isFadeOutEnabled();
         UIs.call(playerUi -> playerUi.onSleepTimerChanged(
                 mode, remainingMillis, fadeOutEnabled));
         if (fragmentListener != null) {

--- a/app/src/main/java/org/schabi/newpipe/player/SleepTimerPlaybackController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/SleepTimerPlaybackController.kt
@@ -164,20 +164,21 @@ internal class SleepTimerPlaybackController(private val player: Player) {
         }
     }
 
-    fun remainingMillis(): Long =
-        when (timer.mode) {
-            SleepTimer.Mode.DURATION -> timer.durationRemainingMillis
-            SleepTimer.Mode.END_OF_CURRENT -> {
-                if (currentQueueItem() === currentItemTarget) {
-                    currentItemRemainingMillis()
-                } else {
-                    SleepTimer.REMAINING_TIME_UNSET
-                }
-            }
+    fun remainingMillis(): Long = when (timer.mode) {
+        SleepTimer.Mode.DURATION -> timer.durationRemainingMillis
 
-            SleepTimer.Mode.END_OF_QUEUE -> queueTargetRemainingMillis()
-            SleepTimer.Mode.NONE -> SleepTimer.REMAINING_TIME_UNSET
+        SleepTimer.Mode.END_OF_CURRENT -> {
+            if (currentQueueItem() === currentItemTarget) {
+                currentItemRemainingMillis()
+            } else {
+                SleepTimer.REMAINING_TIME_UNSET
+            }
         }
+
+        SleepTimer.Mode.END_OF_QUEUE -> queueTargetRemainingMillis()
+
+        SleepTimer.Mode.NONE -> SleepTimer.REMAINING_TIME_UNSET
+    }
 
     private fun prepareStart() {
         resetState()
@@ -233,27 +234,27 @@ internal class SleepTimerPlaybackController(private val player: Player) {
         Toast.makeText(player.context, R.string.sleep_timer_finished, Toast.LENGTH_SHORT).show()
     }
 
-    private fun fadeOutRemainingMillis(): Long =
-        when (timer.mode) {
-            SleepTimer.Mode.DURATION -> timer.durationRemainingMillis
-            SleepTimer.Mode.END_OF_CURRENT -> {
-                if (currentQueueItem() === currentItemTarget) {
-                    currentItemRemainingMillis()
-                } else {
-                    SleepTimer.REMAINING_TIME_UNSET
-                }
-            }
+    private fun fadeOutRemainingMillis(): Long = when (timer.mode) {
+        SleepTimer.Mode.DURATION -> timer.durationRemainingMillis
 
-            SleepTimer.Mode.END_OF_QUEUE -> {
-                if (currentQueueItem() === queueTarget) {
-                    currentItemRemainingMillis()
-                } else {
-                    SleepTimer.REMAINING_TIME_UNSET
-                }
+        SleepTimer.Mode.END_OF_CURRENT -> {
+            if (currentQueueItem() === currentItemTarget) {
+                currentItemRemainingMillis()
+            } else {
+                SleepTimer.REMAINING_TIME_UNSET
             }
-
-            SleepTimer.Mode.NONE -> SleepTimer.REMAINING_TIME_UNSET
         }
+
+        SleepTimer.Mode.END_OF_QUEUE -> {
+            if (currentQueueItem() === queueTarget) {
+                currentItemRemainingMillis()
+            } else {
+                SleepTimer.REMAINING_TIME_UNSET
+            }
+        }
+
+        SleepTimer.Mode.NONE -> SleepTimer.REMAINING_TIME_UNSET
+    }
 
     private fun queueTargetRemainingMillis(): Long {
         val queue = player.playQueue ?: return SleepTimer.REMAINING_TIME_UNSET

--- a/app/src/main/java/org/schabi/newpipe/player/SleepTimerPlaybackController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/SleepTimerPlaybackController.kt
@@ -1,0 +1,327 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
+import androidx.media3.common.C
+import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+import org.schabi.newpipe.R
+import org.schabi.newpipe.player.helper.SleepTimer
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+
+/** Owns sleep-timer state, queue targets, fade-out volume, and lifecycle updates. */
+internal class SleepTimerPlaybackController(private val player: Player) {
+    private val timer = SleepTimer()
+    private val handler = Handler(Looper.getMainLooper())
+    private val tick = Runnable(::onTick)
+
+    private var currentItemTarget: PlayQueueItem? = null
+    private var queueTarget: PlayQueueItem? = null
+    private var queueTargetFollowsLoading = false
+
+    var volumeMultiplier = 1.0f
+        private set
+
+    val isActive: Boolean
+        get() = timer.isActive
+
+    val mode: SleepTimer.Mode
+        get() = timer.mode
+
+    val isFadeOutEnabled: Boolean
+        get() = timer.isFadeOutEnabled
+
+    fun startDuration(durationMillis: Long, fadeOut: Boolean) {
+        prepareStart()
+        timer.startDuration(durationMillis, fadeOut)
+        startUpdates()
+    }
+
+    fun startAtEndOfCurrent(fadeOut: Boolean): Boolean {
+        val item = currentQueueItem() ?: return false
+        prepareStart()
+        currentItemTarget = item
+        timer.startEndOfCurrent(fadeOut)
+        startUpdates()
+        return true
+    }
+
+    fun startAtEndOfQueue(fadeOut: Boolean): Boolean {
+        val queue = player.playQueue ?: return false
+        val item = lastQueueItem() ?: return false
+        prepareStart()
+        queueTarget = item
+        queueTargetFollowsLoading = !queue.isComplete
+        timer.startEndOfQueue(fadeOut)
+        startUpdates()
+        return true
+    }
+
+    fun cancel() {
+        if (!timer.isActive) {
+            return
+        }
+        resetState()
+        setVolumeMultiplier(1.0f)
+        player.notifySleepTimerUpdateToListeners()
+    }
+
+    fun clear() {
+        resetState()
+        setVolumeMultiplier(1.0f)
+    }
+
+    fun onQueueReplaced() {
+        when (timer.mode) {
+            SleepTimer.Mode.END_OF_CURRENT -> {
+                currentItemTarget = currentQueueItem()
+                if (currentItemTarget == null) {
+                    clear()
+                }
+            }
+
+            SleepTimer.Mode.END_OF_QUEUE -> {
+                val queue = player.playQueue
+                queueTarget = lastQueueItem()
+                queueTargetFollowsLoading = queue != null && !queue.isComplete
+                if (queueTarget == null) {
+                    clear()
+                }
+            }
+
+            else -> Unit
+        }
+    }
+
+    fun onShuffleModeChanged() {
+        if (timer.mode != SleepTimer.Mode.END_OF_QUEUE) {
+            return
+        }
+        val queue = player.playQueue ?: return
+        queueTarget = lastQueueItem()
+        queueTargetFollowsLoading = !queue.isComplete
+        player.notifySleepTimerUpdateToListeners()
+    }
+
+    fun onItemEnded(endedItem: PlayQueueItem?, pausePlayback: Boolean) {
+        if (endedItem == null || !timer.isActive) {
+            return
+        }
+        val targetReached =
+            timer.mode == SleepTimer.Mode.END_OF_CURRENT && endedItem === currentItemTarget ||
+                timer.mode == SleepTimer.Mode.END_OF_QUEUE && endedItem === queueTarget
+        if (targetReached) {
+            finish(pausePlayback)
+        }
+    }
+
+    fun onCurrentItemChanged() {
+        if (timer.mode == SleepTimer.Mode.END_OF_CURRENT) {
+            currentItemTarget = currentQueueItem()
+            player.notifySleepTimerUpdateToListeners()
+        }
+    }
+
+    fun onPositionDiscontinuity(item: PlayQueueItem?) {
+        if (timer.mode == SleepTimer.Mode.END_OF_CURRENT) {
+            currentItemTarget = item
+            player.notifySleepTimerUpdateToListeners()
+        }
+    }
+
+    fun onQueueItemSelected(item: PlayQueueItem) {
+        if (timer.mode == SleepTimer.Mode.END_OF_CURRENT) {
+            currentItemTarget = item
+            player.notifySleepTimerUpdateToListeners()
+        }
+    }
+
+    fun onQueueEdited() {
+        val queue = player.playQueue ?: return
+        if (
+            timer.mode == SleepTimer.Mode.END_OF_CURRENT &&
+            findQueueItemIndex(currentItemTarget) < 0
+        ) {
+            currentItemTarget = currentQueueItem()
+            if (currentItemTarget == null) {
+                clear()
+            }
+        } else if (
+            timer.mode == SleepTimer.Mode.END_OF_QUEUE &&
+            (queueTargetFollowsLoading || findQueueItemIndex(queueTarget) < 0)
+        ) {
+            queueTarget = lastQueueItem()
+            queueTargetFollowsLoading = !queue.isComplete
+            if (queueTarget == null) {
+                clear()
+            }
+        }
+    }
+
+    fun remainingMillis(): Long =
+        when (timer.mode) {
+            SleepTimer.Mode.DURATION -> timer.durationRemainingMillis
+            SleepTimer.Mode.END_OF_CURRENT -> {
+                if (currentQueueItem() === currentItemTarget) {
+                    currentItemRemainingMillis()
+                } else {
+                    SleepTimer.REMAINING_TIME_UNSET
+                }
+            }
+
+            SleepTimer.Mode.END_OF_QUEUE -> queueTargetRemainingMillis()
+            SleepTimer.Mode.NONE -> SleepTimer.REMAINING_TIME_UNSET
+        }
+
+    private fun prepareStart() {
+        resetState()
+        setVolumeMultiplier(1.0f)
+    }
+
+    private fun resetState() {
+        handler.removeCallbacks(tick)
+        timer.cancel()
+        currentItemTarget = null
+        queueTarget = null
+        queueTargetFollowsLoading = false
+    }
+
+    private fun startUpdates() {
+        handler.removeCallbacks(tick)
+        handler.post(tick)
+    }
+
+    private fun onTick() {
+        if (!timer.isActive) {
+            return
+        }
+        if (timer.hasDurationExpired()) {
+            finish(true)
+            return
+        }
+
+        setVolumeMultiplier(timer.getFadeOutVolumeMultiplier(fadeOutRemainingMillis()))
+        player.notifySleepTimerUpdateToListeners()
+        handler.postDelayed(tick, UPDATE_INTERVAL_MILLIS)
+    }
+
+    private fun setVolumeMultiplier(value: Float) {
+        val clampedValue = value.coerceIn(0.0f, 1.0f)
+        if (abs(volumeMultiplier - clampedValue) < VOLUME_CHANGE_EPSILON) {
+            return
+        }
+        volumeMultiplier = clampedValue
+        player.applyPlayerVolume()
+    }
+
+    private fun finish(pausePlayback: Boolean) {
+        if (!timer.isActive) {
+            return
+        }
+        resetState()
+        if (pausePlayback && !player.exoPlayerIsNull() && player.playWhenReady) {
+            player.pause()
+        }
+        setVolumeMultiplier(1.0f)
+        player.notifySleepTimerUpdateToListeners()
+        Toast.makeText(player.context, R.string.sleep_timer_finished, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun fadeOutRemainingMillis(): Long =
+        when (timer.mode) {
+            SleepTimer.Mode.DURATION -> timer.durationRemainingMillis
+            SleepTimer.Mode.END_OF_CURRENT -> {
+                if (currentQueueItem() === currentItemTarget) {
+                    currentItemRemainingMillis()
+                } else {
+                    SleepTimer.REMAINING_TIME_UNSET
+                }
+            }
+
+            SleepTimer.Mode.END_OF_QUEUE -> {
+                if (currentQueueItem() === queueTarget) {
+                    currentItemRemainingMillis()
+                } else {
+                    SleepTimer.REMAINING_TIME_UNSET
+                }
+            }
+
+            SleepTimer.Mode.NONE -> SleepTimer.REMAINING_TIME_UNSET
+        }
+
+    private fun queueTargetRemainingMillis(): Long {
+        val queue = player.playQueue ?: return SleepTimer.REMAINING_TIME_UNSET
+        if (player.exoPlayerIsNull()) {
+            return SleepTimer.REMAINING_TIME_UNSET
+        }
+        val currentIndex = queue.index
+        val targetIndex = findQueueItemIndex(queueTarget)
+        if (targetIndex < currentIndex || targetIndex < 0) {
+            return SleepTimer.REMAINING_TIME_UNSET
+        }
+
+        var remainingMillis = currentItemRemainingMillis()
+        if (remainingMillis == SleepTimer.REMAINING_TIME_UNSET) {
+            return SleepTimer.REMAINING_TIME_UNSET
+        }
+        for (index in currentIndex + 1..targetIndex) {
+            val item = queue.getItem(index)
+            if (item == null || item.duration <= 0L) {
+                return SleepTimer.REMAINING_TIME_UNSET
+            }
+            val itemDurationMillis = playbackTimeToWallClockMillis(
+                TimeUnit.SECONDS.toMillis(item.duration)
+            )
+            if (Long.MAX_VALUE - remainingMillis < itemDurationMillis) {
+                return SleepTimer.REMAINING_TIME_UNSET
+            }
+            remainingMillis += itemDurationMillis
+        }
+        return remainingMillis
+    }
+
+    private fun currentItemRemainingMillis(): Long {
+        if (player.exoPlayerIsNull()) {
+            return SleepTimer.REMAINING_TIME_UNSET
+        }
+        val exoPlayer = player.exoPlayer
+        var durationMillis = exoPlayer.duration
+        if (durationMillis == C.TIME_UNSET || durationMillis <= 0L) {
+            val item = currentQueueItem()
+            if (item == null || item.duration <= 0L) {
+                return SleepTimer.REMAINING_TIME_UNSET
+            }
+            durationMillis = TimeUnit.SECONDS.toMillis(item.duration)
+        }
+        val mediaRemainingMillis =
+            (durationMillis - exoPlayer.currentPosition.coerceAtLeast(0L)).coerceAtLeast(0L)
+        return playbackTimeToWallClockMillis(mediaRemainingMillis)
+    }
+
+    private fun playbackTimeToWallClockMillis(playbackTimeMillis: Long): Long {
+        return (playbackTimeMillis / player.playbackSpeed.coerceAtLeast(0.01f)).toLong()
+    }
+
+    private fun currentQueueItem(): PlayQueueItem? = player.playQueue?.item
+
+    private fun lastQueueItem(): PlayQueueItem? {
+        val queue = player.playQueue
+        return if (queue == null || queue.isEmpty) null else queue.getItem(queue.size() - 1)
+    }
+
+    private fun findQueueItemIndex(target: PlayQueueItem?): Int {
+        val queue = player.playQueue
+        return if (queue == null || target == null) -1 else queue.indexOf(target)
+    }
+
+    private companion object {
+        const val UPDATE_INTERVAL_MILLIS = 1_000L
+        const val VOLUME_CHANGE_EPSILON = 0.001f
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/helper/SleepTimerResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/SleepTimerResourcesTest.java
@@ -59,12 +59,15 @@ public class SleepTimerResourcesTest {
     public void playerHandlesDurationAndNaturalPlaybackEndpoints() throws Exception {
         final String player = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/player/Player.java"));
+        final String controller = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/SleepTimerPlaybackController.kt"));
 
-        assertTrue(player.contains("sleepTimer.hasDurationExpired()"));
+        assertTrue(player.contains("sleepTimerController.onItemEnded"));
         assertTrue(player.contains("DISCONTINUITY_REASON_AUTO_TRANSITION"));
-        assertTrue(player.contains("maybeFinishSleepTimerAtEndOfItem"));
-        assertTrue(player.contains("setSleepTimerVolumeMultiplier(1.0f)"));
-        assertTrue(player.contains("pause();"));
+        assertTrue(player.contains("sleepTimerController.startDuration"));
+        assertTrue(controller.contains("timer.hasDurationExpired()"));
+        assertTrue(controller.contains("setVolumeMultiplier(1.0f)"));
+        assertTrue(controller.contains("player.pause()"));
     }
 
     private Element findByAndroidId(final Document document, final String id) {


### PR DESCRIPTION
- Move sleep-timer mode, tick scheduling, fade-out volume, queue targets, and remaining-time calculation into a Kotlin controller
- Keep Player.java responsible for its public timer API and forwarding playback and queue lifecycle events
- Preserve duration, end-of-current, end-of-queue, shuffle, queue-edit, and natural-transition behavior
- Update structural regression coverage for the extracted controller
- Reduce Player.java from 3,308 to 3,044 lines