### PR TITLE
Move backup import validation off the UI thread

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -495,65 +495,78 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private void importDatabase(final StoredFileHelper file, final Uri importDataUri,
                                 final ImportExportManager.BackupContents contents,
                                 final boolean importSettings) {
-        final Context context = requireContext();
-        final SharedPreferences preferences = PreferenceManager
-                .getDefaultSharedPreferences(context);
-        final Map<String, ?> previousPreferences = new HashMap<>(preferences.getAll());
-        ImportExportManager.DatabaseRollback databaseRollback = null;
-        Path stagedDatabase = null;
+        final Activity activity = requireActivity();
+        final Context context = activity.getApplicationContext();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            final SharedPreferences preferences = PreferenceManager
+                    .getDefaultSharedPreferences(context);
+            final Map<String, ?> previousPreferences = new HashMap<>(preferences.getAll());
+            ImportExportManager.DatabaseRollback databaseRollback = null;
+            Path stagedDatabase = null;
 
-        try {
-            manager.ensureDbDirectoryExists();
-
-            final Map<String, ?> importedPreferences;
-            if (!importSettings) {
-                importedPreferences = null;
-            } else if (contents.getHasJsonPreferences()) {
-                importedPreferences = manager.readJsonPrefs(file);
-            } else {
-                importedPreferences = manager.readSerializedPrefs(file);
-            }
-
-            if (contents.getHasDatabase()) {
-                stagedDatabase = manager.stageDb(file);
-                if (stagedDatabase == null) {
-                    throw new IOException("The backup database could not be staged");
-                }
-                NewPipeDatabase.validateImportDatabase(
-                        context, stagedDatabase.getFileName().toString());
-                try {
-                    NewPipeDatabase.checkpoint();
-                } catch (final IllegalStateException ignored) {
-                    // The database has not been opened during this process.
-                }
-                NewPipeDatabase.close();
-                databaseRollback = manager.replaceDb(stagedDatabase);
-            }
-
-            if (importedPreferences != null) {
-                manager.replacePreferences(preferences, importedPreferences);
-                cleanImport(context, preferences);
-            }
-
-            if (databaseRollback != null) {
-                manager.finishDbReplacement(databaseRollback);
-            }
-            finishImport(importDataUri);
-        } catch (final Exception e) {
             try {
-                manager.replacePreferences(preferences, previousPreferences);
-                if (databaseRollback != null) {
-                    manager.rollbackDb(databaseRollback);
+                manager.ensureDbDirectoryExists();
+
+                final Map<String, ?> importedPreferences;
+                if (!importSettings) {
+                    importedPreferences = null;
+                } else if (contents.getHasJsonPreferences()) {
+                    importedPreferences = manager.readJsonPrefs(file);
+                } else {
+                    importedPreferences = manager.readSerializedPrefs(file);
                 }
-            } catch (final Exception rollbackError) {
-                e.addSuppressed(rollbackError);
+
+                if (contents.getHasDatabase()) {
+                    stagedDatabase = manager.stageDb(file);
+                    if (stagedDatabase == null) {
+                        throw new IOException("The backup database could not be staged");
+                    }
+                    NewPipeDatabase.validateImportDatabase(
+                            context, stagedDatabase.getFileName().toString());
+                    try {
+                        NewPipeDatabase.checkpoint();
+                    } catch (final IllegalStateException ignored) {
+                        // The database has not been opened during this process.
+                    }
+                    NewPipeDatabase.close();
+                    databaseRollback = manager.replaceDb(stagedDatabase);
+                }
+
+                if (importedPreferences != null) {
+                    manager.replacePreferences(preferences, importedPreferences);
+                    cleanImport(context, preferences);
+                }
+
+                if (databaseRollback != null) {
+                    manager.finishDbReplacement(databaseRollback);
+                }
+                activity.runOnUiThread(() -> {
+                    if (isAdded()) {
+                        finishImport(importDataUri);
+                    }
+                });
+            } catch (final Exception e) {
+                try {
+                    manager.replacePreferences(preferences, previousPreferences);
+                    if (databaseRollback != null) {
+                        manager.rollbackDb(databaseRollback);
+                    }
+                } catch (final Exception rollbackError) {
+                    e.addSuppressed(rollbackError);
+                }
+                activity.runOnUiThread(() -> {
+                    if (isAdded()) {
+                        showErrorSnackbar(e, "Importing database and settings");
+                    }
+                });
+            } finally {
+                if (stagedDatabase != null) {
+                    manager.discardStagedDb(stagedDatabase);
+                }
+                executor.shutdown();
             }
-            showErrorSnackbar(e, "Importing database and settings");
-        } finally {
-            if (stagedDatabase != null) {
-                manager.discardStagedDb(stagedDatabase);
-            }
-        }
+        });
     }
 
     /**

--- a/app/src/test/java/org/schabi/newpipe/settings/BackupRestoreImportThreadingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/settings/BackupRestoreImportThreadingTest.java
@@ -1,0 +1,45 @@
+package org.schabi.newpipe.settings;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class BackupRestoreImportThreadingTest {
+    @Test
+    public void databaseValidationRunsOffTheUiThread() throws IOException {
+        final String source = readMainSource();
+        final int methodStart = source.indexOf("private void importDatabase(");
+        final int methodEnd = source.indexOf("Remove settings that are not supposed", methodStart);
+        final String method = source.substring(methodStart, methodEnd);
+
+        final int execute = method.indexOf("executor.execute(() -> {");
+        final int validation = method.indexOf("NewPipeDatabase.validateImportDatabase(");
+
+        assertTrue(execute >= 0);
+        assertTrue(validation > execute);
+    }
+
+    @Test
+    public void importResultsReturnToTheUiThread() throws IOException {
+        final String source = readMainSource();
+        final int methodStart = source.indexOf("private void importDatabase(");
+        final int methodEnd = source.indexOf("Remove settings that are not supposed", methodStart);
+        final String method = source.substring(methodStart, methodEnd);
+
+        assertTrue(method.contains("activity.runOnUiThread(() -> {"));
+        assertTrue(method.contains("finishImport(importDataUri);"));
+        assertTrue(method.contains(
+                "showErrorSnackbar(e, \"Importing database and settings\");"));
+    }
+
+    private static String readMainSource() throws IOException {
+        final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+                ? Path.of("src/main/java") : Path.of("app/src/main/java");
+        return Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java"));
+    }
+}


### PR DESCRIPTION
- Run backup staging, Room validation, database replacement, preference migration, and rollback on a dedicated worker thread
- Return success and failure UI updates safely to the main thread
- Preserve database and preference rollback behavior when an import fails
- Add regression coverage requiring validation off the UI thread and UI-thread result delivery