### PR TITLE
Handle YouTube anti-bot access blocks

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
@@ -15,6 +15,7 @@ import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.ServiceList.YouTube
 import org.schabi.newpipe.extractor.exceptions.AccountTerminatedException
 import org.schabi.newpipe.extractor.exceptions.AgeRestrictedContentException
+import org.schabi.newpipe.extractor.exceptions.AntiBotException
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException
 import org.schabi.newpipe.extractor.exceptions.ExtractionException
@@ -249,7 +250,7 @@ class ErrorInfo private constructor(
                 throwable is YoutubeMusicPremiumContentException ->
                     ErrorMessage(R.string.youtube_music_premium_content)
 
-                isSignInBotCheckException(throwable) ->
+                throwable is AntiBotException || isSignInBotCheckException(throwable) ->
                     ErrorMessage(
                         R.string.sign_in_confirm_not_bot_error,
                         getServiceName(serviceId),
@@ -319,8 +320,8 @@ class ErrorInfo private constructor(
                 // we know the content is not supported, no need to let the user report it
                 is ContentNotSupportedException -> false
 
-                // Temporary anti-bot blocks are service/network conditions, not app defects.
-                is ServiceTemporaryBlockedException -> false
+                // Anti-bot blocks are service/network conditions, not app defects.
+                is AntiBotException -> false
 
                 // happens often when there is no internet connection; we don't use
                 // `throwable.isNetworkRelated` since any `IOException` would make that function

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorInfo.kt
@@ -250,17 +250,17 @@ class ErrorInfo private constructor(
                 throwable is YoutubeMusicPremiumContentException ->
                     ErrorMessage(R.string.youtube_music_premium_content)
 
+                throwable is ServiceTemporaryBlockedException ->
+                    ErrorMessage(
+                        R.string.service_temporary_block,
+                        getServiceName(serviceId)
+                    )
+
                 throwable is AntiBotException || isSignInBotCheckException(throwable) ->
                     ErrorMessage(
                         R.string.sign_in_confirm_not_bot_error,
                         getServiceName(serviceId),
                         YOUTUBE_IP_BAN_FAQ_URL
-                    )
-
-                throwable is ServiceTemporaryBlockedException ->
-                    ErrorMessage(
-                        R.string.service_temporary_block,
-                        getServiceName(serviceId)
                     )
 
                 throwable is ContentNotAvailableException ->

--- a/app/src/test/java/org/schabi/newpipe/error/AntiBotErrorInfoTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/error/AntiBotErrorInfoTest.kt
@@ -1,0 +1,22 @@
+package org.schabi.newpipe.error
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.exceptions.AntiBotException
+
+class AntiBotErrorInfoTest {
+    @Test
+    fun antiBotBlocksAreActionableButNotReportable() {
+        val error = ErrorInfo(
+            AntiBotException("Sign in to confirm you're not a bot"),
+            UserAction.REQUESTED_STREAM,
+            "https://www.youtube.com/watch?v=test",
+            ServiceList.YouTube.serviceId
+        )
+
+        assertFalse(error.isReportable)
+        assertTrue(error.isRetryable)
+    }
+}


### PR DESCRIPTION
- Classify extractor `AntiBotException` failures as temporary YouTube access blocks instead of generic parsing errors
- Reuse the existing actionable sign-in confirmation message and FAQ guidance
- Keep retry available while suppressing misleading bug-report actions for service-side blocks
- Add regression coverage for anti-bot reportability and retry behavior