### PR TITLE
Extract player event dispatcher

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -281,10 +281,8 @@ public final class Player implements PlaybackListener, Listener {
 
     private BroadcastReceiver broadcastReceiver;
     private IntentFilter intentFilter;
-    @Nullable
-    private PlayerServiceEventListener fragmentListener = null;
-    @Nullable
-    private PlayerEventListener activityListener = null;
+    @NonNull
+    private final PlayerEventDispatcher eventDispatcher;
 
     @NonNull
     private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
@@ -333,6 +331,7 @@ public final class Player implements PlaybackListener, Listener {
         sponsorBlockController = new SponsorBlockPlaybackController(this);
         playbackParametersController = new PlaybackParametersController(this);
         sleepTimerController = new SleepTimerPlaybackController(this);
+        eventDispatcher = new PlayerEventDispatcher(this);
 
         setupBroadcastReceiver();
 
@@ -1777,9 +1776,7 @@ public final class Player implements PlaybackListener, Listener {
             createErrorNotification(error);
         }
 
-        if (fragmentListener != null) {
-            fragmentListener.onPlayerError(error, isCatchableException);
-        }
+        eventDispatcher.notifyPlayerError(error, isCatchableException);
     }
 
 
@@ -1809,9 +1806,7 @@ public final class Player implements PlaybackListener, Listener {
             createErrorNotification(error, "recovery=exhausted, attempts="
                     + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS + "/"
                     + PlayerHttpErrorRecovery.RecoveryGuard.MAX_ATTEMPTS);
-            if (fragmentListener != null) {
-                fragmentListener.onPlayerError(error, true);
-            }
+            eventDispatcher.notifyPlayerError(error, true);
             return true;
         }
 
@@ -2530,119 +2525,49 @@ public final class Player implements PlaybackListener, Listener {
     //region Activity / fragment binding
 
     public void setFragmentListener(final PlayerServiceEventListener listener) {
-        fragmentListener = listener;
-        UIs.call(PlayerUi::onFragmentListenerSet);
-        notifyQueueUpdateToListeners();
-        notifyMetadataUpdateToListeners();
-        notifyPlaybackUpdateToListeners();
-        notifySleepTimerUpdateToListeners();
-        triggerProgressUpdate();
+        eventDispatcher.setFragmentListener(listener);
     }
 
     public void removeFragmentListener(final PlayerServiceEventListener listener) {
-        if (fragmentListener == listener) {
-            fragmentListener = null;
-        }
+        eventDispatcher.removeFragmentListener(listener);
     }
 
     void setActivityListener(final PlayerEventListener listener) {
-        activityListener = listener;
-        // TODO why not queue update?
-        notifyMetadataUpdateToListeners();
-        notifyPlaybackUpdateToListeners();
-        notifySleepTimerUpdateToListeners();
-        triggerProgressUpdate();
+        eventDispatcher.setActivityListener(listener);
     }
 
     void removeActivityListener(final PlayerEventListener listener) {
-        if (activityListener == listener) {
-            activityListener = null;
-        }
+        eventDispatcher.removeActivityListener(listener);
     }
 
     void stopActivityBinding() {
-        if (fragmentListener != null) {
-            fragmentListener.onServiceStopped();
-            fragmentListener = null;
-        }
-        if (activityListener != null) {
-            activityListener.onServiceStopped();
-            activityListener = null;
-        }
+        eventDispatcher.stopBindings();
     }
 
     private void notifyQueueUpdateToListeners() {
-        if (fragmentListener != null && playQueue != null) {
-            fragmentListener.onQueueUpdate(playQueue);
-        }
-        if (activityListener != null && playQueue != null) {
-            activityListener.onQueueUpdate(playQueue);
-        }
+        eventDispatcher.notifyQueueUpdate();
     }
 
     private void notifyMetadataUpdateToListeners() {
-        final Optional<StreamInfo> streamInfo = getCurrentStreamInfo();
-        streamInfo.ifPresent(info -> {
-            if (fragmentListener != null) {
-                fragmentListener.onMetadataUpdate(info, playQueue);
-            }
-            if (activityListener != null) {
-                activityListener.onMetadataUpdate(info, playQueue);
-            }
-        });
-        if (streamInfo.isEmpty() && currentMetadata != null && playQueue != null) {
-            if (fragmentListener != null) {
-                fragmentListener.onMetadataUpdate(currentMetadata, playQueue);
-            }
-            if (activityListener != null) {
-                activityListener.onMetadataUpdate(currentMetadata, playQueue);
-            }
-        }
+        eventDispatcher.notifyMetadataUpdate();
     }
 
     void notifyPlaybackUpdateToListeners() {
-        if (fragmentListener != null && !exoPlayerIsNull() && playQueue != null) {
-            fragmentListener.onPlaybackUpdate(currentState, getRepeatMode(),
-                    playQueue.isShuffled(), simpleExoPlayer.getPlaybackParameters());
-        }
-        if (activityListener != null && !exoPlayerIsNull() && playQueue != null) {
-            activityListener.onPlaybackUpdate(currentState, getRepeatMode(),
-                    playQueue.isShuffled(), getPlaybackParameters());
-        }
+        eventDispatcher.notifyPlaybackUpdate();
     }
 
     private void notifyProgressUpdateToListeners(final int currentProgress,
                                                  final int duration,
                                                  final int bufferPercent) {
-        if (fragmentListener != null) {
-            fragmentListener.onProgressUpdate(currentProgress, duration, bufferPercent);
-        }
-        if (activityListener != null) {
-            activityListener.onProgressUpdate(currentProgress, duration, bufferPercent);
-        }
+        eventDispatcher.notifyProgressUpdate(currentProgress, duration, bufferPercent);
     }
 
     private void notifyAudioTrackUpdateToListeners() {
-        if (fragmentListener != null) {
-            fragmentListener.onAudioTrackUpdate();
-        }
-        if (activityListener != null) {
-            activityListener.onAudioTrackUpdate();
-        }
+        eventDispatcher.notifyAudioTrackUpdate();
     }
 
     void notifySleepTimerUpdateToListeners() {
-        final SleepTimer.Mode mode = sleepTimerController.getMode();
-        final long remainingMillis = getSleepTimerRemainingMillis();
-        final boolean fadeOutEnabled = sleepTimerController.isFadeOutEnabled();
-        UIs.call(playerUi -> playerUi.onSleepTimerChanged(
-                mode, remainingMillis, fadeOutEnabled));
-        if (fragmentListener != null) {
-            fragmentListener.onSleepTimerChanged(mode, remainingMillis, fadeOutEnabled);
-        }
-        if (activityListener != null) {
-            activityListener.onSleepTimerChanged(mode, remainingMillis, fadeOutEnabled);
-        }
+        eventDispatcher.notifySleepTimerUpdate();
     }
 
     public void useVideoAndSubtitles(final boolean videoAndSubtitlesEnabled) {
@@ -2920,7 +2845,7 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     public Optional<PlayerServiceEventListener> getFragmentListener() {
-        return Optional.ofNullable(fragmentListener);
+        return eventDispatcher.getFragmentListener();
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerEventDispatcher.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerEventDispatcher.kt
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import androidx.media3.common.PlaybackException
+import java.util.Optional
+import org.schabi.newpipe.player.event.PlayerEventListener
+import org.schabi.newpipe.player.event.PlayerServiceEventListener
+import org.schabi.newpipe.player.ui.PlayerUi
+
+/** Owns activity and fragment listener bindings and dispatches player state updates. */
+internal class PlayerEventDispatcher(private val player: Player) {
+    private var fragmentListener: PlayerServiceEventListener? = null
+    private var activityListener: PlayerEventListener? = null
+
+    fun setFragmentListener(listener: PlayerServiceEventListener) {
+        fragmentListener = listener
+        player.UIs().call(PlayerUi::onFragmentListenerSet)
+        notifyQueueUpdate()
+        notifyMetadataUpdate()
+        notifyPlaybackUpdate()
+        notifySleepTimerUpdate()
+        player.triggerProgressUpdate()
+    }
+
+    fun removeFragmentListener(listener: PlayerServiceEventListener) {
+        if (fragmentListener === listener) {
+            fragmentListener = null
+        }
+    }
+
+    fun setActivityListener(listener: PlayerEventListener) {
+        activityListener = listener
+        notifyMetadataUpdate()
+        notifyPlaybackUpdate()
+        notifySleepTimerUpdate()
+        player.triggerProgressUpdate()
+    }
+
+    fun removeActivityListener(listener: PlayerEventListener) {
+        if (activityListener === listener) {
+            activityListener = null
+        }
+    }
+
+    fun stopBindings() {
+        fragmentListener?.onServiceStopped()
+        fragmentListener = null
+        activityListener?.onServiceStopped()
+        activityListener = null
+    }
+
+    fun notifyQueueUpdate() {
+        val queue = player.playQueue ?: return
+        fragmentListener?.onQueueUpdate(queue)
+        activityListener?.onQueueUpdate(queue)
+    }
+
+    fun notifyMetadataUpdate() {
+        val streamInfo = player.currentStreamInfo
+        streamInfo.ifPresent { info ->
+            fragmentListener?.onMetadataUpdate(info, player.playQueue)
+            activityListener?.onMetadataUpdate(info, player.playQueue)
+        }
+
+        val metadata = player.currentMetadata
+        val queue = player.playQueue
+        if (streamInfo.isEmpty && metadata != null && queue != null) {
+            fragmentListener?.onMetadataUpdate(metadata, queue)
+            activityListener?.onMetadataUpdate(metadata, queue)
+        }
+    }
+
+    fun notifyPlaybackUpdate() {
+        val queue = player.playQueue
+        if (player.exoPlayerIsNull() || queue == null) {
+            return
+        }
+        val parameters = player.exoPlayer.playbackParameters
+        fragmentListener?.onPlaybackUpdate(
+            player.currentState,
+            player.repeatMode,
+            queue.isShuffled,
+            parameters
+        )
+        activityListener?.onPlaybackUpdate(
+            player.currentState,
+            player.repeatMode,
+            queue.isShuffled,
+            parameters
+        )
+    }
+
+    fun notifyProgressUpdate(currentProgress: Int, duration: Int, bufferPercent: Int) {
+        fragmentListener?.onProgressUpdate(currentProgress, duration, bufferPercent)
+        activityListener?.onProgressUpdate(currentProgress, duration, bufferPercent)
+    }
+
+    fun notifyAudioTrackUpdate() {
+        fragmentListener?.onAudioTrackUpdate()
+        activityListener?.onAudioTrackUpdate()
+    }
+
+    fun notifySleepTimerUpdate() {
+        val mode = player.sleepTimerMode
+        val remainingMillis = player.sleepTimerRemainingMillis
+        val fadeOutEnabled = player.isSleepTimerFadeOutEnabled
+        player.UIs().call { ui ->
+            ui.onSleepTimerChanged(mode, remainingMillis, fadeOutEnabled)
+        }
+        fragmentListener?.onSleepTimerChanged(mode, remainingMillis, fadeOutEnabled)
+        activityListener?.onSleepTimerChanged(mode, remainingMillis, fadeOutEnabled)
+    }
+
+    fun notifyPlayerError(error: PlaybackException, isCatchable: Boolean) {
+        fragmentListener?.onPlayerError(error, isCatchable)
+    }
+
+    fun getFragmentListener(): Optional<PlayerServiceEventListener> {
+        return Optional.ofNullable(fragmentListener)
+    }
+}


### PR DESCRIPTION
- Move fragment and activity listener ownership into a Kotlin event dispatcher
- Centralize queue, metadata, playback, progress, audio-track, sleep-timer, error, and service-stop delivery
- Preserve the existing Player listener API and PlayerUi notification order
- Keep compatibility delegates for the previously extracted audio and sleep-timer controllers
- Reduce Player.java from 2,969 to 2,894 lines