### PR TITLE
Extract player broadcast controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -76,7 +76,6 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
-import org.schabi.newpipe.fragments.detail.VideoDetailFragment;
 import org.schabi.newpipe.learning.LearningSessionTracker;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.local.media.LocalMediaMetadataLoader;

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -31,26 +31,14 @@ import static androidx.media3.common.Player.RepeatMode;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_NEXT;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PREVIOUS;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_RECREATE_NOTIFICATION;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT;
-import static org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE;
 import static org.schabi.newpipe.util.ListHelper.getPopupResolutionIndex;
 import static org.schabi.newpipe.util.ListHelper.getResolutionIndex;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
-import android.media.AudioManager;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -58,7 +46,6 @@ import android.view.LayoutInflater;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.IntentCompat;
 import androidx.core.math.MathUtils;
 import androidx.preference.PreferenceManager;
@@ -267,8 +254,8 @@ public final class Player implements PlaybackListener, Listener {
     @SuppressWarnings({"MemberName", "java:S116"}) // keep the unusual member name
     private final PlayerUiList UIs;
 
-    private BroadcastReceiver broadcastReceiver;
-    private IntentFilter intentFilter;
+    @NonNull
+    private final PlayerBroadcastController broadcastController;
     @NonNull
     private final PlayerEventDispatcher eventDispatcher;
     @NonNull
@@ -296,8 +283,6 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final PlayerDataSource dataSource;
 
-    private boolean screenOn = true;
-
     /*//////////////////////////////////////////////////////////////////////////
     // Constructor
     //////////////////////////////////////////////////////////////////////////*/
@@ -323,8 +308,7 @@ public final class Player implements PlaybackListener, Listener {
         sleepTimerController = new SleepTimerPlaybackController(this);
         eventDispatcher = new PlayerEventDispatcher(this);
         thumbnailController = new PlayerThumbnailController(this);
-
-        setupBroadcastReceiver();
+        broadcastController = new PlayerBroadcastController(this);
 
         trackSelector = new DefaultTrackSelector(context, PlayerHelper.getQualitySelector());
         dataSource = new PlayerDataSource(context,
@@ -701,7 +685,7 @@ public final class Player implements PlaybackListener, Listener {
 
         audioReactor = new AudioReactor(context, simpleExoPlayer);
 
-        registerBroadcastReceiver();
+        broadcastController.register();
 
         // Setup UIs
         UIs.call(PlayerUi::initPlayer);
@@ -759,7 +743,7 @@ public final class Player implements PlaybackListener, Listener {
         stopActivityBinding();
 
         destroyPlayer();
-        unregisterBroadcastReceiver();
+        broadcastController.unregister();
 
         databaseUpdateDisposable.clear();
         progressUpdateDisposable.set(null);
@@ -816,123 +800,6 @@ public final class Player implements PlaybackListener, Listener {
         simpleExoPlayer.stop();
         setRecovery();
         UIs.call(PlayerUi::smoothStopForImmediateReusing);
-    }
-    //endregion
-
-
-
-    /*//////////////////////////////////////////////////////////////////////////
-    // Broadcast receiver
-    //////////////////////////////////////////////////////////////////////////*/
-    //region Broadcast receiver
-
-    /**
-     * This function prepares the broadcast receiver and is called only in the constructor.
-     * Therefore if you want any PlayerUi to receive a broadcast action, you should add it here,
-     * even if that player ui might never be added to the player. In that case the received
-     * broadcast would not do anything.
-     */
-    private void setupBroadcastReceiver() {
-        if (DEBUG) {
-            Log.d(TAG, "setupBroadcastReceiver() called");
-        }
-
-        broadcastReceiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(final Context ctx, final Intent intent) {
-                onBroadcastReceived(intent);
-            }
-        };
-        intentFilter = new IntentFilter();
-
-        intentFilter.addAction(AudioManager.ACTION_AUDIO_BECOMING_NOISY);
-
-        intentFilter.addAction(ACTION_CLOSE);
-        intentFilter.addAction(ACTION_PLAY_PAUSE);
-        intentFilter.addAction(ACTION_PLAY_PREVIOUS);
-        intentFilter.addAction(ACTION_PLAY_NEXT);
-        intentFilter.addAction(ACTION_FAST_REWIND);
-        intentFilter.addAction(ACTION_FAST_FORWARD);
-        intentFilter.addAction(ACTION_REPEAT);
-        intentFilter.addAction(ACTION_SHUFFLE);
-        intentFilter.addAction(ACTION_RECREATE_NOTIFICATION);
-
-        intentFilter.addAction(VideoDetailFragment.ACTION_VIDEO_FRAGMENT_RESUMED);
-        intentFilter.addAction(VideoDetailFragment.ACTION_VIDEO_FRAGMENT_STOPPED);
-
-        intentFilter.addAction(Intent.ACTION_CONFIGURATION_CHANGED);
-        intentFilter.addAction(Intent.ACTION_SCREEN_ON);
-        intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
-        intentFilter.addAction(Intent.ACTION_HEADSET_PLUG);
-    }
-
-    private void onBroadcastReceived(final Intent intent) {
-        if (intent == null || intent.getAction() == null) {
-            return;
-        }
-
-        if (DEBUG) {
-            Log.d(TAG, "onBroadcastReceived() called with: intent = [" + intent + "]");
-        }
-
-        switch (intent.getAction()) {
-            case AudioManager.ACTION_AUDIO_BECOMING_NOISY:
-                pause();
-                break;
-            case ACTION_CLOSE:
-                service.destroyPlayerAndStopService();
-                break;
-            case ACTION_PLAY_PAUSE:
-                playPause();
-                break;
-            case ACTION_PLAY_PREVIOUS:
-                playPrevious();
-                break;
-            case ACTION_PLAY_NEXT:
-                playNext();
-                break;
-            case ACTION_FAST_REWIND:
-                fastRewind();
-                break;
-            case ACTION_FAST_FORWARD:
-                fastForward();
-                break;
-            case ACTION_REPEAT:
-                cycleNextRepeatMode();
-                break;
-            case ACTION_SHUFFLE:
-                toggleShuffleModeEnabled();
-                break;
-            case Intent.ACTION_SCREEN_OFF:
-                screenOn = false;
-                break;
-            case Intent.ACTION_SCREEN_ON:
-                screenOn = true;
-                break;
-            case Intent.ACTION_CONFIGURATION_CHANGED:
-                if (DEBUG) {
-                    Log.d(TAG, "ACTION_CONFIGURATION_CHANGED received");
-                }
-                break;
-        }
-
-        UIs.call(playerUi -> playerUi.onBroadcastReceived(intent));
-    }
-
-    private void registerBroadcastReceiver() {
-        // Try to unregister current first
-        unregisterBroadcastReceiver();
-        ContextCompat.registerReceiver(context, broadcastReceiver, intentFilter,
-                ContextCompat.RECEIVER_EXPORTED);
-    }
-
-    private void unregisterBroadcastReceiver() {
-        try {
-            context.unregisterReceiver(broadcastReceiver);
-        } catch (final IllegalArgumentException unregisteredException) {
-            Log.w(TAG, "Broadcast receiver already unregistered: "
-                    + unregisteredException.getMessage());
-        }
     }
     //endregion
 
@@ -2792,6 +2659,6 @@ public final class Player implements PlaybackListener, Listener {
      * @return whether the device screen is turned on.
      */
     public boolean isScreenOn() {
-        return screenOn;
+        return broadcastController.isScreenOn();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerBroadcastController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerBroadcastController.kt
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioManager
+import android.util.Log
+import androidx.core.content.ContextCompat
+import org.schabi.newpipe.fragments.detail.VideoDetailFragment
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_CLOSE
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_FORWARD
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_FAST_REWIND
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_NEXT
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PAUSE
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_PLAY_PREVIOUS
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_RECREATE_NOTIFICATION
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_REPEAT
+import org.schabi.newpipe.player.notification.NotificationConstants.ACTION_SHUFFLE
+
+/** Owns player broadcast registration, lifecycle, and notification action routing. */
+internal class PlayerBroadcastController(private val player: Player) {
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            handle(intent)
+        }
+    }
+
+    private val intentFilter = IntentFilter().apply {
+        addAction(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+        addAction(ACTION_CLOSE)
+        addAction(ACTION_PLAY_PAUSE)
+        addAction(ACTION_PLAY_PREVIOUS)
+        addAction(ACTION_PLAY_NEXT)
+        addAction(ACTION_FAST_REWIND)
+        addAction(ACTION_FAST_FORWARD)
+        addAction(ACTION_REPEAT)
+        addAction(ACTION_SHUFFLE)
+        addAction(ACTION_RECREATE_NOTIFICATION)
+        addAction(VideoDetailFragment.ACTION_VIDEO_FRAGMENT_RESUMED)
+        addAction(VideoDetailFragment.ACTION_VIDEO_FRAGMENT_STOPPED)
+        addAction(Intent.ACTION_CONFIGURATION_CHANGED)
+        addAction(Intent.ACTION_SCREEN_ON)
+        addAction(Intent.ACTION_SCREEN_OFF)
+        addAction(Intent.ACTION_HEADSET_PLUG)
+    }
+
+    var isScreenOn = true
+        private set
+
+    fun register() {
+        unregister()
+        ContextCompat.registerReceiver(
+            player.context,
+            receiver,
+            intentFilter,
+            ContextCompat.RECEIVER_EXPORTED
+        )
+    }
+
+    fun unregister() {
+        try {
+            player.context.unregisterReceiver(receiver)
+        } catch (unregisteredException: IllegalArgumentException) {
+            Log.w(
+                Player.TAG,
+                "Broadcast receiver already unregistered: ${unregisteredException.message}"
+            )
+        }
+    }
+
+    private fun handle(intent: Intent?) {
+        val action = intent?.action ?: return
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "onBroadcastReceived() called with: intent = [$intent]")
+        }
+
+        when (action) {
+            AudioManager.ACTION_AUDIO_BECOMING_NOISY -> player.pause()
+            ACTION_CLOSE -> player.service.destroyPlayerAndStopService()
+            ACTION_PLAY_PAUSE -> player.playPause()
+            ACTION_PLAY_PREVIOUS -> player.playPrevious()
+            ACTION_PLAY_NEXT -> player.playNext()
+            ACTION_FAST_REWIND -> player.fastRewind()
+            ACTION_FAST_FORWARD -> player.fastForward()
+            ACTION_REPEAT -> player.cycleNextRepeatMode()
+            ACTION_SHUFFLE -> player.toggleShuffleModeEnabled()
+            Intent.ACTION_SCREEN_OFF -> isScreenOn = false
+            Intent.ACTION_SCREEN_ON -> isScreenOn = true
+            Intent.ACTION_CONFIGURATION_CHANGED -> if (Player.DEBUG) {
+                Log.d(Player.TAG, "ACTION_CONFIGURATION_CHANGED received")
+            }
+        }
+
+        player.UIs().call { ui -> ui.onBroadcastReceived(intent) }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerBroadcastController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerBroadcastController.kt
@@ -92,11 +92,15 @@ internal class PlayerBroadcastController(private val player: Player) {
             ACTION_SHUFFLE -> player.toggleShuffleModeEnabled()
             Intent.ACTION_SCREEN_OFF -> isScreenOn = false
             Intent.ACTION_SCREEN_ON -> isScreenOn = true
-            Intent.ACTION_CONFIGURATION_CHANGED -> if (Player.DEBUG) {
-                Log.d(Player.TAG, "ACTION_CONFIGURATION_CHANGED received")
-            }
+            Intent.ACTION_CONFIGURATION_CHANGED -> logConfigurationChanged()
         }
 
         player.UIs().call { ui -> ui.onBroadcastReceived(intent) }
+    }
+
+    private fun logConfigurationChanged() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "ACTION_CONFIGURATION_CHANGED received")
+        }
     }
 }


### PR DESCRIPTION
- Move broadcast receiver construction, registration, and teardown into a Kotlin controller
- Centralize notification, headset, configuration, and screen-state action routing
- Preserve forwarding of every registered broadcast to active player UIs
- Keep the existing Player screen-state getter unchanged
- Reduce Player.java from 2,797 to 2,664 lines