### PR TITLE
Extract player queue mode controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -24,7 +24,6 @@ import static androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT
 import static androidx.media3.common.Player.DISCONTINUITY_REASON_SKIP;
 import static androidx.media3.common.Player.DiscontinuityReason;
 import static androidx.media3.common.Player.Listener;
-import static androidx.media3.common.Player.REPEAT_MODE_ALL;
 import static androidx.media3.common.Player.REPEAT_MODE_OFF;
 import static androidx.media3.common.Player.REPEAT_MODE_ONE;
 import static androidx.media3.common.Player.RepeatMode;
@@ -239,6 +238,8 @@ public final class Player implements PlaybackListener, Listener {
 
     @NonNull
     private final SleepTimerPlaybackController sleepTimerController;
+    @NonNull
+    private final PlayerQueueModeController queueModeController;
     // audio only mode does not mean that player type is background, but that the player was
     // minimized to background but will resume automatically to the original player type
     private boolean isAudioOnly = false;
@@ -305,6 +306,7 @@ public final class Player implements PlaybackListener, Listener {
         sponsorBlockController = new SponsorBlockPlaybackController(this);
         playbackParametersController = new PlaybackParametersController(this);
         sleepTimerController = new SleepTimerPlaybackController(this);
+        queueModeController = new PlayerQueueModeController(this, sleepTimerController);
         eventDispatcher = new PlayerEventDispatcher(this);
         thumbnailController = new PlayerThumbnailController(this);
         broadcastController = new PlayerBroadcastController(this);
@@ -1136,62 +1138,25 @@ public final class Player implements PlaybackListener, Listener {
 
     @RepeatMode
     public int getRepeatMode() {
-        return exoPlayerIsNull() ? REPEAT_MODE_OFF : simpleExoPlayer.getRepeatMode();
+        return queueModeController.getRepeatMode();
     }
 
     public void cycleNextRepeatMode() {
-        if (!exoPlayerIsNull()) {
-            @RepeatMode final int repeatMode;
-            switch (simpleExoPlayer.getRepeatMode()) {
-                case REPEAT_MODE_OFF:
-                    repeatMode = REPEAT_MODE_ONE;
-                    break;
-                case REPEAT_MODE_ONE:
-                    repeatMode = REPEAT_MODE_ALL;
-                    break;
-                case REPEAT_MODE_ALL:
-                default:
-                    repeatMode = REPEAT_MODE_OFF;
-                    break;
-            }
-            simpleExoPlayer.setRepeatMode(repeatMode);
-        }
+        queueModeController.cycleNextRepeatMode();
     }
 
     @Override
     public void onRepeatModeChanged(@RepeatMode final int repeatMode) {
-        if (DEBUG) {
-            Log.d(TAG, "ExoPlayer - onRepeatModeChanged() called with: "
-                    + "repeatMode = [" + repeatMode + "]");
-        }
-        UIs.call(playerUi -> playerUi.onRepeatModeChanged(repeatMode));
-        notifyPlaybackUpdateToListeners();
+        queueModeController.onRepeatModeChanged(repeatMode);
     }
 
     @Override
     public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
-        if (DEBUG) {
-            Log.d(TAG, "ExoPlayer - onShuffleModeEnabledChanged() called with: "
-                    + "mode = [" + shuffleModeEnabled + "]");
-        }
-
-        if (playQueue != null) {
-            if (shuffleModeEnabled && !playQueue.isShuffled()) {
-                playQueue.shuffle();
-            } else if (!shuffleModeEnabled && playQueue.isShuffled()) {
-                playQueue.unshuffle();
-            }
-            sleepTimerController.onShuffleModeChanged();
-        }
-
-        UIs.call(playerUi -> playerUi.onShuffleModeEnabledChanged(shuffleModeEnabled));
-        notifyPlaybackUpdateToListeners();
+        queueModeController.onShuffleModeEnabledChanged(shuffleModeEnabled);
     }
 
     public void toggleShuffleModeEnabled() {
-        if (!exoPlayerIsNull()) {
-            simpleExoPlayer.setShuffleModeEnabled(!simpleExoPlayer.getShuffleModeEnabled());
-        }
+        queueModeController.toggleShuffleModeEnabled();
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerQueueModeController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerQueueModeController.kt
@@ -17,8 +17,11 @@ internal class PlayerQueueModeController(
     private val sleepTimerController: SleepTimerPlaybackController
 ) {
     @RepeatMode
-    fun getRepeatMode(): Int =
-        if (player.exoPlayerIsNull()) REPEAT_MODE_OFF else player.exoPlayer.repeatMode
+    fun getRepeatMode(): Int = if (player.exoPlayerIsNull()) {
+        REPEAT_MODE_OFF
+    } else {
+        player.exoPlayer.repeatMode
+    }
 
     fun cycleNextRepeatMode() {
         if (player.exoPlayerIsNull()) {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerQueueModeController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerQueueModeController.kt
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+import androidx.media3.common.Player.REPEAT_MODE_ALL
+import androidx.media3.common.Player.REPEAT_MODE_OFF
+import androidx.media3.common.Player.REPEAT_MODE_ONE
+import androidx.media3.common.Player.RepeatMode
+
+/** Owns repeat and shuffle commands and synchronizes queue-mode changes with player surfaces. */
+internal class PlayerQueueModeController(
+    private val player: Player,
+    private val sleepTimerController: SleepTimerPlaybackController
+) {
+    @RepeatMode
+    fun getRepeatMode(): Int =
+        if (player.exoPlayerIsNull()) REPEAT_MODE_OFF else player.exoPlayer.repeatMode
+
+    fun cycleNextRepeatMode() {
+        if (player.exoPlayerIsNull()) {
+            return
+        }
+        val repeatMode = when (player.exoPlayer.repeatMode) {
+            REPEAT_MODE_OFF -> REPEAT_MODE_ONE
+            REPEAT_MODE_ONE -> REPEAT_MODE_ALL
+            else -> REPEAT_MODE_OFF
+        }
+        player.exoPlayer.repeatMode = repeatMode
+    }
+
+    fun onRepeatModeChanged(@RepeatMode repeatMode: Int) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "ExoPlayer - onRepeatModeChanged() called with: repeatMode = [$repeatMode]"
+            )
+        }
+        player.UIs().call { ui -> ui.onRepeatModeChanged(repeatMode) }
+        player.notifyPlaybackUpdateToListeners()
+    }
+
+    fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "ExoPlayer - onShuffleModeEnabledChanged() called with: mode = " +
+                    "[$shuffleModeEnabled]"
+            )
+        }
+
+        player.playQueue?.let { queue ->
+            if (shuffleModeEnabled && !queue.isShuffled) {
+                queue.shuffle()
+            } else if (!shuffleModeEnabled && queue.isShuffled) {
+                queue.unshuffle()
+            }
+            sleepTimerController.onShuffleModeChanged()
+        }
+
+        player.UIs().call { ui -> ui.onShuffleModeEnabledChanged(shuffleModeEnabled) }
+        player.notifyPlaybackUpdateToListeners()
+    }
+
+    fun toggleShuffleModeEnabled() {
+        if (!player.exoPlayerIsNull()) {
+            player.exoPlayer.shuffleModeEnabled = !player.exoPlayer.shuffleModeEnabled
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistShuffleIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistShuffleIntegrationTest.java
@@ -31,11 +31,13 @@ public class LocalPlaylistShuffleIntegrationTest {
     @Test
     public void playerRestoresTheQueueShuffleState() throws Exception {
         final String player = read("java/org/schabi/newpipe/player/Player.java");
+        final String queueModeController = read(
+                "java/org/schabi/newpipe/player/PlayerQueueModeController.kt");
 
         assertTrue(player.contains(
                 "simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled())"));
-        assertTrue(player.contains("shuffleModeEnabled && !playQueue.isShuffled()"));
-        assertTrue(player.contains("!shuffleModeEnabled && playQueue.isShuffled()"));
+        assertTrue(queueModeController.contains("shuffleModeEnabled && !queue.isShuffled"));
+        assertTrue(queueModeController.contains("!shuffleModeEnabled && queue.isShuffled"));
     }
 
     private String read(final String relativePath) throws Exception {


### PR DESCRIPTION
- Move repeat-mode selection and shuffle toggling into a Kotlin controller
- Keep ExoPlayer listener callbacks in Player while delegating queue-mode synchronization
- Preserve shuffled queue updates, sleep-timer coordination, and UI notifications
- Keep the existing Player repeat and shuffle APIs unchanged
- Reduce Player.java from 2,664 to 2,628 lines