### PR TITLE
Extract player local metadata controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -77,7 +77,6 @@ import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.learning.LearningSessionTracker;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
-import org.schabi.newpipe.local.media.LocalMediaMetadataLoader;
 import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.event.PlayerEventListener;
 import org.schabi.newpipe.player.event.PlayerServiceEventListener;
@@ -119,7 +118,6 @@ import org.schabi.newpipe.util.image.ExtractorImageCompat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.Future;
 import java.util.stream.IntStream;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -187,8 +185,6 @@ public final class Player implements PlaybackListener, Listener {
     private PlayQueueItem currentItem;
     @Nullable
     private MediaItemTag currentMetadata;
-    @Nullable
-    private Future<?> localMetadataFuture;
     @NonNull
     private final PlayerHttpErrorRecovery.RecoveryGuard mediaUrlRecoveryGuard =
         new PlayerHttpErrorRecovery.RecoveryGuard();
@@ -260,6 +256,8 @@ public final class Player implements PlaybackListener, Listener {
     private final PlayerEventDispatcher eventDispatcher;
     @NonNull
     private final PlayerThumbnailController thumbnailController;
+    @NonNull
+    private final PlayerLocalMetadataController localMetadataController;
 
     @NonNull
     private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
@@ -309,6 +307,7 @@ public final class Player implements PlaybackListener, Listener {
         queueModeController = new PlayerQueueModeController(this, sleepTimerController);
         eventDispatcher = new PlayerEventDispatcher(this);
         thumbnailController = new PlayerThumbnailController(this);
+        localMetadataController = new PlayerLocalMetadataController(this);
         broadcastController = new PlayerBroadcastController(this);
 
         trackSelector = new DefaultTrackSelector(context, PlayerHelper.getQualitySelector());
@@ -737,7 +736,7 @@ public final class Player implements PlaybackListener, Listener {
         }
 
         thumbnailController.cancel();
-        cancelLocalMetadataLoading();
+        localMetadataController.cancel();
         sleepTimerController.clear();
         saveStreamProgressState();
         setRecovery();
@@ -804,14 +803,6 @@ public final class Player implements PlaybackListener, Listener {
     }
     //endregion
 
-
-
-    private void cancelLocalMetadataLoading() {
-        if (localMetadataFuture != null) {
-            localMetadataFuture.cancel(true);
-            localMetadataFuture = null;
-        }
-    }
 
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -1972,7 +1963,7 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
-        cancelLocalMetadataLoading();
+        localMetadataController.cancel();
 
         playbackParametersController.applySpeedProfile(info);
         sponsorBlockController.updateSegments(info);
@@ -1989,30 +1980,7 @@ public final class Player implements PlaybackListener, Listener {
     private void updateMetadataForLocalMedia(@NonNull final PlayQueueItem item) {
         sponsorBlockController.reset();
         thumbnailController.loadLocal(item);
-        cancelLocalMetadataLoading();
-        localMetadataFuture = LocalMediaMetadataLoader.INSTANCE.load(
-                context,
-                item,
-                metadata -> {
-                    if (!(currentMetadata instanceof LocalMediaItemTag)
-                            || !((LocalMediaItemTag) currentMetadata)
-                                    .getItem().isSameItem(item)) {
-                        return;
-                    }
-                    if (!item.applyLocalMetadata(
-                            metadata.getTitle(),
-                            metadata.getArtist(),
-                            metadata.getAlbum(),
-                            metadata.getDurationSeconds())) {
-                        return;
-                    }
-                    if (playQueue != null) {
-                        playQueue.notifyChange();
-                    }
-                    notifyMetadataUpdateToListeners();
-                    notifyAudioTrackUpdateToListeners();
-                    UIs.call(playerUi -> playerUi.onMetadataChanged(currentMetadata));
-                });
+        localMetadataController.load(item);
         databaseUpdateDisposable.add(recordManager.onViewed(item)
                 .onErrorComplete().subscribe());
         notifyMetadataUpdateToListeners();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -2250,7 +2250,7 @@ public final class Player implements PlaybackListener, Listener {
         eventDispatcher.notifyQueueUpdate();
     }
 
-    private void notifyMetadataUpdateToListeners() {
+    void notifyMetadataUpdateToListeners() {
         eventDispatcher.notifyMetadataUpdate();
     }
 
@@ -2264,7 +2264,7 @@ public final class Player implements PlaybackListener, Listener {
         eventDispatcher.notifyProgressUpdate(currentProgress, duration, bufferPercent);
     }
 
-    private void notifyAudioTrackUpdateToListeners() {
+    void notifyAudioTrackUpdateToListeners() {
         eventDispatcher.notifyAudioTrackUpdate();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import java.util.concurrent.Future
+import org.schabi.newpipe.local.media.LocalMediaMetadataLoader
+import org.schabi.newpipe.player.mediaitem.LocalMediaItemTag
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+
+/** Owns cancellable local-media tag loading and rejects results for stale queue items. */
+internal class PlayerLocalMetadataController(private val player: Player) {
+    private var load: Future<*>? = null
+
+    fun load(item: PlayQueueItem) {
+        cancel()
+        load = LocalMediaMetadataLoader.load(
+            player.context,
+            item
+        ) metadataLoaded@ { metadata ->
+            val currentMetadata = player.currentMetadata
+            if (currentMetadata !is LocalMediaItemTag ||
+                !currentMetadata.item.isSameItem(item)
+            ) {
+                return@metadataLoaded
+            }
+            if (!item.applyLocalMetadata(
+                    metadata.title,
+                    metadata.artist,
+                    metadata.album,
+                    metadata.durationSeconds
+                )
+            ) {
+                return@metadataLoaded
+            }
+            player.playQueue?.notifyChange()
+            player.notifyMetadataUpdateToListeners()
+            player.notifyAudioTrackUpdateToListeners()
+            player.UIs().call { ui -> ui.onMetadataChanged(player.currentMetadata) }
+        }
+    }
+
+    fun cancel() {
+        load?.cancel(true)
+        load = null
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt
@@ -19,7 +19,7 @@ internal class PlayerLocalMetadataController(private val player: Player) {
         load = LocalMediaMetadataLoader.load(
             player.context,
             item
-        ) metadataLoaded@ { metadata ->
+        ) metadataLoaded@{ metadata ->
             val currentMetadata = player.currentMetadata
             if (currentMetadata !is LocalMediaItemTag ||
                 !currentMetadata.item.isSameItem(item)

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt
@@ -38,7 +38,7 @@ internal class PlayerLocalMetadataController(private val player: Player) {
             player.playQueue?.notifyChange()
             player.notifyMetadataUpdateToListeners()
             player.notifyAudioTrackUpdateToListeners()
-            player.UIs().call { ui -> ui.onMetadataChanged(player.currentMetadata) }
+            player.UIs().call { ui -> ui.onMetadataChanged(currentMetadata) }
         }
     }
 

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaMetadataIntegrationTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaMetadataIntegrationTest.kt
@@ -18,19 +18,21 @@ class LocalMediaMetadataIntegrationTest {
 
     @Test
     fun `player resolves tags lazily and rejects stale asynchronous results`() {
-        val player = Files.readString(
-            projectDirectory.resolve("java/org/schabi/newpipe/player/Player.java")
+        val controller = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/player/PlayerLocalMetadataController.kt"
+            )
         )
-        val loaderCall = player.indexOf("LocalMediaMetadataLoader.INSTANCE.load")
-        val staleItemCheck = player.indexOf(".getItem().isSameItem(item)", loaderCall)
-        val metadataMutation = player.indexOf("item.applyLocalMetadata", staleItemCheck)
+        val loaderCall = controller.indexOf("LocalMediaMetadataLoader.load")
+        val staleItemCheck = controller.indexOf("currentMetadata.item.isSameItem(item)", loaderCall)
+        val metadataMutation = controller.indexOf("item.applyLocalMetadata", staleItemCheck)
 
         assertTrue(loaderCall >= 0)
         assertTrue(staleItemCheck > loaderCall)
         assertTrue(metadataMutation > staleItemCheck)
-        assertTrue(player.indexOf("playQueue.notifyChange()", metadataMutation) > metadataMutation)
+        assertTrue(controller.indexOf("playQueue?.notifyChange()", metadataMutation) > metadataMutation)
         assertTrue(
-            player.indexOf("notifyMetadataUpdateToListeners()", metadataMutation) >
+            controller.indexOf("notifyMetadataUpdateToListeners()", metadataMutation) >
                 metadataMutation
         )
     }


### PR DESCRIPTION
- Move cancellable local-media tag loading into a Kotlin controller
- Preserve active-item identity checks so stale asynchronous metadata is ignored
- Keep queue refreshes, metadata notifications, and audio-track updates synchronized
- Update the local metadata integration test to verify the controller-owned flow
- Reduce Player.java from 2,628 to 2,596 lines