### PR TITLE
Extract player history controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -260,7 +260,6 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
     @NonNull
-    @NonNull
     private final CompositeDisposable streamItemDisposable = new CompositeDisposable();
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -75,8 +75,6 @@ import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
-import org.schabi.newpipe.learning.LearningSessionTracker;
-import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.player.equalizer.EqualizerState;
 import org.schabi.newpipe.player.event.PlayerEventListener;
 import org.schabi.newpipe.player.event.PlayerServiceEventListener;
@@ -262,7 +260,6 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
     @NonNull
-    private final CompositeDisposable databaseUpdateDisposable = new CompositeDisposable();
     @NonNull
     private final CompositeDisposable streamItemDisposable = new CompositeDisposable();
 
@@ -275,9 +272,7 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final SharedPreferences prefs;
     @NonNull
-    private final HistoryRecordManager recordManager;
-    @NonNull
-    private final LearningSessionTracker learningSessionTracker;
+    private final PlayerHistoryController historyController;
     @NonNull
     private final PlayerDataSource dataSource;
 
@@ -299,8 +294,7 @@ public final class Player implements PlaybackListener, Listener {
         context = service;
         prefs = PreferenceManager.getDefaultSharedPreferences(context);
         audioController = new PlayerAudioController(this);
-        recordManager = new HistoryRecordManager(context);
-        learningSessionTracker = new LearningSessionTracker(context);
+        historyController = new PlayerHistoryController(this);
         sponsorBlockController = new SponsorBlockPlaybackController(this);
         playbackParametersController = new PlaybackParametersController(this);
         sleepTimerController = new SleepTimerPlaybackController(this);
@@ -378,8 +372,7 @@ public final class Player implements PlaybackListener, Listener {
         // can move the initUIs stuff without breaking the setup for edge cases somehow.
         // when playing from a timestamp, keep the current player as-is.
         if (playerIntentType != PlayerIntentType.TimestampChange) {
-            learningSessionTracker.update(currentItem, currentState == STATE_PLAYING,
-                    audioPlayerSelected());
+            historyController.updateLearningSession();
             @Nullable final PlayerType requestedPlayerType = IntentCompat.getSerializableExtra(
                     intent, PLAYER_TYPE, PlayerType.class);
             if (playerType == PlayerType.MAIN && requestedPlayerType == PlayerType.POPUP
@@ -389,8 +382,7 @@ public final class Player implements PlaybackListener, Listener {
                         .orElse(false));
             }
             playerType = requestedPlayerType;
-            learningSessionTracker.update(currentItem, currentState == STATE_PLAYING,
-                    audioPlayerSelected());
+            historyController.updateLearningSession();
         }
         initUIsForCurrentPlayerType();
         isAudioOnly = audioPlayerSelected();
@@ -551,32 +543,25 @@ public final class Player implements PlaybackListener, Listener {
                 && !newQueue.isEmpty()
                 && newQueue.getItem() != null
                 && newQueue.getItem().getRecoveryPosition() == PlayQueueItem.RECOVERY_UNSET) {
-            databaseUpdateDisposable.add(recordManager.loadStreamState(newQueue.getItem())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    // Do not place initPlayback() in doFinally() because
-                    // it restarts playback after destroy()
-                    //.doFinally()
-                    .subscribe(
-                            state -> {
-                                if (!state.isFinished(newQueue.getItem().getDuration())) {
-                                    // resume playback only if the stream was not played to the end
-                                    newQueue.setRecovery(newQueue.getIndex(),
-                                            state.getProgressMillis());
-                                }
-                                initPlayback(newQueue, playWhenReady);
-                            },
-                            error -> {
-                                if (DEBUG) {
-                                    Log.w(TAG, "Failed to start playback", error);
-                                }
-                                // In case any error we can start playback without history
-                                initPlayback(newQueue, playWhenReady);
-                            },
-                            () -> {
-                                // Completed but not found in history
-                                initPlayback(newQueue, playWhenReady);
-                            }
-                    ));
+            historyController.restoreStreamState(newQueue.getItem(),
+                    state -> {
+                        if (!state.isFinished(newQueue.getItem().getDuration())) {
+                            // resume playback only if the stream was not played to the end
+                            newQueue.setRecovery(newQueue.getIndex(), state.getProgressMillis());
+                        }
+                        initPlayback(newQueue, playWhenReady);
+                    },
+                    error -> {
+                        if (DEBUG) {
+                            Log.w(TAG, "Failed to start playback", error);
+                        }
+                        // In case any error we can start playback without history
+                        initPlayback(newQueue, playWhenReady);
+                    },
+                    () -> {
+                        // Completed but not found in history
+                        initPlayback(newQueue, playWhenReady);
+                    });
         } else {
             // Good to go...
             // In a case of equal PlayQueues we can re-init old one but only when it is disposed
@@ -707,7 +692,7 @@ public final class Player implements PlaybackListener, Listener {
         }
         cancelPendingMediaUrlRecovery();
         mediaUrlRecoveryGuard.reset();
-        learningSessionTracker.stop();
+        historyController.stopLearningSession();
         UIs.call(PlayerUi::destroyPlayer);
         audioController.releaseAudioSession();
 
@@ -745,7 +730,7 @@ public final class Player implements PlaybackListener, Listener {
         destroyPlayer();
         broadcastController.unregister();
 
-        databaseUpdateDisposable.clear();
+        historyController.clear();
         progressUpdateDisposable.set(null);
         streamItemDisposable.clear();
 
@@ -881,8 +866,7 @@ public final class Player implements PlaybackListener, Listener {
             return;
         }
 
-        learningSessionTracker.update(currentItem, currentState == STATE_PLAYING,
-                audioPlayerSelected());
+        historyController.updateLearningSession();
         sponsorBlockController.onProgress();
         onUpdateProgress(Math.max((int) simpleExoPlayer.getCurrentPosition(), 0),
                 (int) simpleExoPlayer.getDuration(), simpleExoPlayer.getBufferedPercentage());
@@ -1012,8 +996,7 @@ public final class Player implements PlaybackListener, Listener {
             Log.d(TAG, "changeState() called with: state = [" + state + "]");
         }
         currentState = state;
-        learningSessionTracker.update(currentItem, state == STATE_PLAYING,
-                audioPlayerSelected());
+        historyController.updateLearningSession();
         switch (state) {
             case STATE_BLOCKED:
                 onBlocked();
@@ -1689,10 +1672,9 @@ public final class Player implements PlaybackListener, Listener {
                 || currentItem.getServiceId() != item.getServiceId()
                 || !currentItem.getUrl().equals(item.getUrl());
 
-        learningSessionTracker.stop();
+        historyController.stopLearningSession();
         currentItem = item;
-        learningSessionTracker.update(currentItem, currentState == STATE_PLAYING,
-                audioPlayerSelected());
+        historyController.updateLearningSession();
         playbackParametersController.applySpeedProfile(item);
 
         if (playQueueIndex != playQueue.getIndex()) {
@@ -1882,45 +1864,11 @@ public final class Player implements PlaybackListener, Listener {
     //region StreamInfo history: views and progress
 
     private void registerStreamViewed() {
-        if (currentItem != null && currentItem.isLocalMedia()) {
-            databaseUpdateDisposable.add(recordManager.onViewed(currentItem)
-                    .onErrorComplete().subscribe());
-        } else {
-            getCurrentStreamInfo().ifPresent(info -> databaseUpdateDisposable
-                    .add(recordManager.onViewed(info).onErrorComplete().subscribe()));
-        }
+        historyController.registerViewed();
     }
 
     private void saveStreamProgressState(final long progressMillis) {
-        if (currentItem != null && currentItem.isLocalMedia()) {
-            if (!prefs.getBoolean(context.getString(R.string.enable_watch_history_key), true)) {
-                return;
-            }
-            databaseUpdateDisposable.add(recordManager.saveStreamState(currentItem, progressMillis)
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .onErrorComplete()
-                    .subscribe());
-            return;
-        }
-        getCurrentStreamInfo().ifPresent(info -> {
-            if (!prefs.getBoolean(context.getString(R.string.enable_watch_history_key), true)) {
-                return;
-            }
-            if (DEBUG) {
-                Log.d(TAG, "saveStreamProgressState() called with: progressMillis=" + progressMillis
-                        + ", currentMetadata=[" + info.getName() + "]");
-            }
-
-            databaseUpdateDisposable.add(recordManager.saveStreamState(info, progressMillis)
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .doOnError(e -> {
-                        if (DEBUG) {
-                            e.printStackTrace();
-                        }
-                    })
-                    .onErrorComplete()
-                    .subscribe());
-        });
+        historyController.saveProgress(progressMillis);
     }
 
     public void saveStreamProgressState() {
@@ -1981,8 +1929,7 @@ public final class Player implements PlaybackListener, Listener {
         sponsorBlockController.reset();
         thumbnailController.loadLocal(item);
         localMetadataController.load(item);
-        databaseUpdateDisposable.add(recordManager.onViewed(item)
-                .onErrorComplete().subscribe());
+        historyController.registerViewed(item);
         notifyMetadataUpdateToListeners();
         notifyAudioTrackUpdateToListeners();
         UIs.call(playerUi -> playerUi.onMetadataChanged(currentMetadata));

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerHistoryController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerHistoryController.kt
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.functions.Action
+import io.reactivex.rxjava3.functions.Consumer
+import org.schabi.newpipe.R
+import org.schabi.newpipe.database.stream.model.StreamStateEntity
+import org.schabi.newpipe.learning.LearningSessionTracker
+import org.schabi.newpipe.local.history.HistoryRecordManager
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+
+/** Owns playback history persistence and active learning-session accounting. */
+internal class PlayerHistoryController(private val player: Player) {
+    private val records = HistoryRecordManager(player.context)
+    private val learningSessions = LearningSessionTracker(player.context)
+    private val updates = CompositeDisposable()
+
+    fun restoreStreamState(
+        item: PlayQueueItem,
+        onSuccess: Consumer<in StreamStateEntity>,
+        onError: Consumer<in Throwable>,
+        onComplete: Action
+    ) {
+        updates.add(
+            records.loadStreamState(item)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(onSuccess, onError, onComplete)
+        )
+    }
+
+    fun registerViewed() {
+        val item = player.currentItem
+        if (item?.isLocalMedia == true) {
+            registerViewed(item)
+        } else {
+            player.currentStreamInfo.ifPresent { info ->
+                updates.add(records.onViewed(info).onErrorComplete().subscribe())
+            }
+        }
+    }
+
+    fun registerViewed(item: PlayQueueItem) {
+        updates.add(records.onViewed(item).onErrorComplete().subscribe())
+    }
+
+    fun saveProgress(progressMillis: Long) {
+        if (!isWatchHistoryEnabled()) {
+            return
+        }
+        val item = player.currentItem
+        if (item?.isLocalMedia == true) {
+            updates.add(
+                records.saveStreamState(item, progressMillis)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .onErrorComplete()
+                    .subscribe()
+            )
+            return
+        }
+
+        player.currentStreamInfo.ifPresent { info ->
+            if (Player.DEBUG) {
+                Log.d(
+                    Player.TAG,
+                    "saveStreamProgressState() called with: progressMillis=$progressMillis, " +
+                        "currentMetadata=[${info.name}]"
+                )
+            }
+            updates.add(
+                records.saveStreamState(info, progressMillis)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .doOnError { error ->
+                        if (Player.DEBUG) {
+                            error.printStackTrace()
+                        }
+                    }
+                    .onErrorComplete()
+                    .subscribe()
+            )
+        }
+    }
+
+    fun updateLearningSession() {
+        learningSessions.update(
+            player.currentItem,
+            player.currentState == Player.STATE_PLAYING,
+            player.audioPlayerSelected()
+        )
+    }
+
+    fun stopLearningSession() {
+        learningSessions.stop()
+    }
+
+    fun clear() {
+        updates.clear()
+    }
+
+    private fun isWatchHistoryEnabled(): Boolean = player.prefs.getBoolean(
+        player.context.getString(R.string.enable_watch_history_key),
+        true
+    )
+}


### PR DESCRIPTION
- Move watch-history subscriptions, view recording, resume lookup, and progress persistence into a Kotlin controller
- Move learning-session lifecycle updates behind the same playback-history boundary
- Centralize disposal of outstanding history operations during player teardown
- Keep Player playback and progress APIs unchanged while delegating persistence
- Reduce Player.java from 2,596 to 2,542 lines