### PR TITLE
Extract player progress controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -32,7 +32,6 @@ import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
 import static org.schabi.newpipe.util.ListHelper.getPopupResolutionIndex;
 import static org.schabi.newpipe.util.ListHelper.getResolutionIndex;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import android.content.Context;
 import android.content.Intent;
@@ -119,11 +118,8 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
-import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-import io.reactivex.rxjava3.disposables.Disposable;
-import io.reactivex.rxjava3.disposables.SerialDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public final class Player implements PlaybackListener, Listener {
@@ -256,9 +252,8 @@ public final class Player implements PlaybackListener, Listener {
     private final PlayerThumbnailController thumbnailController;
     @NonNull
     private final PlayerLocalMetadataController localMetadataController;
-
     @NonNull
-    private final SerialDisposable progressUpdateDisposable = new SerialDisposable();
+    private final PlayerProgressController progressController;
     @NonNull
     private final CompositeDisposable streamItemDisposable = new CompositeDisposable();
 
@@ -299,6 +294,8 @@ public final class Player implements PlaybackListener, Listener {
         sleepTimerController = new SleepTimerPlaybackController(this);
         queueModeController = new PlayerQueueModeController(this, sleepTimerController);
         eventDispatcher = new PlayerEventDispatcher(this);
+        progressController = new PlayerProgressController(this, historyController,
+                sponsorBlockController, eventDispatcher);
         thumbnailController = new PlayerThumbnailController(this);
         localMetadataController = new PlayerLocalMetadataController(this);
         broadcastController = new PlayerBroadcastController(this);
@@ -730,7 +727,7 @@ public final class Player implements PlaybackListener, Listener {
         broadcastController.unregister();
 
         historyController.clear();
-        progressUpdateDisposable.set(null);
+        progressController.clear();
         streamItemDisposable.clear();
 
         UIs.destroyAll(Object.class); // destroy every UI: obviously every UI extends Object
@@ -839,44 +836,24 @@ public final class Player implements PlaybackListener, Listener {
     //////////////////////////////////////////////////////////////////////////*/
     //region Progress loop and updates
 
-    private void onUpdateProgress(final int currentProgress,
-                                  final int duration,
-                                  final int bufferPercent) {
-        if (isPrepared) {
-            UIs.call(ui -> ui.onUpdateProgress(currentProgress, duration, bufferPercent));
-            notifyProgressUpdateToListeners(currentProgress, duration, bufferPercent);
-        }
-    }
-
     public void startProgressLoop() {
-        progressUpdateDisposable.set(getProgressUpdateDisposable());
+        progressController.start();
     }
 
     private void stopProgressLoop() {
-        progressUpdateDisposable.set(null);
+        progressController.stop();
     }
 
     public boolean isProgressLoopRunning() {
-        return progressUpdateDisposable.get() != null;
+        return progressController.isRunning();
     }
 
     public void triggerProgressUpdate() {
-        if (exoPlayerIsNull()) {
-            return;
-        }
-
-        historyController.updateLearningSession();
-        sponsorBlockController.onProgress();
-        onUpdateProgress(Math.max((int) simpleExoPlayer.getCurrentPosition(), 0),
-                (int) simpleExoPlayer.getDuration(), simpleExoPlayer.getBufferedPercentage());
+        progressController.trigger();
     }
 
-    private Disposable getProgressUpdateDisposable() {
-        return Observable.interval(PROGRESS_LOOP_INTERVAL_MILLIS, MILLISECONDS,
-                        AndroidSchedulers.mainThread())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(ignored -> triggerProgressUpdate(),
-                        error -> Log.e(TAG, "Progress update failure: ", error));
+    boolean isPreparedForProgressUpdates() {
+        return isPrepared;
     }
 
     //endregion
@@ -2202,12 +2179,6 @@ public final class Player implements PlaybackListener, Listener {
 
     void notifyPlaybackUpdateToListeners() {
         eventDispatcher.notifyPlaybackUpdate();
-    }
-
-    private void notifyProgressUpdateToListeners(final int currentProgress,
-                                                 final int duration,
-                                                 final int bufferPercent) {
-        eventDispatcher.notifyProgressUpdate(currentProgress, duration, bufferPercent);
     }
 
     void notifyAudioTrackUpdateToListeners() {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerProgressController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerProgressController.kt
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.disposables.SerialDisposable
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import kotlin.math.max
+
+/** Owns periodic playback progress sampling and delivery to player observers. */
+internal class PlayerProgressController(
+    private val player: Player,
+    private val historyController: PlayerHistoryController,
+    private val sponsorBlockController: SponsorBlockPlaybackController,
+    private val eventDispatcher: PlayerEventDispatcher
+) {
+    private val progressUpdates = SerialDisposable()
+
+    fun start() {
+        progressUpdates.set(
+            Observable.interval(
+                Player.PROGRESS_LOOP_INTERVAL_MILLIS.toLong(),
+                MILLISECONDS,
+                AndroidSchedulers.mainThread()
+            )
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                    { trigger() },
+                    { error -> Log.e(Player.TAG, "Progress update failure: ", error) }
+                )
+        )
+    }
+
+    fun stop() {
+        progressUpdates.set(null)
+    }
+
+    fun isRunning(): Boolean = progressUpdates.get() != null
+
+    fun trigger() {
+        if (player.exoPlayerIsNull()) {
+            return
+        }
+
+        historyController.updateLearningSession()
+        sponsorBlockController.onProgress()
+        val exoPlayer = player.exoPlayer
+        dispatch(
+            max(exoPlayer.currentPosition.toInt(), 0),
+            exoPlayer.duration.toInt(),
+            exoPlayer.bufferedPercentage
+        )
+    }
+
+    fun clear() {
+        progressUpdates.set(null)
+    }
+
+    private fun dispatch(currentProgress: Int, duration: Int, bufferPercent: Int) {
+        if (player.isPreparedForProgressUpdates) {
+            player.UIs().call { ui ->
+                ui.onUpdateProgress(currentProgress, duration, bufferPercent)
+            }
+            eventDispatcher.notifyProgressUpdate(currentProgress, duration, bufferPercent)
+        }
+    }
+}


### PR DESCRIPTION
- Move periodic playback progress sampling and Rx timer ownership into a Kotlin controller
- Keep learning-session and SponsorBlock progress hooks on the same one-second tick
- Deliver progress updates to player UIs and bound listeners from one coordinator
- Preserve the existing Player progress-loop API used by playback UIs and event dispatchers
- Reduce Player.java from 2,542 to 2,512 lines