### PR TITLE
Extract player seek controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -13,7 +13,6 @@ import static androidx.media3.common.Player.REPEAT_MODE_ONE;
 import static androidx.media3.common.Player.RepeatMode;
 import static org.schabi.newpipe.extractor.ServiceList.YouTube;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
-import static org.schabi.newpipe.player.helper.PlayerHelper.retrieveSeekDurationFromPreferences;
 import static org.schabi.newpipe.util.ListHelper.getPopupResolutionIndex;
 import static org.schabi.newpipe.util.ListHelper.getResolutionIndex;
 
@@ -230,6 +229,8 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final PlayerProgressController progressController;
     @NonNull
+    private final PlayerSeekController seekController;
+    @NonNull
     private final CompositeDisposable streamItemDisposable = new CompositeDisposable();
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -271,6 +272,7 @@ public final class Player implements PlaybackListener, Listener {
         eventDispatcher = new PlayerEventDispatcher(this);
         progressController = new PlayerProgressController(this, historyController,
                 sponsorBlockController, eventDispatcher);
+        seekController = new PlayerSeekController(this);
         thumbnailController = new PlayerThumbnailController(this);
         localMetadataController = new PlayerLocalMetadataController(this);
         broadcastController = new PlayerBroadcastController(this);
@@ -1409,15 +1411,7 @@ public final class Player implements PlaybackListener, Listener {
 
     @Override // own playback listener (this is a getter)
     public boolean isApproachingPlaybackEdge(final long timeToEndMillis) {
-        // If live, then not near playback edge
-        // If not playing, then not approaching playback edge
-        if (exoPlayerIsNull() || isLive() || !isPlaying()) {
-            return false;
-        }
-
-        final long currentPositionMillis = simpleExoPlayer.getCurrentPosition();
-        final long currentDurationMillis = simpleExoPlayer.getDuration();
-        return currentDurationMillis - currentPositionMillis < timeToEndMillis;
+        return seekController.isApproachingPlaybackEdge(timeToEndMillis);
     }
 
     /**
@@ -1427,20 +1421,7 @@ public final class Player implements PlaybackListener, Listener {
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isLiveEdge() {
-        if (exoPlayerIsNull() || !isLive()) {
-            return false;
-        }
-
-        final Timeline currentTimeline = simpleExoPlayer.getCurrentTimeline();
-        final int currentWindowIndex = simpleExoPlayer.getCurrentMediaItemIndex();
-        if (currentTimeline.isEmpty() || currentWindowIndex < 0
-                || currentWindowIndex >= currentTimeline.getWindowCount()) {
-            return false;
-        }
-
-        final Timeline.Window timelineWindow = new Timeline.Window();
-        currentTimeline.getWindow(currentWindowIndex, timelineWindow);
-        return timelineWindow.getDefaultPositionMs() <= simpleExoPlayer.getCurrentPosition();
+        return seekController.isLiveEdge();
     }
 
     @Override // own playback listener
@@ -1501,27 +1482,11 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     public void seekTo(final long positionMillis) {
-        if (DEBUG) {
-            Log.d(TAG, "seekBy() called with: position = [" + positionMillis + "]");
-        }
-        if (!exoPlayerIsNull()) {
-            // prevent invalid positions when fast-forwarding/-rewinding
-            simpleExoPlayer.seekTo(MathUtils.clamp(positionMillis, 0,
-                    simpleExoPlayer.getDuration()));
-        }
-    }
-
-    private void seekBy(final long offsetMillis) {
-        if (DEBUG) {
-            Log.d(TAG, "seekBy() called with: offsetMillis = [" + offsetMillis + "]");
-        }
-        seekTo(simpleExoPlayer.getCurrentPosition() + offsetMillis);
+        seekController.seekTo(positionMillis);
     }
 
     public void seekToDefault() {
-        if (!exoPlayerIsNull()) {
-            simpleExoPlayer.seekToDefaultPosition();
-        }
+        seekController.seekToDefault();
     }
     //endregion
 
@@ -1628,19 +1593,11 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     public void fastForward() {
-        if (DEBUG) {
-            Log.d(TAG, "fastRewind() called");
-        }
-        seekBy(retrieveSeekDurationFromPreferences(this));
-        triggerProgressUpdate();
+        seekController.fastForward();
     }
 
     public void fastRewind() {
-        if (DEBUG) {
-            Log.d(TAG, "fastRewind() called");
-        }
-        seekBy(-retrieveSeekDurationFromPreferences(this));
-        triggerProgressUpdate();
+        seekController.fastRewind();
     }
     //endregion
 
@@ -2166,15 +2123,7 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     private boolean isLive() {
-        try {
-            return !exoPlayerIsNull() && simpleExoPlayer.isCurrentMediaItemDynamic();
-        } catch (final IndexOutOfBoundsException e) {
-            // Why would this even happen =(... but lets log it anyway, better safe than sorry
-            if (DEBUG) {
-                Log.d(TAG, "player.isCurrentWindowDynamic() failed: ", e);
-            }
-            return false;
-        }
+        return seekController.isLive();
     }
 
     public void setPlaybackQuality(@Nullable final String quality) {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerSeekController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerSeekController.kt
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+import androidx.core.math.MathUtils
+import androidx.media3.common.Timeline
+import org.schabi.newpipe.player.helper.PlayerHelper
+
+/** Owns playback-position queries and user-initiated seek operations. */
+internal class PlayerSeekController(private val player: Player) {
+    fun isApproachingPlaybackEdge(timeToEndMillis: Long): Boolean {
+        if (player.exoPlayerIsNull() || isLive() || !player.isPlaying) {
+            return false
+        }
+
+        val exoPlayer = player.exoPlayer
+        return exoPlayer.duration - exoPlayer.currentPosition < timeToEndMillis
+    }
+
+    fun isLiveEdge(): Boolean {
+        if (player.exoPlayerIsNull() || !isLive()) {
+            return false
+        }
+
+        val exoPlayer = player.exoPlayer
+        val currentTimeline = exoPlayer.currentTimeline
+        val currentWindowIndex = exoPlayer.currentMediaItemIndex
+        if (currentTimeline.isEmpty ||
+            currentWindowIndex < 0 ||
+            currentWindowIndex >= currentTimeline.windowCount
+        ) {
+            return false
+        }
+
+        val timelineWindow = Timeline.Window()
+        currentTimeline.getWindow(currentWindowIndex, timelineWindow)
+        return timelineWindow.defaultPositionMs <= exoPlayer.currentPosition
+    }
+
+    fun seekTo(positionMillis: Long) {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "seekBy() called with: position = [$positionMillis]")
+        }
+        if (!player.exoPlayerIsNull()) {
+            val exoPlayer = player.exoPlayer
+            exoPlayer.seekTo(MathUtils.clamp(positionMillis, 0, exoPlayer.duration))
+        }
+    }
+
+    fun seekToDefault() {
+        if (!player.exoPlayerIsNull()) {
+            player.exoPlayer.seekToDefaultPosition()
+        }
+    }
+
+    fun fastForward() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "fastForward() called")
+        }
+        seekBy(PlayerHelper.retrieveSeekDurationFromPreferences(player).toLong())
+        player.triggerProgressUpdate()
+    }
+
+    fun fastRewind() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "fastRewind() called")
+        }
+        seekBy(-PlayerHelper.retrieveSeekDurationFromPreferences(player).toLong())
+        player.triggerProgressUpdate()
+    }
+
+    private fun seekBy(offsetMillis: Long) {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "seekBy() called with: offsetMillis = [$offsetMillis]")
+        }
+        if (!player.exoPlayerIsNull()) {
+            seekTo(player.exoPlayer.currentPosition + offsetMillis)
+        }
+    }
+
+    fun isLive(): Boolean = try {
+        !player.exoPlayerIsNull() && player.exoPlayer.isCurrentMediaItemDynamic
+    } catch (error: IndexOutOfBoundsException) {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "player.isCurrentWindowDynamic() failed: ", error)
+        }
+        false
+    }
+}


### PR DESCRIPTION
- Move live-edge and approaching-edge position queries into a Kotlin controller
- Move clamped, default-position, fast-forward, and rewind seeking behind the same boundary
- Preserve every existing Player seek API used by playback UIs, media session callbacks, and queue controls
- Keep progress refreshes after fast-forward and rewind
- Reduce Player.java from 2,325 to 2,274 lines