### PR TITLE
Extract player transport controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -231,6 +231,8 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final PlayerSeekController seekController;
     @NonNull
+    private final PlayerTransportController transportController;
+    @NonNull
     private final CompositeDisposable streamItemDisposable = new CompositeDisposable();
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -273,6 +275,7 @@ public final class Player implements PlaybackListener, Listener {
         progressController = new PlayerProgressController(this, historyController,
                 sponsorBlockController, eventDispatcher);
         seekController = new PlayerSeekController(this);
+        transportController = new PlayerTransportController(this, sleepTimerController);
         thumbnailController = new PlayerThumbnailController(this);
         localMetadataController = new PlayerLocalMetadataController(this);
         broadcastController = new PlayerBroadcastController(this);
@@ -1498,98 +1501,23 @@ public final class Player implements PlaybackListener, Listener {
     //region Player actions (play, pause, previous, fast-forward, ...)
 
     public void play() {
-        if (DEBUG) {
-            Log.d(TAG, "play() called");
-        }
-        if (audioReactor == null || playQueue == null || exoPlayerIsNull()) {
-            return;
-        }
-
-        if (!isMuted()) {
-            audioReactor.requestAudioFocus();
-        }
-
-        if (currentState == STATE_COMPLETED) {
-            if (playQueue.getIndex() == 0) {
-                seekToDefault();
-            } else {
-                playQueue.setIndex(0);
-            }
-        }
-
-        if (isStopped()) {
-            // Some phones suspend a paused player after 10 minutes. This causes the player to
-            // enter STATE_IDLE, causing playback to fail. So we try to recover from that here.
-            setRecovery();
-            reloadPlayQueueManager();
-        }
-
-        simpleExoPlayer.play();
-        saveStreamProgressState();
+        transportController.play();
     }
 
     public void pause() {
-        if (DEBUG) {
-            Log.d(TAG, "pause() called");
-        }
-        if (audioReactor == null || exoPlayerIsNull()) {
-            return;
-        }
-
-        audioReactor.abandonAudioFocus();
-        simpleExoPlayer.pause();
-        saveStreamProgressState();
+        transportController.pause();
     }
 
     public void playPause() {
-        if (DEBUG) {
-            Log.d(TAG, "onPlayPause() called");
-        }
-
-        if (getPlayWhenReady()
-                // When state is completed (replay button is shown) then (re)play and do not pause
-                && currentState != STATE_COMPLETED) {
-            pause();
-        } else {
-            play();
-        }
+        transportController.playPause();
     }
 
     public void playPrevious() {
-        if (DEBUG) {
-            Log.d(TAG, "onPlayPrevious() called");
-        }
-        if (exoPlayerIsNull() || playQueue == null) {
-            return;
-        }
-
-        /* If current playback has run for PLAY_PREV_ACTIVATION_LIMIT_MILLIS milliseconds,
-         * restart current track. Also restart the track if the current track
-         * is the first in a queue.*/
-        if (simpleExoPlayer.getCurrentPosition() > PLAY_PREV_ACTIVATION_LIMIT_MILLIS
-                || playQueue.getIndex() == 0) {
-            seekToDefault();
-            playQueue.offsetIndex(0);
-        } else {
-            saveStreamProgressState();
-            playQueue.offsetIndex(-1);
-        }
-        sleepTimerController.onCurrentItemChanged();
-        triggerProgressUpdate();
+        transportController.playPrevious();
     }
 
     public void playNext() {
-        if (DEBUG) {
-            Log.d(TAG, "onPlayNext() called");
-        }
-        if (playQueue == null) {
-            return;
-        }
-
-        saveStreamProgressState();
-        playQueue.offsetIndex(+1);
-        sleepTimerController.onCurrentItemChanged();
-        triggerProgressUpdate();
+        transportController.playNext();
     }
 
     public void fastForward() {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerTransportController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerTransportController.kt
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+
+/** Owns play, pause, and queue-navigation transport actions. */
+internal class PlayerTransportController(
+    private val player: Player,
+    private val sleepTimerController: SleepTimerPlaybackController
+) {
+    fun play() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "play() called")
+        }
+        val audioReactor = player.audioReactor ?: return
+        val playQueue = player.playQueue ?: return
+        if (player.exoPlayerIsNull()) {
+            return
+        }
+
+        if (!player.isMuted) {
+            audioReactor.requestAudioFocus()
+        }
+
+        if (player.currentState == Player.STATE_COMPLETED) {
+            if (playQueue.index == 0) {
+                player.seekToDefault()
+            } else {
+                playQueue.index = 0
+            }
+        }
+
+        if (player.isStopped) {
+            player.setRecovery()
+            player.reloadPlayQueueManager()
+        }
+
+        player.exoPlayer.play()
+        player.saveStreamProgressState()
+    }
+
+    fun pause() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "pause() called")
+        }
+        val audioReactor = player.audioReactor ?: return
+        if (player.exoPlayerIsNull()) {
+            return
+        }
+
+        audioReactor.abandonAudioFocus()
+        player.exoPlayer.pause()
+        player.saveStreamProgressState()
+    }
+
+    fun playPause() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "onPlayPause() called")
+        }
+        if (player.playWhenReady && player.currentState != Player.STATE_COMPLETED) {
+            pause()
+        } else {
+            play()
+        }
+    }
+
+    fun playPrevious() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "onPlayPrevious() called")
+        }
+        val playQueue = player.playQueue ?: return
+        if (player.exoPlayerIsNull()) {
+            return
+        }
+
+        if (player.exoPlayer.currentPosition > Player.PLAY_PREV_ACTIVATION_LIMIT_MILLIS ||
+            playQueue.index == 0
+        ) {
+            player.seekToDefault()
+            playQueue.offsetIndex(0)
+        } else {
+            player.saveStreamProgressState()
+            playQueue.offsetIndex(-1)
+        }
+        sleepTimerController.onCurrentItemChanged()
+        player.triggerProgressUpdate()
+    }
+
+    fun playNext() {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "onPlayNext() called")
+        }
+        val playQueue = player.playQueue ?: return
+
+        player.saveStreamProgressState()
+        playQueue.offsetIndex(1)
+        sleepTimerController.onCurrentItemChanged()
+        player.triggerProgressUpdate()
+    }
+}


### PR DESCRIPTION
- Move play, pause, play-pause, previous, and next actions into a Kotlin controller
- Keep audio-focus acquisition and release coupled to transport state changes
- Preserve completed-queue restart and stopped-player recovery behavior
- Keep queue navigation synchronized with sleep-timer and progress updates
- Preserve the existing Player transport API used by gestures, notifications, and playback UIs
- Reduce Player.java from 2,274 to 2,202 lines