### PR TITLE
Extract player queue synchronizer

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -229,6 +229,8 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final PlayerProgressController progressController;
     @NonNull
+    private final PlayerQueueSynchronizer queueSynchronizer;
+    @NonNull
     private final PlayerSeekController seekController;
     @NonNull
     private final PlayerTransportController transportController;
@@ -277,6 +279,8 @@ public final class Player implements PlaybackListener, Listener {
         seekController = new PlayerSeekController(this);
         transportController = new PlayerTransportController(this, sleepTimerController);
         thumbnailController = new PlayerThumbnailController(this);
+        queueSynchronizer = new PlayerQueueSynchronizer(this, historyController,
+                playbackParametersController, thumbnailController);
         localMetadataController = new PlayerLocalMetadataController(this);
         broadcastController = new PlayerBroadcastController(this);
 
@@ -1429,59 +1433,7 @@ public final class Player implements PlaybackListener, Listener {
 
     @Override // own playback listener
     public void onPlaybackSynchronize(@NonNull final PlayQueueItem item, final boolean wasBlocked) {
-        if (DEBUG) {
-            Log.d(TAG, "Playback - onPlaybackSynchronize(was blocked: " + wasBlocked
-                    + ") called with item=[" + item.getTitle() + "], url=[" + item.getUrl() + "]");
-        }
-        if (exoPlayerIsNull() || playQueue == null || currentItem == item) {
-            return; // nothing to synchronize
-        }
-
-        final int playQueueIndex = playQueue.indexOf(item);
-        final int playlistIndex = simpleExoPlayer.getCurrentMediaItemIndex();
-        final int playlistSize = simpleExoPlayer.getCurrentTimeline().getWindowCount();
-        final boolean removeThumbnailBeforeSync = currentItem == null
-                || currentItem.getServiceId() != item.getServiceId()
-                || !currentItem.getUrl().equals(item.getUrl());
-
-        historyController.stopLearningSession();
-        currentItem = item;
-        historyController.updateLearningSession();
-        playbackParametersController.applySpeedProfile(item);
-
-        if (playQueueIndex != playQueue.getIndex()) {
-            // wrong window (this should be impossible, as this method is called with
-            // `item=playQueue.getItem()`, so the index of that item must be equal to `getIndex()`)
-            Log.e(TAG, "Playback - Play Queue may be not in sync: item index=["
-                    + playQueueIndex + "], " + "queue index=[" + playQueue.getIndex() + "]");
-
-        } else if ((playlistSize > 0 && playQueueIndex >= playlistSize) || playQueueIndex < 0) {
-            // the queue and the player's timeline are not in sync, since the play queue index
-            // points outside of the timeline
-            Log.e(TAG, "Playback - Trying to seek to invalid index=[" + playQueueIndex
-                    + "] with playlist length=[" + playlistSize + "]");
-
-        } else if (wasBlocked || playlistIndex != playQueueIndex || !isPlaying()) {
-            // either the player needs to be unblocked, or the play queue index has just been
-            // changed and needs to be synchronized, or the player is not playing
-            if (DEBUG) {
-                Log.d(TAG, "Playback - Rewinding to correct index=[" + playQueueIndex + "], "
-                        + "from=[" + playlistIndex + "], size=[" + playlistSize + "].");
-            }
-
-            if (removeThumbnailBeforeSync) {
-                // unset the current (now outdated) thumbnail to ensure it is not used during sync
-                thumbnailController.clear();
-            }
-
-            // sync the player index with the queue index, and seek to the correct position
-            if (item.getRecoveryPosition() != PlayQueueItem.RECOVERY_UNSET) {
-                simpleExoPlayer.seekTo(playQueueIndex, item.getRecoveryPosition());
-                playQueue.unsetRecovery(playQueueIndex);
-            } else {
-                simpleExoPlayer.seekToDefaultPosition(playQueueIndex);
-            }
-        }
+        queueSynchronizer.synchronize(item, wasBlocked);
     }
 
     public void seekTo(final long positionMillis) {
@@ -2150,6 +2102,10 @@ public final class Player implements PlaybackListener, Listener {
     @Nullable
     public PlayQueueItem getCurrentItem() {
         return currentItem;
+    }
+
+    void setCurrentItemForPlaybackSynchronization(@NonNull final PlayQueueItem item) {
+        currentItem = item;
     }
 
     public Optional<PlayerServiceEventListener> getFragmentListener() {

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerQueueSynchronizer.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerQueueSynchronizer.kt
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+
+/** Keeps the Media3 timeline position synchronized with the logical play queue. */
+internal class PlayerQueueSynchronizer(
+    private val player: Player,
+    private val historyController: PlayerHistoryController,
+    private val playbackParametersController: PlaybackParametersController,
+    private val thumbnailController: PlayerThumbnailController
+) {
+    fun synchronize(item: PlayQueueItem, wasBlocked: Boolean) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "Playback - onPlaybackSynchronize(was blocked: $wasBlocked) called with " +
+                    "item=[${item.title}], url=[${item.url}]"
+            )
+        }
+        val playQueue = player.playQueue ?: return
+        if (player.exoPlayerIsNull() || player.currentItem === item) {
+            return
+        }
+
+        val exoPlayer = player.exoPlayer
+        val playQueueIndex = playQueue.indexOf(item)
+        val playlistIndex = exoPlayer.currentMediaItemIndex
+        val playlistSize = exoPlayer.currentTimeline.windowCount
+        val previousItem = player.currentItem
+        val removeThumbnailBeforeSync = previousItem == null ||
+            previousItem.serviceId != item.serviceId ||
+            previousItem.url != item.url
+
+        historyController.stopLearningSession()
+        player.setCurrentItemForPlaybackSynchronization(item)
+        historyController.updateLearningSession()
+        playbackParametersController.applySpeedProfile(item)
+
+        when {
+            playQueueIndex != playQueue.index -> {
+                Log.e(
+                    Player.TAG,
+                    "Playback - Play Queue may be not in sync: item index=[$playQueueIndex], " +
+                        "queue index=[${playQueue.index}]"
+                )
+            }
+
+            playlistSize > 0 && playQueueIndex >= playlistSize || playQueueIndex < 0 -> {
+                Log.e(
+                    Player.TAG,
+                    "Playback - Trying to seek to invalid index=[$playQueueIndex] " +
+                        "with playlist length=[$playlistSize]"
+                )
+            }
+
+            wasBlocked || playlistIndex != playQueueIndex || !player.isPlaying -> {
+                if (Player.DEBUG) {
+                    Log.d(
+                        Player.TAG,
+                        "Playback - Rewinding to correct index=[$playQueueIndex], " +
+                            "from=[$playlistIndex], size=[$playlistSize]."
+                    )
+                }
+                if (removeThumbnailBeforeSync) {
+                    thumbnailController.clear()
+                }
+
+                if (item.recoveryPosition != PlayQueueItem.RECOVERY_UNSET) {
+                    exoPlayer.seekTo(playQueueIndex, item.recoveryPosition)
+                    playQueue.unsetRecovery(playQueueIndex)
+                } else {
+                    exoPlayer.seekToDefaultPosition(playQueueIndex)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Move play-queue and Media3 timeline synchronization into a Kotlin coordinator
- Keep learning-session transitions and per-item playback speed updates coupled to synchronization
- Preserve recovery-position seeks, invalid-index guards, and stale-thumbnail clearing
- Keep Player.onPlaybackSynchronize as the unchanged PlaybackListener entry point
- Reduce Player.java from 2,202 to 2,158 lines