### PR TITLE
Extract player lifecycle controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -24,7 +24,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 
-import androidx.media3.common.C;
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.common.PlaybackException;

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1117,7 +1117,7 @@ public final class Player implements PlaybackListener, Listener {
         eventDispatcher.stopBindings();
     }
 
-    private void notifyQueueUpdateToListeners() {
+    void notifyQueueUpdateToListeners() {
         eventDispatcher.notifyQueueUpdate();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -22,7 +22,6 @@ import android.view.LayoutInflater;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.math.MathUtils;
 import androidx.preference.PreferenceManager;
 
 import androidx.media3.common.C;
@@ -129,9 +128,6 @@ public final class Player implements PlaybackListener, Listener {
     private PlayQueue playQueue;
 
     @Nullable
-    private MediaSourceManager playQueueManager;
-
-    @Nullable
     private PlayQueueItem currentItem;
     @NonNull
     private final SponsorBlockPlaybackController sponsorBlockController;
@@ -199,6 +195,8 @@ public final class Player implements PlaybackListener, Listener {
     private final PlayerThumbnailController thumbnailController;
     @NonNull
     private final PlayerLocalMetadataController localMetadataController;
+    @NonNull
+    private final PlayerLifecycleController lifecycleController;
     @NonNull
     private final PlayerMetadataController metadataController;
     @NonNull
@@ -307,6 +305,11 @@ public final class Player implements PlaybackListener, Listener {
                 new MediaSessionPlayerUi(this, mediaSession, browserPlayer),
                 new NotificationPlayerUi(this)
         );
+        lifecycleController = new PlayerLifecycleController(this, context, service, renderFactory,
+                trackSelector, loadController, audioController, broadcastController,
+                errorController, historyController, thumbnailController, localMetadataController,
+                sleepTimerController, progressController, playbackParametersController,
+                streamItemDisposable);
     }
 
     private VideoPlaybackResolver.QualityResolver getQualityResolver() {
@@ -382,53 +385,19 @@ public final class Player implements PlaybackListener, Listener {
     }
 
     void initPlayback(@NonNull final PlayQueue queue, final boolean playOnReady) {
-        destroyPlayer();
-        initPlayer(playOnReady);
-        final boolean playbackSkipSilence = getPrefs().getBoolean(getContext().getString(
-                R.string.playback_skip_silence_key), getPlaybackSkipSilence());
-        final PlaybackParameters savedParameters =
-                PlayerHelper.retrievePlaybackParametersFromPrefs(this);
-        playbackParametersController.applyParameters(
-                savedParameters.speed, savedParameters.pitch, playbackSkipSilence);
-
-        playQueue = queue;
-        playQueue.init();
-        simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled());
-        sleepTimerController.onQueueReplaced();
-        reloadPlayQueueManager();
-
-        UIs.call(PlayerUi::initPlayback);
-
-        applyPlayerVolume();
-        notifyQueueUpdateToListeners();
-        notifySleepTimerUpdateToListeners();
+        lifecycleController.initPlayback(queue, playOnReady);
     }
 
-    private void initPlayer(final boolean playOnReady) {
-        if (DEBUG) {
-            Log.d(TAG, "initPlayer() called with: playOnReady = [" + playOnReady + "]");
-        }
+    void setPlayQueueForLifecycle(@NonNull final PlayQueue queue) {
+        playQueue = queue;
+    }
 
-        simpleExoPlayer = new ExoPlayer.Builder(context, renderFactory)
-                .setTrackSelector(trackSelector)
-                .setLoadControl(loadController)
-                .setUsePlatformDiagnostics(false)
-                .build();
-        simpleExoPlayer.addListener(this);
-        simpleExoPlayer.setPlayWhenReady(playOnReady);
-        simpleExoPlayer.setSeekParameters(PlayerHelper.getSeekParameters(context));
-        simpleExoPlayer.setWakeMode(C.WAKE_MODE_NETWORK);
-        simpleExoPlayer.setHandleAudioBecomingNoisy(true);
-        audioController.attachAudioSession(simpleExoPlayer.getAudioSessionId());
+    void setExoPlayerForLifecycle(@NonNull final ExoPlayer exoPlayer) {
+        simpleExoPlayer = exoPlayer;
+    }
 
-        audioReactor = new AudioReactor(context, simpleExoPlayer);
-
-        broadcastController.register();
-
-        // Setup UIs
-        UIs.call(PlayerUi::initPlayer);
-
-        updateAudioTunneling();
+    void setAudioReactorForLifecycle(@NonNull final AudioReactor reactor) {
+        audioReactor = reactor;
     }
     //endregion
 
@@ -439,104 +408,25 @@ public final class Player implements PlaybackListener, Listener {
     //////////////////////////////////////////////////////////////////////////*/
     //region Destroy and recovery
 
-    private void destroyPlayer() {
-        if (DEBUG) {
-            Log.d(TAG, "destroyPlayer() called");
-        }
-        errorController.resetRecovery();
-        historyController.stopLearningSession();
-        UIs.call(PlayerUi::destroyPlayer);
-        audioController.releaseAudioSession();
-
-        if (!exoPlayerIsNull()) {
-            simpleExoPlayer.removeListener(this);
-            simpleExoPlayer.stop();
-            simpleExoPlayer.release();
-        }
-        if (isProgressLoopRunning()) {
-            stopProgressLoop();
-        }
-        if (playQueue != null) {
-            playQueue.dispose();
-        }
-        if (audioReactor != null) {
-            audioReactor.dispose();
-        }
-        if (playQueueManager != null) {
-            playQueueManager.dispose();
-        }
-    }
-
     public void destroy() {
-        if (DEBUG) {
-            Log.d(TAG, "destroy() called");
-        }
-
-        thumbnailController.cancel();
-        localMetadataController.cancel();
-        sleepTimerController.clear();
-        saveStreamProgressState();
-        setRecovery();
-        stopActivityBinding();
-
-        destroyPlayer();
-        broadcastController.unregister();
-
-        historyController.clear();
-        progressController.clear();
-        streamItemDisposable.clear();
-
-        UIs.destroyAll(Object.class); // destroy every UI: obviously every UI extends Object
+        lifecycleController.destroy();
     }
 
     public void setRecovery() {
-        if (playQueue == null || exoPlayerIsNull()) {
-            return;
-        }
-
-        final int queuePos = playQueue.getIndex();
-        final long windowPos = simpleExoPlayer.getCurrentPosition();
-        final long duration = simpleExoPlayer.getDuration();
-
-        // No checks due to https://github.com/TeamNewPipe/NewPipe/pull/7195#issuecomment-962624380
-        setRecovery(queuePos, MathUtils.clamp(windowPos, 0, duration));
-    }
-
-    private void setRecovery(final int queuePos, final long windowPos) {
-        if (playQueue == null || playQueue.size() <= queuePos) {
-            return;
-        }
-
-        if (DEBUG) {
-            Log.d(TAG, "Setting recovery, queue: " + queuePos + ", pos: " + windowPos);
-        }
-        playQueue.setRecovery(queuePos, windowPos);
+        lifecycleController.setRecovery();
     }
 
     public void reloadPlayQueueManager() {
-        if (playQueueManager != null) {
-            playQueueManager.dispose();
-        }
-
-        if (playQueue != null) {
-            playQueueManager = new MediaSourceManager(this, playQueue);
-        }
+        lifecycleController.reloadPlayQueueManager();
     }
 
     @Override // own playback listener
     public void onPlaybackShutdown() {
-        if (DEBUG) {
-            Log.d(TAG, "onPlaybackShutdown() called");
-        }
-        // destroys the service, which in turn will destroy the player
-        service.destroyPlayerAndStopService();
+        lifecycleController.shutdown();
     }
 
     public void smoothStopForImmediateReusing() {
-        // Pausing would make transition from one stream to a new stream not smooth, so only stop
-        simpleExoPlayer.stop();
-        setRecovery();
-        UIs.call(PlayerUi::smoothStopForImmediateReusing);
+        lifecycleController.smoothStopForImmediateReusing();
     }
     //endregion
 
@@ -596,7 +486,7 @@ public final class Player implements PlaybackListener, Listener {
         progressController.start();
     }
 
-    private void stopProgressLoop() {
+    void stopProgressLoop() {
         progressController.stop();
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.content.Context
+import android.util.Log
+import androidx.core.math.MathUtils
+import androidx.media3.common.C
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import org.schabi.newpipe.R
+import org.schabi.newpipe.player.helper.AudioReactor
+import org.schabi.newpipe.player.helper.LoadController
+import org.schabi.newpipe.player.helper.PlayerHelper
+import org.schabi.newpipe.player.playback.MediaSourceManager
+import org.schabi.newpipe.player.playqueue.PlayQueue
+import org.schabi.newpipe.player.ui.PlayerUi
+
+/** Owns player-engine lifecycle, queue-manager lifetime, and recovery positions. */
+internal class PlayerLifecycleController(
+    private val player: Player,
+    private val context: Context,
+    private val service: PlayerService,
+    private val renderFactory: DefaultRenderersFactory,
+    private val trackSelector: DefaultTrackSelector,
+    private val loadController: LoadController,
+    private val audioController: PlayerAudioController,
+    private val broadcastController: PlayerBroadcastController,
+    private val errorController: PlayerErrorController,
+    private val historyController: PlayerHistoryController,
+    private val thumbnailController: PlayerThumbnailController,
+    private val localMetadataController: PlayerLocalMetadataController,
+    private val sleepTimerController: SleepTimerPlaybackController,
+    private val progressController: PlayerProgressController,
+    private val playbackParametersController: PlaybackParametersController,
+    private val streamItemDisposable: CompositeDisposable
+) {
+    private var playQueueManager: MediaSourceManager? = null
+
+    fun initPlayback(queue: PlayQueue, playOnReady: Boolean) {
+        destroyPlayer()
+        initPlayer(playOnReady)
+        val skipSilence = player.prefs.getBoolean(
+            context.getString(R.string.playback_skip_silence_key),
+            player.playbackSkipSilence
+        )
+        val parameters = PlayerHelper.retrievePlaybackParametersFromPrefs(player)
+        playbackParametersController.applyParameters(
+            parameters.speed,
+            parameters.pitch,
+            skipSilence
+        )
+
+        player.setPlayQueueForLifecycle(queue)
+        queue.init()
+        player.exoPlayer.shuffleModeEnabled = queue.isShuffled
+        sleepTimerController.onQueueReplaced()
+        reloadPlayQueueManager()
+        player.UIs().call(PlayerUi::initPlayback)
+        player.applyPlayerVolume()
+        player.notifyQueueUpdateToListeners()
+        player.notifySleepTimerUpdateToListeners()
+    }
+
+    fun destroy() {
+        if (Player.DEBUG) Log.d(Player.TAG, "destroy() called")
+        thumbnailController.cancel()
+        localMetadataController.cancel()
+        sleepTimerController.clear()
+        player.saveStreamProgressState()
+        setRecovery()
+        player.stopActivityBinding()
+        destroyPlayer()
+        broadcastController.unregister()
+        historyController.clear()
+        progressController.clear()
+        streamItemDisposable.clear()
+        player.UIs().destroyAll(Any::class.java)
+    }
+
+    fun setRecovery() {
+        val queue = player.playQueue ?: return
+        if (player.exoPlayerIsNull()) return
+        val position = MathUtils.clamp(
+            player.exoPlayer.currentPosition,
+            0,
+            player.exoPlayer.duration
+        )
+        setRecovery(queue.index, position)
+    }
+
+    fun reloadPlayQueueManager() {
+        playQueueManager?.dispose()
+        playQueueManager = player.playQueue?.let { MediaSourceManager(player, it) }
+    }
+
+    fun shutdown() {
+        if (Player.DEBUG) Log.d(Player.TAG, "onPlaybackShutdown() called")
+        service.destroyPlayerAndStopService()
+    }
+
+    fun smoothStopForImmediateReusing() {
+        player.exoPlayer.stop()
+        setRecovery()
+        player.UIs().call(PlayerUi::smoothStopForImmediateReusing)
+    }
+
+    private fun initPlayer(playOnReady: Boolean) {
+        if (Player.DEBUG) {
+            Log.d(Player.TAG, "initPlayer() called with: playOnReady = [$playOnReady]")
+        }
+        val exoPlayer = ExoPlayer.Builder(context, renderFactory)
+            .setTrackSelector(trackSelector)
+            .setLoadControl(loadController)
+            .setUsePlatformDiagnostics(false)
+            .build()
+        player.setExoPlayerForLifecycle(exoPlayer)
+        exoPlayer.addListener(player)
+        exoPlayer.playWhenReady = playOnReady
+        exoPlayer.setSeekParameters(PlayerHelper.getSeekParameters(context))
+        exoPlayer.setWakeMode(C.WAKE_MODE_NETWORK)
+        exoPlayer.setHandleAudioBecomingNoisy(true)
+        audioController.attachAudioSession(exoPlayer.audioSessionId)
+        player.setAudioReactorForLifecycle(AudioReactor(context, exoPlayer))
+        broadcastController.register()
+        player.UIs().call(PlayerUi::initPlayer)
+        player.updateAudioTunneling()
+    }
+
+    private fun destroyPlayer() {
+        if (Player.DEBUG) Log.d(Player.TAG, "destroyPlayer() called")
+        errorController.resetRecovery()
+        historyController.stopLearningSession()
+        player.UIs().call(PlayerUi::destroyPlayer)
+        audioController.releaseAudioSession()
+        if (!player.exoPlayerIsNull()) {
+            player.exoPlayer.removeListener(player)
+            player.exoPlayer.stop()
+            player.exoPlayer.release()
+        }
+        if (player.isProgressLoopRunning) player.stopProgressLoop()
+        player.playQueue?.dispose()
+        player.audioReactor?.dispose()
+        playQueueManager?.dispose()
+    }
+
+    private fun setRecovery(queuePosition: Int, windowPosition: Long) {
+        val queue = player.playQueue ?: return
+        if (queue.size() <= queuePosition) return
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "Setting recovery, queue: $queuePosition, pos: $windowPosition"
+            )
+        }
+        queue.setRecovery(queuePosition, windowPosition)
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistShuffleIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistShuffleIntegrationTest.java
@@ -30,12 +30,13 @@ public class LocalPlaylistShuffleIntegrationTest {
 
     @Test
     public void playerRestoresTheQueueShuffleState() throws Exception {
-        final String player = read("java/org/schabi/newpipe/player/Player.java");
+        final String lifecycleController = read(
+                "java/org/schabi/newpipe/player/PlayerLifecycleController.kt");
         final String queueModeController = read(
                 "java/org/schabi/newpipe/player/PlayerQueueModeController.kt");
 
-        assertTrue(player.contains(
-                "simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled())"));
+        assertTrue(lifecycleController.contains(
+                "player.exoPlayer.shuffleModeEnabled = queue.isShuffled"));
         assertTrue(queueModeController.contains("shuffleModeEnabled && !queue.isShuffled"));
         assertTrue(queueModeController.contains("!shuffleModeEnabled && queue.isShuffled"));
     }


### PR DESCRIPTION
- Move Media3 engine creation, teardown, and queue-manager lifetime into Kotlin
- Move recovery-position persistence and complete player destruction into Kotlin
- Reduce `Player.java` from 1,423 to 1,313 lines while preserving its public lifecycle API