### PR TITLE
Extract Media3 listener controller

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -1,14 +1,7 @@
 package org.schabi.newpipe.player;
 
-import static androidx.media3.common.Player.DISCONTINUITY_REASON_AUTO_TRANSITION;
-import static androidx.media3.common.Player.DISCONTINUITY_REASON_INTERNAL;
-import static androidx.media3.common.Player.DISCONTINUITY_REASON_REMOVE;
-import static androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK;
-import static androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT;
-import static androidx.media3.common.Player.DISCONTINUITY_REASON_SKIP;
 import static androidx.media3.common.Player.DiscontinuityReason;
 import static androidx.media3.common.Player.Listener;
-import static androidx.media3.common.Player.REPEAT_MODE_ONE;
 import static androidx.media3.common.Player.RepeatMode;
 import static org.schabi.newpipe.util.ListHelper.getPopupResolutionIndex;
 import static org.schabi.newpipe.util.ListHelper.getResolutionIndex;
@@ -197,6 +190,8 @@ public final class Player implements PlaybackListener, Listener {
     @NonNull
     private final PlayerLifecycleController lifecycleController;
     @NonNull
+    private final PlayerMedia3ListenerController media3ListenerController;
+    @NonNull
     private final PlayerMetadataController metadataController;
     @NonNull
     private final PlayerProgressController progressController;
@@ -295,6 +290,9 @@ public final class Player implements PlaybackListener, Listener {
                 presentationController, popupPlayerReturnState, videoResolver,
                 streamItemDisposable);
         errorController = new PlayerErrorController(this, eventDispatcher, videoResolver);
+        media3ListenerController = new PlayerMedia3ListenerController(this, audioController,
+                metadataController, playbackParametersController, sponsorBlockController,
+                errorController, sleepTimerController);
 
         // The UIs added here should always be present. They will be initialized when the player
         // reaches the initialization step. Make sure the media session ui is before the
@@ -677,7 +675,7 @@ public final class Player implements PlaybackListener, Listener {
 
     @Override
     public void onAudioSessionIdChanged(final int audioSessionId) {
-        audioController.onAudioSessionChanged(audioSessionId);
+        media3ListenerController.onAudioSessionIdChanged(audioSessionId);
     }
 
     /**
@@ -697,107 +695,40 @@ public final class Player implements PlaybackListener, Listener {
     public void onEvents(@NonNull final androidx.media3.common.Player player,
                          @NonNull final androidx.media3.common.Player.Events events) {
         Listener.super.onEvents(player, events);
-        metadataController.onEvents(player);
+        media3ListenerController.onEvents(player);
     }
 
     @Override
     public void onTimelineChanged(@NonNull final Timeline timeline, final int reason) {
-        if (currentItem != null && isLive()) {
-            // A live timeline can reset ExoPlayer's playback parameters while it is prepared or
-            // refreshed. Restore the active channel profile (or the global playback speed) after
-            // the dynamic timeline is available.
-            playbackParametersController.applySpeedProfile(currentItem);
-        }
+        media3ListenerController.onTimelineChanged(timeline, reason);
     }
 
     @Override
     public void onTracksChanged(@NonNull final Tracks tracks) {
-        if (DEBUG) {
-            Log.d(TAG, "ExoPlayer - onTracksChanged(), "
-                    + "track group size = " + tracks.getGroups().size());
-        }
-        UIs.call(playerUi -> playerUi.onTextTracksChanged(tracks));
+        media3ListenerController.onTracksChanged(tracks);
     }
 
     @Override
     public void onPlaybackParametersChanged(@NonNull final PlaybackParameters playbackParameters) {
-        if (DEBUG) {
-            Log.d(TAG, "ExoPlayer - playbackParameters(), speed = [" + playbackParameters.speed
-                    + "], pitch = [" + playbackParameters.pitch + "]");
-        }
-        UIs.call(playerUi -> playerUi.onPlaybackParametersChanged(playbackParameters));
+        media3ListenerController.onPlaybackParametersChanged(playbackParameters);
     }
 
     @Override
     public void onPositionDiscontinuity(@NonNull final PositionInfo oldPosition,
                                         @NonNull final PositionInfo newPosition,
                                         @DiscontinuityReason final int discontinuityReason) {
-        if (DEBUG) {
-            Log.d(TAG, "ExoPlayer - onPositionDiscontinuity() called with "
-                    + "oldPositionIndex = [" + oldPosition.mediaItemIndex + "], "
-                    + "oldPositionMs = [" + oldPosition.positionMs + "], "
-                    + "newPositionIndex = [" + newPosition.mediaItemIndex + "], "
-                    + "newPositionMs = [" + newPosition.positionMs + "], "
-                    + "discontinuityReason = [" + discontinuityReason + "]");
-        }
-        if (playQueue == null) {
-            return;
-        }
-
-        sponsorBlockController.onPositionDiscontinuity(
-                discontinuityReason == DISCONTINUITY_REASON_SEEK, newPosition.positionMs);
-
-        // Refresh the playback if there is a transition to the next video
-        final int newIndex = newPosition.mediaItemIndex;
-        if (newIndex != oldPosition.mediaItemIndex) {
-            UIs.call(PlayerUi::onMediaItemTransition);
-            errorController.resetRecovery();
-        }
-        if (discontinuityReason == DISCONTINUITY_REASON_AUTO_TRANSITION) {
-            sleepTimerController.onItemEnded(
-                    playQueue.getItem(oldPosition.mediaItemIndex), true);
-        }
-        switch (discontinuityReason) {
-            case DISCONTINUITY_REASON_AUTO_TRANSITION:
-            case DISCONTINUITY_REASON_REMOVE:
-                // When player is in single repeat mode and a period transition occurs,
-                // we need to register a view count here since no metadata has changed
-                if (getRepeatMode() == REPEAT_MODE_ONE && newIndex == playQueue.getIndex()) {
-                    registerStreamViewed();
-                    break;
-                }
-            case DISCONTINUITY_REASON_SEEK:
-                if (DEBUG) {
-                    Log.d(TAG, "ExoPlayer - onSeekProcessed() called");
-                }
-                if (stateController.isPrepared()) {
-                    saveStreamProgressState();
-                }
-            case DISCONTINUITY_REASON_SEEK_ADJUSTMENT:
-            case DISCONTINUITY_REASON_INTERNAL:
-                // Player index may be invalid when playback is blocked
-                if (getCurrentState() != STATE_BLOCKED && newIndex != playQueue.getIndex()) {
-                    saveStreamProgressStateCompleted(); // current stream has ended
-                    playQueue.setIndex(newIndex);
-                }
-                break;
-            case DISCONTINUITY_REASON_SKIP:
-                break; // only makes Android Studio linter happy, as there are no ads
-        }
-
-        if (discontinuityReason != DISCONTINUITY_REASON_AUTO_TRANSITION) {
-            sleepTimerController.onPositionDiscontinuity(playQueue.getItem(newIndex));
-        }
+        media3ListenerController.onPositionDiscontinuity(
+                oldPosition, newPosition, discontinuityReason);
     }
 
     @Override
     public void onRenderedFirstFrame() {
-        UIs.call(PlayerUi::onRenderedFirstFrame);
+        media3ListenerController.onRenderedFirstFrame();
     }
 
     @Override
     public void onCues(@NonNull final CueGroup cueGroup) {
-        UIs.call(playerUi -> playerUi.onCues(cueGroup.cues));
+        media3ListenerController.onCues(cueGroup);
     }
 
     //endregion
@@ -926,7 +857,7 @@ public final class Player implements PlaybackListener, Listener {
     //////////////////////////////////////////////////////////////////////////*/
     //region StreamInfo history: views and progress
 
-    private void registerStreamViewed() {
+    void registerStreamViewed() {
         historyController.registerViewed();
     }
 
@@ -1079,15 +1010,7 @@ public final class Player implements PlaybackListener, Listener {
     //region Video size
     @Override // exoplayer listener
     public void onVideoSizeChanged(@NonNull final VideoSize videoSize) {
-        if (DEBUG) {
-            Log.d(TAG, "onVideoSizeChanged() called with: "
-                    + "width / height = [" + videoSize.width + " / " + videoSize.height
-                    + " = " + (((float) videoSize.width) / videoSize.height) + "], "
-                    + "unappliedRotationDegrees = [" + videoSize.unappliedRotationDegrees + "], "
-                    + "pixelWidthHeightRatio = [" + videoSize.pixelWidthHeightRatio + "]");
-        }
-
-        UIs.call(playerUi -> playerUi.onVideoSizeChanged(videoSize));
+        media3ListenerController.onVideoSizeChanged(videoSize);
     }
     //endregion
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
-import android.util.Log;
 import android.view.LayoutInflater;
 
 import androidx.annotation.NonNull;

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerMedia3ListenerController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerMedia3ListenerController.kt
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player
+
+import android.util.Log
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player as Media3Player
+import androidx.media3.common.Player.PositionInfo
+import androidx.media3.common.Timeline
+import androidx.media3.common.Tracks
+import androidx.media3.common.VideoSize
+import androidx.media3.common.text.CueGroup
+import org.schabi.newpipe.player.ui.PlayerUi
+
+/** Owns Media3 listener events that coordinate multiple player controllers. */
+internal class PlayerMedia3ListenerController(
+    private val player: Player,
+    private val audioController: PlayerAudioController,
+    private val metadataController: PlayerMetadataController,
+    private val playbackParametersController: PlaybackParametersController,
+    private val sponsorBlockController: SponsorBlockPlaybackController,
+    private val errorController: PlayerErrorController,
+    private val sleepTimerController: SleepTimerPlaybackController
+) {
+    fun onAudioSessionIdChanged(audioSessionId: Int) {
+        audioController.onAudioSessionChanged(audioSessionId)
+    }
+
+    fun onEvents(media3Player: Media3Player) {
+        metadataController.onEvents(media3Player)
+    }
+
+    fun onTimelineChanged(timeline: Timeline, reason: Int) {
+        val item = player.currentItem
+        if (item != null && player.isLive) {
+            playbackParametersController.applySpeedProfile(item)
+        }
+    }
+
+    fun onTracksChanged(tracks: Tracks) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "ExoPlayer - onTracksChanged(), track group size = ${tracks.groups.size}"
+            )
+        }
+        player.UIs().call { ui -> ui.onTextTracksChanged(tracks) }
+    }
+
+    fun onPlaybackParametersChanged(parameters: PlaybackParameters) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "ExoPlayer - playbackParameters(), speed = [${parameters.speed}], " +
+                    "pitch = [${parameters.pitch}]"
+            )
+        }
+        player.UIs().call { ui -> ui.onPlaybackParametersChanged(parameters) }
+    }
+
+    fun onPositionDiscontinuity(
+        oldPosition: PositionInfo,
+        newPosition: PositionInfo,
+        reason: Int
+    ) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "ExoPlayer - onPositionDiscontinuity() called with " +
+                    "oldPositionIndex = [${oldPosition.mediaItemIndex}], " +
+                    "oldPositionMs = [${oldPosition.positionMs}], " +
+                    "newPositionIndex = [${newPosition.mediaItemIndex}], " +
+                    "newPositionMs = [${newPosition.positionMs}], " +
+                    "discontinuityReason = [$reason]"
+            )
+        }
+        val queue = player.playQueue ?: return
+        sponsorBlockController.onPositionDiscontinuity(
+            reason == Media3Player.DISCONTINUITY_REASON_SEEK,
+            newPosition.positionMs
+        )
+
+        val newIndex = newPosition.mediaItemIndex
+        if (newIndex != oldPosition.mediaItemIndex) {
+            player.UIs().call(PlayerUi::onMediaItemTransition)
+            errorController.resetRecovery()
+        }
+        if (reason == Media3Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
+            sleepTimerController.onItemEnded(queue.getItem(oldPosition.mediaItemIndex), true)
+        }
+
+        when (reason) {
+            Media3Player.DISCONTINUITY_REASON_AUTO_TRANSITION,
+            Media3Player.DISCONTINUITY_REASON_REMOVE -> {
+                if (player.repeatMode == Media3Player.REPEAT_MODE_ONE &&
+                    newIndex == queue.index
+                ) {
+                    player.registerStreamViewed()
+                } else {
+                    handleSeek(queue, newIndex)
+                }
+            }
+
+            Media3Player.DISCONTINUITY_REASON_SEEK -> handleSeek(queue, newIndex)
+
+            Media3Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT,
+            Media3Player.DISCONTINUITY_REASON_INTERNAL -> synchronizeQueueIndex(queue, newIndex)
+
+            Media3Player.DISCONTINUITY_REASON_SKIP -> Unit
+        }
+
+        if (reason != Media3Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
+            sleepTimerController.onPositionDiscontinuity(queue.getItem(newIndex))
+        }
+    }
+
+    fun onRenderedFirstFrame() {
+        player.UIs().call(PlayerUi::onRenderedFirstFrame)
+    }
+
+    fun onCues(cueGroup: CueGroup) {
+        player.UIs().call { ui -> ui.onCues(cueGroup.cues) }
+    }
+
+    fun onVideoSizeChanged(videoSize: VideoSize) {
+        if (Player.DEBUG) {
+            Log.d(
+                Player.TAG,
+                "onVideoSizeChanged() called with: width / height = " +
+                    "[${videoSize.width} / ${videoSize.height} = " +
+                    "${videoSize.width.toFloat() / videoSize.height}], " +
+                    "unappliedRotationDegrees = [${videoSize.unappliedRotationDegrees}], " +
+                    "pixelWidthHeightRatio = [${videoSize.pixelWidthHeightRatio}]"
+            )
+        }
+        player.UIs().call { ui -> ui.onVideoSizeChanged(videoSize) }
+    }
+
+    private fun handleSeek(
+        queue: org.schabi.newpipe.player.playqueue.PlayQueue,
+        newIndex: Int
+    ) {
+        if (Player.DEBUG) Log.d(Player.TAG, "ExoPlayer - onSeekProcessed() called")
+        if (player.isPreparedForProgressUpdates()) {
+            player.saveStreamProgressState()
+        }
+        synchronizeQueueIndex(queue, newIndex)
+    }
+
+    private fun synchronizeQueueIndex(
+        queue: org.schabi.newpipe.player.playqueue.PlayQueue,
+        newIndex: Int
+    ) {
+        if (player.currentState != Player.STATE_BLOCKED && newIndex != queue.index) {
+            player.saveStreamProgressStateCompleted()
+            queue.index = newIndex
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/helper/SleepTimerResourcesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/SleepTimerResourcesTest.java
@@ -59,11 +59,13 @@ public class SleepTimerResourcesTest {
     public void playerHandlesDurationAndNaturalPlaybackEndpoints() throws Exception {
         final String player = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/player/Player.java"));
+        final String listenerController = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/PlayerMedia3ListenerController.kt"));
         final String controller = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/player/SleepTimerPlaybackController.kt"));
 
-        assertTrue(player.contains("sleepTimerController.onItemEnded"));
-        assertTrue(player.contains("DISCONTINUITY_REASON_AUTO_TRANSITION"));
+        assertTrue(listenerController.contains("sleepTimerController.onItemEnded"));
+        assertTrue(listenerController.contains("DISCONTINUITY_REASON_AUTO_TRANSITION"));
         assertTrue(player.contains("sleepTimerController.startDuration"));
         assertTrue(controller.contains("timer.hasDurationExpired()"));
         assertTrue(controller.contains("setVolumeMultiplier(1.0f)"));

--- a/app/src/test/java/org/schabi/newpipe/player/ui/VideoPlayerUiAspectRatioTransitionTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/ui/VideoPlayerUiAspectRatioTransitionTest.java
@@ -29,18 +29,18 @@ public class VideoPlayerUiAspectRatioTransitionTest {
     @Test
     public void cachedPreviousQueueItemAlsoClearsThePreviousVideoAspectRatio() throws Exception {
         final String playerSource = Files.readString(mainDirectory.resolve(
-                "java/org/schabi/newpipe/player/Player.java"));
+                "java/org/schabi/newpipe/player/PlayerMedia3ListenerController.kt"));
         final String uiSource = Files.readString(mainDirectory.resolve(
                 "java/org/schabi/newpipe/player/ui/VideoPlayerUi.java"));
 
         final int itemChangeStart = playerSource.indexOf(
                 "if (newIndex != oldPosition.mediaItemIndex)");
         final int discontinuitySwitchStart = playerSource.indexOf(
-                "switch (discontinuityReason)", itemChangeStart);
+                "when (reason)", itemChangeStart);
         assertTrue(itemChangeStart >= 0);
         assertTrue(discontinuitySwitchStart > itemChangeStart);
         assertTrue(playerSource.substring(itemChangeStart, discontinuitySwitchStart)
-                .contains("UIs.call(PlayerUi::onMediaItemTransition)"));
+                .contains("player.UIs().call(PlayerUi::onMediaItemTransition)"));
         final int transitionMethodStart = uiSource.indexOf(
                 "public void onMediaItemTransition()");
         final int playingMethodStart = uiSource.indexOf(


### PR DESCRIPTION
- Move cross-controller Media3 listener coordination into Kotlin
- Preserve discontinuity, timeline, track, cue, and video-size behavior behind delegated callbacks
- Reduce `Player.java` from 1,312 to 1,241 lines and move the aspect-ratio source assertion to the new owner