### PR TITLE
Fix player engine lifecycle after Kotlin migration

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.kt
@@ -303,6 +303,10 @@ class Player(
         media3Player = exoPlayer
     }
 
+    fun clearExoPlayerForLifecycle() {
+        media3Player = null
+    }
+
     fun setAudioReactorForLifecycle(reactor: AudioReactor) {
         activeAudioReactor = reactor
     }
@@ -593,8 +597,11 @@ class Player(
 
     fun exoPlayerIsNull(): Boolean = media3Player == null
 
+    @get:JvmName("requireExoPlayer")
     val exoPlayer: ExoPlayer
         get() = checkNotNull(media3Player)
+
+    fun getExoPlayer(): ExoPlayer? = media3Player
 
     val isStopped: Boolean
         get() = media3Player?.playbackState == null ||

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
@@ -139,9 +139,14 @@ internal class PlayerLifecycleController(
         player.UIs().call(PlayerUi::destroyPlayer)
         audioController.releaseAudioSession()
         if (!player.exoPlayerIsNull()) {
-            player.exoPlayer.removeListener(player)
-            player.exoPlayer.stop()
-            player.exoPlayer.release()
+            val exoPlayer = player.exoPlayer
+            try {
+                exoPlayer.removeListener(player)
+                exoPlayer.stop()
+                exoPlayer.release()
+            } finally {
+                player.clearExoPlayerForLifecycle()
+            }
         }
         if (player.isProgressLoopRunning) player.stopProgressLoop()
         player.playQueue?.dispose()

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerEngineLifecycleContractTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerEngineLifecycleContractTest.java
@@ -1,0 +1,53 @@
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class PlayerEngineLifecycleContractTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void kotlinPlayerPreservesNullableJavaExoPlayerAccess() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/Player.kt"));
+
+        assertTrue(source.contains("@get:JvmName(\"requireExoPlayer\")"));
+        assertTrue(source.contains("fun getExoPlayer(): ExoPlayer? = media3Player"));
+    }
+
+    @Test
+    public void destroyingPlayerClearsReleasedEngineReference() throws Exception {
+        final String playerSource = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/Player.kt"));
+        final String lifecycleSource = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/PlayerLifecycleController.kt"));
+
+        assertTrue(methodBody(playerSource, "fun clearExoPlayerForLifecycle()")
+                .contains("media3Player = null"));
+        assertTrue(methodBody(lifecycleSource, "private fun destroyPlayer()")
+                .contains("player.clearExoPlayerForLifecycle()"));
+    }
+
+    private static String methodBody(final String source, final String signature) {
+        final int signatureIndex = source.indexOf(signature);
+        assertTrue("Missing method: " + signature, signatureIndex >= 0);
+
+        final int bodyStart = source.indexOf('{', signatureIndex);
+        assertTrue("Missing method body: " + signature, bodyStart >= 0);
+
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unclosed method body: " + signature);
+    }
+}


### PR DESCRIPTION
- Restore nullable Java `getExoPlayer()` access while keeping Kotlin `exoPlayer` non-null and type-safe
- Clear the stored ExoPlayer reference after engine release so lifecycle availability checks stay accurate
- Add regression coverage for the Java compatibility contract and teardown cleanup