### PR TITLE
Harden local audio metadata and embedded artwork

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt
@@ -86,6 +86,25 @@ class LocalMediaBrowserViewModel(application: Application) : AndroidViewModel(ap
 
     fun mediaItem(entry: LocalMediaDocumentEntry): LocalMediaItem? = browser.mediaItem(entry)
 
+    /** Resolve embedded tags before a SAF file becomes a playback queue item. */
+    fun resolveMediaItem(
+        entry: LocalMediaDocumentEntry,
+        onReady: (LocalMediaItem?) -> Unit
+    ) {
+        scanExecutor.execute {
+            val item = browser.mediaItem(entry)?.let { unresolved ->
+                unresolved.withEmbeddedMetadata(
+                    LocalMediaMetadataLoader.readCached(
+                        getApplication<Application>().contentResolver,
+                        unresolved.contentUri,
+                        unresolved.mimeType
+                    )
+                )
+            }
+            mainHandler.post { onReady(item) }
+        }
+    }
+
     fun collect(
         location: LocalMediaDocumentLocation,
         onReady: (List<LocalMediaItem>) -> Unit

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaFragment.kt
@@ -519,7 +519,8 @@ class LocalMediaFragment : Fragment() {
             browserViewModel.open(entry)
             return
         }
-        browserViewModel.mediaItem(entry)?.let { item ->
+        resolveDocumentMediaItem(entry) { item ->
+            item ?: return@resolveDocumentMediaItem
             val queue = LocalMediaPlayQueue(listOf(item.toPlayQueueItem()), 0)
             NavigationHelper.playOnMainPlayer(requireActivity() as AppCompatActivity, queue)
         }
@@ -529,7 +530,19 @@ class LocalMediaFragment : Fragment() {
         if (entry.isDirectory) {
             showFolderActions(entry.location, entry.name, entry.isRoot)
         } else {
-            browserViewModel.mediaItem(entry)?.let(::showActions)
+            resolveDocumentMediaItem(entry) { item -> item?.let(::showActions) }
+        }
+    }
+
+    private fun resolveDocumentMediaItem(
+        entry: LocalMediaDocumentEntry,
+        onReady: (LocalMediaItem?) -> Unit
+    ) {
+        view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.VISIBLE
+        browserViewModel.resolveMediaItem(entry) { item ->
+            if (!isAdded || view == null) return@resolveMediaItem
+            view?.findViewById<View>(R.id.localMediaProgress)?.visibility = View.GONE
+            onReady(item)
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaMetadataLoader.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaMetadataLoader.kt
@@ -15,6 +15,7 @@ import androidx.annotation.WorkerThread
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
+import java.util.Base64
 import java.util.LinkedHashMap
 import java.util.Locale
 import java.util.concurrent.Executors
@@ -25,10 +26,11 @@ data class LocalMediaEmbeddedMetadata(
     val title: String? = null,
     val artist: String? = null,
     val album: String? = null,
-    val durationSeconds: Long = 0L
+    val durationSeconds: Long = 0L,
+    val artwork: ByteArray? = null
 )
 
-/** Resolves embedded tags for only the local item being played and caches the result by URI. */
+/** Resolves embedded metadata for local media and caches the result by content URI. */
 object LocalMediaMetadataLoader {
     private const val CACHE_ENTRY_COUNT = 128
 
@@ -54,16 +56,29 @@ object LocalMediaMetadataLoader {
         item: PlayQueueItem,
         callback: MetadataCallback
     ): Future<*> = executor.submit {
-        val cached = synchronized(cache) { cache[item.url] }
-        val metadata = cached ?: read(
+        val metadata = readCached(
             context.applicationContext.contentResolver,
             item.url,
             item.mimeType
-        ).also { resolved ->
-            synchronized(cache) { cache[item.url] = resolved }
-        }
+        )
         if (!Thread.currentThread().isInterrupted) {
             mainHandler.post { callback.onLoaded(metadata) }
+        }
+    }
+
+    /**
+     * Reads metadata synchronously for callers that are already running on a worker thread.
+     * This is also used by the SAF browser before a selected file is turned into a queue item.
+     */
+    @WorkerThread
+    internal fun readCached(
+        resolver: ContentResolver,
+        contentUri: String,
+        mimeType: String?
+    ): LocalMediaEmbeddedMetadata {
+        synchronized(cache) { cache[contentUri] }?.let { return it }
+        return read(resolver, contentUri, mimeType).also { resolved ->
+            synchronized(cache) { cache[contentUri] = resolved }
         }
     }
 
@@ -74,8 +89,13 @@ object LocalMediaMetadataLoader {
         mimeType: String?
     ): LocalMediaEmbeddedMetadata {
         val retrieverMetadata = readRetrieverMetadata(resolver, contentUri)
-        if (!isOggContainer(mimeType, contentUri)) return retrieverMetadata
+        if (!shouldProbeOggComments(mimeType, contentUri, retrieverMetadata)) {
+            return retrieverMetadata
+        }
 
+        // Some document providers expose OGG/Opus files with generic MIME types and opaque
+        // content:// URIs. The Ogg reader validates the stream signature immediately, so probing
+        // incomplete metadata is safe and avoids depending on the provider's MIME classification.
         val oggMetadata = try {
             resolver.openInputStream(Uri.parse(contentUri))?.use(OggVorbisCommentReader::read)
         } catch (_: Exception) {
@@ -85,7 +105,8 @@ object LocalMediaMetadataLoader {
             title = oggMetadata?.title ?: retrieverMetadata.title,
             artist = oggMetadata?.artist ?: retrieverMetadata.artist,
             album = oggMetadata?.album ?: retrieverMetadata.album,
-            durationSeconds = retrieverMetadata.durationSeconds
+            durationSeconds = retrieverMetadata.durationSeconds,
+            artwork = oggMetadata?.artwork ?: retrieverMetadata.artwork
         )
     }
 
@@ -113,7 +134,8 @@ object LocalMediaMetadataLoader {
                         ?.toLongOrNull()
                         ?.takeIf { it > 0L }
                         ?.div(1_000L)
-                        ?: 0L
+                        ?: 0L,
+                    artwork = retriever.embeddedPicture
                 )
             } ?: LocalMediaEmbeddedMetadata()
         } catch (_: Exception) {
@@ -122,25 +144,43 @@ object LocalMediaMetadataLoader {
             retriever.release()
         }
     }
-
-    private fun isOggContainer(mimeType: String?, contentUri: String): Boolean {
-        val normalizedMimeType = mimeType?.lowercase(Locale.ROOT)
-        val normalizedUri = contentUri.lowercase(Locale.ROOT)
-        return normalizedMimeType == "audio/ogg" ||
-            normalizedMimeType == "application/ogg" ||
-            normalizedMimeType == "audio/opus" ||
-            normalizedUri.endsWith(".ogg") ||
-            normalizedUri.endsWith(".oga") ||
-            normalizedUri.endsWith(".opus")
-    }
 }
+
+internal fun shouldProbeOggComments(
+    mimeType: String?,
+    contentUri: String,
+    metadata: LocalMediaEmbeddedMetadata
+): Boolean {
+    val normalizedMimeType = mimeType?.lowercase(Locale.ROOT).orEmpty()
+    val normalizedUri = contentUri.lowercase(Locale.ROOT)
+    val looksLikeOgg = normalizedMimeType.contains("ogg") ||
+        normalizedMimeType.contains("opus") ||
+        normalizedUri.contains(".ogg") ||
+        normalizedUri.contains(".oga") ||
+        normalizedUri.contains(".opus")
+    return looksLikeOgg || metadata.title == null || metadata.artist == null ||
+        metadata.album == null || metadata.artwork == null
+}
+
+internal fun LocalMediaItem.withEmbeddedMetadata(
+    metadata: LocalMediaEmbeddedMetadata
+): LocalMediaItem = copy(
+    title = metadata.title ?: title,
+    artist = metadata.artist ?: artist,
+    album = metadata.album ?: album,
+    durationSeconds = metadata.durationSeconds.takeIf { it > 0L } ?: durationSeconds
+)
 
 internal object OggVorbisCommentReader {
     private const val PAGE_HEADER_SIZE = 27
-    private const val MAX_SCANNED_BYTES = 8 * 1024 * 1024
-    private const val MAX_PACKET_BYTES = 8 * 1024 * 1024
+    private const val MAX_SCANNED_BYTES = 16 * 1024 * 1024
+    private const val MAX_PACKET_BYTES = 16 * 1024 * 1024
     private const val MAX_COMMENT_COUNT = 4_096
-    private const val MAX_FIELD_BYTES = 2 * 1024 * 1024
+    private const val MAX_FIELD_BYTES = 12 * 1024 * 1024
+    private const val MAX_ARTWORK_BYTES = 8 * 1024 * 1024
+    private const val MAX_PICTURE_BLOCK_BYTES = 10 * 1024 * 1024
+    private const val MAX_PICTURE_TEXT_BYTES = 64 * 1024
+
     private val vorbisCommentHeader = byteArrayOf(
         3,
         'v'.code.toByte(),
@@ -209,6 +249,8 @@ internal object OggVorbisCommentReader {
         var artist: String? = null
         var albumArtist: String? = null
         var album: String? = null
+        var metadataBlockPicture: ByteArray? = null
+        var legacyCoverArt: ByteArray? = null
         repeat(commentCount) {
             val fieldLength = reader.readLength(MAX_FIELD_BYTES) ?: return null
             val field = reader.readString(fieldLength) ?: return null
@@ -218,13 +260,57 @@ internal object OggVorbisCommentReader {
             val value = cleanTag(field.substring(separator + 1)) ?: return@repeat
             when (key) {
                 "TITLE" -> if (title == null) title = value
+
                 "ARTIST" -> if (artist == null) artist = value
+
                 "ALBUMARTIST" -> if (albumArtist == null) albumArtist = value
+
                 "ALBUM" -> if (album == null) album = value
+
+                "METADATA_BLOCK_PICTURE" -> if (metadataBlockPicture == null) {
+                    metadataBlockPicture = decodeMetadataBlockPicture(value)
+                }
+
+                "COVERART" -> if (legacyCoverArt == null) {
+                    legacyCoverArt = decodeLegacyCoverArt(value)
+                }
             }
         }
-        if (title == null && artist == null && albumArtist == null && album == null) return null
-        return LocalMediaEmbeddedMetadata(title, artist ?: albumArtist, album)
+        val artwork = metadataBlockPicture ?: legacyCoverArt
+        if (title == null && artist == null && albumArtist == null && album == null &&
+            artwork == null
+        ) {
+            return null
+        }
+        return LocalMediaEmbeddedMetadata(
+            title = title,
+            artist = artist ?: albumArtist,
+            album = album,
+            artwork = artwork
+        )
+    }
+
+    private fun decodeMetadataBlockPicture(value: String): ByteArray? {
+        val block = decodeBase64(value)?.takeIf { it.size <= MAX_PICTURE_BLOCK_BYTES }
+            ?: return null
+        val reader = BigEndianPacketReader(block)
+        reader.readUnsignedInt() ?: return null // picture type
+        val mimeLength = reader.readLength(MAX_PICTURE_TEXT_BYTES) ?: return null
+        if (!reader.skip(mimeLength)) return null
+        val descriptionLength = reader.readLength(MAX_PICTURE_TEXT_BYTES) ?: return null
+        if (!reader.skip(descriptionLength)) return null
+        repeat(4) { reader.readUnsignedInt() ?: return null } // width, height, depth, colors
+        val dataLength = reader.readLength(MAX_ARTWORK_BYTES) ?: return null
+        return reader.readBytes(dataLength)
+    }
+
+    private fun decodeLegacyCoverArt(value: String): ByteArray? = decodeBase64(value)
+        ?.takeIf { it.size <= MAX_ARTWORK_BYTES }
+
+    private fun decodeBase64(value: String): ByteArray? = try {
+        Base64.getDecoder().decode(value.trim())
+    } catch (_: IllegalArgumentException) {
+        null
     }
 
     private fun ByteArray.startsWith(prefix: ByteArray): Boolean = size >= prefix.size &&
@@ -268,6 +354,36 @@ internal object OggVorbisCommentReader {
             return String(data, position, length, StandardCharsets.UTF_8).also {
                 position += length
             }
+        }
+    }
+
+    private class BigEndianPacketReader(
+        private val data: ByteArray,
+        private var position: Int = 0
+    ) {
+        fun readUnsignedInt(): Long? {
+            if (position > data.size - Integer.BYTES) return null
+            val value = ((data[position].toLong() and 0xff) shl 24) or
+                ((data[position + 1].toLong() and 0xff) shl 16) or
+                ((data[position + 2].toLong() and 0xff) shl 8) or
+                (data[position + 3].toLong() and 0xff)
+            position += Integer.BYTES
+            return value
+        }
+
+        fun readLength(maximum: Int): Int? = readUnsignedInt()
+            ?.takeIf { it <= maximum.toLong() }
+            ?.toInt()
+
+        fun skip(length: Int): Boolean {
+            if (length < 0 || position > data.size - length) return false
+            position += length
+            return true
+        }
+
+        fun readBytes(length: Int): ByteArray? {
+            if (length < 0 || position > data.size - length) return null
+            return data.copyOfRange(position, position + length).also { position += length }
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.os.Handler
@@ -60,7 +59,14 @@ object LocalMediaThumbnailLoader {
     }
 
     fun load(target: ImageView, item: LocalMediaItem) {
-        load(target, item.contentUri, item.mediaStoreId, item.isVideo, item.thumbnailUri)
+        load(
+            target,
+            item.contentUri,
+            item.mediaStoreId,
+            item.isVideo,
+            item.mimeType,
+            item.thumbnailUri
+        )
     }
 
     fun load(target: ImageView, item: PlayQueueItem) {
@@ -69,6 +75,7 @@ object LocalMediaThumbnailLoader {
             item.url,
             item.localMediaId,
             item.streamType == StreamType.VIDEO_STREAM,
+            item.mimeType,
             item.localThumbnailUrl
         )
     }
@@ -79,6 +86,7 @@ object LocalMediaThumbnailLoader {
             entry.contentUri,
             -1L,
             entry.isVideo,
+            entry.mimeType,
             entry.contentUri.takeIf { entry.isVideo }
         )
     }
@@ -98,6 +106,7 @@ object LocalMediaThumbnailLoader {
                 item.url,
                 item.localMediaId,
                 item.streamType == StreamType.VIDEO_STREAM,
+                item.mimeType,
                 item.localThumbnailUrl
             )
         } else {
@@ -131,6 +140,7 @@ object LocalMediaThumbnailLoader {
         contentUri: String,
         mediaStoreId: Long,
         isVideo: Boolean,
+        mimeType: String?,
         thumbnailUri: String?
     ) {
         clear(target)
@@ -158,6 +168,7 @@ object LocalMediaThumbnailLoader {
                 contentUri,
                 mediaStoreId,
                 isVideo,
+                mimeType,
                 thumbnailUri
             )
             if (bitmap != null) cache.put(requestKey, bitmap)
@@ -179,6 +190,7 @@ object LocalMediaThumbnailLoader {
         contentUri: String,
         mediaStoreId: Long,
         isVideo: Boolean,
+        mimeType: String?,
         thumbnailUri: String?
     ): Bitmap? {
         val requestKey = "$isVideo:$contentUri"
@@ -186,7 +198,7 @@ object LocalMediaThumbnailLoader {
         val bitmap = if (isVideo) {
             loadVideoThumbnail(resolver, contentUri, mediaStoreId)
         } else {
-            loadEmbeddedArtwork(resolver, contentUri)
+            loadEmbeddedArtwork(resolver, contentUri, mimeType)
                 ?: loadArtworkUri(resolver, thumbnailUri)
         }
         if (bitmap != null) cache.put(requestKey, bitmap)
@@ -196,19 +208,15 @@ object LocalMediaThumbnailLoader {
     @WorkerThread
     private fun loadEmbeddedArtwork(
         resolver: ContentResolver,
-        contentUri: String
+        contentUri: String,
+        mimeType: String?
     ): Bitmap? {
-        val retriever = MediaMetadataRetriever()
-        return try {
-            resolver.openFileDescriptor(Uri.parse(contentUri), "r")?.use {
-                retriever.setDataSource(it.fileDescriptor)
-            } ?: return null
-            retriever.embeddedPicture?.let(::decodeArtwork)
-        } catch (_: Exception) {
-            null
-        } finally {
-            retriever.release()
-        }
+        val artwork = LocalMediaMetadataLoader.readCached(
+            resolver,
+            contentUri,
+            mimeType
+        ).artwork ?: return null
+        return decodeArtwork(artwork)
     }
 
     @WorkerThread
@@ -259,7 +267,7 @@ object LocalMediaThumbnailLoader {
         return try {
             if (Build.VERSION.SDK_INT >= 29) {
                 resolver.loadThumbnail(
-                    android.net.Uri.parse(contentUri),
+                    Uri.parse(contentUri),
                     Size(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT),
                     null
                 )

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaArtworkTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaArtworkTest.kt
@@ -25,10 +25,15 @@ class LocalMediaArtworkTest {
     }
 
     @Test
-    fun `local audio prefers embedded artwork and updates player surfaces`() {
+    fun `local audio uses shared embedded metadata and updates player surfaces`() {
         val loader = Files.readString(
             projectDirectory.resolve(
                 "java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt"
+            )
+        )
+        val metadataLoader = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaMetadataLoader.kt"
             )
         )
         val thumbnailController = Files.readString(
@@ -42,9 +47,12 @@ class LocalMediaArtworkTest {
             )
         )
 
-        assertTrue(loader.contains("retriever.embeddedPicture"))
+        assertTrue(loader.contains("LocalMediaMetadataLoader.readCached"))
         assertTrue(loader.indexOf("loadEmbeddedArtwork") < loader.indexOf("loadArtworkUri"))
         assertTrue(loader.contains("ArrayBlockingQueue(MAXIMUM_PENDING_THUMBNAILS)"))
+        assertTrue(metadataLoader.contains("retriever.embeddedPicture"))
+        assertTrue(metadataLoader.contains("METADATA_BLOCK_PICTURE"))
+        assertTrue(metadataLoader.contains("COVERART"))
         assertTrue(thumbnailController.contains("LocalMediaThumbnailLoader.loadBitmap"))
         assertTrue(queue.contains("LocalMediaThumbnailLoader.INSTANCE.load"))
     }

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaMetadataIntegrationTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaMetadataIntegrationTest.kt
@@ -6,6 +6,7 @@ package org.schabi.newpipe.local.media
 
 import java.nio.file.Files
 import java.nio.file.Path
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -35,5 +36,60 @@ class LocalMediaMetadataIntegrationTest {
             controller.indexOf("notifyMetadataUpdateToListeners()", metadataMutation) >
                 metadataMutation
         )
+    }
+
+    @Test
+    fun `SAF selection resolves embedded tags before playback queue creation`() {
+        val viewModel = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaBrowserViewModel.kt"
+            )
+        )
+        val fragment = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaFragment.kt"
+            )
+        )
+
+        val resolver = viewModel.indexOf("fun resolveMediaItem(")
+        val metadataRead = viewModel.indexOf("LocalMediaMetadataLoader.readCached", resolver)
+        val callback = viewModel.indexOf("mainHandler.post { onReady(item) }", metadataRead)
+        val fragmentResolution = fragment.indexOf("browserViewModel.resolveMediaItem(entry)")
+        val queueCreation = fragment.indexOf("LocalMediaPlayQueue", fragmentResolution)
+
+        assertTrue(resolver >= 0)
+        assertTrue(metadataRead > resolver)
+        assertTrue(callback > metadataRead)
+        assertTrue(fragmentResolution >= 0)
+        assertTrue(queueCreation > fragmentResolution)
+    }
+
+    @Test
+    fun `embedded metadata replaces SAF filename fallbacks without losing missing values`() {
+        val item = LocalMediaItem(
+            mediaStoreId = -1L,
+            contentUri = "content://documents/42",
+            title = "track-file",
+            artist = "",
+            album = "Fallback album",
+            folder = "Music",
+            mimeType = "application/octet-stream",
+            durationSeconds = 0L,
+            addedAtSeconds = 0L,
+            isVideo = false
+        )
+
+        val resolved = item.withEmbeddedMetadata(
+            LocalMediaEmbeddedMetadata(
+                title = "Embedded title",
+                artist = "Embedded artist",
+                durationSeconds = 123L
+            )
+        )
+
+        assertEquals("Embedded title", resolved.title)
+        assertEquals("Embedded artist", resolved.artist)
+        assertEquals("Fallback album", resolved.album)
+        assertEquals(123L, resolved.durationSeconds)
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/local/media/OggVorbisCommentReaderTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/OggVorbisCommentReaderTest.kt
@@ -8,8 +8,11 @@ package org.schabi.newpipe.local.media
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
+import java.util.Base64
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class OggVorbisCommentReaderTest {
@@ -59,6 +62,43 @@ class OggVorbisCommentReaderTest {
     }
 
     @Test
+    fun `reads FLAC picture block from Vorbis comments`() {
+        val artwork = byteArrayOf(1, 2, 3, 4, 5, 6)
+        val encodedPicture = Base64.getEncoder().encodeToString(flacPictureBlock(artwork))
+        val metadata = OggVorbisCommentReader.read(
+            ByteArrayInputStream(
+                oggPage(vorbisCommentPacket("METADATA_BLOCK_PICTURE=$encodedPicture"))
+            )
+        )
+
+        requireNotNull(metadata)
+        assertArrayEquals(artwork, metadata.artwork)
+    }
+
+    @Test
+    fun `reads legacy cover art from Vorbis comments`() {
+        val artwork = byteArrayOf(10, 20, 30, 40)
+        val encodedArtwork = Base64.getEncoder().encodeToString(artwork)
+        val metadata = OggVorbisCommentReader.read(
+            ByteArrayInputStream(oggPage(vorbisCommentPacket("COVERART=$encodedArtwork")))
+        )
+
+        requireNotNull(metadata)
+        assertArrayEquals(artwork, metadata.artwork)
+    }
+
+    @Test
+    fun `generic document MIME still probes incomplete metadata for Ogg tags`() {
+        assertTrue(
+            shouldProbeOggComments(
+                "application/octet-stream",
+                "content://com.android.providers.downloads.documents/document/42",
+                LocalMediaEmbeddedMetadata()
+            )
+        )
+    }
+
+    @Test
     fun `rejects input that is not an Ogg stream`() {
         assertNull(
             OggVorbisCommentReader.read(
@@ -85,6 +125,22 @@ class OggVorbisCommentReaderTest {
         }.toByteArray()
     }
 
+    private fun flacPictureBlock(artwork: ByteArray): ByteArray {
+        val mime = "image/png".toByteArray(StandardCharsets.US_ASCII)
+        return ByteArrayOutputStream().apply {
+            writeBigEndianInt(3) // front cover
+            writeBigEndianInt(mime.size)
+            write(mime)
+            writeBigEndianInt(0) // description length
+            writeBigEndianInt(1) // width
+            writeBigEndianInt(1) // height
+            writeBigEndianInt(24) // depth
+            writeBigEndianInt(0) // indexed colors
+            writeBigEndianInt(artwork.size)
+            write(artwork)
+        }.toByteArray()
+    }
+
     private fun oggPage(packet: ByteArray): ByteArray {
         require(packet.size < 255)
         return ByteArrayOutputStream().apply {
@@ -101,5 +157,12 @@ class OggVorbisCommentReaderTest {
         write(value ushr 8 and 0xff)
         write(value ushr 16 and 0xff)
         write(value ushr 24 and 0xff)
+    }
+
+    private fun ByteArrayOutputStream.writeBigEndianInt(value: Int) {
+        write(value ushr 24 and 0xff)
+        write(value ushr 16 and 0xff)
+        write(value ushr 8 and 0xff)
+        write(value and 0xff)
     }
 }


### PR DESCRIPTION
- Parse OGG and Opus `METADATA_BLOCK_PICTURE` and legacy `COVERART` tags with bounded decoding
- Probe incomplete local metadata even when SAF providers expose generic MIME types or opaque content URIs
- Share cached embedded metadata between title/tag resolution and artwork loading
- Resolve SAF file metadata on a worker thread before creating the selected playback queue item
- Preserve filename, album, and duration fallbacks when embedded values are missing
- Add regression coverage for Vorbis/Opus artwork, generic SAF MIME handling, and pre-playback metadata resolution
- Addresses #412 and #415