### PR TITLE
Open local group playback in Play queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt
@@ -13,7 +13,8 @@ object LocalMediaGroupQueueBuilder {
         random: Random = Random.Default
     ): LocalMediaPlayQueue = LocalMediaPlayQueue(
         items(group, shuffle, random).map(LocalMediaItem::toPlayQueueItem),
-        0
+        0,
+        true
     )
 
     internal fun items(

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerIntentController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerIntentController.kt
@@ -19,6 +19,7 @@ import org.schabi.newpipe.error.ErrorInfo
 import org.schabi.newpipe.error.ErrorUtil
 import org.schabi.newpipe.error.UserAction
 import org.schabi.newpipe.extractor.stream.StreamInfo
+import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue
 import org.schabi.newpipe.player.playqueue.PlayQueue
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue
@@ -40,7 +41,10 @@ internal class PlayerIntentController(
     private val videoResolver: VideoPlaybackResolver,
     private val streamItemDisposable: CompositeDisposable
 ) {
+    private var openPlayQueueAfterIntent = false
+
     fun handle(intent: Intent) {
+        openPlayQueueAfterIntent = false
         val intentType = IntentCompat.getSerializableExtra(
             intent,
             Player.PLAYER_INTENT_TYPE,
@@ -112,6 +116,8 @@ internal class PlayerIntentController(
         }
 
         val newQueue = playQueueFromCache(intent) ?: return
+        openPlayQueueAfterIntent = player.playerType == PlayerType.MAIN &&
+            (newQueue as? LocalMediaPlayQueue)?.consumeOpenQueueOnStart() == true
         val currentQueue = player.playQueue
         val samePlayQueue =
             currentQueue != null && currentQueue.equalStreamsAndIndex(newQueue)
@@ -170,6 +176,13 @@ internal class PlayerIntentController(
         }
         player.UIs().call(PlayerUi::setupAfterIntent)
         NavigationHelper.sendPlayerStartedEvent(context)
+        if (openPlayQueueAfterIntent) {
+            openPlayQueueAfterIntent = false
+            context.startActivity(
+                Intent(context, PlayQueueActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }
     }
 
     private fun handleTimestampChange(intent: Intent, playWhenReady: Boolean) {

--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/LocalMediaPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/LocalMediaPlayQueue.java
@@ -11,8 +11,46 @@ import java.util.List;
 
 /** A complete queue made from device-local media, or a mixture of local and remote items. */
 public final class LocalMediaPlayQueue extends PlayQueue {
+    private boolean openQueueOnStart;
+
     public LocalMediaPlayQueue(@NonNull final List<PlayQueueItem> items, final int index) {
+        this(items, index, false);
+    }
+
+    public LocalMediaPlayQueue(@NonNull final List<PlayQueueItem> items,
+                               final int index,
+                               final boolean openQueueOnStart) {
         super(index, items);
+        this.openQueueOnStart = openQueueOnStart;
+    }
+
+    /** Request the Play queue screen for the next main-player start. */
+    public void requestOpenQueueOnStart() {
+        openQueueOnStart = true;
+    }
+
+    /** @return whether this queue contains at least one device-local item. */
+    public boolean containsLocalMedia() {
+        return getStreams().stream().anyMatch(PlayQueueItem::isLocalMedia);
+    }
+
+    /**
+     * Consumes the one-shot request to show the queue after playback starts.
+     *
+     * @return whether the queue screen should be opened for this playback request
+     */
+    public boolean consumeOpenQueueOnStart() {
+        final boolean shouldOpen = openQueueOnStart;
+        openQueueOnStart = false;
+        return shouldOpen;
+    }
+
+    @Override
+    public synchronized void shuffleFromStart() {
+        if (containsLocalMedia()) {
+            requestOpenQueueOnStart();
+        }
+        super.shuffleFromStart();
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/util/PlayButtonHelper.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/PlayButtonHelper.kt
@@ -15,6 +15,8 @@ import org.schabi.newpipe.R
 import org.schabi.newpipe.databinding.PlaylistControlBinding
 import org.schabi.newpipe.fragments.list.playlist.PlaylistControlViewHolder
 import org.schabi.newpipe.player.PlayerType
+import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue
+import org.schabi.newpipe.player.playqueue.PlayQueue
 
 /**
  * Utility class for play buttons and their respective click listeners.
@@ -38,7 +40,7 @@ object PlayButtonHelper {
     ) {
         // click listener
         playlistControlBinding.playlistCtrlPlayAllButton.setOnClickListener {
-            NavigationHelper.playOnMainPlayer(activity, fragment.getPlayQueue())
+            NavigationHelper.playOnMainPlayer(activity, mainPlaybackQueue(fragment))
             showHoldToAppendToastIfNeeded(activity)
         }
         playlistControlBinding.playlistCtrlPlayPopupButton.setOnClickListener {
@@ -62,6 +64,14 @@ object PlayButtonHelper {
         playlistControlBinding.playlistCtrlPlayBgButton.setOnLongClickListener {
             NavigationHelper.enqueueOnPlayer(activity, fragment.getPlayQueue(), PlayerType.AUDIO)
             true
+        }
+    }
+
+    private fun mainPlaybackQueue(fragment: PlaylistControlViewHolder): PlayQueue {
+        return fragment.getPlayQueue().also { queue ->
+            if (queue is LocalMediaPlayQueue && queue.containsLocalMedia()) {
+                queue.requestOpenQueueOnStart()
+            }
         }
     }
 

--- a/app/src/test/java/org/schabi/newpipe/player/LocalMediaLibraryNavigationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/LocalMediaLibraryNavigationTest.java
@@ -9,10 +9,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 public class LocalMediaLibraryNavigationTest {
     private final Path mainDirectory = Files.exists(Path.of("src/main"))
@@ -47,5 +49,54 @@ public class LocalMediaLibraryNavigationTest {
         assertTrue(navigation.contains("LocalMediaFragment.newAudioTracksInstance()"));
         assertTrue(localMedia.contains("ARG_OPEN_AUDIO_TRACKS"));
         assertFalse(queueActivity.contains("new LocalMediaPlayQueue"));
+    }
+
+    @Test
+    public void localQueueDestinationIsExplicitAndOneShot() {
+        final PlayQueueItem localItem = mock(PlayQueueItem.class);
+        when(localItem.isLocalMedia()).thenReturn(true);
+        final LocalMediaPlayQueue queue = new LocalMediaPlayQueue(List.of(localItem), 0);
+
+        assertFalse(queue.consumeOpenQueueOnStart());
+        queue.requestOpenQueueOnStart();
+        assertTrue(queue.consumeOpenQueueOnStart());
+        assertFalse(queue.consumeOpenQueueOnStart());
+    }
+
+    @Test
+    public void shuffleMarksOnlyQueuesContainingLocalMedia() {
+        final PlayQueueItem localItem = mock(PlayQueueItem.class);
+        final PlayQueueItem remoteItem = mock(PlayQueueItem.class);
+        when(localItem.isLocalMedia()).thenReturn(true);
+        when(remoteItem.isLocalMedia()).thenReturn(false);
+
+        final LocalMediaPlayQueue localQueue = new LocalMediaPlayQueue(List.of(localItem), 0);
+        localQueue.shuffleFromStart();
+        assertTrue(localQueue.consumeOpenQueueOnStart());
+
+        final LocalMediaPlayQueue remoteQueue = new LocalMediaPlayQueue(List.of(remoteItem), 0);
+        remoteQueue.shuffleFromStart();
+        assertFalse(remoteQueue.consumeOpenQueueOnStart());
+    }
+
+    @Test
+    public void localGroupAndPlaylistMainPlaybackUseQueueDestinationContract()
+            throws Exception {
+        final String groupBuilder = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaGroupQueueBuilder.kt"));
+        final String playButtonHelper = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/util/PlayButtonHelper.kt"));
+        final String intentController = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/player/PlayerIntentController.kt"));
+        final String localPlaylist = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java"));
+
+        assertTrue(groupBuilder.contains("0,\n        true"));
+        assertTrue(playButtonHelper.contains("mainPlaybackQueue(fragment)"));
+        assertTrue(playButtonHelper.contains("queue.requestOpenQueueOnStart()"));
+        assertTrue(intentController.contains("consumeOpenQueueOnStart()"));
+        assertTrue(intentController.contains("PlayQueueActivity::class.java"));
+        assertTrue(localPlaylist.contains("getPlayQueueStartingAt(entry)"));
+        assertFalse(localPlaylist.contains("requestOpenQueueOnStart"));
     }
 }


### PR DESCRIPTION
- Keep individual local track taps on the normal main player
- Open Play queue immediately for local album, artist, genre, and folder Play All or Shuffle
- Apply the same behavior to saved playlist Play All or Shuffle when the playlist contains local media
- Keep popup, background, enqueue, Browse all songs, and remote-only playlist behavior unchanged
- Use a one-shot queue destination marker so later player switches do not reopen the queue
- Add focused regression coverage for single-track, group, playlist, shuffle, and remote-only behavior
- Addresses #416