### PR TITLE
Prevent share resume from forcing portrait fullscreen

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -15,6 +15,7 @@ import static org.schabi.newpipe.player.notification.NotificationConstants.ACTIO
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.database.ContentObserver;
 import android.graphics.Bitmap;
@@ -1108,15 +1109,26 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
 
     public void checkLandscape() {
-        // check if landscape is correct
-        final boolean videoInLandscapeButNotInFullscreen = isLandscape()
-                && !isFullscreen
-                && !player.isAudioOnly();
-
-        if (videoInLandscapeButNotInFullscreen
-                && !DeviceUtils.isTablet(context)) {
+        final Context playerContext = getParentContext().orElse(player.getService());
+        final int orientation = playerContext.getResources().getConfiguration().orientation;
+        if (shouldEnterFullscreenForConfiguration(
+                orientation,
+                isFullscreen,
+                player.isAudioOnly(),
+                DeviceUtils.isTablet(playerContext))) {
             setFullscreen(true);
         }
+    }
+
+    static boolean shouldEnterFullscreenForConfiguration(
+            final int orientation,
+            final boolean fullscreen,
+            final boolean audioOnly,
+            final boolean tablet) {
+        return orientation == Configuration.ORIENTATION_LANDSCAPE
+                && !fullscreen
+                && !audioOnly
+                && !tablet;
     }
 
     //endregion

--- a/app/src/test/java/org/schabi/newpipe/player/ui/MainPlayerUiFullscreenTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/ui/MainPlayerUiFullscreenTest.java
@@ -3,6 +3,8 @@ package org.schabi.newpipe.player.ui;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.content.res.Configuration;
+
 import org.junit.Test;
 
 public class MainPlayerUiFullscreenTest {
@@ -25,5 +27,42 @@ public class MainPlayerUiFullscreenTest {
     @Test
     public void verticalVideoInUnlockedLandscapeTogglesFullscreenDirectly() {
         assertFalse(MainPlayerUi.shouldUseScreenRotationAction(true, true, false));
+    }
+
+    @Test
+    public void portraitResumeNeverAutoEntersFullscreen() {
+        assertFalse(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_PORTRAIT,
+                false,
+                false,
+                false));
+    }
+
+    @Test
+    public void landscapePhoneVideoCanAutoEnterFullscreen() {
+        assertTrue(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_LANDSCAPE,
+                false,
+                false,
+                false));
+    }
+
+    @Test
+    public void fullscreenAudioAndTabletStatesDoNotAutoEnterAgain() {
+        assertFalse(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_LANDSCAPE,
+                true,
+                false,
+                false));
+        assertFalse(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_LANDSCAPE,
+                false,
+                true,
+                false));
+        assertFalse(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_LANDSCAPE,
+                false,
+                false,
+                true));
     }
 }


### PR DESCRIPTION
- Use Android configuration orientation for automatic fullscreen recovery instead of transient display metrics
- Prevent share-sheet/background resume transitions from promoting a portrait player to fullscreen
- Preserve normal landscape auto-fullscreen behavior on phones
- Keep existing fullscreen, audio-only, and tablet behavior unchanged
- Add regression coverage for portrait resume and fullscreen-entry guards