### PR TITLE
Fix share fullscreen transition and restore System UI media controls

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
@@ -15,6 +15,8 @@ import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.Player.RepeatMode;
 import androidx.media3.session.CommandButton;
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession;
+import androidx.media3.session.MediaSession;
+import androidx.media3.session.SessionCommands;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
@@ -212,15 +214,50 @@ public class MediaSessionPlayerUi extends PlayerUi
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-        // avoid costly notification actions update, if nothing changed from last time
+        final List<CommandButton> buttons = IntStream.range(0, newNotificationActions.size())
+                .mapToObj(index -> MediaSessionActionProvider.buttonFor(
+                        newNotificationActions.get(index), index == 0))
+                .collect(Collectors.toList());
+
+        // Avoid the global broadcast when the actions did not change. The media-notification
+        // controller is synchronized below on every update because it can connect after the
+        // initial player setup.
         if (!newNotificationActions.equals(prevNotificationActions)) {
             prevNotificationActions = newNotificationActions;
-            final List<CommandButton> buttons = IntStream.range(0, newNotificationActions.size())
-                    .mapToObj(index -> MediaSessionActionProvider.buttonFor(
-                            newNotificationActions.get(index), index == 0))
-                    .collect(Collectors.toList());
             mediaSession.setMediaButtonPreferences(buttons);
         }
+        syncMediaNotificationController(buttons);
+    }
+
+    /**
+     * Keeps Android's System UI controller authorized for the custom buttons published above.
+     *
+     * <p>Media3 filters media button preferences against the commands available to its special
+     * media-notification controller. If the custom commands are not explicitly available there,
+     * Android 13+ drops the corresponding platform PlaybackState custom actions, which removes
+     * WizeStream's fourth and fifth controls (Repeat and Close by default).</p>
+     *
+     * @param buttons the currently configured Android 13+ media action buttons
+     */
+    private void syncMediaNotificationController(@NonNull final List<CommandButton> buttons) {
+        final MediaSession.ControllerInfo notificationController =
+                mediaSession.getMediaNotificationControllerInfo();
+        if (notificationController == null) {
+            return;
+        }
+
+        final SessionCommands.Builder sessionCommands = new SessionCommands.Builder()
+                .addSessionCommands(
+                        MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.commands);
+        MediaSessionActionProvider.supportedActions().stream()
+                .map(MediaSessionActionProvider::commandFor)
+                .forEach(sessionCommands::add);
+
+        mediaSession.setAvailableCommands(
+                notificationController,
+                sessionCommands.build(),
+                mediaSession.getPlayer().getAvailableCommands());
+        mediaSession.setMediaButtonPreferences(notificationController, buttons);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
+++ b/app/src/main/java/org/schabi/newpipe/player/pip/NativePipController.java
@@ -77,18 +77,20 @@ public final class NativePipController {
             return;
         }
 
-        fragment.prepareNativePipEntry();
+        // Do not prepare the fragment for PiP yet. onUserLeaveHint() is also dispatched when
+        // Android opens transient activities such as the share chooser. Preparing here forces the
+        // detail player fullscreen even though no PiP transition follows, leaving the fragment in
+        // that prepared state until another lifecycle event happens. The confirmed PiP callback
+        // below is the single place that should mutate the player/detail layout.
         final PictureInPictureParams params = buildParams(fragment);
         try {
             activity.setPictureInPictureParams(params);
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S
                     || !fragment.isNativePipPlaying()) {
-                if (!activity.enterPictureInPictureMode(params)) {
-                    fragment.onNativePipModeChanged(false);
-                }
+                activity.enterPictureInPictureMode(params);
             }
-        } catch (final IllegalStateException ignored) {
-            fragment.onNativePipModeChanged(false);
+        } catch (final IllegalArgumentException | IllegalStateException ignored) {
+            // No PiP preparation has happened yet, so there is no layout state to unwind.
         }
     }
 

--- a/app/src/test/java/org/schabi/newpipe/player/mediasession/MediaSessionNotificationActionsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/mediasession/MediaSessionNotificationActionsTest.java
@@ -1,0 +1,46 @@
+package org.schabi.newpipe.player.mediasession;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MediaSessionNotificationActionsTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void androidSystemUiGetsCustomActionCommandsAndPreferences() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java"));
+        final String updateActions = methodBody(source,
+                "private void updateMediaSessionActions()");
+        final String syncController = methodBody(source,
+                "private void syncMediaNotificationController(");
+
+        assertTrue(updateActions.contains("syncMediaNotificationController(buttons);"));
+        assertTrue(syncController.contains("mediaSession.getMediaNotificationControllerInfo()"));
+        assertTrue(syncController.contains("MediaSessionActionProvider.supportedActions()"));
+        assertTrue(syncController.contains("mediaSession.setAvailableCommands("));
+        assertTrue(syncController.contains(
+                "mediaSession.setMediaButtonPreferences(notificationController, buttons);"));
+    }
+
+    private static String methodBody(final String source, final String signature) {
+        final int signatureIndex = source.indexOf(signature);
+        assertTrue("Missing method: " + signature, signatureIndex >= 0);
+        final int bodyStart = source.indexOf('{', signatureIndex);
+        assertTrue("Missing method body: " + signature, bodyStart >= 0);
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unclosed method body: " + signature);
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/pip/InternalActivityNavigationPipTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/pip/InternalActivityNavigationPipTest.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.player.pip;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -25,18 +26,25 @@ public class InternalActivityNavigationPipTest {
     }
 
     @Test
-    public void controllerBlocksPipPreparationDuringInternalNavigation()
+    public void controllerDefersPipPreparationUntilTransitionIsConfirmed()
             throws Exception {
         final String controller = Files.readString(sourceDirectory.resolve(
                 "org/schabi/newpipe/player/pip/NativePipController.java"));
         final String leaveHint = methodBody(controller, "public void onUserLeaveHint()");
         final int internalGuard = leaveHint.indexOf("internalActivityNavigationPending");
-        final int preparePip = leaveHint.indexOf("fragment.prepareNativePipEntry()");
+        final int pipRequest = leaveHint.indexOf("activity.enterPictureInPictureMode(params)");
 
         assertTrue(internalGuard >= 0);
-        assertTrue(preparePip > internalGuard);
+        assertTrue(pipRequest > internalGuard);
+        assertFalse(leaveHint.contains("fragment.prepareNativePipEntry()"));
         assertTrue(controller.contains(
                 "currentFragment().orElse(null), !internalActivityNavigationPending"));
+
+        final String detailFragment = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/fragments/detail/VideoDetailFragment.java"));
+        final String pipModeChanged = methodBody(detailFragment,
+                "public void onNativePipModeChanged(final boolean inPictureInPictureMode)");
+        assertTrue(pipModeChanged.contains("prepareNativePipEntry();"));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/player/pip/NativePipButtonIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/pip/NativePipButtonIntegrationTest.java
@@ -15,7 +15,7 @@ public class NativePipButtonIntegrationTest {
             ? Path.of("src/main/res") : Path.of("app/src/main/res");
 
     @Test
-    public void dedicatedPipEntryAvoidsPreTransitionFullscreenPreparation() throws Exception {
+    public void pipEntryAvoidsPreTransitionFullscreenPreparation() throws Exception {
         final String source = readSource(
                 "org/schabi/newpipe/player/pip/NativePipController.java");
         final String dedicatedEntry = methodBody(source,
@@ -24,7 +24,7 @@ public class NativePipButtonIntegrationTest {
 
         assertTrue(dedicatedEntry.contains("activity.enterPictureInPictureMode(params)"));
         assertFalse(dedicatedEntry.contains("prepareNativePipEntry()"));
-        assertTrue(homeEntry.contains("prepareNativePipEntry()"));
+        assertFalse(homeEntry.contains("prepareNativePipEntry()"));
     }
 
     @Test


### PR DESCRIPTION
- Defer PiP layout preparation until Android confirms the PiP transition, preventing the first Share action from forcing distorted portrait fullscreen.
- Synchronize Media3 custom action permissions with the media-notification controller so Android 13+ System UI can show the configured fourth and fifth controls again.
- Keep existing notification-slot preferences and Android Auto/external-controller behavior intact.
- Add regression coverage for deferred PiP preparation and Media3 System UI action synchronization.