### PR TITLE
Enforce normal playback speed for live streams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlaybackParametersController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlaybackParametersController.kt
@@ -8,9 +8,11 @@ package org.schabi.newpipe.player
 import androidx.media3.common.PlaybackParameters
 import org.schabi.newpipe.R
 import org.schabi.newpipe.extractor.stream.StreamInfo
+import org.schabi.newpipe.extractor.stream.StreamType
 import org.schabi.newpipe.player.helper.ChannelPlaybackProfileManager
 import org.schabi.newpipe.player.helper.PlayerHelper
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
+import org.schabi.newpipe.util.StreamTypeUtil
 
 /** Owns playback parameter application, persistence, and channel-profile restoration. */
 internal class PlaybackParametersController(private val player: Player) {
@@ -79,24 +81,41 @@ internal class PlaybackParametersController(private val player: Player) {
     }
 
     fun applySpeedProfile(item: PlayQueueItem) {
-        if (ChannelPlaybackProfileManager.isAvailable(player.context, item)) {
-            applySpeedProfile(ChannelPlaybackProfileManager.getSpeed(player.context, item))
+        val profileSpeed = if (ChannelPlaybackProfileManager.isAvailable(player.context, item)) {
+            ChannelPlaybackProfileManager.getSpeed(player.context, item)
+        } else {
+            null
         }
+        val preferredSpeed = PlayerHelper.retrievePlaybackParametersFromPrefs(player).speed
+        val targetSpeed = resolvePlaybackSpeed(item.streamType, profileSpeed, preferredSpeed)
+        player.exoPlayer.playbackParameters = PlaybackParameters(targetSpeed, pitch)
     }
 
     fun applySpeedProfile(info: StreamInfo) {
-        if (ChannelPlaybackProfileManager.isAvailable(player.context, info)) {
-            applySpeedProfile(ChannelPlaybackProfileManager.getSpeed(player.context, info))
+        val profileSpeed = if (ChannelPlaybackProfileManager.isAvailable(player.context, info)) {
+            ChannelPlaybackProfileManager.getSpeed(player.context, info)
+        } else {
+            null
         }
+        val preferredSpeed = PlayerHelper.retrievePlaybackParametersFromPrefs(player).speed
+        val targetSpeed = resolvePlaybackSpeed(info.streamType, profileSpeed, preferredSpeed)
+        player.exoPlayer.playbackParameters = PlaybackParameters(targetSpeed, pitch)
     }
 
-    private fun applySpeedProfile(profileSpeed: Float?) {
-        val speed =
-            profileSpeed ?: PlayerHelper.retrievePlaybackParametersFromPrefs(player).speed
-        player.exoPlayer.playbackParameters = PlaybackParameters(speed, pitch)
-    }
+    companion object {
+        const val NORMAL_SPEED = 1.0f
+        private const val DECIMAL_SCALE = 100.0f
 
-    private companion object {
-        const val DECIMAL_SCALE = 100.0f
+        @JvmStatic
+        fun resolvePlaybackSpeed(
+            streamType: StreamType?,
+            profileSpeed: Float?,
+            preferredSpeed: Float
+        ): Float {
+            if (streamType != null && StreamTypeUtil.isLiveStream(streamType)) {
+                return NORMAL_SPEED
+            }
+            return profileSpeed ?: preferredSpeed
+        }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
@@ -50,8 +50,13 @@ internal class PlayerLifecycleController(
             player.playbackSkipSilence
         )
         val parameters = PlayerHelper.retrievePlaybackParametersFromPrefs(player)
+        val initialSpeed = PlaybackParametersController.resolvePlaybackSpeed(
+            queue.item?.streamType,
+            null,
+            parameters.speed
+        )
         playbackParametersController.applyParameters(
-            parameters.speed,
+            initialSpeed,
             parameters.pitch,
             skipSilence
         )

--- a/app/src/test/java/org/schabi/newpipe/player/PlaybackParametersControllerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/player/PlaybackParametersControllerTest.kt
@@ -1,0 +1,92 @@
+package org.schabi.newpipe.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class PlaybackParametersControllerTest {
+    @Test
+    fun liveStreamAlwaysResolvesToNormalSpeed() {
+        assertEquals(
+            PlaybackParametersController.NORMAL_SPEED,
+            PlaybackParametersController.resolvePlaybackSpeed(StreamType.LIVE_STREAM, 1.75f, 2.0f),
+            0.001f
+        )
+        assertEquals(
+            PlaybackParametersController.NORMAL_SPEED,
+            PlaybackParametersController.resolvePlaybackSpeed(StreamType.LIVE_STREAM, null, 1.5f),
+            0.001f
+        )
+    }
+
+    @Test
+    fun audioLiveStreamAlwaysResolvesToNormalSpeed() {
+        assertEquals(
+            PlaybackParametersController.NORMAL_SPEED,
+            PlaybackParametersController.resolvePlaybackSpeed(
+                StreamType.AUDIO_LIVE_STREAM,
+                1.25f,
+                2.0f
+            ),
+            0.001f
+        )
+        assertEquals(
+            PlaybackParametersController.NORMAL_SPEED,
+            PlaybackParametersController.resolvePlaybackSpeed(
+                StreamType.AUDIO_LIVE_STREAM,
+                null,
+                1.75f
+            ),
+            0.001f
+        )
+    }
+
+    @Test
+    fun nonLiveStreamPrefersChannelProfileSpeed() {
+        assertEquals(
+            1.75f,
+            PlaybackParametersController.resolvePlaybackSpeed(
+                StreamType.VIDEO_STREAM,
+                1.75f,
+                2.0f
+            ),
+            0.001f
+        )
+        assertEquals(
+            1.25f,
+            PlaybackParametersController.resolvePlaybackSpeed(
+                StreamType.AUDIO_STREAM,
+                1.25f,
+                1.5f
+            ),
+            0.001f
+        )
+    }
+
+    @Test
+    fun nonLiveStreamFallsBackToPreferredSpeed() {
+        assertEquals(
+            2.0f,
+            PlaybackParametersController.resolvePlaybackSpeed(
+                StreamType.VIDEO_STREAM,
+                null,
+                2.0f
+            ),
+            0.001f
+        )
+        assertEquals(
+            1.5f,
+            PlaybackParametersController.resolvePlaybackSpeed(
+                StreamType.POST_LIVE_STREAM,
+                null,
+                1.5f
+            ),
+            0.001f
+        )
+        assertEquals(
+            1.25f,
+            PlaybackParametersController.resolvePlaybackSpeed(null, null, 1.25f),
+            0.001f
+        )
+    }
+}


### PR DESCRIPTION
- Rebase the intended change from #459 onto the current `pipe` branch without the stale unrelated history.
- Force live video and audio streams to 1.0x while preserving saved per-channel and global VOD playback speeds.
- Restore saved channel/profile speed automatically when returning to non-live content.
- Add focused regression coverage for live, audio-live, VOD, post-live, and fallback speed resolution.
- Preserve contributor credit for @heberjeur.