### PR TITLE
Fix caption translation settings dependency crash

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/VideoAudioSettingsFragment.java
@@ -93,12 +93,14 @@ public class VideoAudioSettingsFragment extends BasePreferenceFragment {
         language.setKey(getString(R.string.caption_translation_language_key));
         language.setDefaultValue(getString(R.string.caption_translation_system_value));
         language.setTitle(R.string.caption_translation_language_title);
-        language.setDependency(getString(R.string.caption_auto_translate_key));
         language.setIconSpaceReserved(false);
         language.setSingleLineTitle(false);
         language.setSummaryProvider(ListPreference.SimpleSummaryProvider.getInstance());
         populateCaptionTranslationLanguages(language);
         category.addPreference(language);
+        // Programmatic preferences need to be attached before setDependency() can resolve
+        // their dependency through the PreferenceManager hierarchy.
+        language.setDependency(getString(R.string.caption_auto_translate_key));
     }
 
     private void populateCaptionTranslationLanguages(final ListPreference preference) {

--- a/app/src/test/java/org/schabi/newpipe/settings/CaptionTranslationPreferenceDependencyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/settings/CaptionTranslationPreferenceDependencyTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.settings;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CaptionTranslationPreferenceDependencyTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void languagePreferenceIsAttachedBeforeRegisteringDependency() throws Exception {
+        final String source = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/settings/VideoAudioSettingsFragment.java"));
+        final String setupMethod = methodBody(
+                source,
+                "private void setupCaptionTranslationPreferences()");
+
+        final int autoTranslateAdded = setupMethod.indexOf(
+                "category.addPreference(autoTranslate);");
+        final int languageAdded = setupMethod.indexOf(
+                "category.addPreference(language);");
+        final int dependencyRegistered = setupMethod.indexOf(
+                "language.setDependency(getString(R.string.caption_auto_translate_key));");
+
+        assertTrue(autoTranslateAdded >= 0);
+        assertTrue(languageAdded > autoTranslateAdded);
+        assertTrue(dependencyRegistered > languageAdded);
+    }
+
+    private static String methodBody(final String source, final String signature) {
+        final int signatureIndex = source.indexOf(signature);
+        assertTrue("Missing method: " + signature, signatureIndex >= 0);
+        final int bodyStart = source.indexOf('{', signatureIndex);
+        assertTrue("Missing method body: " + signature, bodyStart >= 0);
+        int depth = 0;
+        for (int i = bodyStart; i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(bodyStart, i + 1);
+            }
+        }
+        throw new AssertionError("Unclosed method body: " + signature);
+    }
+}


### PR DESCRIPTION
- Attach the programmatically created translation-language preference before registering its `caption_auto_translate` dependency.
- Prevent `Preference.registerDependency()` from failing when opening Video & Audio settings.
- Keep the translation-language preference correctly enabled/disabled by the auto-translate switch.
- Add regression coverage for the required preference registration order.