### PR TITLE
Open local Play All directly in Play queue

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playqueue/LocalMediaPlayQueue.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playqueue/LocalMediaPlayQueue.java
@@ -29,6 +29,11 @@ public final class LocalMediaPlayQueue extends PlayQueue {
         openQueueOnStart = true;
     }
 
+    /** @return whether the next main-player start should open the Play queue. */
+    public boolean shouldOpenQueueOnStart() {
+        return openQueueOnStart;
+    }
+
     /** @return whether this queue contains at least one device-local item. */
     public boolean containsLocalMedia() {
         return getStreams().stream().anyMatch(PlayQueueItem::isLocalMedia);

--- a/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/NavigationHelper.java
@@ -68,6 +68,7 @@ import org.schabi.newpipe.player.PlaybackPresentationMode;
 import org.schabi.newpipe.player.TimestampChangeData;
 import org.schabi.newpipe.player.helper.PlayerHelper;
 import org.schabi.newpipe.player.helper.PlayerHolder;
+import org.schabi.newpipe.player.playqueue.LocalMediaPlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
 import org.schabi.newpipe.settings.SettingsActivity;
@@ -124,6 +125,9 @@ public final class NavigationHelper {
     /* PLAY */
     public static void playOnMainPlayer(final AppCompatActivity activity,
                                         @NonNull final PlayQueue playQueue) {
+        if (playQueuedLocalMediaDirectly(activity, playQueue)) {
+            return;
+        }
         final PlayQueueItem item = playQueue.getItem();
         if (item != null) {
             openVideoDetailFragment(activity, activity.getSupportFragmentManager(),
@@ -135,12 +139,31 @@ public final class NavigationHelper {
     public static void playOnMainPlayer(final Context context,
                                         @NonNull final PlayQueue playQueue,
                                         final boolean switchingPlayers) {
+        if (!switchingPlayers && playQueuedLocalMediaDirectly(context, playQueue)) {
+            return;
+        }
         final PlayQueueItem item = playQueue.getItem();
         if (item != null) {
             openVideoDetail(context,
                     item.getServiceId(), item.getUrl(), item.getTitle(), playQueue,
                     switchingPlayers);
         }
+    }
+
+    private static boolean playQueuedLocalMediaDirectly(final Context context,
+                                                        final PlayQueue playQueue) {
+        if (!(playQueue instanceof LocalMediaPlayQueue)) {
+            return false;
+        }
+        final LocalMediaPlayQueue localQueue = (LocalMediaPlayQueue) playQueue;
+        if (!localQueue.containsLocalMedia() || !localQueue.shouldOpenQueueOnStart()) {
+            return false;
+        }
+
+        final Intent intent = getPlayerIntent(context, PlayerService.class, playQueue,
+                PlayerIntentType.AllOthers);
+        ContextCompat.startForegroundService(context, intent);
+        return true;
     }
 
     public static void playOnPopupPlayer(final Context context,

--- a/app/src/test/java/org/schabi/newpipe/player/LocalMediaLibraryNavigationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/LocalMediaLibraryNavigationTest.java
@@ -57,9 +57,12 @@ public class LocalMediaLibraryNavigationTest {
         when(localItem.isLocalMedia()).thenReturn(true);
         final LocalMediaPlayQueue queue = new LocalMediaPlayQueue(List.of(localItem), 0);
 
+        assertFalse(queue.shouldOpenQueueOnStart());
         assertFalse(queue.consumeOpenQueueOnStart());
         queue.requestOpenQueueOnStart();
+        assertTrue(queue.shouldOpenQueueOnStart());
         assertTrue(queue.consumeOpenQueueOnStart());
+        assertFalse(queue.shouldOpenQueueOnStart());
         assertFalse(queue.consumeOpenQueueOnStart());
     }
 
@@ -90,6 +93,8 @@ public class LocalMediaLibraryNavigationTest {
                 "java/org/schabi/newpipe/player/PlayerIntentController.kt"));
         final String localPlaylist = Files.readString(mainDirectory.resolve(
                 "java/org/schabi/newpipe/local/playlist/LocalPlaylistFragment.java"));
+        final String navigation = Files.readString(mainDirectory.resolve(
+                "java/org/schabi/newpipe/util/NavigationHelper.java"));
 
         assertTrue(groupBuilder.contains("0,\n        true"));
         assertTrue(playButtonHelper.contains("mainPlaybackQueue(fragment)"));
@@ -98,5 +103,11 @@ public class LocalMediaLibraryNavigationTest {
         assertTrue(intentController.contains("PlayQueueActivity::class.java"));
         assertTrue(localPlaylist.contains("getPlayQueueStartingAt(entry)"));
         assertFalse(localPlaylist.contains("requestOpenQueueOnStart"));
+        assertTrue(navigation.contains("playQueuedLocalMediaDirectly(activity, playQueue)"));
+        assertTrue(navigation.contains("playQueuedLocalMediaDirectly(context, playQueue)"));
+        assertTrue(navigation.contains("localQueue.shouldOpenQueueOnStart()"));
+        assertTrue(navigation.contains(
+                "getPlayerIntent(context, PlayerService.class, playQueue,"));
+        assertTrue(navigation.contains("ContextCompat.startForegroundService(context, intent);"));
     }
 }


### PR DESCRIPTION
- Start flagged local collection playback through `PlayerService` directly instead of opening the first item detail screen first.
- Keep individual local tracks and remote-only playlists on the normal detail-player path.
- Preserve the existing one-shot Play queue destination so the queue UI opens only after playback is initialized.
- Cover local Play All / Shuffle flows for groups, folders, and saved playlists.
- Add regression coverage for the pending queue destination and direct main-player routing.
- Fixes #416