### PR TITLE
Keep local audio artwork behind song details

### DIFF
--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -36,7 +36,6 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:foreground="?attr/selectableItemBackground"
-                    android:translationZ="1dp"
                     app:layout_collapseMode="parallax">
 
                     <ImageView

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailThumbnailLayoutTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailThumbnailLayoutTest.java
@@ -25,11 +25,25 @@ public class VideoDetailThumbnailLayoutTest {
         assertThumbnailFillsFrame("layout-w840dp-land/fragment_video_detail.xml");
     }
 
+    @Test
+    public void thumbnailLayerDoesNotForceItselfAboveSongDetails() throws Exception {
+        assertThumbnailDoesNotForceForegroundLayer("layout/fragment_video_detail.xml");
+        assertThumbnailDoesNotForceForegroundLayer(
+                "layout-w840dp-land/fragment_video_detail.xml");
+    }
+
     private void assertThumbnailFillsFrame(final String layout) throws Exception {
         final Element thumbnail = findById(parse(layout), "detail_thumbnail_image_view");
         assertNotNull(layout, thumbnail);
         assertEquals(layout, "centerCrop",
                 thumbnail.getAttributeNS(ANDROID_NAMESPACE, "scaleType"));
+    }
+
+    private void assertThumbnailDoesNotForceForegroundLayer(final String layout) throws Exception {
+        final Element thumbnailRoot = findById(parse(layout), "detail_thumbnail_root_layout");
+        assertNotNull(layout, thumbnailRoot);
+        assertEquals(layout, "",
+                thumbnailRoot.getAttributeNS(ANDROID_NAMESPACE, "translationZ"));
     }
 
     private Element findById(final Document document, final String id) {


### PR DESCRIPTION
- Remove the phone detail thumbnail layer's forced positive Z translation so the runtime front/back ordering can keep song details visible while local audio is playing.
- Preserve pinned-player behavior, which already brings the thumbnail/player layer to the front only when pinning is actually enabled.
- Leave the wide/tablet detail layout unchanged because it already uses the correct layering behavior.
- Add regression coverage ensuring thumbnail layers do not force themselves above the title/details surface.
- Follow-up for #415