### PR TITLE
Add local folder artwork fallback

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowser.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowser.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
 import java.util.ArrayDeque
+import java.util.Locale
 
 data class LocalMediaDocumentLocation(
     val rootUri: String,
@@ -22,11 +23,49 @@ data class LocalMediaDocumentEntry(
     val isRoot: Boolean = false,
     val isAvailable: Boolean = true,
     val sizeBytes: Long = 0L,
-    val lastModified: Long = 0L
+    val lastModified: Long = 0L,
+    val folderArtworkUri: String? = null
 ) {
     val isVideo: Boolean
         get() = mimeType.startsWith("video/")
 }
+
+internal data class LocalFolderArtworkCandidate(
+    val name: String,
+    val mimeType: String?,
+    val uri: String
+)
+
+internal fun chooseLocalFolderArtwork(candidates: List<LocalFolderArtworkCandidate>): String? {
+    val supported = candidates
+        .filter { isSupportedLocalFolderArtwork(it.name, it.mimeType) }
+        .sortedBy { it.name.lowercase(Locale.ROOT) }
+    if (supported.isEmpty()) return null
+
+    folderArtworkNames.forEach { preferredName ->
+        supported.firstOrNull { candidate ->
+            candidate.name.substringBeforeLast('.', candidate.name)
+                .lowercase(Locale.ROOT) == preferredName
+        }?.let { return it.uri }
+    }
+
+    return supported.singleOrNull()?.uri
+}
+
+internal fun isSupportedLocalFolderArtwork(name: String, mimeType: String?): Boolean {
+    val extension = name.substringAfterLast('.', "").lowercase(Locale.ROOT)
+    val normalizedMimeType = mimeType?.lowercase(Locale.ROOT).orEmpty()
+    return extension in folderArtworkExtensions || normalizedMimeType in folderArtworkMimeTypes
+}
+
+private val folderArtworkNames = listOf("cover", "folder", "albumart", "front")
+private val folderArtworkExtensions = setOf("jpg", "jpeg", "png", "webp")
+private val folderArtworkMimeTypes = setOf(
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp"
+)
 
 class LocalMediaDocumentBrowser(private val context: Context) {
     fun roots(rootUris: Set<String>): List<LocalMediaDocumentEntry> = rootUris.map { rootUri ->
@@ -49,10 +88,13 @@ class LocalMediaDocumentBrowser(private val context: Context) {
 
     fun list(location: LocalMediaDocumentLocation): List<LocalMediaDocumentEntry> {
         val directory = resolve(location) ?: return emptyList()
-        return runCatching { directory.listFiles().toList() }
-            .getOrDefault(emptyList())
+        val children = runCatching { directory.listFiles().toList() }.getOrDefault(emptyList())
+        val folderArtworkUri = chooseLocalFolderArtwork(
+            children.filterNot(DocumentFile::isDirectory).map { it.toArtworkCandidate() }
+        )
+        return children
             .filter { it.isDirectory || isSupportedMedia(it.name.orEmpty(), it.type) }
-            .map { document -> document.toEntry(location) }
+            .map { document -> document.toEntry(location, folderArtworkUri) }
             .sortedWith(entryComparator)
     }
 
@@ -69,13 +111,16 @@ class LocalMediaDocumentBrowser(private val context: Context) {
             val (directory, folder) = pending.removeFirst()
             if (!visited.add(directory.uri.toString())) continue
             val children = runCatching { directory.listFiles() }.getOrDefault(emptyArray())
+            val folderArtworkUri = chooseLocalFolderArtwork(
+                children.filterNot(DocumentFile::isDirectory).map { it.toArtworkCandidate() }
+            )
             children.forEach { document ->
                 if (result.size >= maximumItems) return@forEach
                 when {
                     document.isDirectory -> pending.add(document to document.name.orEmpty())
 
                     isSupportedMedia(document.name.orEmpty(), document.type) -> {
-                        result += document.toMediaItem(folder)
+                        result += document.toMediaItem(folder, folderArtworkUri)
                     }
                 }
             }
@@ -98,7 +143,7 @@ class LocalMediaDocumentBrowser(private val context: Context) {
             durationSeconds = 0L,
             addedAtSeconds = entry.lastModified / 1000L,
             isVideo = video,
-            thumbnailUri = entry.contentUri.takeIf { video },
+            thumbnailUri = if (video) entry.contentUri else entry.folderArtworkUri,
             relativePath = entry.location.path.dropLast(1).joinToString("/"),
             sizeBytes = entry.sizeBytes
         )
@@ -116,8 +161,14 @@ class LocalMediaDocumentBrowser(private val context: Context) {
         return document.takeIf { it.isDirectory && it.canRead() }
     }
 
+    private fun DocumentFile.toArtworkCandidate(): LocalFolderArtworkCandidate {
+        val displayName = name.orEmpty().ifBlank { uri.lastPathSegment.orEmpty() }
+        return LocalFolderArtworkCandidate(displayName, type, uri.toString())
+    }
+
     private fun DocumentFile.toEntry(
-        parent: LocalMediaDocumentLocation
+        parent: LocalMediaDocumentLocation,
+        folderArtworkUri: String?
     ): LocalMediaDocumentEntry {
         val displayName = name.orEmpty().ifBlank { uri.lastPathSegment.orEmpty() }
         return LocalMediaDocumentEntry(
@@ -127,11 +178,15 @@ class LocalMediaDocumentBrowser(private val context: Context) {
             mimeType = type.orEmpty().ifBlank { mimeTypeForName(displayName) },
             isDirectory = isDirectory,
             sizeBytes = runCatching { length() }.getOrDefault(0L),
-            lastModified = runCatching { lastModified() }.getOrDefault(0L)
+            lastModified = runCatching { lastModified() }.getOrDefault(0L),
+            folderArtworkUri = folderArtworkUri.takeUnless { isDirectory }
         )
     }
 
-    private fun DocumentFile.toMediaItem(folder: String): LocalMediaItem {
+    private fun DocumentFile.toMediaItem(
+        folder: String,
+        folderArtworkUri: String?
+    ): LocalMediaItem {
         val displayName = name.orEmpty().ifBlank { uri.lastPathSegment.orEmpty() }
         val contentType = type.orEmpty().ifBlank { mimeTypeForName(displayName) }
         val video = contentType.startsWith("video/")
@@ -146,7 +201,7 @@ class LocalMediaDocumentBrowser(private val context: Context) {
             durationSeconds = 0L,
             addedAtSeconds = runCatching { lastModified() / 1000L }.getOrDefault(0L),
             isVideo = video,
-            thumbnailUri = uri.toString().takeIf { video },
+            thumbnailUri = if (video) uri.toString() else folderArtworkUri,
             relativePath = folder,
             sizeBytes = runCatching { length() }.getOrDefault(0L)
         )

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt
@@ -29,7 +29,7 @@ import org.schabi.newpipe.extractor.stream.StreamType
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
 import org.schabi.newpipe.util.image.ImageStrategy
 
-/** Loads thumbnails and embedded artwork from device-local media. */
+/** Loads thumbnails plus embedded or fallback artwork from device-local media. */
 object LocalMediaThumbnailLoader {
     private const val THUMBNAIL_WIDTH = 512
     private const val THUMBNAIL_HEIGHT = 288
@@ -87,7 +87,7 @@ object LocalMediaThumbnailLoader {
             -1L,
             entry.isVideo,
             entry.mimeType,
-            entry.contentUri.takeIf { entry.isVideo }
+            if (entry.isVideo) entry.contentUri else entry.folderArtworkUri
         )
     }
 

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaArtworkTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaArtworkTest.kt
@@ -31,6 +31,11 @@ class LocalMediaArtworkTest {
                 "java/org/schabi/newpipe/local/media/LocalMediaThumbnailLoader.kt"
             )
         )
+        val documentBrowser = Files.readString(
+            projectDirectory.resolve(
+                "java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowser.kt"
+            )
+        )
         val metadataLoader = Files.readString(
             projectDirectory.resolve(
                 "java/org/schabi/newpipe/local/media/LocalMediaMetadataLoader.kt"
@@ -49,7 +54,10 @@ class LocalMediaArtworkTest {
 
         assertTrue(loader.contains("LocalMediaMetadataLoader.readCached"))
         assertTrue(loader.indexOf("loadEmbeddedArtwork") < loader.indexOf("loadArtworkUri"))
+        assertTrue(loader.contains("entry.folderArtworkUri"))
         assertTrue(loader.contains("ArrayBlockingQueue(MAXIMUM_PENDING_THUMBNAILS)"))
+        assertTrue(documentBrowser.contains("chooseLocalFolderArtwork"))
+        assertTrue(documentBrowser.contains("folderArtworkUri"))
         assertTrue(metadataLoader.contains("retriever.embeddedPicture"))
         assertTrue(metadataLoader.contains("METADATA_BLOCK_PICTURE"))
         assertTrue(metadataLoader.contains("COVERART"))

--- a/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowserTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/media/LocalMediaDocumentBrowserTest.kt
@@ -5,6 +5,7 @@ package org.schabi.newpipe.local.media
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -30,7 +31,44 @@ class LocalMediaDocumentBrowserTest {
     }
 
     @Test
+    fun `folder artwork prefers standard cover names`() {
+        val candidates = listOf(
+            artwork("front.png", "image/png", "front"),
+            artwork("folder.webp", "image/webp", "folder"),
+            artwork("cover.JPG", "image/jpeg", "cover"),
+            artwork("albumart.jpeg", "image/jpeg", "albumart")
+        )
+
+        assertEquals("cover", chooseLocalFolderArtwork(candidates))
+        assertEquals("folder", chooseLocalFolderArtwork(candidates.filter { it.uri != "cover" }))
+    }
+
+    @Test
+    fun `single generic folder image is fallback but ambiguous images are not guessed`() {
+        val single = listOf(artwork("concert.png", "image/png", "concert"))
+        assertEquals("concert", chooseLocalFolderArtwork(single))
+
+        val ambiguous = listOf(
+            artwork("concert.png", "image/png", "concert"),
+            artwork("booklet.jpg", "image/jpeg", "booklet")
+        )
+        assertNull(chooseLocalFolderArtwork(ambiguous))
+    }
+
+    @Test
+    fun `folder artwork accepts jpeg png and webp only`() {
+        assertTrue(isSupportedLocalFolderArtwork("cover.jpg", null))
+        assertTrue(isSupportedLocalFolderArtwork("cover.JPEG", null))
+        assertTrue(isSupportedLocalFolderArtwork("opaque", "image/png"))
+        assertTrue(isSupportedLocalFolderArtwork("folder.webp", "application/octet-stream"))
+        assertFalse(isSupportedLocalFolderArtwork("cover.gif", "image/gif"))
+        assertFalse(isSupportedLocalFolderArtwork("notes.txt", "text/plain"))
+    }
+
+    @Test
     fun `whole folder scans have a defensive item limit`() {
         assertEquals(5000, LocalMediaDocumentBrowser.MAXIMUM_GROUP_ITEMS)
     }
+
+    private fun artwork(name: String, mimeType: String?, uri: String) = LocalFolderArtworkCandidate(name, mimeType, uri)
 }


### PR DESCRIPTION
- Use same-folder artwork as a fallback for local audio opened through the Storage Access Framework browser.
- Keep embedded artwork first, then use the existing thumbnail fallback path before the music placeholder.
- Prefer `cover`, `folder`, `albumart`, and `front` image names, while accepting a single unambiguous image when no standard name exists.
- Avoid guessing when a folder contains multiple unrelated images.
- Support JPEG, PNG, and WebP folder artwork in local browsing and grouped Play All / Shuffle queues.
- Add regression coverage for artwork selection priority, ambiguity handling, supported image types, and fallback wiring.
- Addresses #412