### PR TITLE
Fix Media3 TTML subtitle playback

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.player.helper;
 
 import android.content.Context;
 import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.Nullable;
 
@@ -11,6 +12,8 @@ import androidx.media3.common.audio.AudioProcessor;
 import androidx.media3.exoplayer.audio.AudioSink;
 import androidx.media3.exoplayer.audio.DefaultAudioSink;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
+import androidx.media3.exoplayer.text.TextOutput;
+import androidx.media3.exoplayer.text.TextRenderer;
 import androidx.media3.exoplayer.video.VideoRendererEventListener;
 
 import org.schabi.newpipe.player.visualizer.VisualizerAudioProcessor;
@@ -69,6 +72,28 @@ public final class CustomRenderersFactory extends DefaultRenderersFactory {
         out.add(new CustomMediaCodecVideoRenderer(context, getCodecAdapterFactory(),
                 mediaCodecSelector, allowedVideoJoiningTimeMs, enableDecoderFallback, eventHandler,
                 eventListener, MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY));
+    }
+
+    /**
+     * WizeStream still attaches extractor-provided sidecar captions through
+     * {@code SingleSampleMediaSource}. Media3 1.4+ disables renderer-time subtitle decoding by
+     * default and otherwise rejects raw TTML/WebVTT samples with
+     * {@code ERROR_CODE_FAILED_RUNTIME_CHECK}. Keep legacy decoding enabled until the custom
+     * subtitle source path is migrated to Media3's extraction-time {@code SubtitleParser} flow.
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void buildTextRenderers(final Context context,
+                                      final TextOutput output,
+                                      final Looper outputLooper,
+                                      @ExtensionRendererMode final int extensionRendererMode,
+                                      final ArrayList<Renderer> out) {
+        final int rendererCountBefore = out.size();
+        super.buildTextRenderers(context, output, outputLooper, extensionRendererMode, out);
+        if (out.size() > rendererCountBefore
+                && out.get(out.size() - 1) instanceof TextRenderer) {
+            ((TextRenderer) out.get(out.size() - 1)).experimentalSetLegacyDecodingEnabled(true);
+        }
     }
 
     @Nullable

--- a/app/src/test/java/org/schabi/newpipe/player/helper/CustomRenderersFactorySubtitleTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/CustomRenderersFactorySubtitleTest.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.player.helper;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class CustomRenderersFactorySubtitleTest {
+    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
+            ? Path.of("src/main/java") : Path.of("app/src/main/java");
+
+    @Test
+    public void sidecarSubtitlesKeepLegacyRendererDecodingEnabled() throws Exception {
+        final String rendererFactory = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/helper/CustomRenderersFactory.java"));
+        final String playerDataSource = Files.readString(sourceDirectory.resolve(
+                "org/schabi/newpipe/player/helper/PlayerDataSource.java"));
+
+        assertTrue(rendererFactory.contains("buildTextRenderers"));
+        assertTrue(rendererFactory.contains("experimentalSetLegacyDecodingEnabled(true)"));
+        assertTrue(playerDataSource.contains("new SingleSampleMediaSource.Factory"));
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/1015000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1015000.txt
@@ -1,6 +1,7 @@
-- Added YouTube caption auto-translation with a configurable target language.
-- Expanded local music with embedded metadata/artwork and same-folder cover images.
+- Added YouTube caption auto-translation with configurable target language.
+- Expanded local music metadata, embedded artwork, and folder cover images.
 - Improved local Play All, Shuffle, and direct Play queue navigation.
-- Improved Android media controls, PiP/share behavior, and fullscreen transitions.
-- Live streams now stay at normal 1x speed while saved VOD speed preferences are preserved.
+- Improved Android media controls, PiP/share, and fullscreen transitions.
+- Fixed TTML caption playback after the Media3 migration.
+- Live streams stay at 1x while saved VOD speed preferences are preserved.
 - Improved player, download, sync, and playback stability.


### PR DESCRIPTION
- Enable renderer-time subtitle decoding for the current `SingleSampleMediaSource` sidecar-caption path.
- Prevent Media3 `ERROR_CODE_FAILED_RUNTIME_CHECK` failures when YouTube captions arrive as raw TTML/WebVTT samples.
- Keep already-transcoded Media3 cue tracks compatible while bridging the custom subtitle source path.
- Add regression coverage tying the renderer compatibility flag to the sidecar subtitle source implementation.
- Update the 1.15.0 Fastlane changelog with the TTML playback fix while keeping it ASCII-only and below IzzyOnDroid's 500-byte limit.
- Treat this as a WizeStream 1.15.0 release blocker before publishing the tag.