### PR TITLE
Fix caption translation integration test

### DIFF
--- a/app/src/test/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolverCaptionTranslationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/resolver/VideoPlaybackResolverCaptionTranslationTest.java
@@ -21,7 +21,13 @@ public class VideoPlaybackResolverCaptionTranslationTest {
         assertTrue(source.contains(
                 "YoutubeCaptionTranslationHelper.addTranslatedSubtitleFromExtractedStreams"));
         assertTrue(source.contains("CaptionTranslationPreferences.getTargetLanguage(context)"));
-        assertTrue(source.indexOf("addTranslatedSubtitleFromExtractedStreams")
-                < source.indexOf("getUrlAndNonTorrentStreams"));
+
+        final int subtitleBlock = source.indexOf("// Create subtitle sources.");
+        final int translationCall = source.indexOf(
+                "addTranslatedSubtitleFromExtractedStreams", subtitleBlock);
+        final int filteringCall = source.indexOf("getUrlAndNonTorrentStreams(", subtitleBlock);
+        assertTrue(subtitleBlock >= 0);
+        assertTrue(translationCall > subtitleBlock);
+        assertTrue(filteringCall > translationCall);
     }
 }


### PR DESCRIPTION
- Fix the caption translation integration test that falsely matched the static import of `getUrlAndNonTorrentStreams` before the resolver body.
- Scope the ordering assertions to the subtitle-resolution block so they verify the translation call runs before subtitle filtering.
- Keep the production caption translation implementation unchanged.
- Restore CI after the merged caption translation fix.