### PR TITLE
Fix FCast Chromecast discovery crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -268,7 +268,7 @@ dependencies {
     compileOnly("org.json:json:20231013")
 
     // Open casting support for FCast and Chromecast-compatible receivers
-    implementation("org.fcast:sender-sdk:0.5.0")
+    implementation("org.fcast:sender-sdk:0.6.1")
 
     // Checkstyle
     checkstyle(libs.puppycrawl.checkstyle)


### PR DESCRIPTION
- Upgrade the FCast Android sender SDK from 0.5.0 to 0.6.1
- Safely handle valueless Chromecast mDNS TXT records instead of decoding a null byte array
- Include FCast upstream NSD discovery hardening for Android 12 and other pre-Android 14 devices
- Preserve the existing WizeStream casting API and behavior