### PR TITLE
Add focused player and extractor regression coverage

### DIFF
--- a/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliUtilsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliUtilsTest.java
@@ -1,0 +1,96 @@
+package org.schabi.newpipe.extractor.services.bilibili;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+
+import java.util.LinkedHashMap;
+
+public class BilibiliUtilsTest {
+    @Test
+    public void convertsKnownAvAndBvIdentifiersBothWays() {
+        assertEquals("BV17x411w7KC", utils.av2bv(170001));
+        assertEquals(170001L, utils.bv2av("BV17x411w7KC"));
+        assertEquals(455017605L, utils.bv2av(utils.av2bv(455017605L)));
+    }
+
+    @Test
+    public void identifiesFirstPartFromMissingOrExplicitPageParameter() {
+        assertTrue(utils.isFirstP("https://www.bilibili.com/video/BV17x411w7KC"));
+        assertTrue(utils.isFirstP("https://www.bilibili.com/video/BV17x411w7KC?p=1"));
+        assertFalse(utils.isFirstP("https://www.bilibili.com/video/BV17x411w7KC?p=2"));
+    }
+
+    @Test
+    public void viewApiUrlPreservesRequestedPart() {
+        assertEquals(
+                "https://api.bilibili.com/x/web-interface/view?bvid=BV17x411w7KC&p=1",
+                utils.getUrl("https://www.bilibili.com/video/BV17x411w7KC", "BV17x411w7KC"));
+        assertEquals(
+                "https://api.bilibili.com/x/web-interface/view?bvid=BV17x411w7KC&p=3",
+                utils.getUrl("https://www.bilibili.com/video/BV17x411w7KC?p=3&share_source=copy_web",
+                        "BV17x411w7KC"));
+    }
+
+    @Test
+    public void stripsQueryFromBvIdentifier() {
+        assertEquals("BV17x411w7KC", utils.getPureBV("BV17x411w7KC?p=2"));
+        assertEquals("BV17x411w7KC", utils.getPureBV("BV17x411w7KC"));
+    }
+
+    @Test
+    public void parsesDurationsAndFormatsSubtitleTimestamps() {
+        assertEquals(65L, utils.getDurationFromString("1:05"));
+        assertEquals(3_723L, utils.getDurationFromString("1:02:03"));
+        assertEquals("01:02:03,456", utils.sec2time(3_723.456));
+    }
+
+    @Test
+    public void convertsBccCaptionsToSrt() throws Exception {
+        final JsonObject bcc = JsonParser.object().from(
+                "{\"body\":[{\"from\":1.25,\"to\":2.5,\"content\":\"hello\"}]}"
+        );
+
+        assertEquals("1\n00:00:01,250 --> 00:00:02,500\nhello\n\n", utils.bcc2srt(bcc));
+    }
+
+    @Test
+    public void incrementsExistingPaginationParameter() throws Exception {
+        assertEquals(
+                "https://api.bilibili.com/x/test?pn=3&ps=30",
+                utils.getNextPageFromCurrentUrl(
+                        "https://api.bilibili.com/x/test?pn=2&ps=30", "pn", 1));
+    }
+
+    @Test
+    public void canInitializeMissingPaginationParameter() throws Exception {
+        assertEquals(
+                "https://api.bilibili.com/x/test?pn=2",
+                utils.getNextPageFromCurrentUrl(
+                        "https://api.bilibili.com/x/test", "pn", 1, true, "1", "?"));
+    }
+
+    @Test
+    public void missingPaginationParameterFailsClearly() {
+        assertThrows(ParsingException.class,
+                () -> utils.getNextPageFromCurrentUrl(
+                        "https://api.bilibili.com/x/test?ps=30", "pn", 1));
+    }
+
+    @Test
+    public void percentSpaceEncodingAndQueryOrderStayStable() {
+        assertEquals("hello%20world", utils.formatParamWithPercentSpace("hello world"));
+
+        final LinkedHashMap<String, String> params = new LinkedHashMap<>();
+        params.put("mid", "123");
+        params.put("pn", "2");
+        assertEquals("mid=123&pn=2", utils.createQueryString(params));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/bitchute/BitchuteParserHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/bitchute/BitchuteParserHelperTest.java
@@ -1,0 +1,53 @@
+package org.schabi.newpipe.extractor.services.bitchute;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class BitchuteParserHelperTest {
+    @Test
+    public void extractsSearchAuthorizationTokensFromExpectedMarkup() {
+        assertTrue(BitchuteParserHelper.extractAndStoreSearchAuth(
+                "<script>searchAuth('2026-09-06T07:00:00.000000+00:00', 'nonce-123')</script>"));
+    }
+
+    @Test
+    public void rejectsSearchAuthorizationMarkupWhenEitherTokenIsMissing() {
+        assertFalse(BitchuteParserHelper.extractAndStoreSearchAuth(
+                "<script>searchAuth('2026-09-06T07:00:00.000000+00:00')</script>"));
+        assertFalse(BitchuteParserHelper.extractAndStoreSearchAuth(
+                "<script>const searchAuth = 'not-a-call';</script>"));
+    }
+
+    @Test
+    public void extractsAndCachesCommentAuthorizationPerVideo() {
+        final String firstId = "test-video-a";
+        final String secondId = "test-video-b";
+
+        assertTrue(BitchuteParserHelper.extractAndStoreCfAuth(
+                firstId, "window.config = {cf_auth: 'auth-a', other: true};"));
+        assertTrue(BitchuteParserHelper.extractAndStoreCfAuth(
+                secondId, "window.config = {cf_auth: 'auth-b'};"));
+
+        assertEquals("auth-a", BitchuteParserHelper.getCfAuth(firstId));
+        assertEquals("auth-b", BitchuteParserHelper.getCfAuth(secondId));
+    }
+
+    @Test
+    public void malformedCommentAuthorizationDoesNotCreateCacheEntry() {
+        final String id = "test-video-missing-auth";
+
+        assertFalse(BitchuteParserHelper.extractAndStoreCfAuth(
+                id, "window.config = {comments_enabled: true};"));
+        assertNull(BitchuteParserHelper.getCfAuth(id));
+    }
+
+    @Test
+    public void prependsCanonicalBitChuteBaseUrl() {
+        assertEquals("https://www.bitchute.com/video/example/",
+                BitchuteParserHelper.prependBaseUrl("/video/example/"));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/niconico/NiconicoParsingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/niconico/NiconicoParsingTest.java
@@ -1,0 +1,72 @@
+package org.schabi.newpipe.extractor.services.niconico;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.localization.DateWrapper;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class NiconicoParsingTest {
+    @Test
+    public void snapshotTimestampIsNormalizedToUtcByDateWrapper() {
+        final DateWrapper parsed = NiconicoServiceParsingHelper.parseSnapshotDateTime(
+                "2026-09-06T12:34:56+09:00");
+
+        assertEquals(OffsetDateTime.parse("2026-09-06T03:34:56Z"),
+                parsed.offsetDateTime());
+    }
+
+    @Test
+    public void rssTimestampUsesJapanTimeThenNormalizesToUtc() {
+        final DateWrapper parsed = NiconicoServiceParsingHelper.parseRSSDateTime(
+                "2026年09月06日 12：34：56");
+
+        assertEquals(OffsetDateTime.parse("2026-09-06T03:34:56Z"),
+                parsed.offsetDateTime());
+    }
+
+    @Test
+    public void masterPlaylistCollectsAudioAndVideoEntries() {
+        final String master = "#EXTM3U\n"
+                + "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"audio\","
+                + "URI=\"https://cdn.example/audio.m3u8?token=a\"\n"
+                + "https://cdn.example/video.m3u8?token=v#";
+
+        final Map<String, List<String>> parsed = M3U8Parser.parseMasterM3U8(
+                master, "user_session=abc", 1234L);
+
+        assertEquals(List.of(
+                "https://cdn.example/audio.m3u8?token=a#cookie=user_session%3Dabc&length=1234"),
+                parsed.get("audio"));
+        assertEquals(List.of(
+                "https://cdn.example/video.m3u8?token=v#cookie=user_session%3Dabc&length=1234"),
+                parsed.get("video"));
+    }
+
+    @Test
+    public void masterPlaylistEncodesCookieBeforeAppendingTransportMetadata() {
+        final String master = "#EXT-X-MEDIA:TYPE=AUDIO,"
+                + "URI=\"https://cdn.example/audio.m3u8?token=a\"";
+
+        final String audio = M3U8Parser.parseMasterM3U8(
+                master, "session=a b+c", 99L).get("audio").get(0);
+
+        assertTrue(audio.contains("cookie=session%3Da+b%2Bc"));
+        assertTrue(audio.endsWith("&length=99"));
+    }
+
+    @Test
+    public void emptyMasterPlaylistProducesNoSyntheticTracks() {
+        final Map<String, List<String>> parsed = M3U8Parser.parseMasterM3U8(
+                "#EXTM3U\n#EXT-X-VERSION:3", "session=test", 0L);
+
+        assertTrue(parsed.isEmpty());
+        assertFalse(parsed.containsKey("audio"));
+        assertFalse(parsed.containsKey("video"));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/rumble/RumbleParsingHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/rumble/RumbleParsingHelperTest.java
@@ -1,0 +1,88 @@
+package org.schabi.newpipe.extractor.services.rumble;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.Test;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.exceptions.PrivateContentException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class RumbleParsingHelperTest {
+    private static final String URL = "https://rumble.com/v-test.html";
+
+    @Test
+    public void parsesRelatedStreamDurationsAcrossSupportedShapes() throws Exception {
+        assertEquals(45, RumbleParsingHelper.parseDurationStringForRelatedStreams("0:45"));
+        assertEquals(3_723, RumbleParsingHelper.parseDurationStringForRelatedStreams("1:02:03"));
+        assertEquals(93_784, RumbleParsingHelper.parseDurationString("1d 02h 03m 04s", "\\D+"));
+    }
+
+    @Test
+    public void rejectsUnknownDurationShape() {
+        assertThrows(ParsingException.class,
+                () -> RumbleParsingHelper.parseDurationString("1:2:3:4:5", ":"));
+    }
+
+    @Test
+    public void extractSafelyReturnsValueOrNullWithoutEscalatingOptionalMetadata() throws Exception {
+        assertEquals("ok", RumbleParsingHelper.extractSafely(false, "unused", () -> "ok"));
+        assertNull(RumbleParsingHelper.extractSafely(false, "optional", () -> {
+            throw new IllegalStateException("missing");
+        }));
+    }
+
+    @Test
+    public void extractSafelyWrapsRequiredMetadataFailures() {
+        final ParsingException error = assertThrows(ParsingException.class,
+                () -> RumbleParsingHelper.extractSafely(true, "required metadata", () -> {
+                    throw new IllegalStateException("missing");
+                }));
+        assertTrue(error.getMessage().contains("required metadata"));
+    }
+
+    @Test
+    public void extractsEmbedIdFromScriptAndCachesIt() throws Exception {
+        final String pageUrl = "https://rumble.com/v-cache-test.html";
+        final String html = "<script src=\"https://rumble.com/embed/vabc123.xyz789/\"></script>";
+
+        assertEquals("yz789", RumbleParsingHelper.getEmbedVideoId(pageUrl, () -> html));
+        assertEquals("yz789", RumbleParsingHelper.getEmbedVideoId(pageUrl, () -> {
+            throw new AssertionError("cached embed id should avoid re-reading page content");
+        }));
+    }
+
+    @Test
+    public void privateForbiddenPageMapsToPrivateContent() {
+        final Document doc = Jsoup.parse("<html><head><title>Private video</title></head></html>", URL);
+        assertThrows(PrivateContentException.class,
+                () -> RumbleParsingHelper.checkIfContentIsAccessible(response(403, "private"), doc));
+    }
+
+    @Test
+    public void ordinaryMissingPageMapsToContentNotAvailable() {
+        final Document doc = Jsoup.parse("<html><head><title>Video not found</title></head></html>", URL);
+        final ContentNotAvailableException error = assertThrows(ContentNotAvailableException.class,
+                () -> RumbleParsingHelper.checkIfContentIsAccessible(response(404, "missing"), doc));
+        assertTrue(error.getMessage().contains("404"));
+    }
+
+    private static Response response(final int code, final String body) {
+        return new Response(
+                code,
+                "response",
+                Collections.emptyMap(),
+                body,
+                body.getBytes(StandardCharsets.UTF_8),
+                URL
+        );
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/ui/MainPlayerUiFullscreenTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/ui/MainPlayerUiFullscreenTest.java
@@ -39,6 +39,15 @@ public class MainPlayerUiFullscreenTest {
     }
 
     @Test
+    public void undefinedOrientationNeverAutoEntersFullscreen() {
+        assertFalse(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_UNDEFINED,
+                false,
+                false,
+                false));
+    }
+
+    @Test
     public void landscapePhoneVideoCanAutoEnterFullscreen() {
         assertTrue(MainPlayerUi.shouldEnterFullscreenForConfiguration(
                 Configuration.ORIENTATION_LANDSCAPE,
@@ -64,5 +73,20 @@ public class MainPlayerUiFullscreenTest {
                 false,
                 false,
                 true));
+    }
+
+    @Test
+    public void combinedAudioTabletAndFullscreenFlagsStayOutOfAutoFullscreen() {
+        assertFalse(MainPlayerUi.shouldEnterFullscreenForConfiguration(
+                Configuration.ORIENTATION_LANDSCAPE,
+                true,
+                true,
+                true));
+    }
+
+    @Test
+    public void orientationActionDoesNotDependOnFullscreenStateForHorizontalVideo() {
+        assertTrue(MainPlayerUi.shouldUseScreenRotationAction(false, false, true));
+        assertTrue(MainPlayerUi.shouldUseScreenRotationAction(false, true, true));
     }
 }


### PR DESCRIPTION
- Expand fullscreen transition policy coverage without changing player or fullscreen production code.
- Add focused BitChute parser tests for search authorization, comment authorization, malformed markup, and canonical URLs.
- Add Rumble parser tests for duration parsing, optional metadata, embed ID caching, private content, and missing content handling.
- Add BiliBili utility tests for AV/BV conversion, page selection, URLs, subtitle conversion, pagination, duration parsing, and query encoding.
- Add NicoNico tests for snapshot/RSS timestamps, HLS audio/video parsing, cookie transport metadata, and empty playlists.
- Keep this stage test-only so future player/fullscreen and non-YouTube extractor changes have narrower regression gates.