### PR TITLE
Harden CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Create and checkout branch
         if: github.event_name == 'pull_request'
@@ -60,8 +62,19 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Verify source-inspection tests do not grow
+        run: python3 scripts/check-source-inspection-tests.py "$(git rev-parse HEAD^)"
+
       - name: Build debug APK and run JVM tests
         run: ./gradlew assembleDebug lintDebug testDebugUnitTest --stacktrace -DskipFormatKtlint
+
+      - name: Upload lint report when checks fail
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: lint-report
+          path: app/build/reports/lint-results-debug.*
+          if-no-files-found: ignore
 
       - name: Verify debug APK identity
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,8 +121,9 @@ configure<ApplicationExtension> {
 
     lint {
         lintConfig = file("lint.xml")
-        // Continue the debug build even when errors are found
-        abortOnError = false
+        baseline = file("lint-baseline.xml")
+        // Treat newly reported lint errors as CI failures.
+        abortOnError = true
     }
 
     compileOptions {
@@ -200,7 +201,6 @@ tasks.register<Checkstyle>("runCheckstyle") {
     exclude("**/R.java")
     exclude("**/BuildConfig.java")
     exclude("main/java/org/schabi/newpipe/extractor/**")
-    exclude("test/java/org/schabi/newpipe/extractor/**")
     exclude("main/java/us/shandian/giga/**")
 
     classpath = configurations.getByName("checkstyle")

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,141 @@
+<?xml version='1.0' encoding='utf-8'?>
+<issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.1)" variant="all" version="9.2.1">
+    <issue id="NewApi" message="Call requires API level 24 (current min is 23): `java.util.SplittableRandom#nextInt`" errorLine1="        return cards[random.nextInt(cards.length)];" errorLine2="                            ~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java" line="216" column="29" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 24 (current min is 23): `java.util.SplittableRandom#nextInt`" errorLine1="        int chromiumVersion = (random.nextInt(8)) + 130;" errorLine2="                                      ~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java" line="223" column="39" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 24 (current min is 23): `java.util.SplittableRandom#nextInt`" errorLine1="                1920 - 60 - random.nextInt(60)," errorLine2="                                   ~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java" line="229" column="36" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 24 (current min is 23): `java.util.SplittableRandom#nextInt`" errorLine1="                1080 - 90 - random.nextInt(60)" errorLine2="                                   ~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java" line="230" column="36" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 24 (current min is 23): `new java.util.SplittableRandom`" errorLine1="        currentDevice = forgeDevice(new SplittableRandom());" errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java" line="246" column="37" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 26 (current min is 23): `android.app.Activity#setPictureInPictureParams`" errorLine1="            activity.setPictureInPictureParams(buildParams(fragment, false));" errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/pip/NativePipController.java" line="165" column="22" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 26 (current min is 23): `buildParams`" errorLine1="            activity.setPictureInPictureParams(buildParams(fragment, false));" errorLine2="                                               ~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/pip/NativePipController.java" line="165" column="48" />
+    </issue>
+    <issue id="NewApi" message="Call requires API level 24 (current min is 23): `java.lang.String#chars`" errorLine1="                &amp;&amp; value.chars().noneMatch(Character::isWhitespace);" errorLine2="                         ~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/ProxySettingsFragment.java" line="109" column="26" />
+    </issue>
+    <issue id="WrongConstant" message="Must be one or more of: MediaCodec.BUFFER_FLAG_SYNC_FRAME, MediaCodec.BUFFER_FLAG_KEY_FRAME, MediaCodec.BUFFER_FLAG_CODEC_CONFIG, MediaCodec.BUFFER_FLAG_END_OF_STREAM, MediaCodec.BUFFER_FLAG_PARTIAL_FRAME, MediaCodec.BUFFER_FLAG_DECODE_ONLY, but could be MediaExtractor.SAMPLE_FLAG_SYNC, MediaExtractor.SAMPLE_FLAG_ENCRYPTED, MediaExtractor.SAMPLE_FLAG_PARTIAL_FRAME" errorLine1="                info.set(0, size, extractor.getSampleTime(), extractor.getSampleFlags());" errorLine2="                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/us/shandian/giga/postprocessing/M4aFromMp4Demuxer.java" line="80" column="62" />
+    </issue>
+    <issue id="WrongConstant" message="Must be one of: SessionResult.RESULT_SUCCESS, SessionError.INFO_CANCELLED, SessionError.ERROR_UNKNOWN, SessionError.ERROR_INVALID_STATE, SessionError.ERROR_BAD_VALUE, SessionError.ERROR_PERMISSION_DENIED, SessionError.ERROR_IO, SessionError.ERROR_SESSION_DISCONNECTED, SessionError.ERROR_NOT_SUPPORTED, SessionError.ERROR_SESSION_AUTHENTICATION_EXPIRED, SessionError.ERROR_SESSION_PREMIUM_ACCOUNT_REQUIRED, SessionError.ERROR_SESSION_CONCURRENT_STREAM_LIMIT, SessionError.ERROR_SESSION_PARENTAL_CONTROL_RESTRICTED, SessionError.ERROR_SESSION_NOT_AVAILABLE_IN_REGION, SessionError.ERROR_SESSION_SKIP_LIMIT_REACHED, SessionError.ERROR_SESSION_SETUP_REQUIRED" errorLine1="                            new SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED));" errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/PlayerService.java" line="398" column="47" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter can only be accessed from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="    private static final class CardPreferenceGroupAdapter extends PreferenceGroupAdapter {" errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="75" column="67" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            super(preferenceScreen);" errorLine2="            ~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="84" column="13" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            super(preferenceScreen);" errorLine2="                  ~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="84" column="19" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter.onBindViewHolder can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="        public void onBindViewHolder(@NonNull final PreferenceViewHolder holder," errorLine2="                    ~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="100" column="21" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter.onBindViewHolder can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            super.onBindViewHolder(holder, position);" errorLine2="                  ~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="102" column="19" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter.onBindViewHolder can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            super.onBindViewHolder(holder, position);" errorLine2="                                   ~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="102" column="36" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter.getItem can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            final Preference preference = getItem(position);" errorLine2="                                          ~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="104" column="43" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter.getItem can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            return position &gt;= 0 &amp;&amp; position &lt; getItemCount() &amp;&amp; !isCategory(getItem(position));" errorLine2="                                                                             ~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="123" column="78" />
+    </issue>
+    <issue id="RestrictedApi" message="PreferenceGroupAdapter.getItemCount can only be called from within the same library group prefix (referenced groupId=`androidx.preference` with prefix androidx from groupId=`WizeStream`)" errorLine1="            return position &gt;= 0 &amp;&amp; position &lt; getItemCount() &amp;&amp; !isCategory(getItem(position));" errorLine2="                                               ~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/settings/BasePreferenceFragment.java" line="123" column="48" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.BROWSER_SERVICE_EXTRAS_KEY_SEARCH_SUPPORTED can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="        putBoolean(MediaConstants.BROWSER_SERVICE_EXTRAS_KEY_SEARCH_SUPPORTED, true)" errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="117" column="35" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_BROWSABLE can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="            MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_BROWSABLE," errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="122" column="28" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_CATEGORY_GRID_ITEM can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="            MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_CATEGORY_GRID_ITEM" errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="123" column="28" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_PLAYABLE can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="            MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_PLAYABLE," errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="126" column="28" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="            MediaConstants.DESCRIPTION_EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM" errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="127" column="28" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="                MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE," errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="226" column="32" />
+    </issue>
+    <issue id="RestrictedApi" message="MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE can only be accessed from within the same library (androidx.media3:media3-session)" errorLine1="                    MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE," errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/java/org/schabi/newpipe/player/mediabrowser/MediaBrowserImpl.kt" line="248" column="36" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorPrimary&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/dialog_playlists.xml" line="24" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorPrimary&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/feed_group_add_new_grid_item.xml" line="30" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorPrimary&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/feed_group_add_new_item.xml" line="32" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/feed_group_card_grid_item.xml" line="28" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/feed_group_card_item.xml" line="31" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnPrimaryContainer&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/feed_group_import_grid_item.xml" line="30" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnPrimaryContainer&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/feed_group_import_item.xml" line="28" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="                    android:tint=&quot;?attr/colorPrimary&quot;" errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/fragment_feed.xml" line="78" column="21" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/item_search_suggestion.xml" line="32" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/item_search_suggestion.xml" line="70" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout-land/list_stream_playlist_card_item.xml" line="155" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/list_stream_playlist_card_item.xml" line="157" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/list_stream_playlist_grid_item.xml" line="155" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/list_stream_playlist_item.xml" line="155" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="    android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/picker_icon_item.xml" line="13" column="5" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorControlNormal&quot; /&gt;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/sponsor_block_category_widget.xml" line="15" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="            android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/statistic_playlist_control.xml" line="26" column="13" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?android:attr/textColorSecondary&quot;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/stream_quality_item.xml" line="16" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorOnSurfaceVariant&quot;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/subscription_groups_header.xml" line="30" column="9" />
+    </issue>
+    <issue id="UseAppTint" message="Must use `app:tint` instead of `android:tint`" errorLine1="        android:tint=&quot;?attr/colorOnSurfaceVariant&quot; /&gt;" errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location file="src/main/res/layout/subscription_groups_header.xml" line="42" column="9" />
+    </issue>
+</issues>

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/AdditionalStreamingServicesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/AdditionalStreamingServicesTest.java
@@ -52,7 +52,11 @@ class AdditionalStreamingServicesTest {
                         .fromQuery("privacy", singletonList(bitChuteVideos), emptyList()).getUrl());
         assertEquals("https://rumble.com/search/channel?q=world+news",
                 ServiceList.Rumble.getSearchQHFactory()
-                        .fromQuery("world news", singletonList(rumbleChannels), emptyList()).getUrl());
+                        .fromQuery(
+                                "world news",
+                                singletonList(rumbleChannels),
+                                emptyList())
+                        .getUrl());
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliUtilsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliUtilsTest.java
@@ -35,7 +35,8 @@ public class BilibiliUtilsTest {
                 utils.getUrl("https://www.bilibili.com/video/BV17x411w7KC", "BV17x411w7KC"));
         assertEquals(
                 "https://api.bilibili.com/x/web-interface/view?bvid=BV17x411w7KC&p=3",
-                utils.getUrl("https://www.bilibili.com/video/BV17x411w7KC?p=3&share_source=copy_web",
+                utils.getUrl(
+                        "https://www.bilibili.com/video/BV17x411w7KC?p=3&share_source=copy_web",
                         "BV17x411w7KC"));
     }
 

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/rumble/RumbleParsingHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/rumble/RumbleParsingHelperTest.java
@@ -21,9 +21,12 @@ public class RumbleParsingHelperTest {
 
     @Test
     public void parsesRelatedStreamDurationsAcrossSupportedShapes() throws Exception {
-        assertEquals(45, RumbleParsingHelper.parseDurationStringForRelatedStreams("0:45"));
-        assertEquals(3_723, RumbleParsingHelper.parseDurationStringForRelatedStreams("1:02:03"));
-        assertEquals(93_784, RumbleParsingHelper.parseDurationString("1d 02h 03m 04s", "\\D+"));
+        assertEquals(45,
+                RumbleParsingHelper.parseDurationStringForRelatedStreams("0:45"));
+        assertEquals(3_723,
+                RumbleParsingHelper.parseDurationStringForRelatedStreams("1:02:03"));
+        assertEquals(93_784,
+                RumbleParsingHelper.parseDurationString("1d 02h 03m 04s", "\\D+"));
     }
 
     @Test
@@ -33,7 +36,7 @@ public class RumbleParsingHelperTest {
     }
 
     @Test
-    public void extractSafelyReturnsValueOrNullWithoutEscalatingOptionalMetadata() throws Exception {
+    public void extractSafelyReturnsNullForOptionalMetadataFailure() throws Exception {
         assertEquals("ok", RumbleParsingHelper.extractSafely(false, "unused", () -> "ok"));
         assertNull(RumbleParsingHelper.extractSafely(false, "optional", () -> {
             throw new IllegalStateException("missing");
@@ -52,7 +55,8 @@ public class RumbleParsingHelperTest {
     @Test
     public void extractsEmbedIdFromScriptAndCachesIt() throws Exception {
         final String pageUrl = "https://rumble.com/v-cache-test.html";
-        final String html = "<script src=\"https://rumble.com/embed/vabc123.xyz789/\"></script>";
+        final String html =
+                "<script src=\"https://rumble.com/embed/vabc123.xyz789/\"></script>";
 
         assertEquals("yz789", RumbleParsingHelper.getEmbedVideoId(pageUrl, () -> html));
         assertEquals("yz789", RumbleParsingHelper.getEmbedVideoId(pageUrl, () -> {
@@ -62,16 +66,21 @@ public class RumbleParsingHelperTest {
 
     @Test
     public void privateForbiddenPageMapsToPrivateContent() {
-        final Document doc = Jsoup.parse("<html><head><title>Private video</title></head></html>", URL);
+        final Document doc = Jsoup.parse(
+                "<html><head><title>Private video</title></head></html>", URL);
         assertThrows(PrivateContentException.class,
-                () -> RumbleParsingHelper.checkIfContentIsAccessible(response(403, "private"), doc));
+                () -> RumbleParsingHelper.checkIfContentIsAccessible(
+                        response(403, "private"), doc));
     }
 
     @Test
     public void ordinaryMissingPageMapsToContentNotAvailable() {
-        final Document doc = Jsoup.parse("<html><head><title>Video not found</title></head></html>", URL);
-        final ContentNotAvailableException error = assertThrows(ContentNotAvailableException.class,
-                () -> RumbleParsingHelper.checkIfContentIsAccessible(response(404, "missing"), doc));
+        final Document doc = Jsoup.parse(
+                "<html><head><title>Video not found</title></head></html>", URL);
+        final ContentNotAvailableException error = assertThrows(
+                ContentNotAvailableException.class,
+                () -> RumbleParsingHelper.checkIfContentIsAccessible(
+                        response(404, "missing"), doc));
         assertTrue(error.getMessage().contains("404"));
     }
 

--- a/scripts/check-source-inspection-tests.py
+++ b/scripts/check-source-inspection-tests.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Prevent new production-source inspection tests from being added.
+
+Existing source-reading tests are architecture guards that predate this gate. Rather
+than trying to reproduce a brittle repository-wide count, compare each current test
+file with a base commit and fail if a source-inspecting file gains test methods.
+Behavioral tests can still be added in dedicated files without touching this debt.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+TEST_ROOT = Path("app/src/test")
+SOURCE_READ_MARKERS = (
+    "Files.readString(",
+    "Files.readAllLines(",
+    "Files.readAllBytes(",
+    ".readText(",
+    ".readLines(",
+)
+PRODUCTION_CODE_MARKERS = (
+    'Path.of("src/main/java")',
+    'Path.of("app/src/main/java")',
+    '"src/main/java/',
+    '"app/src/main/java/',
+)
+TEST_ANNOTATION = re.compile(r"(?m)^\s*@Test\b")
+
+
+def is_source_inspection_test(text: str) -> bool:
+    return (
+        any(marker in text for marker in SOURCE_READ_MARKERS)
+        and any(marker in text for marker in PRODUCTION_CODE_MARKERS)
+    )
+
+
+def test_count(text: str) -> int:
+    return len(TEST_ANNOTATION.findall(text))
+
+
+def read_from_git(ref: str, path: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path.as_posix()}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: check-source-inspection-tests.py <base-commit>", file=sys.stderr)
+        return 2
+
+    base_ref = sys.argv[1]
+    violations: list[str] = []
+    inspected_files = 0
+
+    for path in sorted(TEST_ROOT.rglob("*")):
+        if path.suffix not in {".java", ".kt"}:
+            continue
+
+        current = path.read_text(encoding="utf-8")
+        if not is_source_inspection_test(current):
+            continue
+
+        inspected_files += 1
+        current_count = test_count(current)
+        previous = read_from_git(base_ref, path)
+        previous_count = (
+            test_count(previous)
+            if previous is not None and is_source_inspection_test(previous)
+            else 0
+        )
+
+        if current_count > previous_count:
+            violations.append(
+                f"{path}: source-inspection tests grew from "
+                f"{previous_count} to {current_count}"
+            )
+
+    print(f"Existing production-source inspection files checked: {inspected_files}")
+    if not violations:
+        print("No source-inspection test growth detected.")
+        return 0
+
+    print(
+        "New source-inspection tests are not allowed; add behavioral coverage instead:",
+        file=sys.stderr,
+    )
+    for violation in violations:
+        print(f"  - {violation}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Make Android lint errors fail CI while baselining the 46 pre-existing lint errors so only new errors block builds.
- Bring integrated extractor unit tests under Checkstyle while keeping legacy extractor production code and the old downloader package grandfathered for now.
- Add a diff-based CI guard that prevents production-source inspection tests from growing and steers new coverage toward behavioral tests.
- Clean up the newly checked extractor tests so they pass Checkstyle without changing their behavior.
- Upload lint reports automatically when JVM/build checks fail to make lint regressions easier to diagnose.
- Keep this stage focused on quality enforcement only; no player, fullscreen, or extractor production behavior changes.