### PR TITLE
Fix local folder artwork tint

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/media/LocalMediaDocumentIconStyleTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/media/LocalMediaDocumentIconStyleTest.kt
@@ -1,0 +1,41 @@
+package org.schabi.newpipe.local.media
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.widget.ImageView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.R
+
+@RunWith(AndroidJUnit4::class)
+class LocalMediaDocumentIconStyleTest {
+    @Test
+    fun mediaArtworkClearsDirectoryTintAndPaddingAcrossRowReuse() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val icon = ImageView(ContextThemeWrapper(baseContext, R.style.LightTheme))
+
+        applyLocalMediaDocumentIconStyle(icon, isDirectory = true)
+        assertNotNull(icon.imageTintList)
+        assertTrue(icon.paddingLeft > 0)
+        assertEquals(ImageView.ScaleType.FIT_CENTER, icon.scaleType)
+
+        applyLocalMediaDocumentIconStyle(icon, isDirectory = false)
+        assertNull(icon.imageTintList)
+        assertEquals(0, icon.paddingLeft)
+        assertEquals(0, icon.paddingTop)
+        assertEquals(0, icon.paddingRight)
+        assertEquals(0, icon.paddingBottom)
+        assertEquals(ImageView.ScaleType.CENTER_CROP, icon.scaleType)
+
+        applyLocalMediaDocumentIconStyle(icon, isDirectory = true)
+        assertNotNull(icon.imageTintList)
+        assertTrue(icon.paddingLeft > 0)
+        assertEquals(ImageView.ScaleType.FIT_CENTER, icon.scaleType)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentAdapter.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/media/LocalMediaDocumentAdapter.kt
@@ -3,12 +3,15 @@
  */
 package org.schabi.newpipe.local.media
 
+import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.color.MaterialColors
+import kotlin.math.roundToInt
 import org.schabi.newpipe.R
 
 class LocalMediaDocumentAdapter(
@@ -47,8 +50,10 @@ class LocalMediaDocumentAdapter(
         fun bind(entry: LocalMediaDocumentEntry) {
             if (entry.isDirectory) {
                 LocalMediaThumbnailLoader.clear(icon)
+                applyLocalMediaDocumentIconStyle(icon, isDirectory = true)
                 icon.setImageResource(R.drawable.ic_create_new_folder)
             } else {
+                applyLocalMediaDocumentIconStyle(icon, isDirectory = false)
                 LocalMediaThumbnailLoader.load(icon, entry)
             }
             title.text = entry.name
@@ -78,6 +83,26 @@ class LocalMediaDocumentAdapter(
 
         fun recycle() {
             LocalMediaThumbnailLoader.clear(icon)
+            applyLocalMediaDocumentIconStyle(icon, isDirectory = false)
         }
     }
 }
+
+internal fun applyLocalMediaDocumentIconStyle(icon: ImageView, isDirectory: Boolean) {
+    if (isDirectory) {
+        val tintColor = MaterialColors.getColor(
+            icon,
+            com.google.android.material.R.attr.colorOnSurfaceVariant
+        )
+        icon.imageTintList = ColorStateList.valueOf(tintColor)
+        val padding = (DIRECTORY_ICON_PADDING_DP * icon.resources.displayMetrics.density).roundToInt()
+        icon.setPadding(padding, padding, padding, padding)
+        icon.scaleType = ImageView.ScaleType.FIT_CENTER
+    } else {
+        icon.imageTintList = null
+        icon.setPadding(0, 0, 0, 0)
+        icon.scaleType = ImageView.ScaleType.CENTER_CROP
+    }
+}
+
+private const val DIRECTORY_ICON_PADDING_DP = 8

--- a/app/src/main/res/layout/list_local_media_document_item.xml
+++ b/app/src/main/res/layout/list_local_media_document_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
@@ -14,9 +13,7 @@
         android:id="@+id/localMediaDocumentIcon"
         android:layout_width="40dp"
         android:layout_height="40dp"
-        android:contentDescription="@null"
-        android:padding="8dp"
-        app:tint="?attr/colorOnSurfaceVariant" />
+        android:contentDescription="@null" />
 
     <LinearLayout
         android:layout_width="0dp"


### PR DESCRIPTION
- Remove the permanent tint and padding from local media document artwork rows so album covers keep their original colors.
- Apply Material 3 tint and icon padding only to directory rows, while media rows use untinted center-crop artwork.
- Reset tint, padding, and scale type explicitly across RecyclerView reuse so folder and media presentation cannot leak into each other.
- Add Android regression coverage for directory-to-media-to-directory row reuse.
- Keep embedded-artwork, same-folder artwork, Play Queue, player, and metadata resolution behavior unchanged.