### PR TITLE
Keep active video above scrolling details

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayout.java
@@ -2,6 +2,8 @@ package org.schabi.newpipe.views;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -10,7 +12,14 @@ import androidx.core.view.WindowInsetsCompat;
 
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 
+import org.schabi.newpipe.R;
+
 public class CustomCollapsingToolbarLayout extends CollapsingToolbarLayout {
+    @Nullable
+    private ViewGroup playerPlaceholder;
+    @Nullable
+    private View playerLayer;
+
     public CustomCollapsingToolbarLayout(@NonNull final Context context) {
         super(context);
         overrideListener();
@@ -27,6 +36,55 @@ public class CustomCollapsingToolbarLayout extends CollapsingToolbarLayout {
                                          final int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         overrideListener();
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        final View placeholder = findViewById(R.id.player_placeholder);
+        if (!(placeholder instanceof ViewGroup)) {
+            return;
+        }
+
+        playerPlaceholder = (ViewGroup) placeholder;
+        playerLayer = findDirectChildContaining(placeholder);
+        playerPlaceholder.setOnHierarchyChangeListener(new ViewGroup.OnHierarchyChangeListener() {
+            @Override
+            public void onChildViewAdded(final View parent, final View child) {
+                updatePlayerLayerZOrder();
+            }
+
+            @Override
+            public void onChildViewRemoved(final View parent, final View child) {
+                updatePlayerLayerZOrder();
+            }
+        });
+        updatePlayerLayerZOrder();
+    }
+
+    @Nullable
+    private View findDirectChildContaining(@NonNull final View descendant) {
+        View current = descendant;
+        while (current.getParent() instanceof View && current.getParent() != this) {
+            current = (View) current.getParent();
+        }
+        return current.getParent() == this ? current : null;
+    }
+
+    private void updatePlayerLayerZOrder() {
+        if (playerPlaceholder == null || playerLayer == null) {
+            return;
+        }
+
+        // Keep ordinary thumbnails/artwork in the normal collapsing-toolbar stack so song details
+        // can draw above them. Once the actual video player is attached, restore the one-dp layer
+        // lift that keeps scrolling title/uploader content from being painted over the video.
+        final float desiredTranslationZ = playerPlaceholder.getChildCount() > 0
+                ? getResources().getDisplayMetrics().density : 0.0f;
+        if (Float.compare(playerLayer.getTranslationZ(), desiredTranslationZ) != 0) {
+            playerLayer.setTranslationZ(desiredTranslationZ);
+        }
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayout.java
+++ b/app/src/main/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayout.java
@@ -72,6 +72,10 @@ public class CustomCollapsingToolbarLayout extends CollapsingToolbarLayout {
         return current.getParent() == this ? current : null;
     }
 
+    static float playerLayerTranslationZ(final boolean playerAttached, final float density) {
+        return playerAttached ? Math.max(density, 0.0f) : 0.0f;
+    }
+
     private void updatePlayerLayerZOrder() {
         if (playerPlaceholder == null || playerLayer == null) {
             return;
@@ -80,8 +84,9 @@ public class CustomCollapsingToolbarLayout extends CollapsingToolbarLayout {
         // Keep ordinary thumbnails/artwork in the normal collapsing-toolbar stack so song details
         // can draw above them. Once the actual video player is attached, restore the one-dp layer
         // lift that keeps scrolling title/uploader content from being painted over the video.
-        final float desiredTranslationZ = playerPlaceholder.getChildCount() > 0
-                ? getResources().getDisplayMetrics().density : 0.0f;
+        final float desiredTranslationZ = playerLayerTranslationZ(
+                playerPlaceholder.getChildCount() > 0,
+                getResources().getDisplayMetrics().density);
         if (Float.compare(playerLayer.getTranslationZ(), desiredTranslationZ) != 0) {
             playerLayer.setTranslationZ(desiredTranslationZ);
         }

--- a/app/src/test/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayoutTest.java
+++ b/app/src/test/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayoutTest.java
@@ -1,0 +1,37 @@
+package org.schabi.newpipe.views;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.schabi.newpipe.R;
+
+@RunWith(RobolectricTestRunner.class)
+public class CustomCollapsingToolbarLayoutTest {
+    @Test
+    public void activeVideoPlayerRendersAboveScrollingDetailContent() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final View root = LayoutInflater.from(context)
+                .inflate(R.layout.fragment_video_detail, null, false);
+        final View thumbnailLayer = root.findViewById(R.id.detail_thumbnail_root_layout);
+        final FrameLayout playerPlaceholder = root.findViewById(R.id.player_placeholder);
+
+        assertEquals(0.0f, thumbnailLayer.getTranslationZ(), 0.0f);
+
+        final View playerView = new View(context);
+        playerPlaceholder.addView(playerView);
+        assertTrue(thumbnailLayer.getTranslationZ() > 0.0f);
+
+        playerPlaceholder.removeView(playerView);
+        assertEquals(0.0f, thumbnailLayer.getTranslationZ(), 0.0f);
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayoutTest.java
+++ b/app/src/test/java/org/schabi/newpipe/views/CustomCollapsingToolbarLayoutTest.java
@@ -1,37 +1,28 @@
 package org.schabi.newpipe.views;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import android.content.Context;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.widget.FrameLayout;
-
-import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.schabi.newpipe.R;
 
-@RunWith(RobolectricTestRunner.class)
 public class CustomCollapsingToolbarLayoutTest {
     @Test
-    public void activeVideoPlayerRendersAboveScrollingDetailContent() {
-        final Context context = ApplicationProvider.getApplicationContext();
-        final View root = LayoutInflater.from(context)
-                .inflate(R.layout.fragment_video_detail, null, false);
-        final View thumbnailLayer = root.findViewById(R.id.detail_thumbnail_root_layout);
-        final FrameLayout playerPlaceholder = root.findViewById(R.id.player_placeholder);
+    public void activeVideoPlayerRaisesThePlayerLayer() {
+        assertEquals(3.0f,
+                CustomCollapsingToolbarLayout.playerLayerTranslationZ(true, 3.0f),
+                0.0f);
+    }
 
-        assertEquals(0.0f, thumbnailLayer.getTranslationZ(), 0.0f);
+    @Test
+    public void detachedPlayerRestoresTheNormalLayerOrder() {
+        assertEquals(0.0f,
+                CustomCollapsingToolbarLayout.playerLayerTranslationZ(false, 3.0f),
+                0.0f);
+    }
 
-        final View playerView = new View(context);
-        playerPlaceholder.addView(playerView);
-        assertTrue(thumbnailLayer.getTranslationZ() > 0.0f);
-
-        playerPlaceholder.removeView(playerView);
-        assertEquals(0.0f, thumbnailLayer.getTranslationZ(), 0.0f);
+    @Test
+    public void invalidDensityNeverCreatesANegativeLayerOffset() {
+        assertEquals(0.0f,
+                CustomCollapsingToolbarLayout.playerLayerTranslationZ(true, -1.0f),
+                0.0f);
     }
 }


### PR DESCRIPTION
- Keep the active video player layer above scrolling title, uploader, views, and like/dislike content on the phone detail screen.
- Raise the thumbnail/player layer only while an actual player view is attached, so the recent local-audio artwork fix remains intact when no video player is present.
- Restore the player layer to the normal stack immediately when the video view is removed.
- Add dependency-free JVM regression coverage for the player-attached and detached layer offsets.