### PR TITLE
Repair local playlist uploader avatars

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/database/StreamUploaderAvatarDaoTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/database/StreamUploaderAvatarDaoTest.kt
@@ -1,0 +1,101 @@
+package org.schabi.newpipe.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import java.io.IOException
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.schabi.newpipe.database.stream.dao.StreamDAO
+import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class StreamUploaderAvatarDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var streamDao: StreamDAO
+    private val youtubeServiceId = ServiceList.YouTube.serviceId
+    private val sharedUploader = "https://youtube.com/channel/shared"
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        streamDao = db.streamDAO()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun knownAvatarRepairsOnlyMatchingMissingRows() {
+        streamDao.insertAll(
+            listOf(
+                stream("known", sharedUploader, "https://example.com/known.jpg"),
+                stream("missing", sharedUploader, null),
+                stream("existing", sharedUploader, "https://example.com/existing.jpg"),
+                stream("other", "https://youtube.com/channel/other", null)
+            )
+        )
+
+        assertEquals(
+            "https://example.com/known.jpg",
+            streamDao.findKnownUploaderAvatar(youtubeServiceId, sharedUploader)
+        )
+        assertEquals(
+            1,
+            streamDao.backfillMissingUploaderAvatar(
+                youtubeServiceId,
+                sharedUploader,
+                "https://example.com/resolved.jpg"
+            )
+        )
+
+        assertEquals(
+            "https://example.com/resolved.jpg",
+            streamDao.getStreamDirect(
+                youtubeServiceId,
+                "https://youtube.com/watch?v=missing"
+            )?.uploaderAvatarUrl
+        )
+        assertEquals(
+            "https://example.com/known.jpg",
+            streamDao.getStreamDirect(
+                youtubeServiceId,
+                "https://youtube.com/watch?v=known"
+            )?.uploaderAvatarUrl
+        )
+        assertEquals(
+            "https://example.com/existing.jpg",
+            streamDao.getStreamDirect(
+                youtubeServiceId,
+                "https://youtube.com/watch?v=existing"
+            )?.uploaderAvatarUrl
+        )
+        assertNull(
+            streamDao.getStreamDirect(
+                youtubeServiceId,
+                "https://youtube.com/watch?v=other"
+            )?.uploaderAvatarUrl
+        )
+    }
+
+    private fun stream(id: String, uploaderUrl: String, avatarUrl: String?): StreamEntity {
+        return StreamEntity(
+            serviceId = youtubeServiceId,
+            url = "https://youtube.com/watch?v=$id",
+            title = id,
+            streamType = StreamType.VIDEO_STREAM,
+            duration = 60,
+            uploader = "Uploader",
+            uploaderUrl = uploaderUrl,
+            uploaderAvatarUrl = avatarUrl
+        )
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntry.kt
@@ -49,6 +49,10 @@ data class PlaylistStreamEntry(
                 this,
                 ImageStrategy.dbUrlToImageList(streamEntity.thumbnailUrl)
             )
+            ExtractorImageCompat.setUploaderAvatarImages(
+                this,
+                ImageStrategy.dbUrlToImageList(streamEntity.uploaderAvatarUrl)
+            )
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
@@ -38,6 +38,32 @@ abstract class StreamDAO : BasicDAO<StreamEntity> {
     @Query("UPDATE streams SET uploader_url = :uploaderUrl WHERE url = :url AND service_id = :serviceId")
     abstract fun setUploaderUrl(serviceId: Long, url: String, uploaderUrl: String): Completable
 
+    @Query(
+        """
+        SELECT uploader_avatar_url FROM streams
+        WHERE service_id = :serviceId
+        AND uploader_url = :uploaderUrl
+        AND uploader_avatar_url IS NOT NULL
+        AND TRIM(uploader_avatar_url) != ''
+        LIMIT 1
+        """
+    )
+    abstract fun findKnownUploaderAvatar(serviceId: Int, uploaderUrl: String): String?
+
+    @Query(
+        """
+        UPDATE streams SET uploader_avatar_url = :avatarUrl
+        WHERE service_id = :serviceId
+        AND uploader_url = :uploaderUrl
+        AND (uploader_avatar_url IS NULL OR TRIM(uploader_avatar_url) = '')
+        """
+    )
+    abstract fun backfillMissingUploaderAvatar(
+        serviceId: Int,
+        uploaderUrl: String,
+        avatarUrl: String
+    ): Int
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     internal abstract fun silentInsertInternal(stream: StreamEntity): Long
 

--- a/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
@@ -45,6 +45,7 @@ abstract class StreamDAO : BasicDAO<StreamEntity> {
         AND uploader_url = :uploaderUrl
         AND uploader_avatar_url IS NOT NULL
         AND TRIM(uploader_avatar_url) != ''
+        ORDER BY uid ASC
         LIMIT 1
         """
     )

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistManager.java
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistManager.java
@@ -129,7 +129,12 @@ public class LocalPlaylistManager {
     }
 
     public Flowable<List<PlaylistStreamEntry>> getPlaylistStreams(final long playlistId) {
-        return playlistStreamTable.getOrderedStreamsOf(playlistId).subscribeOn(Schedulers.io());
+        return playlistStreamTable.getOrderedStreamsOf(playlistId)
+                .concatMapSingle(streams -> LocalPlaylistUploaderAvatarBackfill
+                        .backfill(database, streams)
+                        .toSingleDefault(streams)
+                        .onErrorReturnItem(streams))
+                .subscribeOn(Schedulers.io());
     }
 
     public Maybe<Integer> renamePlaylist(final long playlistId, final String name) {

--- a/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistUploaderAvatarBackfill.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/playlist/LocalPlaylistUploaderAvatarBackfill.kt
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.local.playlist
+
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.playlist.PlaylistStreamEntry
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.util.ExtractorHelper
+import org.schabi.newpipe.util.image.ImageStrategy
+
+internal data class LocalPlaylistUploaderKey(
+    val serviceId: Int,
+    val uploaderUrl: String
+)
+
+/** Repairs missing uploader avatars already stored in local playlists. */
+object LocalPlaylistUploaderAvatarBackfill {
+    @JvmStatic
+    fun backfill(
+        database: AppDatabase,
+        entries: List<PlaylistStreamEntry>
+    ): Completable = Completable.fromAction {
+        val streamDao = database.streamDAO()
+        val unresolved = missingUploaderKeys(entries).filterTo(mutableListOf()) { key ->
+            val knownAvatar = streamDao.findKnownUploaderAvatar(
+                key.serviceId,
+                key.uploaderUrl
+            )
+            if (knownAvatar.isNullOrBlank()) {
+                true
+            } else {
+                applyUploaderAvatar(entries, key, knownAvatar)
+                streamDao.backfillMissingUploaderAvatar(
+                    key.serviceId,
+                    key.uploaderUrl,
+                    knownAvatar
+                )
+                false
+            }
+        }
+
+        selectYoutubeUploaderLookupCandidate(unresolved)?.let { key ->
+            val resolvedAvatar = runCatching {
+                val channel = ExtractorHelper.getChannelInfo(
+                    key.serviceId,
+                    key.uploaderUrl,
+                    false
+                ).blockingGet()
+                ImageStrategy.imageListToDbUrl(channel.avatars)
+            }.getOrNull()
+
+            if (!resolvedAvatar.isNullOrBlank()) {
+                applyUploaderAvatar(entries, key, resolvedAvatar)
+                streamDao.backfillMissingUploaderAvatar(
+                    key.serviceId,
+                    key.uploaderUrl,
+                    resolvedAvatar
+                )
+            }
+        }
+    }.subscribeOn(Schedulers.io())
+}
+
+internal fun missingUploaderKeys(
+    entries: List<PlaylistStreamEntry>
+): List<LocalPlaylistUploaderKey> = entries.asSequence()
+    .map(PlaylistStreamEntry::streamEntity)
+    .filterNot { it.isLocalMedia }
+    .filter { it.uploaderAvatarUrl.isNullOrBlank() }
+    .mapNotNull { stream ->
+        stream.uploaderUrl
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?.let { LocalPlaylistUploaderKey(stream.serviceId, it) }
+    }
+    .distinct()
+    .toList()
+
+internal fun selectYoutubeUploaderLookupCandidate(
+    unresolved: List<LocalPlaylistUploaderKey>
+): LocalPlaylistUploaderKey? = unresolved.singleOrNull()
+    ?.takeIf { it.serviceId == ServiceList.YouTube.serviceId }
+
+internal fun applyUploaderAvatar(
+    entries: List<PlaylistStreamEntry>,
+    key: LocalPlaylistUploaderKey,
+    avatarUrl: String
+) {
+    entries.asSequence()
+        .map(PlaylistStreamEntry::streamEntity)
+        .filter { stream ->
+            stream.serviceId == key.serviceId &&
+                stream.uploaderUrl == key.uploaderUrl &&
+                stream.uploaderAvatarUrl.isNullOrBlank()
+        }
+        .forEach { it.uploaderAvatarUrl = avatarUrl }
+}

--- a/app/src/test/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntryTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/database/playlist/PlaylistStreamEntryTest.kt
@@ -1,0 +1,34 @@
+package org.schabi.newpipe.database.playlist
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class PlaylistStreamEntryTest {
+    @Test
+    fun toStreamInfoItemCarriesStoredUploaderAvatar() {
+        val stream = StreamEntity(
+            serviceId = ServiceList.YouTube.serviceId,
+            url = "https://youtube.com/watch?v=abcdefghijk",
+            title = "Video",
+            streamType = StreamType.VIDEO_STREAM,
+            duration = 60,
+            uploader = "Uploader",
+            uploaderUrl = "https://youtube.com/channel/test",
+            uploaderAvatarUrl = "https://example.com/avatar.jpg"
+        )
+        val entry = PlaylistStreamEntry(
+            streamEntity = stream,
+            progressMillis = 0,
+            streamId = 1,
+            joinIndex = 0
+        )
+
+        assertEquals(
+            "https://example.com/avatar.jpg",
+            entry.toStreamInfoItem().uploaderAvatarUrl
+        )
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistUploaderAvatarBackfillTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/playlist/LocalPlaylistUploaderAvatarBackfillTest.kt
@@ -1,0 +1,124 @@
+package org.schabi.newpipe.local.playlist
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.schabi.newpipe.database.playlist.PlaylistStreamEntry
+import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class LocalPlaylistUploaderAvatarBackfillTest {
+    private val youtubeServiceId = ServiceList.YouTube.serviceId
+
+    @Test
+    fun missingUploaderKeysGroupsRowsAndIgnoresKnownAndLocalMedia() {
+        val entries = listOf(
+            entry("one", youtubeServiceId, "https://youtube.com/channel/shared", null),
+            entry("two", youtubeServiceId, "https://youtube.com/channel/shared", ""),
+            entry(
+                "three",
+                youtubeServiceId,
+                "https://youtube.com/channel/known",
+                "https://example.com/avatar.jpg"
+            ),
+            entry(
+                "local",
+                youtubeServiceId,
+                "https://youtube.com/channel/local",
+                null,
+                StreamEntity.SOURCE_TYPE_LOCAL
+            )
+        )
+
+        assertEquals(
+            listOf(
+                LocalPlaylistUploaderKey(
+                    youtubeServiceId,
+                    "https://youtube.com/channel/shared"
+                )
+            ),
+            missingUploaderKeys(entries)
+        )
+    }
+
+    @Test
+    fun networkLookupRequiresExactlyOneYoutubeUploader() {
+        val youtube = LocalPlaylistUploaderKey(
+            youtubeServiceId,
+            "https://youtube.com/channel/shared"
+        )
+        val otherYoutube = LocalPlaylistUploaderKey(
+            youtubeServiceId,
+            "https://youtube.com/channel/other"
+        )
+        val otherService = LocalPlaylistUploaderKey(
+            youtubeServiceId + 1,
+            "https://example.com/channel"
+        )
+
+        assertEquals(youtube, selectYoutubeUploaderLookupCandidate(listOf(youtube)))
+        assertNull(selectYoutubeUploaderLookupCandidate(listOf(youtube, otherYoutube)))
+        assertNull(selectYoutubeUploaderLookupCandidate(listOf(otherService)))
+    }
+
+    @Test
+    fun applyUploaderAvatarFillsOnlyMatchingMissingRows() {
+        val key = LocalPlaylistUploaderKey(
+            youtubeServiceId,
+            "https://youtube.com/channel/shared"
+        )
+        val missing = entry("one", youtubeServiceId, key.uploaderUrl, null)
+        val existing = entry(
+            "two",
+            youtubeServiceId,
+            key.uploaderUrl,
+            "https://example.com/existing.jpg"
+        )
+        val other = entry(
+            "three",
+            youtubeServiceId,
+            "https://youtube.com/channel/other",
+            null
+        )
+        val entries = listOf(missing, existing, other)
+
+        applyUploaderAvatar(entries, key, "https://example.com/resolved.jpg")
+
+        assertEquals(
+            "https://example.com/resolved.jpg",
+            missing.streamEntity.uploaderAvatarUrl
+        )
+        assertEquals(
+            "https://example.com/existing.jpg",
+            existing.streamEntity.uploaderAvatarUrl
+        )
+        assertNull(other.streamEntity.uploaderAvatarUrl)
+    }
+
+    private fun entry(
+        id: String,
+        serviceId: Int,
+        uploaderUrl: String?,
+        avatarUrl: String?,
+        sourceType: String = StreamEntity.SOURCE_TYPE_REMOTE
+    ): PlaylistStreamEntry {
+        val stream = StreamEntity(
+            serviceId = serviceId,
+            url = "https://example.com/$id",
+            title = id,
+            streamType = StreamType.VIDEO_STREAM,
+            duration = 60,
+            uploader = "Uploader",
+            uploaderUrl = uploaderUrl,
+            uploaderAvatarUrl = avatarUrl,
+            sourceType = sourceType
+        )
+        return PlaylistStreamEntry(
+            streamEntity = stream,
+            progressMillis = 0,
+            streamId = 0,
+            joinIndex = 0
+        )
+    }
+}


### PR DESCRIPTION
- Repair missing uploader avatars in existing local playlists by reusing any avatar already stored for the same service and uploader.
- Resolve one remaining single-channel YouTube uploader with a single cached channel lookup instead of per-video requests.
- Persist repaired avatar URLs back to all matching stored streams so the fix survives future playlist loads.
- Carry stored uploader avatars through PlaylistStreamEntry-to-StreamInfoItem conversion.
- Add JVM coverage for grouping, lookup selection, in-memory repair, and mapper behavior.
- Add Android Room coverage to verify missing avatars are backfilled without overwriting existing values.
- Fixes #405