### PR TITLE
Ignore surface detach errors during player teardown

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerLifecycleController.kt
@@ -141,12 +141,15 @@ internal class PlayerLifecycleController(
         if (Player.DEBUG) Log.d(Player.TAG, "destroyPlayer() called")
         errorController.resetRecovery()
         historyController.stopLearningSession()
+        val exoPlayer = player.getExoPlayer()
+        // Stop receiving playback errors before UIs detach their video surfaces. Media3 may report
+        // a surface-detach timeout while the player is deliberately shutting down; surfacing that
+        // expected teardown failure would show an erroneous playback error to the user.
+        exoPlayer?.removeListener(player)
         player.UIs().call(PlayerUi::destroyPlayer)
         audioController.releaseAudioSession()
-        if (!player.exoPlayerIsNull()) {
-            val exoPlayer = player.exoPlayer
+        if (exoPlayer != null) {
             try {
-                exoPlayer.removeListener(player)
                 exoPlayer.stop()
                 exoPlayer.release()
             } finally {


### PR DESCRIPTION
- Unregister the player error listener before video UIs detach their surfaces during shutdown
- Prevent Media3 surface-detach timeouts from being shown as genuine playback failures after Back is pressed
- Keep normal playback error reporting unchanged while the player is active