### PR TITLE
Avoid Android JIT crashes while parsing repeated request URLs

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
@@ -242,6 +242,9 @@ public final class DownloaderImpl extends Downloader {
      * Reuses parsed URLs so repeated extractor requests do not repeatedly enter OkHttp's hostname
      * canonicalizer. Apart from avoiding duplicate work, this works around an Android Runtime JIT
      * crash observed on some Android 16 custom-ROM builds while that Kotlin method becomes hot.
+     *
+     * @param url the absolute request URL
+     * @return the cached or newly parsed OkHttp URL
      */
     @NonNull
     HttpUrl parseUrl(@NonNull final String url) {

--- a/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
+++ b/app/src/main/java/org/schabi/newpipe/DownloaderImpl.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,6 +33,7 @@ import java.util.stream.Stream;
 
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
@@ -44,12 +46,32 @@ public final class DownloaderImpl extends Downloader {
             "youtube_restricted_mode_key";
     public static final String YOUTUBE_RESTRICTED_MODE_COOKIE = "PREF=f2=8000000";
     public static final String YOUTUBE_DOMAIN = "youtube.com";
+    static final int PARSED_URL_CACHE_SIZE = 64;
+
+    private static final String YOUTUBE_INNERTUBE_URL =
+            "https://www.youtube.com/youtubei/v1/";
+    private static final String[] COMMON_YOUTUBE_API_URLS = {
+            YOUTUBE_INNERTUBE_URL + "browse?prettyPrint=false",
+            YOUTUBE_INNERTUBE_URL + "next?prettyPrint=false",
+            YOUTUBE_INNERTUBE_URL + "player?prettyPrint=false",
+            YOUTUBE_INNERTUBE_URL + "search?prettyPrint=false"
+    };
 
     private static DownloaderImpl instance;
     private final Map<String, String> mCookies;
+    private final Map<String, HttpUrl> parsedUrls = new LinkedHashMap<>(
+            PARSED_URL_CACHE_SIZE, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<String, HttpUrl> eldest) {
+            return size() > PARSED_URL_CACHE_SIZE;
+        }
+    };
     private final OkHttpClient client;
 
     private DownloaderImpl(final OkHttpClient.Builder builder) {
+        for (final String url : COMMON_YOUTUBE_API_URLS) {
+            parseUrl(url);
+        }
         this.client = builder
                 .addInterceptor(chain -> {
                     final okhttp3.Request originalRequest = chain.request();
@@ -200,7 +222,7 @@ public final class DownloaderImpl extends Downloader {
 
         final okhttp3.Request.Builder requestBuilder = new okhttp3.Request.Builder()
                 .method(httpMethod, requestBody)
-                .url(url)
+                .url(parseUrl(url))
                 .addHeader("User-Agent", USER_AGENT);
 
         final String cookies = getCookies(url);
@@ -214,6 +236,25 @@ public final class DownloaderImpl extends Downloader {
                     requestBuilder.addHeader(headerName, headerValue));
         });
         return requestBuilder.build();
+    }
+
+    /**
+     * Reuses parsed URLs so repeated extractor requests do not repeatedly enter OkHttp's hostname
+     * canonicalizer. Apart from avoiding duplicate work, this works around an Android Runtime JIT
+     * crash observed on some Android 16 custom-ROM builds while that Kotlin method becomes hot.
+     */
+    @NonNull
+    HttpUrl parseUrl(@NonNull final String url) {
+        synchronized (parsedUrls) {
+            final HttpUrl cachedUrl = parsedUrls.get(url);
+            if (cachedUrl != null) {
+                return cachedUrl;
+            }
+
+            final HttpUrl parsedUrl = HttpUrl.get(url);
+            parsedUrls.put(url, parsedUrl);
+            return parsedUrl;
+        }
     }
 
     @Nullable

--- a/app/src/test/java/org/schabi/newpipe/DownloaderImplTest.java
+++ b/app/src/test/java/org/schabi/newpipe/DownloaderImplTest.java
@@ -8,7 +8,9 @@ package org.schabi.newpipe;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 
@@ -19,6 +21,20 @@ import okhttp3.RequestBody;
 import okio.Buffer;
 
 public class DownloaderImplTest {
+    @Test
+    public void parsedUrlsAreReusedAndBounded() {
+        final DownloaderImpl downloader = DownloaderImpl.init(null);
+        final String repeatedUrl = "https://www.youtube.com/youtubei/v1/next?prettyPrint=false";
+
+        assertSame(downloader.parseUrl(repeatedUrl), downloader.parseUrl(repeatedUrl));
+
+        final Object firstUrl = downloader.parseUrl("https://example.com/0");
+        for (int i = 1; i <= DownloaderImpl.PARSED_URL_CACHE_SIZE; i++) {
+            downloader.parseUrl("https://example.com/" + i);
+        }
+        assertNotSame(firstUrl, downloader.parseUrl("https://example.com/0"));
+    }
+
     @Test
     public void postWithoutDataUsesEmptyRequestBody() throws IOException {
         final RequestBody requestBody = DownloaderImpl.buildRequestBody("POST", null);


### PR DESCRIPTION
- Preparse common YouTube Innertube endpoints during downloader initialization
- Reuse exact parsed URLs through a synchronized 64-entry LRU cache
- Avoid repeatedly entering OkHttp hostname canonicalization on affected Android 16 custom ROMs
- Add regression coverage for URL reuse and bounded eviction
- Fixes #479