### PR TITLE
Restore video surface after screen wake

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
@@ -53,6 +53,21 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
         player.setVideoSurface(holder.getSurface());
     }
 
+    /**
+     * Rebinds the current surface after the display wakes if Android retained the view without
+     * dispatching a fresh surface callback.
+     *
+     * @param holder holder belonging to the visible player surface
+     * @return whether a valid surface was rebound
+     */
+    public boolean rebindVideoSurfaceIfValid(final SurfaceHolder holder) {
+        if (!holder.getSurface().isValid()) {
+            return false;
+        }
+        bindVideoSurface(holder);
+        return true;
+    }
+
     @Override
     public void surfaceDestroyed(final SurfaceHolder holder) {
         if (placeholderSurface == null) {

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -435,12 +435,15 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
             // Restore video source when user returns to the fragment
             fragmentIsVisible = true;
             player.useVideoAndSubtitles(true);
+            restoreVideoSurfaceAfterResume();
 
             // When a user returns from background, the system UI will always be shown even if
             // controls are invisible: hide it in that case
             if (!isControlsVisible()) {
                 hideSystemUIIfNeeded();
             }
+        } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction()) && fragmentIsVisible) {
+            restoreVideoSurfaceAfterResume();
         }
     }
     //endregion

--- a/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/VideoPlayerUi.java
@@ -1133,6 +1133,7 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @Override
     public void onRenderedFirstFrame() {
         super.onRenderedFirstFrame();
+        restoreVideoAspectRatioFromPlayer();
         //TODO check if this causes black screen when switching to fullscreen
         animate(binding.surfaceForeground, false, DEFAULT_CONTROLS_DURATION);
     }
@@ -1695,6 +1696,10 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
     @Override
     public void onVideoSizeChanged(@NonNull final VideoSize videoSize) {
         super.onVideoSizeChanged(videoSize);
+        applyVideoAspectRatio(videoSize);
+    }
+
+    private void applyVideoAspectRatio(@NonNull final VideoSize videoSize) {
         final float displayAspectRatio = calculateDisplayAspectRatio(
                 videoSize.width, videoSize.height, videoSize.unappliedRotationDegrees,
                 videoSize.pixelWidthHeightRatio);
@@ -1702,6 +1707,13 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
             return;
         }
         binding.surfaceView.setAspectRatio(displayAspectRatio);
+    }
+
+    private void restoreVideoAspectRatioFromPlayer() {
+        final ExoPlayer exoPlayer = player.getExoPlayer();
+        if (exoPlayer != null) {
+            applyVideoAspectRatio(exoPlayer.getVideoSize());
+        }
     }
 
     static float calculateDisplayAspectRatio(final int width,
@@ -1758,6 +1770,25 @@ public abstract class VideoPlayerUi extends PlayerUi implements SeekBar.OnSeekBa
 
             surfaceIsSetup = true;
         }
+    }
+
+    /**
+     * Recovers a retained video view after the display wakes. Some devices neither recreate the
+     * surface nor resend an unchanged video size, so explicitly restore both pieces of state once
+     * the resumed view has reached the UI queue.
+     */
+    protected final void restoreVideoSurfaceAfterResume() {
+        if (!player.getPlaybackPresentationMode().rendersVideo()) {
+            return;
+        }
+        setupVideoSurfaceIfNeeded();
+        binding.surfaceView.post(() -> {
+            if (binding.getRoot().getParent() == null || surfaceHolderCallback == null) {
+                return;
+            }
+            restoreVideoAspectRatioFromPlayer();
+            surfaceHolderCallback.rebindVideoSurfaceIfValid(binding.surfaceView.getHolder());
+        });
     }
 
     private void clearVideoSurface() {

--- a/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceWakeRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/playback/SurfaceWakeRecoveryTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package org.schabi.newpipe.player.playback;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+
+import androidx.media3.common.Player;
+
+import org.junit.Test;
+
+public class SurfaceWakeRecoveryTest {
+    @Test
+    public void wakeRecoveryOnlyRebindsAValidSurface() {
+        final Context context = mock(Context.class);
+        final Player player = mock(Player.class);
+        final SurfaceHolder holder = mock(SurfaceHolder.class);
+        final Surface surface = mock(Surface.class);
+        when(holder.getSurface()).thenReturn(surface);
+
+        final SurfaceHolderCallback callback = new SurfaceHolderCallback(context, player);
+        when(surface.isValid()).thenReturn(false);
+        assertFalse(callback.rebindVideoSurfaceIfValid(holder));
+        verify(player, never()).setVideoSurface(surface);
+
+        when(surface.isValid()).thenReturn(true);
+        assertTrue(callback.rebindVideoSurfaceIfValid(holder));
+        verify(player).setVideoSurface(surface);
+    }
+}


### PR DESCRIPTION
- Rebind a retained main-player surface after the display turns back on
- Restore the current Media3 video aspect ratio when returning from audio-only background playback
- Recheck video geometry when the first resumed frame is rendered
- Skip surface rebinding while Android reports a released or invalid surface
- Add behavioral coverage for safe wake-time surface recovery