### PR TITLE
Avoid background player service restarts

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -279,10 +279,12 @@ public class MainActivity extends AppCompatActivity {
         sharedPrefEditor.putBoolean(KEY_IS_IN_BACKGROUND, false).apply();
         Log.d(TAG, "App moved to foreground");
         nativePipController.onMainActivityStarted();
+        openMiniPlayerUponPlayerStarted();
     }
 
     @Override
     protected void onStop() {
+        unregisterPlayerStartedReceiver();
         super.onStop();
         sharedPrefEditor.putBoolean(KEY_IS_IN_BACKGROUND, true).apply();
         Log.d(TAG, "App moved to background");
@@ -647,9 +649,7 @@ public class MainActivity extends AppCompatActivity {
         if (!isChangingConfigurations()) {
             StateSaver.clearStateFiles();
         }
-        if (broadcastReceiver != null) {
-            unregisterReceiver(broadcastReceiver);
-        }
+        unregisterPlayerStartedReceiver();
     }
 
     @Override
@@ -1290,6 +1290,9 @@ public class MainActivity extends AppCompatActivity {
             // if the player is already open, no need for a broadcast receiver
             openMiniPlayerIfMissing();
         } else {
+            if (broadcastReceiver != null) {
+                return;
+            }
             // listen for player start intent being sent around
             broadcastReceiver = new BroadcastReceiver() {
                 @Override
@@ -1300,8 +1303,7 @@ public class MainActivity extends AppCompatActivity {
                         openMiniPlayerIfMissing();
                         // At this point the player is added 100%, we can unregister. Other actions
                         // are useless since the fragment will not be removed after that.
-                        unregisterReceiver(broadcastReceiver);
-                        broadcastReceiver = null;
+                        unregisterPlayerStartedReceiver();
                     }
                 }
             };
@@ -1313,6 +1315,13 @@ public class MainActivity extends AppCompatActivity {
             // If the PlayerHolder is not bound yet, but the service is running, try to bind to it.
             // Once the connection is established, the ACTION_PLAYER_STARTED will be sent.
             PlayerHolder.getInstance().tryBindIfNeeded(this);
+        }
+    }
+
+    private void unregisterPlayerStartedReceiver() {
+        if (broadcastReceiver != null) {
+            unregisterReceiver(broadcastReceiver);
+            broadcastReceiver = null;
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -138,6 +138,7 @@ public class MainActivity extends AppCompatActivity {
 
     private boolean servicesShown = false;
     private boolean contextualSearchToolbarActive;
+    private boolean activityStarted;
 
     private BroadcastReceiver broadcastReceiver;
     private final Map<Integer, HomeDrawerPolicy.KioskTarget> drawerKioskTargets = new HashMap<>();
@@ -234,8 +235,6 @@ public class MainActivity extends AppCompatActivity {
         if (DeviceUtils.isTv(this)) {
             FocusOverlayView.setupFocusObserver(this);
         }
-        openMiniPlayerUponPlayerStarted();
-
         if (PermissionHelper.checkPostNotificationsPermission(this,
                 PermissionHelper.POST_NOTIFICATIONS_REQUEST_CODE)) {
             // Schedule worker for checking for new streams and creating corresponding notifications
@@ -276,6 +275,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
+        activityStarted = true;
         sharedPrefEditor.putBoolean(KEY_IS_IN_BACKGROUND, false).apply();
         Log.d(TAG, "App moved to foreground");
         nativePipController.onMainActivityStarted();
@@ -284,6 +284,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onStop() {
+        activityStarted = false;
         unregisterPlayerStartedReceiver();
         super.onStop();
         sharedPrefEditor.putBoolean(KEY_IS_IN_BACKGROUND, true).apply();
@@ -1286,11 +1287,13 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
 
-        if (PlayerHolder.getInstance().isPlayerOpen()) {
+        final boolean playerOpen = PlayerHolder.getInstance().isPlayerOpen();
+        if (playerOpen) {
             // if the player is already open, no need for a broadcast receiver
             openMiniPlayerIfMissing();
         } else {
-            if (broadcastReceiver != null) {
+            if (!shouldRegisterPlayerStartedReceiver(
+                    activityStarted, playerOpen, broadcastReceiver != null)) {
                 return;
             }
             // listen for player start intent being sent around
@@ -1323,6 +1326,12 @@ public class MainActivity extends AppCompatActivity {
             unregisterReceiver(broadcastReceiver);
             broadcastReceiver = null;
         }
+    }
+
+    static boolean shouldRegisterPlayerStartedReceiver(final boolean activityStarted,
+                                                       final boolean playerOpen,
+                                                       final boolean receiverRegistered) {
+        return activityStarted && !playerOpen && !receiverRegistered;
     }
 
     private void openDetailFragmentFromCommentReplies(

--- a/app/src/test/java/org/schabi/newpipe/MainActivityPlayerReceiverLifecycleTest.java
+++ b/app/src/test/java/org/schabi/newpipe/MainActivityPlayerReceiverLifecycleTest.java
@@ -1,35 +1,17 @@
 package org.schabi.newpipe;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 public class MainActivityPlayerReceiverLifecycleTest {
 
     @Test
-    public void playerStartedReceiverOnlyRunsWhileActivityIsForeground() throws Exception {
-        final String source = Files.readString(
-                Path.of("src/main/java/org/schabi/newpipe/MainActivity.java"),
-                StandardCharsets.UTF_8
-        );
-
-        assertTrue(methodBody(source, "protected void onStart()")
-                .contains("openMiniPlayerUponPlayerStarted();"));
-        assertTrue(methodBody(source, "protected void onStop()")
-                .contains("unregisterPlayerStartedReceiver();"));
-        assertTrue(methodBody(source, "protected void onDestroy()")
-                .contains("unregisterPlayerStartedReceiver();"));
-        assertTrue(methodBody(source, "private void openMiniPlayerUponPlayerStarted()")
-                .contains("if (broadcastReceiver != null)"));
-    }
-
-    private static String methodBody(final String source, final String signature) {
-        final int start = source.indexOf(signature);
-        final int nextMethod = source.indexOf("\n    @Override", start + signature.length());
-        return source.substring(start, nextMethod < 0 ? source.length() : nextMethod);
+    public void registersOnlyWhileForegroundAndWaitingForPlayer() {
+        assertTrue(MainActivity.shouldRegisterPlayerStartedReceiver(true, false, false));
+        assertFalse(MainActivity.shouldRegisterPlayerStartedReceiver(false, false, false));
+        assertFalse(MainActivity.shouldRegisterPlayerStartedReceiver(true, true, false));
+        assertFalse(MainActivity.shouldRegisterPlayerStartedReceiver(true, false, true));
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/MainActivityPlayerReceiverLifecycleTest.java
+++ b/app/src/test/java/org/schabi/newpipe/MainActivityPlayerReceiverLifecycleTest.java
@@ -1,0 +1,35 @@
+package org.schabi.newpipe;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class MainActivityPlayerReceiverLifecycleTest {
+
+    @Test
+    public void playerStartedReceiverOnlyRunsWhileActivityIsForeground() throws Exception {
+        final String source = Files.readString(
+                Path.of("src/main/java/org/schabi/newpipe/MainActivity.java"),
+                StandardCharsets.UTF_8
+        );
+
+        assertTrue(methodBody(source, "protected void onStart()")
+                .contains("openMiniPlayerUponPlayerStarted();"));
+        assertTrue(methodBody(source, "protected void onStop()")
+                .contains("unregisterPlayerStartedReceiver();"));
+        assertTrue(methodBody(source, "protected void onDestroy()")
+                .contains("unregisterPlayerStartedReceiver();"));
+        assertTrue(methodBody(source, "private void openMiniPlayerUponPlayerStarted()")
+                .contains("if (broadcastReceiver != null)"));
+    }
+
+    private static String methodBody(final String source, final String signature) {
+        final int start = source.indexOf(signature);
+        final int nextMethod = source.indexOf("\n    @Override", start + signature.length());
+        return source.substring(start, nextMethod < 0 ? source.length() : nextMethod);
+    }
+}


### PR DESCRIPTION
- Unregister the player-start receiver when MainActivity moves to the background.
- Re-arm the receiver when MainActivity returns to the foreground.
- Avoid duplicate receiver registrations while waiting for the player service.
- Add regression coverage for the receiver lifecycle.