### PR TITLE
Fix fullscreen and media notification regressions

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -271,6 +271,7 @@ public final class VideoDetailFragment
     private int viewPagerBaseBottomMargin;
     private boolean detailLayoutRecreationPending;
     private boolean detailLayoutRecreationRequested;
+    private int pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
 
     private ContentObserver settingsContentObserver;
     @Nullable
@@ -475,8 +476,12 @@ public final class VideoDetailFragment
 
     private void syncFullscreenWithOrientation(
             @NonNull final Optional<MainPlayerUi> playerUi) {
-        syncFullscreenWithOrientation(
-                playerUi, getResources().getConfiguration().orientation);
+        final int currentOrientation = getResources().getConfiguration().orientation;
+        if (pendingFullscreenOrientation != Configuration.ORIENTATION_UNDEFINED
+                && pendingFullscreenOrientation != currentOrientation) {
+            return;
+        }
+        syncFullscreenWithOrientation(playerUi, currentOrientation);
     }
 
     private void syncFullscreenWithOrientation(
@@ -488,12 +493,33 @@ public final class VideoDetailFragment
             return;
         }
 
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            playerUi.ifPresent(ui -> ui.setFullscreen(true));
-        } else if (orientation == Configuration.ORIENTATION_PORTRAIT) {
-            playerUi.filter(ui -> ui.isFullscreen() && !ui.isVerticalVideo())
-                    .ifPresent(ui -> ui.setFullscreen(false));
+        final MainPlayerUi ui = playerUi.orElse(null);
+        if (ui == null) {
+            return;
         }
+
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            ui.setFullscreen(true);
+        } else if (orientation == Configuration.ORIENTATION_PORTRAIT
+                && ui.isFullscreen() && !ui.isVerticalVideo()) {
+            ui.setFullscreen(false);
+        }
+
+        if (isFullscreenStateApplied(orientation, ui.isFullscreen(), ui.isVerticalVideo())) {
+            pendingFullscreenOrientation = Configuration.ORIENTATION_UNDEFINED;
+        }
+    }
+
+    static boolean isFullscreenStateApplied(final int orientation,
+                                            final boolean fullscreen,
+                                            final boolean verticalVideo) {
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            return fullscreen;
+        }
+        if (orientation == Configuration.ORIENTATION_PORTRAIT && !verticalVideo) {
+            return !fullscreen;
+        }
+        return true;
     }
 
     static boolean shouldKeepPhonePlayerLayoutForLandscape(
@@ -1811,6 +1837,11 @@ public final class VideoDetailFragment
                     }
                     playerUi.setupVideoSurfaceIfNeeded();
                     updatePinnedPlayerLayout();
+                    // A configuration change can temporarily detach the player UI. Retry the
+                    // requested fullscreen transition only after the rebuilt layout and surface
+                    // are attached, so the request is not lost and the old surface dimensions
+                    // are not cached.
+                    syncFullscreenWithOrientation(Optional.of(playerUi));
                 }
             });
         });
@@ -2758,6 +2789,9 @@ public final class VideoDetailFragment
                 ? ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                 : ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
 
+        pendingFullscreenOrientation = isLandscape
+                ? Configuration.ORIENTATION_PORTRAIT
+                : Configuration.ORIENTATION_LANDSCAPE;
         activity.setRequestedOrientation(newOrientation);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerService.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerService.java
@@ -46,6 +46,7 @@ import org.schabi.newpipe.ktx.BundleKt;
 import org.schabi.newpipe.player.mediabrowser.MediaBrowserImpl;
 import org.schabi.newpipe.player.mediabrowser.MediaBrowserPlaybackPreparer;
 import org.schabi.newpipe.player.mediasession.MediaSessionActionProvider;
+import org.schabi.newpipe.player.mediasession.MediaSessionPlayerUi;
 import org.schabi.newpipe.player.notification.NotificationPlayerUi;
 import org.schabi.newpipe.player.notification.NotificationUtil;
 import org.schabi.newpipe.util.ThemeHelper;
@@ -377,6 +378,15 @@ public final class PlayerService extends MediaLibraryService {
                         session, controller)
                         .setAvailableSessionCommands(commands.build())
                         .build();
+            }
+
+            @Override
+            public void onPostConnect(@NonNull final MediaSession session,
+                                      @NonNull final MediaSession.ControllerInfo controller) {
+                if (player != null) {
+                    player.UIs().get(MediaSessionPlayerUi.class).ifPresent(
+                            ui -> ui.onMediaSessionControllerConnected(controller));
+                }
             }
 
             @Override

--- a/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java
@@ -119,6 +119,27 @@ public class MediaSessionPlayerUi extends PlayerUi
         return Optional.of(mediaSession);
     }
 
+    /**
+     * Republishes configured actions after Android's media-notification controller connects.
+     * The controller commonly connects after player initialization, especially on newer OEM
+     * System UI implementations, so the initial action update cannot reliably target it.
+     *
+     * @param controller the controller whose connection has completed
+     */
+    public void onMediaSessionControllerConnected(
+            @NonNull final MediaSession.ControllerInfo controller) {
+        if (shouldRefreshNotificationActions(
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU,
+                mediaSession.isMediaNotificationController(controller))) {
+            updateMediaSessionActions();
+        }
+    }
+
+    static boolean shouldRefreshNotificationActions(final boolean systemUiActionsSupported,
+                                                    final boolean notificationController) {
+        return systemUiActionsSupported && notificationController;
+    }
+
 
     private ForwardingPlayer getForwardingPlayer() {
         // ForwardingPlayer means that all media session actions called on this player are

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailOrientationHandlingTest.java
@@ -17,14 +17,23 @@ public class VideoDetailOrientationHandlingTest {
             ? Path.of("src/main") : Path.of("app/src/main");
 
     @Test
-    public void configurationOwnsFullscreenWithoutDeferredOrientationState()
-            throws Exception {
-        final String fragment = readFragment();
-        assertTrue(fragment.contains("final int orientation = newConfig.orientation;"));
-        assertTrue(fragment.contains("ui.setFullscreen(true)"));
-        assertTrue(fragment.contains("ui.setFullscreen(false)"));
-        assertFalse(fragment.contains("pendingFullscreenOrientation"));
-        assertFalse(fragment.contains("fullscreenStateForOrientation("));
+    public void fullscreenTransitionCompletesOnlyAfterTargetStateIsApplied() {
+        assertFalse(VideoDetailFragment.isFullscreenStateApplied(
+                Configuration.ORIENTATION_LANDSCAPE, false, false));
+        assertTrue(VideoDetailFragment.isFullscreenStateApplied(
+                Configuration.ORIENTATION_LANDSCAPE, true, false));
+        assertFalse(VideoDetailFragment.isFullscreenStateApplied(
+                Configuration.ORIENTATION_PORTRAIT, true, false));
+        assertTrue(VideoDetailFragment.isFullscreenStateApplied(
+                Configuration.ORIENTATION_PORTRAIT, false, false));
+    }
+
+    @Test
+    public void portraitVerticalVideoDoesNotWaitForAnOrientationDrivenExit() {
+        assertTrue(VideoDetailFragment.isFullscreenStateApplied(
+                Configuration.ORIENTATION_PORTRAIT, true, true));
+        assertTrue(VideoDetailFragment.isFullscreenStateApplied(
+                Configuration.ORIENTATION_UNDEFINED, false, false));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/player/mediasession/MediaSessionNotificationActionsTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/mediasession/MediaSessionNotificationActionsTest.java
@@ -1,46 +1,20 @@
 package org.schabi.newpipe.player.mediasession;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 public class MediaSessionNotificationActionsTest {
-    private final Path sourceDirectory = Files.exists(Path.of("src/main/java"))
-            ? Path.of("src/main/java") : Path.of("app/src/main/java");
-
     @Test
-    public void androidSystemUiGetsCustomActionCommandsAndPreferences() throws Exception {
-        final String source = Files.readString(sourceDirectory.resolve(
-                "org/schabi/newpipe/player/mediasession/MediaSessionPlayerUi.java"));
-        final String updateActions = methodBody(source,
-                "private void updateMediaSessionActions()");
-        final String syncController = methodBody(source,
-                "private void syncMediaNotificationController(");
-
-        assertTrue(updateActions.contains("syncMediaNotificationController(buttons);"));
-        assertTrue(syncController.contains("mediaSession.getMediaNotificationControllerInfo()"));
-        assertTrue(syncController.contains("MediaSessionActionProvider.supportedActions()"));
-        assertTrue(syncController.contains("mediaSession.setAvailableCommands("));
-        assertTrue(syncController.contains(
-                "mediaSession.setMediaButtonPreferences(notificationController, buttons);"));
+    public void refreshesActionsWhenAndroidSystemUiFinishesConnecting() {
+        assertTrue(MediaSessionPlayerUi.shouldRefreshNotificationActions(true, true));
     }
 
-    private static String methodBody(final String source, final String signature) {
-        final int signatureIndex = source.indexOf(signature);
-        assertTrue("Missing method: " + signature, signatureIndex >= 0);
-        final int bodyStart = source.indexOf('{', signatureIndex);
-        assertTrue("Missing method body: " + signature, bodyStart >= 0);
-        int depth = 0;
-        for (int i = bodyStart; i < source.length(); i++) {
-            if (source.charAt(i) == '{') {
-                depth++;
-            } else if (source.charAt(i) == '}' && --depth == 0) {
-                return source.substring(bodyStart, i + 1);
-            }
-        }
-        throw new AssertionError("Unclosed method body: " + signature);
+    @Test
+    public void ignoresNonNotificationAndPreAndroid13Controllers() {
+        assertFalse(MediaSessionPlayerUi.shouldRefreshNotificationActions(true, false));
+        assertFalse(MediaSessionPlayerUi.shouldRefreshNotificationActions(false, true));
+        assertFalse(MediaSessionPlayerUi.shouldRefreshNotificationActions(false, false));
     }
 }


### PR DESCRIPTION
- Preserve orientation-driven fullscreen requests across detail-layout recreation
- Retry fullscreen synchronization after the rebuilt player view and video surface are attached
- Republish configured Android 13+ notification actions when the System UI media controller connects
- Replace notification source inspection with behavioral regression coverage
- Fixes #495