### PR TITLE
Add selectable content blocking targets

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -70,9 +70,12 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
         super.onAttach(context);
 
         if (infoListAdapter == null) {
-            infoListAdapter = new InfoListAdapter(activity);
+            infoListAdapter = new InfoListAdapter(activity, getContentBlockingTarget());
         }
     }
+
+    @NonNull
+    protected abstract ContentBlockingHelper.Target getContentBlockingTarget();
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelTabFragment.java
@@ -37,6 +37,7 @@ import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.player.playqueue.ChannelTabPlayQueue;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.util.ChannelTabHelper;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.PlayButtonHelper;
 import org.schabi.newpipe.util.ServiceHelper;
@@ -93,6 +94,12 @@ public class ChannelTabFragment extends BaseListInfoFragment<InfoItem, ChannelTa
 
     public ChannelTabFragment() {
         super(UserAction.REQUESTED_CHANNEL);
+    }
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.CHANNEL_PAGES;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentRepliesFragment.java
@@ -24,6 +24,7 @@ import org.schabi.newpipe.extractor.stream.Description;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
 import org.schabi.newpipe.util.CommentTextSizeHelper;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
@@ -64,6 +65,12 @@ public final class CommentRepliesFragment
         this.commentsInfoItem = commentsInfoItem;
         // setting "" as title since the title will be properly set right after
         setInitialData(commentsInfoItem.getServiceId(), commentsInfoItem.getUrl(), "");
+    }
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.COMMENTS;
     }
 
     @Nullable

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -19,6 +19,7 @@ import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
 import org.schabi.newpipe.ktx.ViewUtils;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 
 import io.reactivex.rxjava3.core.Single;
@@ -38,6 +39,12 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
 
     public CommentsFragment() {
         super(UserAction.REQUESTED_COMMENTS);
+    }
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.COMMENTS;
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
@@ -31,6 +31,7 @@ import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.KioskTranslator;
 import org.schabi.newpipe.util.Localization;
@@ -67,6 +68,12 @@ public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInf
 
     public KioskFragment() {
         super(UserAction.REQUESTED_KIOSK);
+    }
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.KIOSKS;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/playlist/PlaylistFragment.java
@@ -61,6 +61,7 @@ import org.schabi.newpipe.local.search.ContextualSearchHelper;
 import org.schabi.newpipe.local.search.ContextualSearchable;
 import org.schabi.newpipe.player.playqueue.PlayQueue;
 import org.schabi.newpipe.player.playqueue.PlaylistPlayQueue;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.ExpandableSearchViewHelper;
 import org.schabi.newpipe.util.Localization;
@@ -89,6 +90,12 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class PlaylistFragment extends BaseListInfoFragment<StreamInfoItem, PlaylistInfo>
         implements PlaylistControlViewHolder, ContextualSearchable {
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.REMOTE_PLAYLISTS;
+    }
 
     private CompositeDisposable disposables;
     private Subscription bookmarkReactor;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -72,6 +72,7 @@ import org.schabi.newpipe.local.feed.SavedSearchFeedManager;
 import org.schabi.newpipe.local.history.HistoryRecordManager;
 import org.schabi.newpipe.settings.NewPipeSettings;
 import org.schabi.newpipe.util.Constants;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 import org.schabi.newpipe.util.DeviceUtils;
 import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.KeyboardUtil;
@@ -102,6 +103,12 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
     private static final int MENU_SAVE_SEARCH_FEED = 0x534601;
     private static final int MENU_REFRESH_SEARCH_FEED = 0x534602;
     private static final int MENU_DELETE_SEARCH_FEED = 0x534603;
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.SEARCH;
+    }
 
     /*//////////////////////////////////////////////////////////////////////////
     // Search

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/videos/RelatedItemsFragment.java
@@ -24,6 +24,7 @@ import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.ktx.ViewUtils;
+import org.schabi.newpipe.util.ContentBlockingHelper;
 
 import java.io.Serializable;
 import java.util.function.Supplier;
@@ -59,6 +60,12 @@ public class RelatedItemsFragment extends BaseListInfoFragment<InfoItem, Related
 
     public RelatedItemsFragment() {
         super(UserAction.REQUESTED_STREAM);
+    }
+
+    @NonNull
+    @Override
+    protected ContentBlockingHelper.Target getContentBlockingTarget() {
+        return ContentBlockingHelper.Target.RELATED_ITEMS;
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -93,6 +93,7 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private final InfoItemBuilder infoItemBuilder;
     private final List<InfoItem> infoItemList;
     private final HistoryRecordManager recordManager;
+    private final ContentBlockingHelper.Target contentBlockingTarget;
 
     private boolean useMiniVariant = false;
     private boolean useWideRelatedVariant = false;
@@ -102,11 +103,13 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     private Supplier<View> headerSupplier = null;
 
-    public InfoListAdapter(final Context context) {
+    public InfoListAdapter(final Context context,
+                           @NonNull final ContentBlockingHelper.Target contentBlockingTarget) {
         layoutInflater = LayoutInflater.from(context);
         recordManager = new HistoryRecordManager(context);
         infoItemBuilder = new InfoItemBuilder(context);
         infoItemList = new ArrayList<>();
+        this.contentBlockingTarget = contentBlockingTarget;
     }
 
     public void setOnStreamSelectedListener(final OnClickGesture<StreamInfoItem> listener) {
@@ -151,7 +154,7 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         final boolean hideMembersOnly = MembersOnlyContentHelper.shouldHide(
                 infoItemBuilder.getContext());
         final ContentBlockingHelper.Rules blockingRules = ContentBlockingHelper.getRules(
-                infoItemBuilder.getContext());
+                infoItemBuilder.getContext(), contentBlockingTarget);
         for (final InfoItem item : data) {
             if (!hideMembersOnly || !(item instanceof StreamInfoItem)
                     || !((StreamInfoItem) item).requiresMembership()) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -582,7 +582,10 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         }
 
         val hideMembersOnly = MembersOnlyContentHelper.shouldHide(requireContext())
-        val blockingRules = ContentBlockingHelper.getRules(requireContext())
+        val blockingRules = ContentBlockingHelper.getRules(
+            requireContext(),
+            ContentBlockingHelper.Target.SUBSCRIPTIONS
+        )
         val streamFilteredItems = loadedState.items.filter { item ->
             val streamWithState = item.streamWithState
             if (hideMembersOnly && streamWithState.stream.requiresMembership) {

--- a/app/src/main/java/org/schabi/newpipe/util/ContentBlockingHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ContentBlockingHelper.java
@@ -29,11 +29,16 @@ public final class ContentBlockingHelper {
     }
 
     @NonNull
-    public static Rules getRules(@NonNull final Context context) {
+    public static Rules getRules(@NonNull final Context context,
+                                 @NonNull final Target target) {
         final SharedPreferences preferences = preferences(context);
+        final String targetsKey = context.getString(R.string.content_blocking_targets_key);
+        final Set<String> enabledTargets = preferences.contains(targetsKey)
+                ? copySet(preferences, targetsKey) : null;
         return Rules.create(
                 preferences.getBoolean(context.getString(
-                        R.string.content_blocking_enabled_key), true),
+                        R.string.content_blocking_enabled_key), true)
+                        && isTargetEnabled(enabledTargets, target),
                 copySet(preferences, context.getString(R.string.blocked_videos_key)),
                 copySet(preferences, context.getString(R.string.blocked_channels_key)),
                 preferences.getString(context.getString(
@@ -93,7 +98,30 @@ public final class ContentBlockingHelper {
         return context.getString(R.string.content_blocking_enabled_key).equals(key)
                 || context.getString(R.string.blocked_videos_key).equals(key)
                 || context.getString(R.string.blocked_channels_key).equals(key)
-                || context.getString(R.string.blocked_keywords_key).equals(key);
+                || context.getString(R.string.blocked_keywords_key).equals(key)
+                || context.getString(R.string.content_blocking_targets_key).equals(key);
+    }
+
+    static boolean isTargetEnabled(@Nullable final Set<String> enabledTargets,
+                                   @NonNull final Target target) {
+        return enabledTargets == null || enabledTargets.contains(target.preferenceValue);
+    }
+
+    public enum Target {
+        SEARCH("search"),
+        KIOSKS("kiosks"),
+        RELATED_ITEMS("related_items"),
+        CHANNEL_PAGES("channel_pages"),
+        SUBSCRIPTIONS("subscriptions"),
+        REMOTE_PLAYLISTS("remote_playlists"),
+        COMMENTS("comments");
+
+        @NonNull
+        private final String preferenceValue;
+
+        Target(@NonNull final String preferenceValue) {
+            this.preferenceValue = preferenceValue;
+        }
     }
 
     private static void enable(@NonNull final Context context) {

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -463,6 +463,31 @@
     <string name="show_age_restricted_content">show_age_restricted_content</string>
     <string name="youtube_restricted_mode_enabled">youtube_restricted_mode_enabled</string>
     <string name="hide_members_only_videos_key">hide_members_only_videos</string>
+    <string name="content_blocking_target_search_value">search</string>
+    <string name="content_blocking_target_kiosks_value">kiosks</string>
+    <string name="content_blocking_target_related_items_value">related_items</string>
+    <string name="content_blocking_target_channel_pages_value">channel_pages</string>
+    <string name="content_blocking_target_subscriptions_value">subscriptions</string>
+    <string name="content_blocking_target_remote_playlists_value">remote_playlists</string>
+    <string name="content_blocking_target_comments_value">comments</string>
+    <string-array name="content_blocking_target_value_list">
+        <item>@string/content_blocking_target_search_value</item>
+        <item>@string/content_blocking_target_kiosks_value</item>
+        <item>@string/content_blocking_target_related_items_value</item>
+        <item>@string/content_blocking_target_channel_pages_value</item>
+        <item>@string/content_blocking_target_subscriptions_value</item>
+        <item>@string/content_blocking_target_remote_playlists_value</item>
+        <item>@string/content_blocking_target_comments_value</item>
+    </string-array>
+    <string-array name="content_blocking_target_description_list">
+        <item>@string/content_blocking_target_search</item>
+        <item>@string/content_blocking_target_kiosks</item>
+        <item>@string/content_blocking_target_related_items</item>
+        <item>@string/content_blocking_target_channel_pages</item>
+        <item>@string/content_blocking_target_subscriptions</item>
+        <item>@string/content_blocking_target_remote_playlists</item>
+        <item>@string/content_blocking_target_comments</item>
+    </string-array>
     <string name="enable_search_history_key">enable_search_history</string>
     <string name="enable_watch_history_key">enable_watch_history</string>
     <string name="main_page_content_key">main_page_content</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,6 +409,7 @@
     <string name="content">Content</string>
     <string name="content_blocking_settings_key" translatable="false">content_blocking_settings</string>
     <string name="content_blocking_enabled_key" translatable="false">content_blocking_enabled</string>
+    <string name="content_blocking_targets_key" translatable="false">content_blocking_targets</string>
     <string name="blocked_videos_key" translatable="false">blocked_videos</string>
     <string name="blocked_channels_key" translatable="false">blocked_channels</string>
     <string name="blocked_keywords_key" translatable="false">blocked_keywords</string>
@@ -419,6 +420,15 @@
     <string name="content_blocking_summary">Hide videos, channels, and posts using your blocking rules</string>
     <string name="content_blocking_enabled_title">Enable content blocking</string>
     <string name="content_blocking_enabled_summary">Apply blocked videos, channels, and keywords to remote content lists</string>
+    <string name="content_blocking_targets_title">Apply blocking to</string>
+    <string name="content_blocking_targets_summary">Choose which remote content lists use your blocking rules</string>
+    <string name="content_blocking_target_search">Search results</string>
+    <string name="content_blocking_target_kiosks">Kiosks and What’s New</string>
+    <string name="content_blocking_target_related_items">Related items</string>
+    <string name="content_blocking_target_channel_pages">Channel pages</string>
+    <string name="content_blocking_target_subscriptions">Subscriptions and channel groups</string>
+    <string name="content_blocking_target_remote_playlists">Remote playlists</string>
+    <string name="content_blocking_target_comments">Comments</string>
     <string name="blocked_keywords_title">Blocked keywords</string>
     <string name="manage_blocked_channels_title">Blocked channels</string>
     <string name="manage_blocked_videos_title">Blocked videos</string>

--- a/app/src/main/res/xml/content_blocking_settings.xml
+++ b/app/src/main/res/xml/content_blocking_settings.xml
@@ -11,6 +11,16 @@
         app:iconSpaceReserved="false"
         app:singleLineTitle="false" />
 
+    <MultiSelectListPreference
+        android:defaultValue="@array/content_blocking_target_value_list"
+        android:entries="@array/content_blocking_target_description_list"
+        android:entryValues="@array/content_blocking_target_value_list"
+        android:key="@string/content_blocking_targets_key"
+        android:summary="@string/content_blocking_targets_summary"
+        android:title="@string/content_blocking_targets_title"
+        app:iconSpaceReserved="false"
+        app:singleLineTitle="false" />
+
     <EditTextPreference
         android:dialogTitle="@string/blocked_keywords_title"
         android:key="@string/blocked_keywords_key"

--- a/app/src/test/java/org/schabi/newpipe/util/ContentBlockingHelperTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ContentBlockingHelperTest.java
@@ -81,6 +81,38 @@ class ContentBlockingHelperTest {
         assertFalse(rules.isBlocked(stream("video-1", "Video", "Channel", null)));
     }
 
+    @Test
+    void missingTargetPreferencePreservesFilteringEverywhere() {
+        for (final ContentBlockingHelper.Target target : ContentBlockingHelper.Target.values()) {
+            assertTrue(ContentBlockingHelper.isTargetEnabled(null, target));
+        }
+    }
+
+    @Test
+    void explicitTargetSelectionFiltersOnlyChosenSurfaces() {
+        final Set<String> selectedTargets = Set.of("search", "related_items");
+
+        assertTrue(ContentBlockingHelper.isTargetEnabled(
+                selectedTargets, ContentBlockingHelper.Target.SEARCH));
+        assertTrue(ContentBlockingHelper.isTargetEnabled(
+                selectedTargets, ContentBlockingHelper.Target.RELATED_ITEMS));
+        assertFalse(ContentBlockingHelper.isTargetEnabled(
+                selectedTargets, ContentBlockingHelper.Target.CHANNEL_PAGES));
+        assertFalse(ContentBlockingHelper.isTargetEnabled(
+                selectedTargets, ContentBlockingHelper.Target.SUBSCRIPTIONS));
+        assertFalse(ContentBlockingHelper.isTargetEnabled(
+                selectedTargets, ContentBlockingHelper.Target.REMOTE_PLAYLISTS));
+        assertFalse(ContentBlockingHelper.isTargetEnabled(
+                selectedTargets, ContentBlockingHelper.Target.COMMENTS));
+    }
+
+    @Test
+    void emptyTargetSelectionDisablesFilteringOnEverySurface() {
+        for (final ContentBlockingHelper.Target target : ContentBlockingHelper.Target.values()) {
+            assertFalse(ContentBlockingHelper.isTargetEnabled(Set.of(), target));
+        }
+    }
+
     private static StreamInfoItem stream(final String url,
                                          final String title,
                                          final String uploader,


### PR DESCRIPTION
- Add an Apply blocking to multi-select setting with backward-compatible defaults
- Scope content blocking independently for search, kiosks, related items, channel pages, subscriptions, remote playlists, and comments
- Keep local history and local playlists outside remote content blocking
- Refresh active lists when target selections change
- Add behavioral coverage for default, selected, and empty target sets
- Fixes #497