### PR TITLE
Retain Shorts in subscription feeds

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolver.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolver.kt
@@ -1,0 +1,32 @@
+package org.schabi.newpipe.local.feed.service
+
+import java.time.OffsetDateTime
+import org.schabi.newpipe.extractor.localization.DateWrapper
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+
+internal object FeedItemDateResolver {
+    /**
+     * Gives undated Shorts a deterministic order and lets the feed database retain them.
+     *
+     * YouTube's Shorts tab does not expose upload dates. The feed normally rejects undated
+     * non-live items so that it can order and expire them. A first-seen date is the closest useful
+     * approximation: [StreamDAO][org.schabi.newpipe.database.stream.dao.StreamDAO] preserves it on
+     * later refreshes, even when another approximate value is supplied.
+     *
+     * @param streams items returned by one feed extraction, in newest-first source order
+     * @param fetchedAt time at which the extraction completed
+     */
+    fun applyFirstSeenDates(streams: List<StreamInfoItem>, fetchedAt: OffsetDateTime) {
+        var undatedShortIndex = 0L
+
+        streams.forEach { stream ->
+            if (stream.uploadDate == null && stream.isShortFormContent) {
+                stream.uploadDate = DateWrapper(
+                    fetchedAt.minusSeconds(undatedShortIndex),
+                    true
+                )
+                undatedShortIndex++
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -316,6 +316,11 @@ class FeedLoadManager(private val context: Context) {
                     .filterIsInstance<StreamInfoItem>()
             }
 
+            FeedItemDateResolver.applyFirstSeenDates(
+                streams!!,
+                OffsetDateTime.now(ZoneOffset.UTC)
+            )
+
             return Notification.createOnNext(
                 FeedUpdateInfo(
                     subscriptionEntity,

--- a/app/src/test/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolverTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolverTest.kt
@@ -1,0 +1,53 @@
+package org.schabi.newpipe.local.feed.service
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.schabi.newpipe.extractor.localization.DateWrapper
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class FeedItemDateResolverTest {
+    private val fetchedAt = OffsetDateTime.of(2026, 9, 8, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    @Test
+    fun `undated shorts receive ordered approximate first seen dates`() {
+        val first = stream("https://youtube.com/shorts/first", isShort = true)
+        val second = stream("https://youtube.com/shorts/second", isShort = true)
+
+        FeedItemDateResolver.applyFirstSeenDates(listOf(first, second), fetchedAt)
+
+        assertEquals(fetchedAt, first.uploadDate!!.offsetDateTime())
+        assertEquals(fetchedAt.minusSeconds(1), second.uploadDate!!.offsetDateTime())
+        assertTrue(first.uploadDate!!.isApproximation)
+        assertTrue(second.uploadDate!!.isApproximation)
+    }
+
+    @Test
+    fun `existing dates and undated regular videos are unchanged`() {
+        val originalDate = DateWrapper(fetchedAt.minusDays(1))
+        val datedShort = stream("https://youtube.com/shorts/dated", isShort = true).apply {
+            uploadDate = originalDate
+        }
+        val regularVideo = stream("https://youtube.com/watch?v=regular", isShort = false)
+
+        FeedItemDateResolver.applyFirstSeenDates(listOf(datedShort, regularVideo), fetchedAt)
+
+        assertEquals(originalDate, datedShort.uploadDate)
+        assertFalse(datedShort.uploadDate!!.isApproximation)
+        assertNull(regularVideo.uploadDate)
+    }
+
+    private fun stream(url: String, isShort: Boolean) = StreamInfoItem(
+        0,
+        url,
+        "Title",
+        StreamType.VIDEO_STREAM
+    ).apply {
+        setShortFormContent(isShort)
+    }
+}


### PR DESCRIPTION
- Preserve Shorts returned without upload dates by assigning approximate first-seen timestamps
- Keep source ordering while allowing existing database retention and cleanup behavior
- Leave dated Shorts and undated regular videos unchanged
- Add focused regression coverage for undated Shorts

Closes #505