### PR TITLE
Fix subscription backup imports

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/subscription/SubscriptionManagerTest.java
@@ -101,6 +101,30 @@ public class SubscriptionManagerTest {
     }
 
     @Test
+    public void importedSubscriptionsDoNotReplaceExistingLocalSettings() {
+        final SubscriptionEntity existing = createSubscriptionEntity();
+        existing.setNotificationMode(1);
+        existing.setNotificationKeywords("lessons");
+        manager.insertSubscription(existing);
+
+        final SubscriptionEntity duplicate = createSubscriptionEntity();
+        duplicate.setName("Backup name");
+        duplicate.setNotificationMode(0);
+        final SubscriptionEntity imported = createSubscriptionEntity();
+        imported.setUrl("https://example.com/channel/imported");
+        imported.setName("Imported channel");
+
+        assertEquals(1, manager.insertImportedSubscriptions(List.of(duplicate, imported)));
+
+        final SubscriptionEntity preserved = database.subscriptionDAO()
+                .getSubscriptionDirect(SERVICE_ID, CHANNEL_URL);
+        assertEquals(CHANNEL_NAME, preserved.getName());
+        assertEquals(1, preserved.getNotificationMode());
+        assertEquals("lessons", preserved.getNotificationKeywords());
+        assertEquals(2, database.subscriptionDAO().getAllDirect().size());
+    }
+
+    @Test
     public void youtubeAndMusicMembershipsShareOneSubscription() {
         manager.insertSubscription(createSubscriptionEntity());
 

--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeDataMigrationManagerTest.kt
@@ -17,6 +17,8 @@ import org.schabi.newpipe.NewPipeDatabase
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.AppDatabase
 import org.schabi.newpipe.database.playlist.model.PlaylistEntity
+import org.schabi.newpipe.database.subscription.NotificationMode
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager
 import org.schabi.newpipe.settings.sponsorblock.SponsorBlockBehavior
 import org.schabi.newpipe.settings.sponsorblock.SponsorBlockCategoryConfig
@@ -71,6 +73,7 @@ class NewPipeDataMigrationManagerTest {
         assertEquals(1, preview.progressItems)
         assertEquals(1, preview.playlists)
         assertEquals(1, preview.playlistItems)
+        assertEquals(2, preview.subscriptions)
 
         val result = manager.importData(
             sourcePath,
@@ -92,6 +95,64 @@ class NewPipeDataMigrationManagerTest {
         assertTrue(playlists.any { it.name == "Lessons (Imported)" })
         val imported = playlists.single { it.name == "Lessons (Imported)" }
         assertEquals(1, target.playlistStreamDAO().getOrderedStreamsDirect(imported.uid).size)
+    }
+
+    @Test
+    fun compatibleSubscriptionsAreMergedWithoutReplacingExistingSettings() {
+        val target = NewPipeDatabase.getInstance(context)
+        target.subscriptionDAO().insert(
+            SubscriptionEntity(
+                serviceId = SubscriptionEntity.YOUTUBE_SERVICE_ID,
+                url = "https://www.youtube.com/channel/existing",
+                name = "Local name",
+                notificationMode = NotificationMode.ENABLED,
+                notificationKeywords = "lessons"
+            )
+        )
+        val manager = NewPipeDataMigrationManager(context)
+
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = false,
+                importPlaylists = false,
+                importSubscriptions = true
+            )
+        )
+
+        val subscriptions = target.subscriptionDAO().getAllDirect()
+        assertEquals(1, result.subscriptions)
+        assertEquals(1, result.skippedItems)
+        assertEquals(2, subscriptions.size)
+        val existing = subscriptions.single { it.url!!.endsWith("/existing") }
+        assertEquals("Local name", existing.name)
+        assertEquals(NotificationMode.ENABLED, existing.notificationMode)
+        assertEquals("lessons", existing.notificationKeywords)
+        val imported = subscriptions.single { it.url!!.endsWith("/imported") }
+        assertEquals("Imported channel", imported.name)
+        assertEquals("https://example.com/avatar.jpg", imported.avatarUrl)
+    }
+
+    @Test
+    fun subscriptionOnlyBackupIsAccepted() {
+        sourcePath.toFile().delete()
+        createSubscriptionOnlySourceDatabase(sourcePath)
+        val manager = NewPipeDataMigrationManager(context)
+
+        val preview = manager.inspect(sourcePath)
+        val result = manager.importData(
+            sourcePath,
+            NewPipeDataMigrationManager.Selection(
+                importHistory = false,
+                importPlaylists = false,
+                importSubscriptions = true
+            )
+        )
+
+        assertEquals(1, preview.subscriptions)
+        assertFalse(preview.hasHistory)
+        assertFalse(preview.hasPlaylists)
+        assertEquals(1, result.subscriptions)
     }
 
     @Test
@@ -278,6 +339,12 @@ class NewPipeDataMigrationManagerTest {
                     "join_index INTEGER NOT NULL)"
             )
             source.execSQL(
+                "CREATE TABLE subscriptions (" +
+                    "uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, " +
+                    "url TEXT NOT NULL, name TEXT, avatar_url TEXT, " +
+                    "subscriber_count INTEGER, description TEXT)"
+            )
+            source.execSQL(
                 "INSERT INTO streams VALUES " +
                     "(1, 0, 'https://example.com/watch/1', 'Lesson one', " +
                     "'VIDEO_STREAM', 300, 'Teacher')"
@@ -286,6 +353,27 @@ class NewPipeDataMigrationManagerTest {
             source.execSQL("INSERT INTO stream_state VALUES (1, 90000)")
             source.execSQL("INSERT INTO playlists VALUES (10, 'Lessons')")
             source.execSQL("INSERT INTO playlist_stream_join VALUES (10, 1, 0)")
+            source.execSQL(
+                "INSERT INTO subscriptions VALUES " +
+                    "(1, 0, 'https://www.youtube.com/channel/existing', " +
+                    "'Backup name', NULL, NULL, NULL), " +
+                    "(2, 0, 'https://www.youtube.com/channel/imported', " +
+                    "'Imported channel', 'https://example.com/avatar.jpg', 42, 'Description')"
+            )
+        }
+    }
+
+    private fun createSubscriptionOnlySourceDatabase(path: Path) {
+        SQLiteDatabase.openOrCreateDatabase(path.toFile(), null).use { source ->
+            source.execSQL(
+                "CREATE TABLE subscriptions (" +
+                    "uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, " +
+                    "url TEXT NOT NULL, name TEXT)"
+            )
+            source.execSQL(
+                "INSERT INTO subscriptions VALUES " +
+                    "(1, 0, 'https://www.youtube.com/channel/imported', 'Imported channel')"
+            )
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/SubscriptionManager.kt
@@ -107,6 +107,30 @@ class SubscriptionManager(context: Context) {
         }
     }
 
+    /**
+     * Inserts imported subscriptions without replacing any existing local subscription data.
+     *
+     * @return the number of newly inserted subscriptions
+     */
+    fun insertImportedSubscriptions(entities: List<SubscriptionEntity>): Int {
+        val insertedEntities = database.runInTransaction<List<SubscriptionEntity>> {
+            entities.mapNotNull { entity ->
+                if (entity.serviceId == SubscriptionEntity.YOUTUBE_SERVICE_ID) {
+                    entity.youtubeModeMask = currentYoutubeModeMask
+                }
+                val uid = subscriptionTable.insertIgnore(entity)
+                if (uid == -1L) {
+                    null
+                } else {
+                    entity.uid = uid
+                    entity
+                }
+            }
+        }
+        insertedEntities.forEach(::recordSubscriptionUpsert)
+        return insertedEntities.size
+    }
+
     fun updateChannelInfo(info: ChannelInfo): Completable = subscriptionTable.getSubscription(info.serviceId, info.url)
         .flatMapCompletable {
             Completable.fromRunnable {

--- a/app/src/main/java/org/schabi/newpipe/local/subscription/workers/SubscriptionImportWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/subscription/workers/SubscriptionImportWorker.kt
@@ -16,19 +16,15 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.rx3.await
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import org.schabi.newpipe.R
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.local.subscription.SubscriptionManager
 import org.schabi.newpipe.streams.io.SharpInputStream
 import org.schabi.newpipe.streams.io.StoredFileHelper
-import org.schabi.newpipe.util.ExtractorHelper
 
 class SubscriptionImportWorker(
     appContext: Context,
@@ -53,105 +49,35 @@ class SubscriptionImportWorker(
                 return Result.failure()
             }
 
-        val mutex = Mutex()
-        var processedCount = 0
         val totalCount = subscriptions.size
-        val loadingTitle =
-            applicationContext.resources.getQuantityString(
-                R.plurals.load_subscriptions,
-                totalCount,
-                totalCount
-            )
-
-        val resolvedSubscriptions =
-            try {
-                withContext(Dispatchers.IO.limitedParallelism(PARALLEL_EXTRACTIONS)) {
-                    subscriptions
-                        .map { subscription ->
-                            async {
-                                val resolved =
-                                    try {
-                                        val channelInfo =
-                                            ExtractorHelper
-                                                .getChannelInfo(subscription.serviceId, subscription.url, true)
-                                                .await()
-                                        val channelTab =
-                                            channelInfo.tabs.firstOrNull()?.let { tab ->
-                                                try {
-                                                    ExtractorHelper
-                                                        .getChannelTab(subscription.serviceId, tab, true)
-                                                        .await()
-                                                } catch (e: CancellationException) {
-                                                    throw e
-                                                } catch (e: Exception) {
-                                                    Log.w(
-                                                        TAG,
-                                                        "Could not load the first tab for ${subscription.url}; " +
-                                                            "importing the channel without initial feed items",
-                                                        e
-                                                    )
-                                                    null
-                                                }
-                                            }
-                                        channelInfo to channelTab
-                                    } catch (e: CancellationException) {
-                                        throw e
-                                    } catch (e: Exception) {
-                                        Log.e(
-                                            TAG,
-                                            "Skipping subscription that could not be loaded: " +
-                                                subscription.url,
-                                            e
-                                        )
-                                        null
-                                    }
-
-                                val currentProgress = mutex.withLock { ++processedCount }
-                                setForeground(
-                                    createForegroundInfo(
-                                        loadingTitle,
-                                        subscription.name,
-                                        currentProgress,
-                                        totalCount
-                                    )
-                                )
-                                resolved
-                            }
-                        }.awaitAll()
-                        .filterNotNull()
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "Error while processing subscription data", e)
-                withContext(Dispatchers.Main) {
-                    Toast
-                        .makeText(applicationContext, R.string.subscriptions_import_unsuccessful, Toast.LENGTH_SHORT)
-                        .show()
-                }
-                return Result.failure()
-            }
-
-        val importedCount = resolvedSubscriptions.size
-        val skippedCount = totalCount - importedCount
         val importingTitle =
             applicationContext.resources.getQuantityString(
                 R.plurals.import_subscriptions,
-                importedCount,
-                importedCount
+                totalCount,
+                totalCount
             )
-        setForeground(createForegroundInfo(importingTitle, null, 0, importedCount))
+        val supportedServiceIds = ServiceList.all().mapTo(mutableSetOf()) { it.serviceId }
+        val entities = prepareSubscriptionEntities(subscriptions, supportedServiceIds)
+        setForeground(
+            createForegroundInfo(
+                importingTitle,
+                null,
+                totalCount - entities.size,
+                totalCount
+            )
+        )
 
         val subscriptionManager = SubscriptionManager(applicationContext)
         var insertedCount = 0
+        var processedCount = totalCount - entities.size
         try {
-            for (chunk in resolvedSubscriptions.chunked(BUFFER_COUNT_BEFORE_INSERT)) {
+            for (chunk in entities.chunked(BUFFER_COUNT_BEFORE_INSERT)) {
                 withContext(Dispatchers.IO) {
-                    subscriptionManager.upsertAll(chunk)
+                    insertedCount += subscriptionManager.insertImportedSubscriptions(chunk)
                 }
-                insertedCount += chunk.size
+                processedCount += chunk.size
                 setForeground(
-                    createForegroundInfo(importingTitle, null, insertedCount, importedCount)
+                    createForegroundInfo(importingTitle, null, processedCount, totalCount)
                 )
             }
         } catch (e: CancellationException) {
@@ -166,13 +92,14 @@ class SubscriptionImportWorker(
             return Result.failure()
         }
 
+        val skippedCount = totalCount - insertedCount
         withContext(Dispatchers.Main) {
             Toast
                 .makeText(
                     applicationContext,
                     applicationContext.getString(
                         R.string.subscriptions_import_complete_summary,
-                        importedCount,
+                        insertedCount,
                         skippedCount
                     ),
                     Toast.LENGTH_LONG
@@ -181,7 +108,7 @@ class SubscriptionImportWorker(
 
         return Result.success(
             workDataOf(
-                IMPORTED_COUNT_KEY to importedCount,
+                IMPORTED_COUNT_KEY to insertedCount,
                 SKIPPED_COUNT_KEY to skippedCount
             )
         )
@@ -256,7 +183,6 @@ class SubscriptionImportWorker(
         private const val NOTIFICATION_ID = 4568
         private const val NOTIFICATION_CHANNEL_ID = "newpipe"
         private const val DEFAULT_MIME = "application/octet-stream"
-        private const val PARALLEL_EXTRACTIONS = 8
         private const val BUFFER_COUNT_BEFORE_INSERT = 50
 
         const val WORK_NAME = "SubscriptionImportWorker"
@@ -274,6 +200,22 @@ class SubscriptionImportWorker(
             return when {
                 pointIndex == -1 || pointIndex >= fileName.length - 1 -> DEFAULT_MIME
                 else -> fileName.substring(pointIndex + 1)
+            }
+        }
+
+        internal fun prepareSubscriptionEntities(
+            subscriptions: List<SubscriptionItem>,
+            supportedServiceIds: Set<Int>
+        ): List<SubscriptionEntity> = subscriptions.mapNotNull { subscription ->
+            val url = subscription.url.trim()
+            if (subscription.serviceId !in supportedServiceIds || url.isEmpty()) {
+                null
+            } else {
+                SubscriptionEntity(
+                    serviceId = subscription.serviceId,
+                    url = url,
+                    name = subscription.name.trim().ifEmpty { url }
+                )
             }
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -52,6 +52,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private static final String ZIP_MIME_TYPE = "application/zip";
 
     private enum MigrationOption {
+        SUBSCRIPTIONS,
         HISTORY,
         PLAYLISTS,
         SETTINGS,
@@ -267,6 +268,12 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
 
         final List<String> optionLabels = new ArrayList<>();
         final List<MigrationOption> optionTypes = new ArrayList<>();
+        if (preview.getHasSubscriptions()) {
+            optionLabels.add(getString(
+                    R.string.migration_subscriptions_option,
+                    preview.getSubscriptions()));
+            optionTypes.add(MigrationOption.SUBSCRIPTIONS);
+        }
         if (preview.getHasHistory()) {
             optionLabels.add(getString(
                     R.string.migration_history_option,
@@ -310,6 +317,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         dialog.setOnCancelListener(ignored -> manager.discardStagedDb(stagedDatabase));
         dialog.setOnShowListener(ignored -> dialog.getButton(DialogInterface.BUTTON_POSITIVE)
                 .setOnClickListener(button -> {
+                    boolean importSubscriptions = false;
                     boolean importHistory = false;
                     boolean importPlaylists = false;
                     boolean importSettings = false;
@@ -319,6 +327,9 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                             continue;
                         }
                         switch (optionTypes.get(i)) {
+                            case SUBSCRIPTIONS:
+                                importSubscriptions = true;
+                                break;
                             case HISTORY:
                                 importHistory = true;
                                 break;
@@ -335,7 +346,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                 break;
                         }
                     }
-                    if (!importHistory && !importPlaylists
+                    if (!importSubscriptions && !importHistory && !importPlaylists
                             && !importSettings && !importSponsorBlock) {
                         Toast.makeText(requireContext(), R.string.migration_nothing_selected,
                                 Toast.LENGTH_SHORT).show();
@@ -350,7 +361,8 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                     importHistory,
                                     importPlaylists,
                                     importSettings,
-                                    importSponsorBlock));
+                                    importSponsorBlock,
+                                    importSubscriptions));
                 }));
         dialog.show();
     }
@@ -377,6 +389,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                         migrationResult.getProgressItems(),
                                         migrationResult.getPlaylists(),
                                         migrationResult.getPlaylistItems(),
+                                        migrationResult.getSubscriptions(),
                                         migrationResult.getCompatibleSettings(),
                                         migrationResult.getSponsorBlockSettings(),
                                         migrationResult.getSkippedItems()))

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeDataMigrationManager.kt
@@ -12,6 +12,8 @@ import org.schabi.newpipe.database.playlist.model.PlaylistEntity
 import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
+import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.stream.StreamType
 
 class NewPipeDataMigrationManager(private val context: Context) {
@@ -25,6 +27,7 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val progressItems: Int,
         val playlists: Int,
         val playlistItems: Int,
+        val subscriptions: Int,
         val compatibleSettings: Int,
         val sponsorBlockSettings: Int,
         val sourceApp: SourceApp
@@ -33,12 +36,14 @@ class NewPipeDataMigrationManager(private val context: Context) {
             get() = historyItems > 0 || progressItems > 0
         val hasPlaylists: Boolean
             get() = playlists > 0
+        val hasSubscriptions: Boolean
+            get() = subscriptions > 0
         val hasCompatibleSettings: Boolean
             get() = compatibleSettings > 0
         val hasSponsorBlockSettings: Boolean
             get() = sponsorBlockSettings > 0
         val hasImportableData: Boolean
-            get() = hasHistory || hasPlaylists ||
+            get() = hasHistory || hasPlaylists || hasSubscriptions ||
                 hasCompatibleSettings || hasSponsorBlockSettings
     }
 
@@ -46,7 +51,8 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val importHistory: Boolean,
         val importPlaylists: Boolean,
         val importSettings: Boolean = false,
-        val importSponsorBlock: Boolean = false
+        val importSponsorBlock: Boolean = false,
+        val importSubscriptions: Boolean = false
     )
 
     data class Result(
@@ -54,6 +60,7 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val progressItems: Int,
         val playlists: Int,
         val playlistItems: Int,
+        val subscriptions: Int,
         val compatibleSettings: Int,
         val sponsorBlockSettings: Int,
         val skippedItems: Int
@@ -78,6 +85,11 @@ class NewPipeDataMigrationManager(private val context: Context) {
             progressItems = if (schema.hasProgress) source.countRows(STATE_TABLE) else 0,
             playlists = if (schema.hasPlaylists) source.countRows(PLAYLIST_TABLE) else 0,
             playlistItems = if (schema.hasPlaylists) source.countRows(PLAYLIST_JOIN_TABLE) else 0,
+            subscriptions = if (schema.hasSubscriptions) {
+                source.countRows(SUBSCRIPTION_TABLE)
+            } else {
+                0
+            },
             compatibleSettings = compatibleSettings.size,
             sponsorBlockSettings = sponsorBlockSettings.size,
             sourceApp = if (schema.isPipePipe) SourceApp.PIPEPIPE else SourceApp.NEWPIPE
@@ -90,7 +102,11 @@ class NewPipeDataMigrationManager(private val context: Context) {
         sourcePreferences: Map<String, *> = emptyMap<String, Any>()
     ): Result = openSource(databasePath).use { source ->
         val schema = inspectSchema(source)
-        val streams = readStreams(source)
+        val streams = if (selection.importHistory || selection.importPlaylists) {
+            readStreams(source)
+        } else {
+            emptyMap()
+        }
         val target = NewPipeDatabase.getInstance(context)
         val settingsMigration = CompatibleSettingsMigration(context)
         val compatibleSettings = settingsMigration.prepare(sourcePreferences)
@@ -101,7 +117,7 @@ class NewPipeDataMigrationManager(private val context: Context) {
         }
         var settingsRollback: CompatibleSettingsMigration.Rollback? = null
         var sponsorBlockRollback: CompatibleSettingsMigration.Rollback? = null
-        var result = Result(0, 0, 0, 0, 0, 0, 0)
+        var result = Result(0, 0, 0, 0, 0, 0, 0, 0)
 
         try {
             if (selection.importSettings && compatibleSettings.size > 0) {
@@ -126,7 +142,38 @@ class NewPipeDataMigrationManager(private val context: Context) {
                 var progressItems = 0
                 var playlists = 0
                 var playlistItems = 0
+                var subscriptions = 0
                 var skippedItems = 0
+
+                if (selection.importSubscriptions && schema.hasSubscriptions) {
+                    val supportedServiceIds = ServiceList.all()
+                        .mapTo(mutableSetOf()) { it.serviceId }
+                    source.rawQuery("SELECT * FROM $SUBSCRIPTION_TABLE", null).use { cursor ->
+                        while (cursor.moveToNext()) {
+                            val serviceId = cursor.long("service_id")?.toInt()
+                            val url = cursor.string("url")?.trim().orEmpty()
+                            if (serviceId == null || serviceId !in supportedServiceIds ||
+                                url.isEmpty()
+                            ) {
+                                skippedItems++
+                                continue
+                            }
+                            val entity = SubscriptionEntity(
+                                serviceId = serviceId,
+                                url = url,
+                                name = cursor.string("name")?.trim().orEmpty().ifEmpty { url },
+                                avatarUrl = cursor.string("avatar_url"),
+                                subscriberCount = cursor.long("subscriber_count"),
+                                description = cursor.string("description")
+                            )
+                            if (target.subscriptionDAO().insertIgnore(entity) != -1L) {
+                                subscriptions++
+                            } else {
+                                skippedItems++
+                            }
+                        }
+                    }
+                }
 
                 if (selection.importHistory && schema.hasHistory) {
                     source.rawQuery(
@@ -255,6 +302,7 @@ class NewPipeDataMigrationManager(private val context: Context) {
                     progressItems,
                     playlists,
                     playlistItems,
+                    subscriptions,
                     if (selection.importSettings) compatibleSettings.size else 0,
                     if (selection.importSponsorBlock) sponsorBlockSettings.size else 0,
                     skippedItems
@@ -288,27 +336,30 @@ class NewPipeDataMigrationManager(private val context: Context) {
 
     private fun inspectSchema(source: SQLiteDatabase): SourceSchema {
         val streamColumns = source.columnsOf(STREAM_TABLE)
-        if (!streamColumns.containsAll(REQUIRED_STREAM_COLUMNS)) {
-            throw UnsupportedSourceException(
-                "The source database does not contain a compatible NewPipe streams table"
-            )
-        }
+        val hasStreams = streamColumns.containsAll(REQUIRED_STREAM_COLUMNS)
         val historyColumns = source.columnsOf(HISTORY_TABLE)
         val stateColumns = source.columnsOf(STATE_TABLE)
         val playlistColumns = source.columnsOf(PLAYLIST_TABLE)
         val joinColumns = source.columnsOf(PLAYLIST_JOIN_TABLE)
+        val subscriptionColumns = source.columnsOf(SUBSCRIPTION_TABLE)
         val schema = SourceSchema(
-            hasHistory = historyColumns.containsAll(REQUIRED_HISTORY_COLUMNS),
-            hasProgress = stateColumns.containsAll(REQUIRED_STATE_COLUMNS),
-            hasPlaylists = playlistColumns.containsAll(REQUIRED_PLAYLIST_COLUMNS) &&
+            hasHistory = hasStreams && historyColumns.containsAll(REQUIRED_HISTORY_COLUMNS),
+            hasProgress = hasStreams && stateColumns.containsAll(REQUIRED_STATE_COLUMNS),
+            hasPlaylists = hasStreams &&
+                playlistColumns.containsAll(REQUIRED_PLAYLIST_COLUMNS) &&
                 joinColumns.containsAll(REQUIRED_PLAYLIST_JOIN_COLUMNS),
+            hasSubscriptions = subscriptionColumns.containsAll(
+                REQUIRED_SUBSCRIPTION_COLUMNS
+            ),
             playlistColumns = playlistColumns,
             isPipePipe = source.tableExists(PIPEPIPE_SPONSORBLOCK_WHITELIST_TABLE) ||
                 source.userVersion() >= PIPEPIPE_DATABASE_VERSION_FLOOR
         )
-        if (!schema.hasHistory && !schema.hasProgress && !schema.hasPlaylists) {
+        if (!schema.hasHistory && !schema.hasProgress && !schema.hasPlaylists &&
+            !schema.hasSubscriptions
+        ) {
             throw UnsupportedSourceException(
-                "The source database does not contain compatible history or playlist data"
+                "The source database does not contain compatible migration data"
             )
         }
         return schema
@@ -420,6 +471,7 @@ class NewPipeDataMigrationManager(private val context: Context) {
         val hasHistory: Boolean,
         val hasProgress: Boolean,
         val hasPlaylists: Boolean,
+        val hasSubscriptions: Boolean,
         val playlistColumns: Set<String>,
         val isPipePipe: Boolean
     ) {
@@ -433,6 +485,7 @@ class NewPipeDataMigrationManager(private val context: Context) {
         private const val STATE_TABLE = "stream_state"
         private const val PLAYLIST_TABLE = "playlists"
         private const val PLAYLIST_JOIN_TABLE = "playlist_stream_join"
+        private const val SUBSCRIPTION_TABLE = "subscriptions"
         private const val PIPEPIPE_SPONSORBLOCK_WHITELIST_TABLE = "sponsorblock_whitelist"
         private const val PIPEPIPE_DATABASE_VERSION_FLOOR = 900
 
@@ -456,6 +509,11 @@ class NewPipeDataMigrationManager(private val context: Context) {
             "playlist_id",
             "stream_id",
             "join_index"
+        )
+        private val REQUIRED_SUBSCRIPTION_COLUMNS = setOf(
+            "service_id",
+            "url",
+            "name"
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,7 +505,7 @@
     <string name="import_data_title">Import full backup</string>
     <string name="import_compatible_data_key" translatable="false">import_compatible_data</string>
     <string name="import_compatible_data_title">Import from NewPipe or compatible app</string>
-    <string name="import_compatible_data_summary">Merge watch history, playback positions, local playlists, compatible settings, and PipePipe SponsorBlock settings from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
+    <string name="import_compatible_data_summary">Merge subscriptions, watch history, playback positions, local playlists, compatible settings, and PipePipe SponsorBlock settings from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
     <string name="export_data_title">Export full backup</string>
     <string name="clear_cookie_title">Clear reCAPTCHA cookies</string>
     <string name="recaptcha_cookies_cleared">reCAPTCHA cookies have been cleared</string>
@@ -527,6 +527,7 @@
     <string name="backup_incompatible_message">Full restore accepts only backups created by a supported version of WizeStream. This archive may be from another app, an older unverified format, or an incompatible WizeStream version. Nothing on this device was changed.</string>
     <string name="migration_invalid_backup">This backup does not contain compatible NewPipe data or settings.</string>
     <string name="migration_choose_data_title">Choose data to merge</string>
+    <string name="migration_subscriptions_option">Subscriptions: %1$d</string>
     <string name="migration_history_option">Watch history: %1$d entries and %2$d playback positions</string>
     <string name="migration_playlists_option">Local playlists: %1$d playlists and %2$d items</string>
     <string name="migration_settings_option">Compatible app settings: %1$d</string>
@@ -534,7 +535,7 @@
     <string name="migration_import_button">Merge data</string>
     <string name="migration_nothing_selected">Select at least one data category.</string>
     <string name="migration_complete_title">Migration complete</string>
-    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, %4$d playlist items, %5$d compatible settings, and %6$d SponsorBlock settings. Skipped %7$d incompatible items.</string>
+    <string name="migration_complete_message">Merged %1$d history entries, %2$d playback positions, %3$d playlists, %4$d playlist items, %5$d subscriptions, %6$d compatible settings, and %7$d SponsorBlock settings. Skipped %8$d incompatible or existing items.</string>
     <string name="backup_exported_with_file">Backup exported: %s</string>
     <string name="backup_import_succeeded_restart">Import succeeded. WizeStream will restart to finish loading the backup.</string>
     <string name="restart">Restart</string>

--- a/app/src/test/java/org/schabi/newpipe/local/subscription/workers/SubscriptionImportWorkerTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/subscription/workers/SubscriptionImportWorkerTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.withSettings
 import org.mockito.junit.MockitoJUnitRunner
+import org.schabi.newpipe.database.subscription.SubscriptionEntity
 import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.subscription.SubscriptionItem as ExtractorSubscriptionItem
 import org.schabi.newpipe.streams.io.StoredFileHelper
@@ -77,6 +78,43 @@ class SubscriptionImportWorkerTest {
 
         assertEquals(84, subscriptions.size)
         assertEquals("Channel 83", subscriptions.last().name)
+    }
+
+    @Test
+    fun `large imports are converted directly to subscription entities`() {
+        val subscriptions = List(350) { index ->
+            SubscriptionItem(
+                ServiceList.YouTube.serviceId,
+                "https://www.youtube.com/channel/test$index",
+                "Channel $index"
+            )
+        }
+
+        val entities = SubscriptionImportWorker.prepareSubscriptionEntities(
+            subscriptions,
+            setOf(ServiceList.YouTube.serviceId)
+        )
+
+        assertEquals(350, entities.size)
+        assertEquals("Channel 349", entities.last().name)
+        assertEquals(SubscriptionEntity.YOUTUBE_SERVICE_ID, entities.last().serviceId)
+    }
+
+    @Test
+    fun `unsupported services and empty urls are skipped without network resolution`() {
+        val validUrl = "https://www.youtube.com/channel/valid"
+        val entities = SubscriptionImportWorker.prepareSubscriptionEntities(
+            listOf(
+                SubscriptionItem(ServiceList.YouTube.serviceId, validUrl, ""),
+                SubscriptionItem(Int.MAX_VALUE, "https://example.com/channel", "Unknown"),
+                SubscriptionItem(ServiceList.YouTube.serviceId, "   ", "Missing")
+            ),
+            setOf(ServiceList.YouTube.serviceId)
+        )
+
+        assertEquals(1, entities.size)
+        assertEquals(validUrl, entities.single().url)
+        assertEquals(validUrl, entities.single().name)
     }
 
     @Test


### PR DESCRIPTION
- Import subscription records directly without per-channel network extraction
- Add subscriptions as a selectable compatible-backup merge category
- Preserve existing local subscriptions and notification settings
- Support subscription-only NewPipe-style backup databases
- Add large-import, duplicate-preservation, and migration regression coverage

Closes #504