### PR TITLE
Recover stuck YouTube HLS playlists

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerHttpErrorRecovery.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylistTracker;
 
 import org.schabi.newpipe.extractor.stream.VideoStream;
 import org.schabi.newpipe.player.playqueue.PlayQueueItem;
@@ -102,7 +103,8 @@ final class PlayerHttpErrorRecovery {
 
     static boolean isRecoverableMediaUrlFailure(@NonNull final Throwable error) {
         return isRecoverableStatusCode(findInvalidResponseCode(error))
-                || hasUnknownHostCause(error);
+                || hasUnknownHostCause(error)
+                || hasPlaylistStuckCause(error);
     }
 
     static boolean isYouTubeService(final int serviceId) {
@@ -132,6 +134,17 @@ final class PlayerHttpErrorRecovery {
         Throwable current = error;
         while (current != null) {
             if (current instanceof UnknownHostException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    static boolean hasPlaylistStuckCause(@NonNull final Throwable error) {
+        Throwable current = error;
+        while (current != null) {
+            if (current instanceof HlsPlaylistTracker.PlaylistStuckException) {
                 return true;
             }
             current = current.getCause();

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerHlsRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerHlsRecoveryTest.java
@@ -1,0 +1,23 @@
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylistTracker;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class PlayerHlsRecoveryTest {
+    @Test
+    public void treatsNestedStuckHlsPlaylistAsRecoverable() {
+        final Throwable error = new RuntimeException("source", new IOException("network",
+                new HlsPlaylistTracker.PlaylistStuckException(null)));
+
+        assertTrue(PlayerHttpErrorRecovery.hasPlaylistStuckCause(error));
+        assertTrue(PlayerHttpErrorRecovery.isRecoverableMediaUrlFailure(error));
+        assertFalse(PlayerHttpErrorRecovery.hasPlaylistStuckCause(
+                new RuntimeException("source", new IOException("network"))));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import androidx.media3.datasource.HttpDataSource;
+import androidx.media3.exoplayer.hls.playlist.HlsPlaylistTracker;
 
 import org.junit.Test;
 import org.schabi.newpipe.extractor.MediaFormat;
@@ -51,6 +52,17 @@ public class PlayerHttpErrorRecoveryTest {
         assertFalse(PlayerHttpErrorRecovery.hasUnknownHostCause(
                 new RuntimeException("source", new IOException("network"))));
         assertFalse(PlayerHttpErrorRecovery.isRecoverableMediaUrlFailure(
+                new RuntimeException("source", new IOException("network"))));
+    }
+
+    @Test
+    public void treatsNestedStuckHlsPlaylistAsRecoverable() {
+        final Throwable error = new RuntimeException("source", new IOException("network",
+                new HlsPlaylistTracker.PlaylistStuckException(null)));
+
+        assertTrue(PlayerHttpErrorRecovery.hasPlaylistStuckCause(error));
+        assertTrue(PlayerHttpErrorRecovery.isRecoverableMediaUrlFailure(error));
+        assertFalse(PlayerHttpErrorRecovery.hasPlaylistStuckCause(
                 new RuntimeException("source", new IOException("network"))));
     }
 

--- a/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/PlayerHttpErrorRecoveryTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import androidx.media3.datasource.HttpDataSource;
-import androidx.media3.exoplayer.hls.playlist.HlsPlaylistTracker;
 
 import org.junit.Test;
 import org.schabi.newpipe.extractor.MediaFormat;
@@ -52,17 +51,6 @@ public class PlayerHttpErrorRecoveryTest {
         assertFalse(PlayerHttpErrorRecovery.hasUnknownHostCause(
                 new RuntimeException("source", new IOException("network"))));
         assertFalse(PlayerHttpErrorRecovery.isRecoverableMediaUrlFailure(
-                new RuntimeException("source", new IOException("network"))));
-    }
-
-    @Test
-    public void treatsNestedStuckHlsPlaylistAsRecoverable() {
-        final Throwable error = new RuntimeException("source", new IOException("network",
-                new HlsPlaylistTracker.PlaylistStuckException(null)));
-
-        assertTrue(PlayerHttpErrorRecovery.hasPlaylistStuckCause(error));
-        assertTrue(PlayerHttpErrorRecovery.isRecoverableMediaUrlFailure(error));
-        assertFalse(PlayerHttpErrorRecovery.hasPlaylistStuckCause(
                 new RuntimeException("source", new IOException("network"))));
     }
 


### PR DESCRIPTION
- Detect Media3 `PlaylistStuckException` through nested playback-error causes
- Refresh YouTube stream metadata and rebuild the current media source with bounded backoff
- Preserve the current queue item and playback recovery position
- Suppress premature error reporting while automatic recovery remains available
- Add regression coverage for the reported nested HLS failure