### PR TITLE
Balance Shorts in subscription feeds

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/database/FeedDAOTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/database/FeedDAOTest.kt
@@ -228,6 +228,32 @@ class FeedDAOTest {
         assertEqual(soundCloudStreams, listOf(soundCloudStream))
     }
 
+    @Test
+    fun approximateUploadDateCanBeRepositionedWithoutReplacingAnExactDate() {
+        val approximate = stream1.copy(
+            uid = 10,
+            url = "https://youtube.com/shorts/approximate",
+            uploadDate = OffsetDateTime.parse("2026-09-08T12:00:00Z"),
+            isUploadDateApproximation = true
+        )
+        val exact = stream2.copy(
+            uid = 11,
+            url = "https://youtube.com/watch?v=exact",
+            uploadDate = OffsetDateTime.parse("2026-09-07T12:00:00Z"),
+            isUploadDateApproximation = false
+        )
+        streamDAO.insertAll(listOf(approximate, exact))
+        val correctedDate = OffsetDateTime.parse("2026-09-01T12:00:00Z")
+
+        assertEquals(
+            1,
+            streamDAO.updateApproximateUploadDate(serviceId, approximate.url, correctedDate)
+        )
+        assertEquals(0, streamDAO.updateApproximateUploadDate(serviceId, exact.url, correctedDate))
+        assertEquals(correctedDate, streamDAO.getStreamDirect(approximate.uid)!!.uploadDate)
+        assertEquals(exact.uploadDate, streamDAO.getStreamDirect(exact.uid)!!.uploadDate)
+    }
+
     private fun assertEqual(streams: List<StreamWithState>?, allowedStreams: List<StreamEntity>) {
         assertNotNull(streams)
         assertEquals(

--- a/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/dao/StreamDAO.kt
@@ -40,6 +40,21 @@ abstract class StreamDAO : BasicDAO<StreamEntity> {
 
     @Query(
         """
+        UPDATE streams
+        SET upload_date = :uploadDate
+        WHERE service_id = :serviceId
+        AND url = :url
+        AND is_upload_date_approximation = 1
+        """
+    )
+    abstract fun updateApproximateUploadDate(
+        serviceId: Int,
+        url: String,
+        uploadDate: OffsetDateTime
+    ): Int
+
+    @Query(
+        """
         SELECT uploader_avatar_url FROM streams
         WHERE service_id = :serviceId
         AND uploader_url = :uploaderUrl

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedDatabaseManager.kt
@@ -123,8 +123,22 @@ class FeedDatabaseManager(context: Context) {
         items: List<StreamInfoItem>,
         youtubeModeMask: Int = SubscriptionEntity.YOUTUBE_MODE_REGULAR,
         oldestAllowedDate: OffsetDateTime = FEED_OLDEST_ALLOWED_DATE,
-        uploaderAvatarUrl: String? = null
+        uploaderAvatarUrl: String? = null,
+        repositionApproximateShorts: Boolean = false
     ) {
+        if (repositionApproximateShorts) {
+            items.forEach { item ->
+                val uploadDate = item.uploadDate
+                if (item.isShortFormContent && uploadDate?.isApproximation == true) {
+                    streamTable.updateApproximateUploadDate(
+                        item.serviceId,
+                        item.url,
+                        uploadDate.offsetDateTime()
+                    )
+                }
+            }
+        }
+
         val itemsToInsert = items.mapNotNull { stream ->
             val uploadDate = stream.uploadDate
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolver.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolver.kt
@@ -1,32 +1,53 @@
 package org.schabi.newpipe.local.feed.service
 
+import java.time.Duration
 import java.time.OffsetDateTime
 import org.schabi.newpipe.extractor.localization.DateWrapper
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 
 internal object FeedItemDateResolver {
     /**
-     * Gives undated Shorts a deterministic order and lets the feed database retain them.
+     * Gives undated Shorts approximate dates so the feed database can retain and order them.
      *
      * YouTube's Shorts tab does not expose upload dates. The feed normally rejects undated
-     * non-live items so that it can order and expire them. A first-seen date is the closest useful
-     * approximation: [StreamDAO][org.schabi.newpipe.database.stream.dao.StreamDAO] preserves it on
-     * later refreshes, even when another approximate value is supplied.
+     * non-live items so that it can order and expire them. When dated items are available from the
+     * same channel refresh, distribute Shorts across that date range instead of promoting every
+     * Short above all regular videos. If no dated item is available, first-seen order is the closest
+     * useful approximation. Approximate dates can be repositioned on later refreshes without
+     * replacing any exact upload date.
      *
      * @param streams items returned by one feed extraction, in newest-first source order
      * @param fetchedAt time at which the extraction completed
+     * @return whether stored approximate Short dates should be repositioned to the inferred range
      */
-    fun applyFirstSeenDates(streams: List<StreamInfoItem>, fetchedAt: OffsetDateTime) {
-        var undatedShortIndex = 0L
-
-        streams.forEach { stream ->
-            if (stream.uploadDate == null && stream.isShortFormContent) {
-                stream.uploadDate = DateWrapper(
-                    fetchedAt.minusSeconds(undatedShortIndex),
-                    true
-                )
-                undatedShortIndex++
-            }
+    fun applyApproximateDates(streams: List<StreamInfoItem>, fetchedAt: OffsetDateTime): Boolean {
+        val undatedShorts = streams.filter { it.uploadDate == null && it.isShortFormContent }
+        if (undatedShorts.isEmpty()) {
+            return false
         }
+
+        val datedItems = streams
+            .mapNotNull { it.uploadDate?.offsetDateTime() }
+            .filterNot { it.isAfter(fetchedAt) }
+        val newestKnownDate = datedItems.maxOrNull()
+        val oldestKnownDate = datedItems.minOrNull()
+        val knownRangeSeconds = if (newestKnownDate != null && oldestKnownDate != null) {
+            Duration.between(oldestKnownDate, newestKnownDate).seconds
+        } else {
+            0L
+        }
+
+        undatedShorts.forEachIndexed { index, stream ->
+            val approximateDate = if (newestKnownDate != null && knownRangeSeconds > 0) {
+                val position = index + 1L
+                val slots = undatedShorts.size + 1L
+                newestKnownDate.minusSeconds(maxOf(1L, knownRangeSeconds * position / slots))
+            } else {
+                val offset = index.toLong() + if (newestKnownDate == null) 0L else 1L
+                (newestKnownDate ?: fetchedAt).minusSeconds(offset)
+            }
+            stream.uploadDate = DateWrapper(approximateDate, true)
+        }
+        return newestKnownDate != null
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -316,7 +316,7 @@ class FeedLoadManager(private val context: Context) {
                     .filterIsInstance<StreamInfoItem>()
             }
 
-            FeedItemDateResolver.applyFirstSeenDates(
+            val repositionExistingShorts = FeedItemDateResolver.applyApproximateDates(
                 streams!!,
                 OffsetDateTime.now(ZoneOffset.UTC)
             )
@@ -326,7 +326,8 @@ class FeedLoadManager(private val context: Context) {
                     subscriptionEntity,
                     originalInfo!!,
                     streams!!,
-                    errors
+                    errors,
+                    repositionExistingShorts
                 )
             )
         } catch (e: Throwable) {
@@ -391,7 +392,8 @@ class FeedLoadManager(private val context: Context) {
                                 info.uid,
                                 info.streams,
                                 updateModeMask,
-                                uploaderAvatarUrl = info.avatarUrl
+                                uploaderAvatarUrl = info.avatarUrl,
+                                repositionApproximateShorts = info.repositionExistingShorts
                             )
                             subscriptionManager.updateFromInfo(info)
 

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedUpdateInfo.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedUpdateInfo.kt
@@ -27,13 +27,15 @@ data class FeedUpdateInfo(
     val description: String?,
     val subscriberCount: Long?,
     val streams: List<StreamInfoItem>,
-    val errors: List<Throwable>
+    val errors: List<Throwable>,
+    val repositionExistingShorts: Boolean
 ) {
     constructor(
         subscription: SubscriptionEntity,
         info: Info,
         streams: List<StreamInfoItem>,
-        errors: List<Throwable>
+        errors: List<Throwable>,
+        repositionExistingShorts: Boolean
     ) : this(
         uid = subscription.uid,
         notificationMode = subscription.notificationMode,
@@ -50,7 +52,8 @@ data class FeedUpdateInfo(
         description = (info as? ChannelInfo)?.description,
         subscriberCount = (info as? ChannelInfo)?.subscriberCount,
         streams = streams,
-        errors = errors
+        errors = errors,
+        repositionExistingShorts = repositionExistingShorts
     )
 
     /**

--- a/app/src/test/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolverTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/service/FeedItemDateResolverTest.kt
@@ -19,12 +19,14 @@ class FeedItemDateResolverTest {
         val first = stream("https://youtube.com/shorts/first", isShort = true)
         val second = stream("https://youtube.com/shorts/second", isShort = true)
 
-        FeedItemDateResolver.applyFirstSeenDates(listOf(first, second), fetchedAt)
+        val shouldReposition =
+            FeedItemDateResolver.applyApproximateDates(listOf(first, second), fetchedAt)
 
         assertEquals(fetchedAt, first.uploadDate!!.offsetDateTime())
         assertEquals(fetchedAt.minusSeconds(1), second.uploadDate!!.offsetDateTime())
         assertTrue(first.uploadDate!!.isApproximation)
         assertTrue(second.uploadDate!!.isApproximation)
+        assertFalse(shouldReposition)
     }
 
     @Test
@@ -35,11 +37,47 @@ class FeedItemDateResolverTest {
         }
         val regularVideo = stream("https://youtube.com/watch?v=regular", isShort = false)
 
-        FeedItemDateResolver.applyFirstSeenDates(listOf(datedShort, regularVideo), fetchedAt)
+        FeedItemDateResolver.applyApproximateDates(listOf(datedShort, regularVideo), fetchedAt)
 
         assertEquals(originalDate, datedShort.uploadDate)
         assertFalse(datedShort.uploadDate!!.isApproximation)
         assertNull(regularVideo.uploadDate)
+    }
+
+    @Test
+    fun `undated shorts are distributed between dated channel items`() {
+        val newestVideo = stream("https://youtube.com/watch?v=newest", isShort = false).apply {
+            uploadDate = DateWrapper(fetchedAt.minusDays(1))
+        }
+        val oldestVideo = stream("https://youtube.com/watch?v=oldest", isShort = false).apply {
+            uploadDate = DateWrapper(fetchedAt.minusDays(11))
+        }
+        val firstShort = stream("https://youtube.com/shorts/first", isShort = true)
+        val secondShort = stream("https://youtube.com/shorts/second", isShort = true)
+        val thirdShort = stream("https://youtube.com/shorts/third", isShort = true)
+
+        val shouldReposition = FeedItemDateResolver.applyApproximateDates(
+            listOf(newestVideo, oldestVideo, firstShort, secondShort, thirdShort),
+            fetchedAt
+        )
+
+        assertEquals(
+            fetchedAt.minusDays(3).minusHours(12),
+            firstShort.uploadDate!!.offsetDateTime()
+        )
+        assertEquals(fetchedAt.minusDays(6), secondShort.uploadDate!!.offsetDateTime())
+        assertEquals(
+            fetchedAt.minusDays(8).minusHours(12),
+            thirdShort.uploadDate!!.offsetDateTime()
+        )
+        assertTrue(firstShort.uploadDate!!.isApproximation)
+        assertTrue(
+            firstShort.uploadDate!!.offsetDateTime() > secondShort.uploadDate!!.offsetDateTime()
+        )
+        assertTrue(
+            secondShort.uploadDate!!.offsetDateTime() > thirdShort.uploadDate!!.offsetDateTime()
+        )
+        assertTrue(shouldReposition)
     }
 
     private fun stream(url: String, isShort: Boolean) = StreamInfoItem(


### PR DESCRIPTION
- Keep undated Shorts in subscription feeds without assigning every item the refresh time
- Distribute approximate Short dates across the real dated range from the same channel refresh
- Ignore future scheduled dates when calculating the range
- Reposition approximate dates already stored by the previous implementation
- Preserve exact upload dates and first-seen behavior for channels with no dated items
- Add resolver and database regression coverage