### PR TITLE
Expand What's New stream filters

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/stream/StreamStatisticsEntry.kt
@@ -14,6 +14,7 @@ import org.schabi.newpipe.database.LocalItem
 import org.schabi.newpipe.database.history.model.StreamHistoryEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity.Companion.STREAM_PROGRESS_MILLIS
+import org.schabi.newpipe.extractor.localization.DateWrapper
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.player.playqueue.PlayQueueItem
 import org.schabi.newpipe.util.image.ExtractorImageCompat
@@ -50,6 +51,9 @@ data class StreamStatisticsEntry(
             duration = streamEntity.duration
             uploaderName = streamEntity.uploader
             uploaderUrl = streamEntity.uploaderUrl
+            uploadDate = streamEntity.uploadDate?.let {
+                DateWrapper(it, streamEntity.isUploadDateApproximation ?: false)
+            }
             ExtractorImageCompat.setThumbnailImages(
                 this,
                 ImageStrategy.dbUrlToImageList(streamEntity.thumbnailUrl)

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -46,6 +46,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.evernote.android.state.State
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.Item
 import com.xwray.groupie.OnItemClickListener
@@ -329,16 +330,24 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         val dialogItems = arrayOf(
             getString(R.string.feed_show_watched),
             getString(R.string.feed_show_partially_watched),
-            getString(R.string.feed_show_upcoming)
+            getString(R.string.feed_show_upcoming),
+            getString(R.string.channel_tab_livestreams),
+            getString(R.string.videos_string),
+            getString(R.string.channel_tab_shorts)
         )
+
+        val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
 
         val checkedDialogItems = booleanArrayOf(
             viewModel.getShowPlayedItemsFromPreferences(),
             viewModel.getShowPartiallyPlayedItemsFromPreferences(),
-            viewModel.getShowFutureItemsFromPreferences()
+            viewModel.getShowFutureItemsFromPreferences(),
+            preferences.getBoolean(getString(R.string.feed_show_live_items_key), true),
+            preferences.getBoolean(getString(R.string.feed_show_video_items_key), true),
+            preferences.getBoolean(getString(R.string.feed_show_shorts_items_key), true)
         )
 
-        AlertDialog.Builder(requireContext())
+        MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.feed_hide_streams_title)
             .setMultiChoiceItems(dialogItems, checkedDialogItems) { _, which, isChecked ->
                 checkedDialogItems[which] = isChecked
@@ -347,6 +356,12 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
                 viewModel.setSaveShowPlayedItems(checkedDialogItems[0])
                 viewModel.setSaveShowPartiallyPlayedItems(checkedDialogItems[1])
                 viewModel.setSaveShowFutureItems(checkedDialogItems[2])
+                preferences.edit {
+                    putBoolean(getString(R.string.feed_show_live_items_key), checkedDialogItems[3])
+                    putBoolean(getString(R.string.feed_show_video_items_key), checkedDialogItems[4])
+                    putBoolean(getString(R.string.feed_show_shorts_items_key), checkedDialogItems[5])
+                }
+                latestLoadedState?.let { showFilteredFeedItems(it, false) }
             }
             .setNegativeButton(R.string.cancel, null)
             .show()
@@ -586,12 +601,30 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             requireContext(),
             ContentBlockingHelper.Target.SUBSCRIPTIONS
         )
+        val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        val shownStreamCategories = buildSet {
+            if (preferences.getBoolean(getString(R.string.feed_show_live_items_key), true)) {
+                add(StreamListFilter.LIVE)
+            }
+            if (preferences.getBoolean(getString(R.string.feed_show_video_items_key), true)) {
+                add(StreamListFilter.VIDEOS)
+            }
+            if (preferences.getBoolean(getString(R.string.feed_show_shorts_items_key), true)) {
+                add(StreamListFilter.SHORTS)
+            }
+            if (viewModel.getShowFutureItemsFromPreferences()) {
+                add(StreamListFilter.UPCOMING)
+            }
+        }
         val streamFilteredItems = loadedState.items.filter { item ->
             val streamWithState = item.streamWithState
             if (hideMembersOnly && streamWithState.stream.requiresMembership) {
                 return@filter false
             }
             val stream = streamWithState.stream.toStreamInfoItem()
+            if (StreamListFilter.categoryOf(stream) !in shownStreamCategories) {
+                return@filter false
+            }
             if (blockingRules.isBlocked(stream)) {
                 return@filter false
             }

--- a/app/src/main/java/org/schabi/newpipe/util/StreamListFilter.kt
+++ b/app/src/main/java/org/schabi/newpipe/util/StreamListFilter.kt
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.util
 
 import androidx.annotation.IdRes
+import java.time.OffsetDateTime
 import org.schabi.newpipe.R
 import org.schabi.newpipe.database.stream.StreamStatisticsEntry
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
@@ -12,6 +13,7 @@ enum class StreamListFilter(@IdRes val chipId: Int) {
     LIVE(R.id.filter_live),
     VIDEOS(R.id.filter_videos),
     SHORTS(R.id.filter_shorts),
+    UPCOMING(R.id.filter_upcoming),
     PARTIALLY_WATCHED(R.id.filter_partially_watched);
 
     companion object {
@@ -31,11 +33,13 @@ enum class StreamListFilter(@IdRes val chipId: Int) {
 
             UNWATCHED -> state == null || !state.isValid(stream.duration)
 
-            LIVE -> StreamTypeUtil.isLiveStream(stream.streamType)
+            LIVE -> categoryOf(stream) == LIVE
 
-            VIDEOS -> !StreamTypeUtil.isLiveStream(stream.streamType) && !isShort(stream)
+            VIDEOS -> categoryOf(stream) == VIDEOS
 
-            SHORTS -> isShort(stream)
+            SHORTS -> categoryOf(stream) == SHORTS
+
+            UPCOMING -> categoryOf(stream) == UPCOMING
 
             PARTIALLY_WATCHED -> state?.isValid(stream.duration) == true &&
                 !state.isFinished(stream.duration)
@@ -50,6 +54,17 @@ enum class StreamListFilter(@IdRes val chipId: Int) {
             historyEntry.toStreamInfoItem(),
             StreamStateEntity(historyEntry.streamId, historyEntry.progressMillis)
         )
+
+        @JvmStatic
+        fun categoryOf(
+            stream: StreamInfoItem,
+            now: OffsetDateTime = OffsetDateTime.now()
+        ): StreamListFilter = when {
+            stream.uploadDate?.offsetDateTime()?.isAfter(now) == true -> UPCOMING
+            StreamTypeUtil.isLiveStream(stream.streamType) -> LIVE
+            isShort(stream) -> SHORTS
+            else -> VIDEOS
+        }
 
         private fun isShort(stream: StreamInfoItem): Boolean {
             return !StreamTypeUtil.isLiveStream(stream.streamType) &&

--- a/app/src/main/res/layout/list_stream_filter_chips.xml
+++ b/app/src/main/res/layout/list_stream_filter_chips.xml
@@ -50,6 +50,14 @@
             android:text="@string/channel_tab_shorts" />
 
         <com.google.android.material.chip.Chip
+            android:id="@+id/filter_upcoming"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkable="true"
+            android:text="@string/feed_show_upcoming" />
+
+        <com.google.android.material.chip.Chip
             android:id="@+id/filter_partially_watched"
             style="@style/Widget.Material3.Chip.Filter"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -507,6 +507,9 @@
     <string name="feed_show_watched_items_key">feed_show_played_items</string>
     <string name="feed_show_partially_watched_items_key">feed_show_partially_watched_items</string>
     <string name="feed_show_future_items_key">feed_show_future_items</string>
+    <string name="feed_show_live_items_key">feed_show_live_items</string>
+    <string name="feed_show_video_items_key">feed_show_video_items</string>
+    <string name="feed_show_shorts_items_key">feed_show_shorts_items</string>
 
     <string name="show_thumbnail_key">show_thumbnail_key</string>
 

--- a/app/src/test/java/org/schabi/newpipe/local/feed/FeedFilterPersistenceTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/local/feed/FeedFilterPersistenceTest.kt
@@ -15,6 +15,7 @@ class FeedFilterPersistenceTest {
     fun storedFilterRestoresAndUnknownValuesFallBackSafely() {
         assertEquals(StreamListFilter.LIVE, FeedFragment.restoreStreamFilter("LIVE"))
         assertEquals(StreamListFilter.SHORTS, FeedFragment.restoreStreamFilter("SHORTS"))
+        assertEquals(StreamListFilter.UPCOMING, FeedFragment.restoreStreamFilter("UPCOMING"))
         assertEquals(StreamListFilter.NONE, FeedFragment.restoreStreamFilter("REMOVED_FILTER"))
         assertEquals(StreamListFilter.NONE, FeedFragment.restoreStreamFilter(null))
     }

--- a/app/src/test/java/org/schabi/newpipe/util/StreamListFilterTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/util/StreamListFilterTest.kt
@@ -1,12 +1,14 @@
 package org.schabi.newpipe.util
 
 import java.time.OffsetDateTime
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.schabi.newpipe.database.stream.StreamStatisticsEntry
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.database.stream.model.StreamStateEntity
+import org.schabi.newpipe.extractor.localization.DateWrapper
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.stream.StreamType
 
@@ -61,6 +63,18 @@ class StreamListFilterTest {
                 null
             )
         )
+    }
+
+    @Test
+    fun `upcoming is separate from live videos and shorts`() {
+        val now = OffsetDateTime.parse("2026-09-08T12:00:00Z")
+        val upcoming = stream(type = StreamType.LIVE_STREAM).apply {
+            uploadDate = DateWrapper(OffsetDateTime.parse("2100-01-01T00:00:00Z"))
+        }
+
+        assertTrue(StreamListFilter.matches(StreamListFilter.UPCOMING, upcoming, null))
+        assertFalse(StreamListFilter.matches(StreamListFilter.LIVE, upcoming, null))
+        assertEquals(StreamListFilter.UPCOMING, StreamListFilter.categoryOf(upcoming, now))
     }
 
     @Test
@@ -148,6 +162,12 @@ class StreamListFilterTest {
         )
         assertTrue(
             StreamListFilter.matches(
+                StreamListFilter.UPCOMING,
+                historyEntry(uploadDate = OffsetDateTime.parse("2100-01-01T00:00:00Z"))
+            )
+        )
+        assertTrue(
+            StreamListFilter.matches(
                 StreamListFilter.PARTIALLY_WATCHED,
                 historyEntry(duration = 600, progressMillis = 120_000)
             )
@@ -172,7 +192,8 @@ class StreamListFilterTest {
         url: String = "https://example.com/watch/video",
         duration: Long = 600,
         type: StreamType = StreamType.VIDEO_STREAM,
-        progressMillis: Long = 0
+        progressMillis: Long = 0,
+        uploadDate: OffsetDateTime? = null
     ) = StreamStatisticsEntry(
         streamEntity = StreamEntity(
             serviceId = 0,
@@ -181,7 +202,7 @@ class StreamListFilterTest {
             streamType = type,
             duration = duration,
             uploader = "Uploader"
-        ),
+        ).apply { this.uploadDate = uploadDate },
         progressMillis = progressMillis,
         streamId = 1,
         latestAccessDate = OffsetDateTime.parse("2026-08-21T12:00:00Z"),


### PR DESCRIPTION
- Add an Upcoming filter chip to stream lists
- Add Live, Videos, and Shorts visibility controls to What's New
- Keep Upcoming separate from currently live streams
- Use a Material 3 multi-choice dialog
- Preserve all visibility choices in preferences
- Add behavioral coverage for category matching and saved filters