### PR TITLE
Add NewPipe-compatible data export

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeCompatibleExportManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeCompatibleExportManagerTest.kt
@@ -1,0 +1,254 @@
+package org.schabi.newpipe.settings
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.net.Uri
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.nio.file.Path
+import java.util.zip.ZipFile
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.settings.export.NewPipeCompatibleExportManager
+import org.schabi.newpipe.streams.io.StoredFileHelper
+
+@RunWith(AndroidJUnit4::class)
+class NewPipeCompatibleExportManagerTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @get:Rule
+    val migrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java
+    )
+
+    private lateinit var sourcePath: Path
+    private lateinit var destinationPath: Path
+    private lateinit var archivePath: Path
+
+    @Before
+    fun setUp() {
+        sourcePath = context.cacheDir.resolve("portable-export-source.db").toPath()
+        destinationPath = context.getDatabasePath(PORTABLE_DATABASE_NAME).toPath()
+        archivePath = context.cacheDir.resolve("portable-export.zip").toPath()
+        sourcePath.toFile().delete()
+        context.deleteDatabase(PORTABLE_DATABASE_NAME)
+        archivePath.toFile().delete()
+        createSourceDatabase(sourcePath)
+    }
+
+    @After
+    fun tearDown() {
+        sourcePath.toFile().delete()
+        context.deleteDatabase(PORTABLE_DATABASE_NAME)
+        archivePath.toFile().delete()
+    }
+
+    @Test
+    fun createsNewPipeNineDatabaseWithOnlyPortablePlaybackData() {
+        val result = NewPipeCompatibleExportManager(
+            sourcePath,
+            context.cacheDir.toPath()
+        ).createDatabase(destinationPath)
+
+        assertEquals(1, result.subscriptions)
+        assertEquals(1, result.historyItems)
+        assertEquals(1, result.progressItems)
+        assertEquals(3, result.skippedItems)
+
+        migrationTestHelper.runMigrationsAndValidate(
+            PORTABLE_DATABASE_NAME,
+            9,
+            true
+        ).close()
+
+        SQLiteDatabase.openDatabase(
+            destinationPath.toString(),
+            null,
+            SQLiteDatabase.OPEN_READONLY
+        ).use { database ->
+            assertEquals(9, database.version)
+            assertEquals(
+                "7591e8039faa74d8c0517dc867af9d3e",
+                database.singleString(
+                    "SELECT identity_hash FROM room_master_table WHERE id = 42"
+                )
+            )
+            assertEquals(EXPECTED_TABLES, database.userTables())
+            assertEquals(EXPECTED_SUBSCRIPTION_COLUMNS, database.columns("subscriptions"))
+            assertEquals(EXPECTED_STREAM_COLUMNS, database.columns("streams"))
+            assertEquals(
+                "https://example.com/remote",
+                database.singleString("SELECT url FROM streams")
+            )
+            assertEquals(
+                "https://example.com/channel",
+                database.singleString("SELECT url FROM subscriptions")
+            )
+            assertEquals(1, database.singleInt("SELECT notification_mode FROM subscriptions"))
+            assertEquals("ok", database.singleString("PRAGMA quick_check"))
+            database.rawQuery("PRAGMA foreign_key_check", null).use { cursor ->
+                assertFalse(cursor.moveToFirst())
+            }
+        }
+    }
+
+    @Test
+    fun archiveContainsOnlyThePortableNewPipeDatabase() {
+        archivePath.toFile().createNewFile()
+        val file = StoredFileHelper(
+            context,
+            null,
+            Uri.fromFile(archivePath.toFile()),
+            "portable-export-test"
+        )
+
+        NewPipeCompatibleExportManager(sourcePath, context.cacheDir.toPath()).export(file)
+
+        ZipFile(archivePath.toFile()).use { archive ->
+            assertEquals(listOf("newpipe.db"), archive.entries().toList().map { it.name })
+        }
+    }
+
+    private fun createSourceDatabase(path: Path) {
+        SQLiteDatabase.openOrCreateDatabase(path.toFile(), null).use { database ->
+            database.execSQL(
+                "CREATE TABLE subscriptions (" +
+                    "uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, url TEXT, " +
+                    "name TEXT, avatar_url TEXT, subscriber_count INTEGER, description TEXT, " +
+                    "notification_mode INTEGER NOT NULL, youtube_mode_mask INTEGER NOT NULL, " +
+                    "notification_keywords TEXT NOT NULL)"
+            )
+            database.execSQL(
+                "INSERT INTO subscriptions VALUES " +
+                    "(1, 0, 'https://example.com/channel', 'Channel', NULL, " +
+                    "100, NULL, 2, 1, ''), " +
+                    "(2, 5, 'https://example.com/wizestream-only', 'WizeStream only', NULL, " +
+                    "100, NULL, 1, 1, '')"
+            )
+            database.execSQL(
+                "CREATE TABLE streams (" +
+                    "uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, url TEXT NOT NULL, " +
+                    "title TEXT NOT NULL, stream_type TEXT NOT NULL, duration INTEGER NOT NULL, " +
+                    "uploader TEXT NOT NULL, uploader_url TEXT, thumbnail_url TEXT, " +
+                    "view_count INTEGER, textual_upload_date TEXT, upload_date INTEGER, " +
+                    "is_upload_date_approximation INTEGER, source_type TEXT NOT NULL)"
+            )
+            database.execSQL(
+                "INSERT INTO streams VALUES " +
+                    "(10, 0, 'https://example.com/remote', 'Remote', 'VIDEO_STREAM', 120, " +
+                    "'Uploader', NULL, NULL, 10, NULL, NULL, 0, 'REMOTE'), " +
+                    "(20, -1, 'local://20', 'Local', 'VIDEO_STREAM', 60, 'Device', NULL, NULL, " +
+                    "NULL, NULL, NULL, 0, 'LOCAL'), " +
+                    "(30, 0, 'https://example.com/unwatched', 'Unwatched', 'VIDEO_STREAM', 60, " +
+                    "'Uploader', NULL, NULL, NULL, NULL, NULL, 0, 'REMOTE')"
+            )
+            database.execSQL(
+                "CREATE TABLE stream_history (" +
+                    "stream_id INTEGER NOT NULL, access_date INTEGER NOT NULL, " +
+                    "repeat_count INTEGER NOT NULL)"
+            )
+            database.execSQL(
+                "INSERT INTO stream_history VALUES (10, 1000, 1), (20, 2000, 1)"
+            )
+            database.execSQL(
+                "CREATE TABLE stream_state (" +
+                    "stream_id INTEGER PRIMARY KEY, progress_time INTEGER NOT NULL)"
+            )
+            database.execSQL("INSERT INTO stream_state VALUES (10, 30000), (20, 15000)")
+        }
+    }
+
+    private fun SQLiteDatabase.singleString(query: String): String = rawQuery(
+        query,
+        null
+    ).use { cursor ->
+        assertTrue(cursor.moveToFirst())
+        cursor.getString(0)
+    }
+
+    private fun SQLiteDatabase.singleInt(query: String): Int = rawQuery(
+        query,
+        null
+    ).use { cursor ->
+        assertTrue(cursor.moveToFirst())
+        cursor.getInt(0)
+    }
+
+    private fun SQLiteDatabase.userTables(): Set<String> {
+        val result = mutableSetOf<String>()
+        rawQuery(
+            "SELECT name FROM sqlite_master " +
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != 'android_metadata'",
+            null
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                result += cursor.getString(0)
+            }
+        }
+        return result
+    }
+
+    private fun SQLiteDatabase.columns(table: String): Set<String> {
+        val result = mutableSetOf<String>()
+        rawQuery("PRAGMA table_info(`$table`)", null).use { cursor ->
+            while (cursor.moveToNext()) {
+                result += cursor.getString(cursor.getColumnIndexOrThrow("name"))
+            }
+        }
+        return result
+    }
+
+    private companion object {
+        const val PORTABLE_DATABASE_NAME = "portable-export-destination.db"
+        val EXPECTED_TABLES = setOf(
+            "subscriptions",
+            "search_history",
+            "streams",
+            "stream_history",
+            "stream_state",
+            "playlists",
+            "playlist_stream_join",
+            "remote_playlists",
+            "feed",
+            "feed_group",
+            "feed_group_subscription_join",
+            "feed_last_updated",
+            "room_master_table"
+        )
+        val EXPECTED_SUBSCRIPTION_COLUMNS = setOf(
+            "uid",
+            "service_id",
+            "url",
+            "name",
+            "avatar_url",
+            "subscriber_count",
+            "description",
+            "notification_mode"
+        )
+        val EXPECTED_STREAM_COLUMNS = setOf(
+            "uid",
+            "service_id",
+            "url",
+            "title",
+            "stream_type",
+            "duration",
+            "uploader",
+            "uploader_url",
+            "thumbnail_url",
+            "view_count",
+            "textual_upload_date",
+            "upload_date",
+            "is_upload_date_approximation"
+        )
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -30,6 +30,7 @@ import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.local.subscription.SubscriptionsImportExportHelper;
 import org.schabi.newpipe.settings.export.BackupFileLocator;
 import org.schabi.newpipe.settings.export.ImportExportManager;
+import org.schabi.newpipe.settings.export.NewPipeCompatibleExportManager;
 import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
@@ -69,11 +70,15 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private final ActivityResultLauncher<Intent> requestExportPathLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
                     this::requestExportPathResult);
+    private final ActivityResultLauncher<Intent> requestCompatibleExportPathLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
+                    this::requestCompatibleExportPathResult);
     private final ActivityResultLauncher<Intent> requestMigrationPathLauncher =
             registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
                     this::requestMigrationPathResult);
     private SubscriptionsImportExportHelper importExportHelper;
     private NewPipeDataMigrationManager migrationManager;
+    private NewPipeCompatibleExportManager compatibleExportManager;
 
 
     @Override
@@ -87,6 +92,7 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                     @Nullable final String rootKey) {
         manager = new ImportExportManager(new BackupFileLocator(requireContext()));
         migrationManager = new NewPipeDataMigrationManager(requireContext());
+        compatibleExportManager = new NewPipeCompatibleExportManager(requireContext());
 
         importExportDataPathKey = getString(R.string.import_export_data_path);
 
@@ -129,6 +135,20 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                     getContext()
             );
 
+            return true;
+        });
+
+        final Preference exportCompatiblePreference =
+                requirePreference(R.string.export_compatible_data_key);
+        exportCompatiblePreference.setOnPreferenceClickListener(preference -> {
+            NoFileManagerSafeGuard.launchSafe(
+                    requestCompatibleExportPathLauncher,
+                    StoredFileHelper.getNewSystemPicker(requireContext(),
+                            "NewPipeData-" + exportDateFormat.format(new Date()) + ".zip",
+                            ZIP_MIME_TYPE, getImportExportDataUri()),
+                    TAG,
+                    getContext()
+            );
             return true;
         });
 
@@ -181,6 +201,15 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                     requireContext(), result.getData().getData(), ZIP_MIME_TYPE);
 
             exportDatabase(file, lastExportDataUri);
+        }
+    }
+
+    private void requestCompatibleExportPathResult(final ActivityResult result) {
+        if (result.getResultCode() == Activity.RESULT_OK && result.getData() != null) {
+            final Uri exportDataUri = result.getData().getData();
+            final StoredFileHelper file = new StoredFileHelper(
+                    requireContext(), exportDataUri, ZIP_MIME_TYPE);
+            exportNewPipeCompatibleData(file, exportDataUri);
         }
     }
 
@@ -424,6 +453,40 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         } catch (final Exception e) {
             showErrorSnackbar(e, "Exporting database and settings");
         }
+    }
+
+    private void exportNewPipeCompatibleData(final StoredFileHelper file,
+                                             final Uri exportDataUri) {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+            try {
+                NewPipeDatabase.checkpoint();
+                final NewPipeCompatibleExportManager.ExportResult exportResult =
+                        compatibleExportManager.export(file);
+                if (getActivity() != null) {
+                    requireActivity().runOnUiThread(() -> {
+                        saveLastImportExportDataUri(exportDataUri);
+                        new MaterialAlertDialogBuilder(requireContext())
+                                .setTitle(R.string.export_compatible_data_complete_title)
+                                .setMessage(getString(
+                                        R.string.export_compatible_data_complete_message,
+                                        exportResult.getSubscriptions(),
+                                        exportResult.getHistoryItems(),
+                                        exportResult.getProgressItems(),
+                                        exportResult.getSkippedItems()))
+                                .setPositiveButton(R.string.ok, null)
+                                .show();
+                    });
+                }
+            } catch (final Exception e) {
+                if (getActivity() != null) {
+                    requireActivity().runOnUiThread(() ->
+                            showErrorSnackbar(e, "Exporting NewPipe-compatible data"));
+                }
+            } finally {
+                executor.shutdown();
+            }
+        });
     }
 
     private void showImportConfirmation(final StoredFileHelper file, final Uri importDataUri) {

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeCompatibleExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeCompatibleExportManager.kt
@@ -1,0 +1,304 @@
+package org.schabi.newpipe.settings.export
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.deleteIfExists
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.streams.io.SharpOutputStream
+import org.schabi.newpipe.streams.io.StoredFileHelper
+import org.schabi.newpipe.util.ZipHelper
+
+/** Creates a data-only backup that current NewPipe releases can restore directly. */
+class NewPipeCompatibleExportManager internal constructor(
+    private val sourceDatabase: Path,
+    private val temporaryDirectory: Path
+) {
+    constructor(context: Context) : this(
+        context.getDatabasePath(AppDatabase.DATABASE_NAME).toPath(),
+        context.cacheDir.toPath()
+    )
+
+    data class ExportResult(
+        val subscriptions: Int,
+        val historyItems: Int,
+        val progressItems: Int,
+        val skippedItems: Int
+    )
+
+    /**
+     * Writes an archive containing only a NewPipe schema-version-9 database.
+     *
+     * WizeStream settings and private tables are deliberately excluded so restoring this archive
+     * cannot expose NewPipe to WizeStream's newer Room schema.
+     */
+    @Throws(Exception::class)
+    fun export(file: StoredFileHelper): ExportResult {
+        Files.createDirectories(temporaryDirectory)
+        val portableDatabase = Files.createTempFile(
+            temporaryDirectory,
+            "newpipe-compatible-",
+            ".db"
+        )
+        return try {
+            val result = createDatabase(portableDatabase)
+            try {
+                ZipOutputStream(
+                    SharpOutputStream(file.openAndTruncateStream()).buffered()
+                ).use { output ->
+                    ZipHelper.addFileToZip(
+                        output,
+                        BackupFileLocator.FILE_NAME_DB,
+                        portableDatabase
+                    )
+                }
+            } catch (error: Throwable) {
+                file.delete()
+                throw error
+            }
+            result
+        } finally {
+            portableDatabase.deleteIfExists()
+        }
+    }
+
+    internal fun createDatabase(destinationPath: Path): ExportResult {
+        check(Files.isRegularFile(sourceDatabase)) {
+            "The WizeStream database is not available"
+        }
+        destinationPath.deleteIfExists()
+
+        val destination = SQLiteDatabase.openDatabase(
+            destinationPath.toString(),
+            null,
+            SQLiteDatabase.CREATE_IF_NECESSARY
+        )
+        var sourceAttached = false
+        try {
+            destination.setForeignKeyConstraintsEnabled(false)
+            destination.execSQL(
+                "ATTACH DATABASE ? AS wizestream_source",
+                arrayOf(sourceDatabase.toString())
+            )
+            sourceAttached = true
+            destination.beginTransaction()
+            try {
+                NEWPIPE_SCHEMA.forEach(destination::execSQL)
+                copyPortableData(destination)
+                destination.version = NEWPIPE_DATABASE_VERSION
+                destination.execSQL(
+                    "CREATE TABLE IF NOT EXISTS room_master_table " +
+                        "(id INTEGER PRIMARY KEY, identity_hash TEXT)"
+                )
+                destination.execSQL(
+                    "INSERT OR REPLACE INTO room_master_table (id, identity_hash) " +
+                        "VALUES(42, ?)",
+                    arrayOf(NEWPIPE_IDENTITY_HASH)
+                )
+                destination.setTransactionSuccessful()
+            } finally {
+                destination.endTransaction()
+            }
+
+            validateDatabase(destination)
+            val subscriptions = destination.rowCount("subscriptions")
+            val historyItems = destination.rowCount("stream_history")
+            val progressItems = destination.rowCount("stream_state")
+            return ExportResult(
+                subscriptions = subscriptions,
+                historyItems = historyItems,
+                progressItems = progressItems,
+                skippedItems =
+                    destination.rowCount("wizestream_source.subscriptions") - subscriptions +
+                        destination.rowCount("wizestream_source.stream_history") - historyItems +
+                        destination.rowCount("wizestream_source.stream_state") - progressItems
+            )
+        } finally {
+            if (sourceAttached) {
+                destination.execSQL("DETACH DATABASE wizestream_source")
+            }
+            destination.close()
+        }
+    }
+
+    private fun copyPortableData(database: SQLiteDatabase) {
+        database.execSQL(
+            "INSERT INTO subscriptions " +
+                "(uid, service_id, url, name, avatar_url, subscriber_count, description, " +
+                "notification_mode) " +
+                "SELECT uid, service_id, url, name, avatar_url, subscriber_count, description, " +
+                "CASE WHEN notification_mode = 0 THEN 0 ELSE 1 END " +
+                "FROM wizestream_source.subscriptions WHERE service_id BETWEEN " +
+                "$NEWPIPE_FIRST_SERVICE_ID AND $NEWPIPE_LAST_SERVICE_ID"
+        )
+        database.execSQL(
+            "INSERT INTO streams " +
+                "(uid, service_id, url, title, stream_type, duration, uploader, uploader_url, " +
+                "thumbnail_url, view_count, textual_upload_date, upload_date, " +
+                "is_upload_date_approximation) " +
+                "SELECT s.uid, s.service_id, s.url, s.title, s.stream_type, s.duration, " +
+                "s.uploader, s.uploader_url, s.thumbnail_url, s.view_count, " +
+                "s.textual_upload_date, s.upload_date, s.is_upload_date_approximation " +
+                "FROM wizestream_source.streams s " +
+                "WHERE s.source_type = 'REMOTE' AND s.service_id BETWEEN " +
+                "$NEWPIPE_FIRST_SERVICE_ID AND $NEWPIPE_LAST_SERVICE_ID AND " +
+                "(EXISTS (SELECT 1 FROM wizestream_source.stream_history h " +
+                "WHERE h.stream_id = s.uid) OR " +
+                "EXISTS (SELECT 1 FROM wizestream_source.stream_state st " +
+                "WHERE st.stream_id = s.uid))"
+        )
+        database.execSQL(
+            "INSERT INTO stream_history (stream_id, access_date, repeat_count) " +
+                "SELECT h.stream_id, h.access_date, h.repeat_count " +
+                "FROM wizestream_source.stream_history h " +
+                "INNER JOIN streams s ON s.uid = h.stream_id"
+        )
+        database.execSQL(
+            "INSERT INTO stream_state (stream_id, progress_time) " +
+                "SELECT st.stream_id, st.progress_time " +
+                "FROM wizestream_source.stream_state st " +
+                "INNER JOIN streams s ON s.uid = st.stream_id"
+        )
+    }
+
+    private fun validateDatabase(database: SQLiteDatabase) {
+        database.rawQuery("PRAGMA quick_check", null).use { cursor ->
+            if (!cursor.moveToFirst() || cursor.getString(0) != "ok") {
+                throw IOException("The portable database failed SQLite integrity validation")
+            }
+        }
+        database.rawQuery("PRAGMA foreign_key_check", null).use { cursor ->
+            if (cursor.moveToFirst()) {
+                throw IOException("The portable database contains invalid references")
+            }
+        }
+        val tables = mutableSetOf<String>()
+        database.rawQuery(
+            "SELECT name FROM sqlite_master WHERE type = 'table'",
+            null
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                tables += cursor.getString(0)
+            }
+        }
+        if (!tables.containsAll(REQUIRED_NEWPIPE_TABLES)) {
+            throw IOException("The portable database is missing required NewPipe tables")
+        }
+    }
+
+    private fun SQLiteDatabase.rowCount(table: String): Int = rawQuery(
+        "SELECT COUNT(*) FROM $table",
+        null
+    ).use { cursor ->
+        check(cursor.moveToFirst())
+        cursor.getInt(0)
+    }
+
+    private companion object {
+        const val NEWPIPE_DATABASE_VERSION = 9
+        const val NEWPIPE_IDENTITY_HASH = "7591e8039faa74d8c0517dc867af9d3e"
+        const val NEWPIPE_FIRST_SERVICE_ID = 0
+        const val NEWPIPE_LAST_SERVICE_ID = 4
+
+        val REQUIRED_NEWPIPE_TABLES = setOf(
+            "subscriptions",
+            "search_history",
+            "streams",
+            "stream_history",
+            "stream_state",
+            "playlists",
+            "playlist_stream_join",
+            "remote_playlists",
+            "feed",
+            "feed_group",
+            "feed_group_subscription_join",
+            "feed_last_updated",
+            "room_master_table"
+        )
+
+        val NEWPIPE_SCHEMA = listOf(
+            "CREATE TABLE IF NOT EXISTS subscriptions (" +
+                "uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "service_id INTEGER NOT NULL, url TEXT, name TEXT, avatar_url TEXT, " +
+                "subscriber_count INTEGER, description TEXT, notification_mode INTEGER NOT NULL)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS index_subscriptions_service_id_url " +
+                "ON subscriptions (service_id, url)",
+            "CREATE TABLE IF NOT EXISTS search_history (" +
+                "creation_date INTEGER, service_id INTEGER NOT NULL, search TEXT, " +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+            "CREATE INDEX IF NOT EXISTS index_search_history_search " +
+                "ON search_history (search)",
+            "CREATE TABLE IF NOT EXISTS streams (" +
+                "uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, service_id INTEGER NOT NULL, " +
+                "url TEXT NOT NULL, title TEXT NOT NULL, stream_type TEXT NOT NULL, " +
+                "duration INTEGER NOT NULL, uploader TEXT NOT NULL, uploader_url TEXT, " +
+                "thumbnail_url TEXT, view_count INTEGER, textual_upload_date TEXT, " +
+                "upload_date INTEGER, is_upload_date_approximation INTEGER)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS index_streams_service_id_url " +
+                "ON streams (service_id, url)",
+            "CREATE TABLE IF NOT EXISTS stream_history (" +
+                "stream_id INTEGER NOT NULL, access_date INTEGER NOT NULL, " +
+                "repeat_count INTEGER NOT NULL, PRIMARY KEY(stream_id, access_date), " +
+                "FOREIGN KEY(stream_id) REFERENCES streams(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE)",
+            "CREATE INDEX IF NOT EXISTS index_stream_history_stream_id " +
+                "ON stream_history (stream_id)",
+            "CREATE TABLE IF NOT EXISTS stream_state (" +
+                "stream_id INTEGER NOT NULL, progress_time INTEGER NOT NULL, " +
+                "PRIMARY KEY(stream_id), FOREIGN KEY(stream_id) REFERENCES streams(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE)",
+            "CREATE TABLE IF NOT EXISTS playlists (" +
+                "uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT, " +
+                "is_thumbnail_permanent INTEGER NOT NULL, thumbnail_stream_id INTEGER NOT NULL, " +
+                "display_index INTEGER NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS playlist_stream_join (" +
+                "playlist_id INTEGER NOT NULL, stream_id INTEGER NOT NULL, " +
+                "join_index INTEGER NOT NULL, PRIMARY KEY(playlist_id, join_index), " +
+                "FOREIGN KEY(playlist_id) REFERENCES playlists(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, " +
+                "FOREIGN KEY(stream_id) REFERENCES streams(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS " +
+                "index_playlist_stream_join_playlist_id_join_index " +
+                "ON playlist_stream_join (playlist_id, join_index)",
+            "CREATE INDEX IF NOT EXISTS index_playlist_stream_join_stream_id " +
+                "ON playlist_stream_join (stream_id)",
+            "CREATE TABLE IF NOT EXISTS remote_playlists (" +
+                "uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, service_id INTEGER NOT NULL, " +
+                "name TEXT, url TEXT, thumbnail_url TEXT, uploader TEXT, " +
+                "display_index INTEGER NOT NULL, stream_count INTEGER)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS index_remote_playlists_service_id_url " +
+                "ON remote_playlists (service_id, url)",
+            "CREATE TABLE IF NOT EXISTS feed (" +
+                "stream_id INTEGER NOT NULL, subscription_id INTEGER NOT NULL, " +
+                "PRIMARY KEY(stream_id, subscription_id), " +
+                "FOREIGN KEY(stream_id) REFERENCES streams(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, " +
+                "FOREIGN KEY(subscription_id) REFERENCES subscriptions(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+            "CREATE INDEX IF NOT EXISTS index_feed_subscription_id ON feed (subscription_id)",
+            "CREATE TABLE IF NOT EXISTS feed_group (" +
+                "uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT NOT NULL, " +
+                "icon_id INTEGER NOT NULL, sort_order INTEGER NOT NULL)",
+            "CREATE INDEX IF NOT EXISTS index_feed_group_sort_order ON feed_group (sort_order)",
+            "CREATE TABLE IF NOT EXISTS feed_group_subscription_join (" +
+                "group_id INTEGER NOT NULL, subscription_id INTEGER NOT NULL, " +
+                "PRIMARY KEY(group_id, subscription_id), " +
+                "FOREIGN KEY(group_id) REFERENCES feed_group(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, " +
+                "FOREIGN KEY(subscription_id) REFERENCES subscriptions(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+            "CREATE INDEX IF NOT EXISTS " +
+                "index_feed_group_subscription_join_subscription_id " +
+                "ON feed_group_subscription_join (subscription_id)",
+            "CREATE TABLE IF NOT EXISTS feed_last_updated (" +
+                "subscription_id INTEGER NOT NULL, last_updated INTEGER, " +
+                "PRIMARY KEY(subscription_id), " +
+                "FOREIGN KEY(subscription_id) REFERENCES subscriptions(uid) " +
+                "ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)"
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -507,6 +507,11 @@
     <string name="import_compatible_data_title">Import from NewPipe or compatible app</string>
     <string name="import_compatible_data_summary">Merge subscriptions, watch history, playback positions, local playlists, compatible settings, and PipePipe SponsorBlock settings from a NewPipe-style ZIP backup without replacing existing WizeStream data.</string>
     <string name="export_data_title">Export full backup</string>
+    <string name="export_compatible_data_key" translatable="false">export_compatible_data</string>
+    <string name="export_compatible_data_title">Export for NewPipe</string>
+    <string name="export_compatible_data_summary">Create a NewPipe-compatible ZIP containing subscriptions, watch history, and playback positions. WizeStream settings and app-specific data are excluded.</string>
+    <string name="export_compatible_data_complete_title">NewPipe backup exported</string>
+    <string name="export_compatible_data_complete_message">Exported %1$d subscriptions, %2$d history items, and %3$d playback positions. Skipped %4$d records that NewPipe cannot use. Import this ZIP using NewPipe’s backup restore screen.</string>
     <string name="clear_cookie_title">Clear reCAPTCHA cookies</string>
     <string name="recaptcha_cookies_cleared">reCAPTCHA cookies have been cleared</string>
     <string name="import_data_summary">Restore subscriptions, playlists, app settings, SponsorBlock settings, and local data from a ZIP backup.</string>

--- a/app/src/main/res/xml/backup_restore_settings.xml
+++ b/app/src/main/res/xml/backup_restore_settings.xml
@@ -31,6 +31,13 @@
         app:iconSpaceReserved="false" />
 
     <Preference
+        android:key="@string/export_compatible_data_key"
+        android:summary="@string/export_compatible_data_summary"
+        android:title="@string/export_compatible_data_title"
+        app:singleLineTitle="false"
+        app:iconSpaceReserved="false" />
+
+    <Preference
         android:key="@string/reset_settings"
         android:title="@string/reset_settings_title"
         android:summary="@string/reset_settings_summary"

--- a/app/src/test/java/org/schabi/newpipe/settings/WizeStreamBrandingTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/WizeStreamBrandingTest.kt
@@ -23,6 +23,10 @@ class WizeStreamBrandingTest {
             "import_settings_vulnerable_format",
             "import_compatible_data_title",
             "import_compatible_data_summary",
+            "export_compatible_data_title",
+            "export_compatible_data_summary",
+            "export_compatible_data_complete_title",
+            "export_compatible_data_complete_message",
             "migration_invalid_backup"
         )
 


### PR DESCRIPTION
- Add an explicit **Export for NewPipe** action without changing WizeStream full backups.
- Generate a clean NewPipe schema-v9 archive containing supported subscriptions, watch history, and playback positions.
- Exclude WizeStream settings, local media, unsupported services, and app-specific database fields while reporting skipped records.
- Validate the exported database against the shared Room v9 schema and verify the portable ZIP contents with instrumentation tests.
- Closes #514