### PR TITLE
Keep Shorts auto-queue short-form only

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerHelper.java
@@ -161,10 +161,10 @@ public final class PlayerHelper {
      * if a candidate next video's url already exists in the existing items.
      * </p>
      * <p>
-     * For short-form playback, the first non-repeating short-form related stream is preferred.
-     * If none is available, the first related stream is checked. If that stream is unavailable or
-     * already queued, a random stream with a non-repeating URL is selected from
-     * {@link StreamInfo#getRelatedItems()}. Non-stream items are ignored.
+     * For short-form playback, only a non-repeating short-form related stream is returned. If none
+     * is available, auto-queueing stops instead of switching into regular video playback. For
+     * regular playback, the first related stream is checked before selecting a random
+     * non-repeating stream. Non-stream items are ignored.
      * </p>
      *
      * @param info                   currently playing stream
@@ -193,6 +193,7 @@ public final class PlayerHelper {
                     return getAutoQueuedSinglePlayQueue((StreamInfoItem) item);
                 }
             }
+            return null;
         }
 
         if (relatedItems.get(0) instanceof StreamInfoItem

--- a/app/src/test/java/org/schabi/newpipe/player/helper/PlayerHelperAutoQueueTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/helper/PlayerHelperAutoQueueTest.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.player.helper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -36,15 +37,26 @@ public class PlayerHelperAutoQueueTest {
     }
 
     @Test
-    public void fallsBackToRegularRelatedVideoWhenNoShortIsAvailable() {
+    public void stopsShortFormQueueWhenNoShortIsAvailable() {
         final StreamInfoItem longVideo = stream("long", false);
         final StreamInfo info = infoWithRelated(longVideo);
 
         final PlayQueue queue = PlayerHelper.autoQueueOf(
                 info, Collections.emptyList(), true);
 
-        assertNotNull(queue);
-        assertEquals(longVideo.getUrl(), queue.getItem().getUrl());
+        assertNull(queue);
+    }
+
+    @Test
+    public void stopsShortFormQueueWhenOnlyShortIsAlreadyQueued() {
+        final StreamInfoItem longVideo = stream("long", false);
+        final StreamInfoItem repeatedShort = stream("short", true);
+        final StreamInfo info = infoWithRelated(longVideo, repeatedShort);
+
+        final PlayQueue queue = PlayerHelper.autoQueueOf(
+                info, List.of(new PlayQueueItem(repeatedShort)), true);
+
+        assertNull(queue);
     }
 
     @Test


### PR DESCRIPTION
- Keep automatic queues in short-form mode when the current item is a Short.
- Stop queue extension when no unused related Short is available instead of falling back to a standard video.
- Preserve the existing related-video selection behavior for regular playback.
- Add regression coverage for missing and already-queued Shorts.
- Closes #515