### PR TITLE
Recover manifest-only YouTube livestreams

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -196,7 +196,9 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
     @Nullable
     static MediaSource maybeBuildLiveMediaSource(final PlayerDataSource dataSource,
                                                  final StreamInfo info) {
-        if (!StreamTypeUtil.isLiveStream(info.getStreamType())) {
+        final boolean isManifestOnlyYoutubeLive = isManifestOnlyYoutubeLive(info);
+        if (!StreamTypeUtil.isLiveStream(info.getStreamType())
+                && !isManifestOnlyYoutubeLive) {
             return null;
         }
 
@@ -204,8 +206,9 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
             final StreamInfoTag tag = StreamInfoTag.of(info);
             // Manifest-only YouTube lives can expose a finite DASH DVR window whose declared end
             // is only a few seconds beyond the initial live edge. HLS keeps refreshing its media
-            // playlist, so prefer it for this narrow fallback path.
-            if (shouldPreferHlsForManifestOnlyYoutubeLive(info)) {
+            // playlist, so prefer it for this narrow fallback path. Some YouTube client responses
+            // also misclassify these lives as regular videos, so do not rely on the stream type.
+            if (isManifestOnlyYoutubeLive) {
                 return buildLiveMediaSource(dataSource, info.getHlsUrl(), C.CONTENT_TYPE_HLS, tag);
             }
             // Prefer DASH over HLS because of an exoPlayer bug that causes the background player to
@@ -225,11 +228,11 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
         return null;
     }
 
-    static boolean shouldPreferHlsForManifestOnlyYoutubeLive(final StreamInfo info) {
+    static boolean isManifestOnlyYoutubeLive(final StreamInfo info) {
         return info.getServiceId() == ServiceList.YouTube.getServiceId()
-                && StreamTypeUtil.isLiveStream(info.getStreamType())
                 && info.getAudioStreams().isEmpty()
                 && info.getVideoStreams().isEmpty()
+                && info.getVideoOnlyStreams().isEmpty()
                 && !info.getHlsUrl().isEmpty();
     }
 

--- a/app/src/test/java/org/schabi/newpipe/player/resolver/PlaybackResolverLiveManifestTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/resolver/PlaybackResolverLiveManifestTest.java
@@ -17,7 +17,15 @@ public class PlaybackResolverLiveManifestTest {
     public void manifestOnlyYoutubeLivePrefersRefreshableHls() {
         final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
 
-        assertTrue(PlaybackResolver.shouldPreferHlsForManifestOnlyYoutubeLive(info));
+        assertTrue(PlaybackResolver.isManifestOnlyYoutubeLive(info));
+    }
+
+    @Test
+    public void misclassifiedManifestOnlyYoutubeLiveStillUsesHls() {
+        final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
+        info.setStreamType(StreamType.VIDEO_STREAM);
+
+        assertTrue(PlaybackResolver.isManifestOnlyYoutubeLive(info));
     }
 
     @Test
@@ -25,14 +33,30 @@ public class PlaybackResolverLiveManifestTest {
         final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
         info.setVideoStreams(Collections.singletonList(mock(VideoStream.class)));
 
-        assertFalse(PlaybackResolver.shouldPreferHlsForManifestOnlyYoutubeLive(info));
+        assertFalse(PlaybackResolver.isManifestOnlyYoutubeLive(info));
+    }
+
+    @Test
+    public void youtubeLiveWithVideoOnlyStreamsRetainsDirectStreamSelection() {
+        final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
+        info.setVideoOnlyStreams(Collections.singletonList(mock(VideoStream.class)));
+
+        assertFalse(PlaybackResolver.isManifestOnlyYoutubeLive(info));
     }
 
     @Test
     public void nonYoutubeManifestOnlyLiveRetainsDashPreference() {
         final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId() + 1);
 
-        assertFalse(PlaybackResolver.shouldPreferHlsForManifestOnlyYoutubeLive(info));
+        assertFalse(PlaybackResolver.isManifestOnlyYoutubeLive(info));
+    }
+
+    @Test
+    public void youtubeWithoutHlsDoesNotUseManifestOnlyFallback() {
+        final StreamInfo info = createLiveInfo(ServiceList.YouTube.getServiceId());
+        info.setHlsUrl("");
+
+        assertFalse(PlaybackResolver.isManifestOnlyYoutubeLive(info));
     }
 
     private static StreamInfo createLiveInfo(final int serviceId) {


### PR DESCRIPTION
- Play YouTube HLS manifests when live client responses are misclassified as regular videos
- Require all direct audio, video, and video-only stream lists to be empty before using the fallback
- Preserve existing direct-stream and non-YouTube resolution behavior
- Add regression coverage for misclassified manifest-only livestreams and fallback boundaries