### PR TITLE
Fix landscape playback queue crash

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayQueueLandscapeLayoutTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/player/ui/PlayQueueLandscapeLayoutTest.kt
@@ -1,0 +1,44 @@
+package org.schabi.newpipe.player.ui
+
+import android.content.res.Configuration
+import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.R
+
+@RunWith(AndroidJUnit4::class)
+class PlayQueueLandscapeLayoutTest {
+    @Test
+    fun landscapePlaybackQueueIncludesHiddenVisualizer() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val targetContext = instrumentation.targetContext
+            val landscapeConfiguration =
+                Configuration(targetContext.resources.configuration).apply {
+                    orientation = Configuration.ORIENTATION_LANDSCAPE
+                    screenWidthDp = 800
+                    screenHeightDp = 450
+                }
+            val landscapeContext =
+                targetContext.createConfigurationContext(landscapeConfiguration)
+            val themedContext = ContextThemeWrapper(landscapeContext, R.style.LightTheme)
+            val root = LayoutInflater.from(themedContext).inflate(
+                R.layout.activity_player_queue_control,
+                FrameLayout(themedContext),
+                false
+            )
+
+            assertNotNull(root.findViewById<View>(R.id.play_queue))
+            val visualizer = root.findViewById<View>(R.id.audio_visualizer)
+            assertNotNull(visualizer)
+            assertEquals(View.GONE, visualizer.visibility)
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayQueueActivity.java
@@ -160,7 +160,8 @@ public final class PlayQueueActivity extends AppCompatActivity
             menu.findItem(R.id.action_equalizer)
                     .setChecked(player.getEqualizerState().isEnabled());
             menu.findItem(R.id.action_visualizer)
-                    .setVisible(player.audioPlayerSelected());
+                    .setVisible(player.audioPlayerSelected()
+                            && queueControlBinding.audioVisualizer != null);
             final PlayQueueItem currentItem = player.getPlayQueue() == null
                     ? null : player.getPlayQueue().getItem();
             menu.findItem(R.id.action_browse_local_media)
@@ -359,6 +360,12 @@ public final class PlayQueueActivity extends AppCompatActivity
         final boolean showVisualizer = visualizerVisible
                 && player != null
                 && player.audioPlayerSelected();
+        if (queueControlBinding.audioVisualizer == null) {
+            visualizerVisible = false;
+            queueControlBinding.playQueue.setVisibility(View.VISIBLE);
+            updateVisualizerMenuItem();
+            return;
+        }
         queueControlBinding.playQueue.setVisibility(showVisualizer ? View.GONE : View.VISIBLE);
         queueControlBinding.audioVisualizer.setVisibility(
                 showVisualizer ? View.VISIBLE : View.GONE);
@@ -374,7 +381,9 @@ public final class PlayQueueActivity extends AppCompatActivity
     }
 
     private void suspendVisualizerProcessing() {
-        queueControlBinding.audioVisualizer.setAudioProcessor(null);
+        if (queueControlBinding.audioVisualizer != null) {
+            queueControlBinding.audioVisualizer.setAudioProcessor(null);
+        }
         if (player != null
                 && player.audioPlayerSelected()
                 && player.getPlaybackPresentationMode()

--- a/app/src/main/res/layout-land/activity_player_queue_control.xml
+++ b/app/src/main/res/layout-land/activity_player_queue_control.xml
@@ -42,6 +42,19 @@
         app:layoutManager="LinearLayoutManager"
         tools:listitem="@layout/play_queue_item" />
 
+    <org.schabi.newpipe.views.AudioVisualizerView
+        android:id="@+id/audio_visualizer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/progress_bar"
+        android:layout_below="@id/appbar"
+        android:layout_toStartOf="@id/control_pane"
+        android:layout_toLeftOf="@id/control_pane"
+        android:background="?attr/colorSurface"
+        android:contentDescription="@string/audio_visualizer"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <RelativeLayout
         android:id="@+id/control_pane"
         android:layout_width="200dp"


### PR DESCRIPTION
- Add the missing audio visualizer to the landscape and Samsung DeX playback queue layout
- Keep the queue visible and disable visualizer controls if a future layout variant omits the view
- Add Android regression coverage for landscape playback queue inflation
- Fixes #519