### PR TITLE
Fix phone fullscreen desktop detection

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/DesktopModeDetector.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DesktopModeDetector.java
@@ -1,0 +1,14 @@
+package org.schabi.newpipe.util;
+
+final class DesktopModeDetector {
+    private static final int POINTER_MIN_SMALLEST_WIDTH_DP = 600;
+
+    private DesktopModeDetector() {
+    }
+
+    static boolean shouldTreatCursorInputAsDesktop(final boolean cursorInputAvailable,
+                                                   final int smallestScreenWidthDp) {
+        return cursorInputAvailable
+                && smallestScreenWidthDp >= POINTER_MIN_SMALLEST_WIDTH_DP;
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -34,7 +34,6 @@ public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
     private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
-    private static final int DESKTOP_POINTER_MIN_SMALLEST_WIDTH_DP = 600;
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -186,7 +185,7 @@ public final class DeviceUtils {
                 break;
             }
         }
-        if (shouldTreatCursorInputAsDesktop(hasActiveCursor,
+        if (DesktopModeDetector.shouldTreatCursorInputAsDesktop(hasActiveCursor,
                 context.getResources().getConfiguration().smallestScreenWidthDp)) {
             return true;
         }
@@ -243,12 +242,6 @@ public final class DeviceUtils {
         }
 
         return false;
-    }
-
-    static boolean shouldTreatCursorInputAsDesktop(final boolean cursorInputAvailable,
-                                                   final int smallestScreenWidthDp) {
-        return cursorInputAvailable
-                && smallestScreenWidthDp >= DESKTOP_POINTER_MIN_SMALLEST_WIDTH_DP;
     }
 
     public static boolean isTablet(@NonNull final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -177,7 +177,9 @@ public final class DeviceUtils {
         boolean hasActiveCursor = false;
         for (final int id : im.getInputDeviceIds()) {
             final InputDevice inputDevice = im.getInputDevice(id);
-            if (inputDevice != null && inputDevice.isEnabled()
+            if (inputDevice != null
+                    && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1
+                    || inputDevice.isEnabled())
                     && (inputDevice.supportsSource(InputDevice.SOURCE_MOUSE)
                     || inputDevice.supportsSource(InputDevice.SOURCE_TOUCHPAD)
                     || inputDevice.supportsSource(InputDevice.SOURCE_TRACKBALL))) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -34,6 +34,7 @@ public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
     private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
+    private static final int DESKTOP_POINTER_MIN_SMALLEST_WIDTH_DP = 600;
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -170,18 +171,24 @@ public final class DeviceUtils {
      */
     @SuppressWarnings("JavaReflectionMemberAccess")
     public static boolean isDesktopMode(@NonNull final Context context) {
-        // Adapted from https://stackoverflow.com/a/64615568
-        // to check for all input devices that have an active cursor
+        // Pointer-capable virtual devices can be exposed on phones by OEM Android builds.
+        // Only use an enabled cursor device as a desktop signal on a large-screen
+        // configuration; UiModeManager and the Samsung checks below remain authoritative.
         final InputManager im = (InputManager) context.getSystemService(INPUT_SERVICE);
+        boolean hasActiveCursor = false;
         for (final int id : im.getInputDeviceIds()) {
             final InputDevice inputDevice = im.getInputDevice(id);
-            if (inputDevice.supportsSource(InputDevice.SOURCE_BLUETOOTH_STYLUS)
-                    || inputDevice.supportsSource(InputDevice.SOURCE_MOUSE)
-                    || inputDevice.supportsSource(InputDevice.SOURCE_STYLUS)
+            if (inputDevice != null && inputDevice.isEnabled()
+                    && (inputDevice.supportsSource(InputDevice.SOURCE_MOUSE)
                     || inputDevice.supportsSource(InputDevice.SOURCE_TOUCHPAD)
-                    || inputDevice.supportsSource(InputDevice.SOURCE_TRACKBALL)) {
-                return true;
+                    || inputDevice.supportsSource(InputDevice.SOURCE_TRACKBALL))) {
+                hasActiveCursor = true;
+                break;
             }
+        }
+        if (shouldTreatCursorInputAsDesktop(hasActiveCursor,
+                context.getResources().getConfiguration().smallestScreenWidthDp)) {
+            return true;
         }
 
         final UiModeManager uiModeManager =
@@ -236,6 +243,12 @@ public final class DeviceUtils {
         }
 
         return false;
+    }
+
+    static boolean shouldTreatCursorInputAsDesktop(final boolean cursorInputAvailable,
+                                                   final int smallestScreenWidthDp) {
+        return cursorInputAvailable
+                && smallestScreenWidthDp >= DESKTOP_POINTER_MIN_SMALLEST_WIDTH_DP;
     }
 
     public static boolean isTablet(@NonNull final Context context) {

--- a/app/src/test/java/org/schabi/newpipe/util/DeviceUtilsDesktopModeTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/DeviceUtilsDesktopModeTest.java
@@ -8,18 +8,18 @@ import org.junit.Test;
 public class DeviceUtilsDesktopModeTest {
     @Test
     public void phonePointerDoesNotEnableDesktopMode() {
-        assertFalse(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 411));
-        assertFalse(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 599));
+        assertFalse(DesktopModeDetector.shouldTreatCursorInputAsDesktop(true, 411));
+        assertFalse(DesktopModeDetector.shouldTreatCursorInputAsDesktop(true, 599));
     }
 
     @Test
     public void largeScreenPointerCanEnableDesktopMode() {
-        assertTrue(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 600));
-        assertTrue(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 840));
+        assertTrue(DesktopModeDetector.shouldTreatCursorInputAsDesktop(true, 600));
+        assertTrue(DesktopModeDetector.shouldTreatCursorInputAsDesktop(true, 840));
     }
 
     @Test
     public void largeScreenWithoutPointerDoesNotUsePointerFallback() {
-        assertFalse(DeviceUtils.shouldTreatCursorInputAsDesktop(false, 840));
+        assertFalse(DesktopModeDetector.shouldTreatCursorInputAsDesktop(false, 840));
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/util/DeviceUtilsDesktopModeTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/DeviceUtilsDesktopModeTest.java
@@ -1,0 +1,25 @@
+package org.schabi.newpipe.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class DeviceUtilsDesktopModeTest {
+    @Test
+    public void phonePointerDoesNotEnableDesktopMode() {
+        assertFalse(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 411));
+        assertFalse(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 599));
+    }
+
+    @Test
+    public void largeScreenPointerCanEnableDesktopMode() {
+        assertTrue(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 600));
+        assertTrue(DeviceUtils.shouldTreatCursorInputAsDesktop(true, 840));
+    }
+
+    @Test
+    public void largeScreenWithoutPointerDoesNotUsePointerFallback() {
+        assertFalse(DeviceUtils.shouldTreatCursorInputAsDesktop(false, 840));
+    }
+}


### PR DESCRIPTION
- Prevent phone-sized Android configurations from being misclassified as desktop mode by pointer or virtual input devices
- Require an enabled cursor source and a large-screen configuration for the generic desktop fallback
- Preserve Android desk-mode and Samsung DeX detection
- Add regression coverage for phone and large-screen boundaries
- Fixes #495