### PR TITLE
Fix legacy copy toast theme

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/util/LegacyTextSelectionThemeTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/util/LegacyTextSelectionThemeTest.kt
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2026 WizeStream contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package org.schabi.newpipe.util
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.schabi.newpipe.R
+
+@RunWith(AndroidJUnit4::class)
+class LegacyTextSelectionThemeTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun searchSuggestionThemesResolveFrameworkLinkTextColor() {
+        listOf(R.style.LightTheme, R.style.DarkTheme, R.style.BlackTheme).forEach { theme ->
+            val appContext = ContextThemeWrapper(context, theme)
+            val suggestionContext = ContextThemeWrapper(appContext, R.style.SearchSuggestionTheme)
+            val attributes = suggestionContext.obtainStyledAttributes(
+                intArrayOf(android.R.attr.textColorLink)
+            )
+
+            try {
+                assertNotNull(attributes.getColorStateList(0))
+            } finally {
+                attributes.recycle()
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,6 +23,7 @@
         <item name="snackbarTextViewStyle">@style/Widget.wizestream.Snackbar.TextView</item>
         <item name="toolbarSearchColor">?attr/colorOnSurface</item>
         <item name="colorControlActivated">?attr/colorPrimary</item>
+        <item name="android:textColorLink">?attr/colorPrimary</item>
     </style>
     <style name="Base" parent="Base.V21"/>
 

--- a/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/ThemeColorIntegrationTest.java
@@ -62,6 +62,8 @@ public class ThemeColorIntegrationTest {
         final String baseTheme = styleBody(styles, "Base.V21");
         assertTrue(baseTheme.contains(
                 "<item name=\"colorControlActivated\">?attr/colorPrimary</item>"));
+        assertTrue(baseTheme.contains(
+                "<item name=\"android:textColorLink\">?attr/colorPrimary</item>"));
         assertFalse(baseTheme.contains(
                 "<item name=\"colorControlActivated\">?attr/colorSecondary</item>"));
     }


### PR DESCRIPTION
- Define the framework link-text color in the shared Material 3 app theme
- Preserve the active theme primary color for legacy system text actions
- Verify search-suggestion text selection under Light, Dark, and Black themes
- Fixes #522