### PR TITLE
Add requested mobile playback and library features

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
 - Block individual videos or channels from their context menus, and hide content by title or uploader
   keywords using locally stored rules under **Settings > Content > Blocked content**
 - Browse video details, related content, comments, playlists, and channel tabs where supported
+- Choose **Top** or **Newest** YouTube comments using the service's ordering, including pagination
 - Sort channel videos by latest, popular, or oldest, and use podcast tabs on supported channels
 - Browse read-only YouTube channel posts with text, images, polls, links, videos, playlists, and
   pagination
@@ -219,6 +220,8 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
   audio > Visualizer style**
 - Tune playback with a built-in 10-band equalizer, five presets, a saved custom curve, and automatic
   clipping headroom
+- Enable adaptive **Loudness normalization** and **Dynamic range compression** in **Settings > Video
+  and audio**; both are off by default and apply to decoded audio in the built-in player
 - Browse and resume audio safely through Android Auto, including voice search and a bounded
   **Continue listening** section; video and visualizers are never shown on the driving surface
 - Cast compatible streams to discovered FCast and Chromecast-compatible receivers on Android 8 and
@@ -237,6 +240,8 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
 - Use swipe seeking, fullscreen volume and brightness swipes, hold-to-speed-up, configurable
   pinch-to-zoom and two-finger panning, an optional two-finger playback-speed gesture, and swipe down
   to the miniplayer
+- Lock fullscreen touch controls from the player's expanded controls; use **Unlock** or leave
+  fullscreen to restore touch interaction
 - Optionally keep visible video playback in Android's native picture-in-picture window on Android 8
   and newer
 - Optionally keep the video visible while scrolling its details page
@@ -258,6 +263,10 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
 - Create, rename, search, play, shuffle, share, and bulk-manage local playlists; remove watched or
   duplicate entries, bookmark remote playlists, and sort remote playlist contents
 - Swipe a video out of a local playlist with an **Undo** action
+- Organize local and bookmarked online playlists into **Categories**, with rename, move, and delete
+  actions; categories are local to the device and included in complete WizeStream backups
+- Long-press a video in search, channel lists, or feeds and choose **Select** to enqueue, add to a
+  playlist, or download several items; **Select all loaded videos** affects the currently loaded list
 - Browse and play local audio and video files with search, filters, sorting, thumbnails, detailed
   metadata, refresh/rescan controls, and main, background, or popup playback
 - Search locally within subscriptions, playlists, feeds, watch history, and Downloads, then carry a
@@ -274,6 +283,9 @@ shared upstream, but WizeStream remains responsible for defects caused by its bu
 - Import or export subscriptions separately, create complete WizeStream backups, and merge compatible
   watch history, playback positions, local playlists, settings, and SponsorBlock data from NewPipe-style
   backups without replacing existing data
+- Schedule daily or weekly backups in **Settings > Backup and restore** after choosing a folder;
+  retain the latest seven automatic backups and see the last backup status. Android determines the
+  exact run time based on battery and storage conditions
 
 ### Learning Mode
 

--- a/app/src/androidTest/java/org/schabi/newpipe/player/TouchLockOverlayTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/player/TouchLockOverlayTest.java
@@ -36,7 +36,12 @@ public class TouchLockOverlayTest {
             root.addView(playback, new FrameLayout.LayoutParams(400, 400));
             final TouchLockOverlay overlay = new TouchLockOverlay(context, null);
             final Button unlock = new Button(context);
+            final AtomicInteger unlockTouches = new AtomicInteger();
             unlock.setText("Unlock");
+            unlock.setOnTouchListener((view, event) -> {
+                unlockTouches.incrementAndGet();
+                return false;
+            });
             unlock.setOnClickListener(view -> overlay.setVisibility(View.GONE));
             overlay.addView(unlock, new FrameLayout.LayoutParams(100, 100,
                     Gravity.RIGHT | Gravity.BOTTOM));
@@ -48,6 +53,9 @@ public class TouchLockOverlayTest {
             tap(root, 50, 50);
             assertEquals(0, playbackTouches.get());
             tap(root, 350, 350);
+            assertTrue(unlockTouches.get() > 0);
+            // Unattached views queue performClick until attachment; execute that callback here.
+            unlock.performClick();
             assertEquals(View.GONE, overlay.getVisibility());
             tap(root, 50, 50);
             assertTrue(playbackTouches.get() > 0);

--- a/app/src/androidTest/java/org/schabi/newpipe/player/TouchLockOverlayTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/player/TouchLockOverlayTest.java
@@ -1,0 +1,68 @@
+package org.schabi.newpipe.player;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.Button;
+import android.widget.FrameLayout;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.schabi.newpipe.views.TouchLockOverlay;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(AndroidJUnit4.class)
+public class TouchLockOverlayTest {
+    @Test
+    public void blocksPlaybackTouchesButKeepsUnlockReachable() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+            final Context context = ApplicationProvider.getApplicationContext();
+            final FrameLayout root = new FrameLayout(context);
+            final AtomicInteger playbackTouches = new AtomicInteger();
+            final View playback = new View(context);
+            playback.setOnTouchListener((view, event) -> {
+                playbackTouches.incrementAndGet();
+                return true;
+            });
+            root.addView(playback, new FrameLayout.LayoutParams(400, 400));
+            final TouchLockOverlay overlay = new TouchLockOverlay(context, null);
+            final Button unlock = new Button(context);
+            unlock.setText("Unlock");
+            unlock.setOnClickListener(view -> overlay.setVisibility(View.GONE));
+            overlay.addView(unlock, new FrameLayout.LayoutParams(100, 100,
+                    Gravity.RIGHT | Gravity.BOTTOM));
+            root.addView(overlay, new FrameLayout.LayoutParams(400, 400));
+            final int exact = View.MeasureSpec.makeMeasureSpec(400, View.MeasureSpec.EXACTLY);
+            root.measure(exact, exact);
+            root.layout(0, 0, 400, 400);
+
+            tap(root, 50, 50);
+            assertEquals(0, playbackTouches.get());
+            tap(root, 350, 350);
+            assertEquals(View.GONE, overlay.getVisibility());
+            tap(root, 50, 50);
+            assertTrue(playbackTouches.get() > 0);
+        });
+    }
+
+    private static void tap(final View root, final float x, final float y) {
+        final MotionEvent down = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, x, y, 0);
+        final MotionEvent up = MotionEvent.obtain(0, 20, MotionEvent.ACTION_UP, x, y, 0);
+        try {
+            root.dispatchTouchEvent(down);
+            root.dispatchTouchEvent(up);
+        } finally {
+            down.recycle();
+            up.recycle();
+        }
+    }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/settings/DatabaseSnapshotTest.java
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/DatabaseSnapshotTest.java
@@ -1,0 +1,78 @@
+package org.schabi.newpipe.settings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import androidx.annotation.NonNull;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.schabi.newpipe.settings.export.DatabaseSnapshot;
+
+import java.io.File;
+
+@RunWith(AndroidJUnit4.class)
+public class DatabaseSnapshotTest {
+    @Test
+    public void snapshotIncludesWalRowsSchemaVersionAndSequences() throws Exception {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final File snapshot = File.createTempFile("snapshot-test", ".db", context.getCacheDir());
+        final SupportSQLiteOpenHelper.Configuration configuration =
+                SupportSQLiteOpenHelper.Configuration.builder(context)
+                        .name("snapshot-source-test.db")
+                        .callback(new SupportSQLiteOpenHelper.Callback(23) {
+                            @Override
+                            public void onCreate(@NonNull final SupportSQLiteDatabase db) {
+                                db.execSQL("CREATE TABLE items (id INTEGER PRIMARY KEY"
+                                        + " AUTOINCREMENT, title TEXT, data BLOB, score REAL)");
+                                db.execSQL("CREATE INDEX item_title ON items(title)");
+                            }
+
+                            @Override
+                            public void onUpgrade(@NonNull final SupportSQLiteDatabase db,
+                                                  final int oldVersion, final int newVersion) {
+                            }
+                        }).build();
+        try (SupportSQLiteOpenHelper helper =
+                     new FrameworkSQLiteOpenHelperFactory().create(configuration)) {
+            helper.setWriteAheadLoggingEnabled(true);
+            final SupportSQLiteDatabase source = helper.getWritableDatabase();
+            source.execSQL("INSERT INTO items VALUES (41, 'kept', X'0102', 1.5)");
+            source.execSQL("INSERT INTO items VALUES (99, NULL, NULL, NULL)");
+            source.execSQL("DELETE FROM items WHERE id = 99");
+            DatabaseSnapshot.create(source, snapshot);
+            source.execSQL("DELETE FROM items");
+            try (SQLiteDatabase restored = SQLiteDatabase.openOrCreateDatabase(snapshot, null)) {
+                assertEquals(23, restored.getVersion());
+                try (Cursor rows = restored.rawQuery("SELECT * FROM items", null)) {
+                    assertTrue(rows.moveToFirst());
+                    assertEquals(41, rows.getLong(0));
+                    assertEquals("kept", rows.getString(1));
+                    assertEquals(2, rows.getBlob(2).length);
+                    assertEquals(1.5, rows.getDouble(3), 0.0);
+                }
+                restored.execSQL("INSERT INTO items(title) VALUES ('next')");
+                try (Cursor rows = restored.rawQuery("SELECT MAX(id) FROM items", null)) {
+                    assertTrue(rows.moveToFirst());
+                    assertEquals(100, rows.getLong(0));
+                }
+                try (Cursor check = restored.rawQuery("PRAGMA integrity_check", null)) {
+                    assertTrue(check.moveToFirst());
+                    assertEquals("ok", check.getString(0));
+                }
+            }
+        } finally {
+            context.deleteDatabase("snapshot-source-test.db");
+            SQLiteDatabase.deleteDatabase(snapshot);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/App.kt
+++ b/app/src/main/java/org/schabi/newpipe/App.kt
@@ -131,6 +131,7 @@ open class App :
 
         configureRxJavaErrorHandler()
         initializeDeviceSyncScheduling()
+        org.schabi.newpipe.settings.export.ScheduledBackupWorker.schedule(this)
         initializeDeviceSyncListener()
     }
 

--- a/app/src/main/java/org/schabi/newpipe/App.kt
+++ b/app/src/main/java/org/schabi/newpipe/App.kt
@@ -131,7 +131,11 @@ open class App :
 
         configureRxJavaErrorHandler()
         initializeDeviceSyncScheduling()
-        org.schabi.newpipe.settings.export.ScheduledBackupWorker.schedule(this)
+        runCatching {
+            org.schabi.newpipe.settings.export.ScheduledBackupWorker.schedule(this)
+        }.onFailure { error ->
+            Log.e(TAG, "Could not initialize automatic backups", error)
+        }
         initializeDeviceSyncListener()
     }
 

--- a/app/src/main/java/org/schabi/newpipe/extractor/comments/CommentSortOrder.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/comments/CommentSortOrder.java
@@ -1,0 +1,6 @@
+package org.schabi.newpipe.extractor.comments;
+
+public enum CommentSortOrder {
+    TOP,
+    NEWEST
+}

--- a/app/src/main/java/org/schabi/newpipe/extractor/comments/CommentsExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/comments/CommentsExtractor.java
@@ -14,6 +14,16 @@ public abstract class CommentsExtractor extends ListExtractor<CommentsInfoItem> 
         super(service, uiHandler);
     }
 
+    public void setSortOrder(final CommentSortOrder order) {
+        if (order != CommentSortOrder.TOP) {
+            throw new UnsupportedOperationException("Comment sorting is unavailable");
+        }
+    }
+
+    public CommentSortOrder getSortOrder() {
+        return CommentSortOrder.TOP;
+    }
+
     /**
      * @apiNote Warning: This method is experimental and may get removed in a future release.
      * @return <code>true</code> if the comments are disabled otherwise <code>false</code> (default)

--- a/app/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
@@ -13,6 +13,11 @@ import org.schabi.newpipe.extractor.utils.ExtractorHelper;
 import java.io.IOException;
 
 public final class CommentsInfo extends ListInfo<CommentsInfoItem> {
+    private CommentSortOrder sortOrder = CommentSortOrder.TOP;
+
+    public CommentSortOrder getSortOrder() {
+        return sortOrder;
+    }
 
     private CommentsInfo(
             final int serviceId,
@@ -30,6 +35,16 @@ public final class CommentsInfo extends ListInfo<CommentsInfoItem> {
         return getInfo(service.getCommentsExtractor(url));
     }
 
+    public static CommentsInfo getInfo(final StreamingService service, final String url,
+                                      final CommentSortOrder sortOrder)
+            throws ExtractionException, IOException {
+        final CommentsExtractor extractor = service.getCommentsExtractor(url);
+        if (extractor != null) {
+            extractor.setSortOrder(sortOrder);
+        }
+        return getInfo(extractor);
+    }
+
     public static CommentsInfo getInfo(final CommentsExtractor commentsExtractor)
             throws IOException, ExtractionException {
         // for services which do not have a comments extractor
@@ -44,6 +59,7 @@ public final class CommentsInfo extends ListInfo<CommentsInfoItem> {
         final ListLinkHandler listUrlIdHandler = commentsExtractor.getLinkHandler();
 
         final CommentsInfo commentsInfo = new CommentsInfo(serviceId, listUrlIdHandler, name);
+        commentsInfo.sortOrder = commentsExtractor.getSortOrder();
         commentsInfo.setCommentsExtractor(commentsExtractor);
         final InfoItemsPage<CommentsInfoItem> initialCommentsPage =
                 ExtractorHelper.getItemsPageOrLogError(commentsInfo, commentsExtractor);

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSort.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSort.java
@@ -1,0 +1,42 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.comments.CommentSortOrder;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+
+/** Reads YouTube's server-provided sort continuation, never sorts a partial page locally. */
+final class YoutubeCommentSort {
+    private YoutubeCommentSort() {
+    }
+
+    static String continuation(final JsonObject response, final CommentSortOrder order)
+            throws ParsingException {
+        for (final Object endpoint : response.getArray("onResponseReceivedEndpoints")) {
+            if (!(endpoint instanceof JsonObject)) {
+                continue;
+            }
+            final JsonObject command = ((JsonObject) endpoint).getObject(
+                    "reloadContinuationItemsCommand");
+            for (final Object item : command.getArray("continuationItems")) {
+                if (!(item instanceof JsonObject)) {
+                    continue;
+                }
+                final JsonArray sorts = ((JsonObject) item).getObject("commentsHeaderRenderer")
+                        .getObject("sortMenu").getObject("sortFilterSubMenuRenderer")
+                        .getArray("subMenuItems");
+                // The service defines this order independently of translated menu titles.
+                final int index = order == CommentSortOrder.NEWEST ? 1 : 0;
+                if (sorts.size() > index) {
+                    final String token = sorts.getObject(index).getObject("serviceEndpoint")
+                            .getObject("continuationCommand").getString("token");
+                    if (token != null && !token.isEmpty()) {
+                        return token;
+                    }
+                }
+            }
+        }
+        throw new ParsingException("The requested comment order is unavailable");
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.comments.CommentsExtractor;
+import org.schabi.newpipe.extractor.comments.CommentSortOrder;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItemsCollector;
 import org.schabi.newpipe.extractor.downloader.Downloader;
@@ -38,6 +39,17 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
      * Whether comments are disabled on video.
      */
     private boolean commentsDisabled;
+    private CommentSortOrder sortOrder = CommentSortOrder.TOP;
+
+    @Override
+    public void setSortOrder(final CommentSortOrder order) {
+        sortOrder = java.util.Objects.requireNonNull(order);
+    }
+
+    @Override
+    public CommentSortOrder getSortOrder() {
+        return sortOrder;
+    }
 
     /**
      * The second ajax <b>/next</b> response.
@@ -60,6 +72,10 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
             return getInfoItemsPageForDisabledComments();
         }
 
+        if (sortOrder == CommentSortOrder.NEWEST) {
+            return getPage(new Page(getUrl(),
+                    YoutubeCommentSort.continuation(ajaxJson, sortOrder)));
+        }
         return extractComments(ajaxJson, ajaxJsonSafe);
     }
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -27,6 +27,8 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.BaseStateFragment;
 import org.schabi.newpipe.fragments.OnScrollBelowItemsListener;
 import org.schabi.newpipe.info_list.InfoListAdapter;
+import org.schabi.newpipe.info_list.StreamSelectionController;
+import org.schabi.newpipe.info_list.dialog.StreamDialogEntry;
 import org.schabi.newpipe.info_list.ItemViewMode;
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog;
 import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
@@ -264,6 +266,12 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
     @Override
     protected void initListeners() {
         super.initListeners();
+        streamSelection = new StreamSelectionController(this, itemsList,
+                () -> infoListAdapter.getItemsList().stream()
+                        .filter(StreamInfoItem.class::isInstance)
+                        .map(StreamInfoItem.class::cast)
+                        .collect(java.util.stream.Collectors.toList()),
+                infoListAdapter::getStreamAtPosition);
         infoListAdapter.setOnStreamSelectedListener(new OnClickGesture<>() {
             @Override
             public void selected(final StreamInfoItem selectedItem) {
@@ -272,7 +280,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
 
             @Override
             public void held(final StreamInfoItem selectedItem) {
-                showInfoItemDialog(selectedItem);
+                if (!streamSelection.toggleIfActive(selectedItem)) {
+                    showInfoItemDialog(selectedItem);
+                }
             }
         });
 
@@ -404,6 +414,9 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
     }
 
     private void onStreamSelected(final StreamInfoItem selectedItem) {
+        if (streamSelection.toggleIfActive(selectedItem)) {
+            return;
+        }
         onItemSelected(selectedItem);
         if (shouldPlayOnBackground(selectedItem)) {
             NavigationHelper.playOnBackgroundPlayer(requireContext(),
@@ -428,7 +441,10 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
 
     protected void showInfoItemDialog(final StreamInfoItem item) {
         try {
-            new InfoItemDialog.Builder(getActivity(), getContext(), this, item).create().show();
+            new InfoItemDialog.Builder(getActivity(), getContext(), this, item)
+                    .addEntry(new StreamDialogEntry(R.string.stream_select,
+                            (fragment, selected) -> streamSelection.start(selected)))
+                    .create().show();
         } catch (final IllegalArgumentException e) {
             InfoItemDialog.Builder.reportErrorDuringInitialization(e, item);
         }
@@ -459,8 +475,22 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
 
     @Override
     protected void startLoading(final boolean forceLoad) {
+        if (streamSelection != null) {
+            streamSelection.finish();
+        }
         useInitialItemListLoadScrollListener();
         super.startLoading(forceLoad);
+    }
+
+    private StreamSelectionController streamSelection;
+
+    @Override
+    public void onDestroyView() {
+        if (streamSelection != null) {
+            streamSelection.destroy();
+            streamSelection = null;
+        }
+        super.onDestroyView();
     }
 
     protected abstract void loadMoreItems();

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -15,6 +15,9 @@ import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.UserAction;
 import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
+import org.schabi.newpipe.extractor.comments.CommentSortOrder;
+import org.schabi.newpipe.extractor.ServiceList;
+import com.google.android.material.chip.ChipGroup;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
@@ -29,6 +32,7 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
     private final CompositeDisposable disposables = new CompositeDisposable();
 
     private TextView emptyStateDesc;
+    private CommentSortOrder sortOrder = CommentSortOrder.TOP;
 
     public static CommentsFragment getInstance(final int serviceId, final String url,
                                                final String name) {
@@ -52,6 +56,24 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
         super.initViews(rootView, savedInstanceState);
 
         emptyStateDesc = rootView.findViewById(R.id.empty_state_desc);
+        if (savedInstanceState != null) {
+            sortOrder = savedInstanceState.getBoolean("comments_newest", false)
+                    ? CommentSortOrder.NEWEST : CommentSortOrder.TOP;
+        }
+        final ChipGroup sorting = rootView.findViewById(R.id.comment_sort);
+        sorting.setVisibility(serviceId == ServiceList.YouTube.getServiceId()
+                ? View.VISIBLE : View.GONE);
+        sorting.check(sortOrder == CommentSortOrder.NEWEST
+                ? R.id.comments_newest : R.id.comments_top);
+        sorting.setOnCheckedStateChangeListener((group, checkedIds) -> {
+            final CommentSortOrder selected = checkedIds.contains(R.id.comments_newest)
+                    ? CommentSortOrder.NEWEST : CommentSortOrder.TOP;
+            if (sortOrder != selected) {
+                sortOrder = selected;
+                currentNextPage = null;
+                startLoading(true);
+            }
+        });
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -71,6 +93,12 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
         disposables.clear();
     }
 
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle state) {
+        super.onSaveInstanceState(state);
+        state.putBoolean("comments_newest", sortOrder == CommentSortOrder.NEWEST);
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
     // Load and handle
     //////////////////////////////////////////////////////////////////////////*/
@@ -82,7 +110,7 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
 
     @Override
     protected Single<CommentsInfo> loadResult(final boolean forceLoad) {
-        return ExtractorHelper.getCommentsInfo(serviceId, url, forceLoad);
+        return ExtractorHelper.getCommentsInfo(serviceId, url, forceLoad, sortOrder);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/InfoListAdapter.java
@@ -256,6 +256,16 @@ public class InfoListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         return infoItemList;
     }
 
+    @Nullable
+    public StreamInfoItem getStreamAtPosition(final int position) {
+        final int index = position - (hasHeader() ? 1 : 0);
+        if (index < 0 || index >= infoItemList.size()) {
+            return null;
+        }
+        final InfoItem item = infoItemList.get(index);
+        return item instanceof StreamInfoItem ? (StreamInfoItem) item : null;
+    }
+
     @Override
     public int getItemCount() {
         int count = infoItemList.size();

--- a/app/src/main/java/org/schabi/newpipe/info_list/StreamSelection.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/StreamSelection.java
@@ -1,0 +1,46 @@
+package org.schabi.newpipe.info_list;
+
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Selection survives row recycling and distinguishes the same URL on different services. */
+public final class StreamSelection {
+    private final Set<String> keys = new HashSet<>();
+
+    private static String key(final StreamInfoItem item) {
+        return item.getServiceId() + ":" + item.getUrl();
+    }
+
+    public boolean contains(final StreamInfoItem item) {
+        return item != null && keys.contains(key(item));
+    }
+
+    public void toggle(final StreamInfoItem item) {
+        if (!keys.remove(key(item))) {
+            keys.add(key(item));
+        }
+    }
+
+    public void selectAll(final List<StreamInfoItem> items) {
+        items.forEach(item -> keys.add(key(item)));
+    }
+
+    public List<StreamInfoItem> itemsInDisplayOrder(final List<StreamInfoItem> items) {
+        final List<StreamInfoItem> selected = new ArrayList<>();
+        final Set<String> seen = new HashSet<>();
+        for (final StreamInfoItem item : items) {
+            if (contains(item) && seen.add(key(item))) {
+                selected.add(item);
+            }
+        }
+        return selected;
+    }
+
+    public void clear() {
+        keys.clear();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/info_list/StreamSelectionController.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/StreamSelectionController.java
@@ -1,0 +1,169 @@
+package org.schabi.newpipe.info_list;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ActionMode;
+import androidx.core.graphics.ColorUtils;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.color.MaterialColors;
+
+import org.schabi.newpipe.R;
+import org.schabi.newpipe.database.stream.model.StreamEntity;
+import org.schabi.newpipe.download.BulkDownloadDialog;
+import org.schabi.newpipe.download.BulkDownloadItem;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.local.dialog.PlaylistDialog;
+import org.schabi.newpipe.player.playqueue.SinglePlayQueue;
+import org.schabi.newpipe.util.NavigationHelper;
+
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+
+/** Shared contextual actions for remote lists and the local subscription feed. */
+public final class StreamSelectionController implements ActionMode.Callback {
+    private final Fragment fragment;
+    private final RecyclerView recycler;
+    private final Supplier<List<StreamInfoItem>> items;
+    private final StreamSelection selection = new StreamSelection();
+    private final CompositeDisposable disposables = new CompositeDisposable();
+    private final RecyclerView.ItemDecoration decoration;
+    private ActionMode actionMode;
+
+    public StreamSelectionController(final Fragment fragment, final RecyclerView recycler,
+                                     final Supplier<List<StreamInfoItem>> items,
+                                     final IntFunction<StreamInfoItem> itemAtPosition) {
+        this.fragment = fragment;
+        this.recycler = recycler;
+        this.items = items;
+        decoration = new RecyclerView.ItemDecoration() {
+            private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+            @Override
+            public void onDrawOver(@NonNull final Canvas canvas,
+                                   @NonNull final RecyclerView parent,
+                                   @NonNull final RecyclerView.State state) {
+                paint.setColor(ColorUtils.setAlphaComponent(MaterialColors.getColor(parent,
+                        com.google.android.material.R.attr.colorPrimary), 50));
+                for (int index = 0; index < parent.getChildCount(); index++) {
+                    final View child = parent.getChildAt(index);
+                    final int position = parent.getChildAdapterPosition(child);
+                    final boolean selected = position != RecyclerView.NO_POSITION
+                            && selection.contains(itemAtPosition.apply(position));
+                    child.setSelected(selected);
+                    if (selected) {
+                        canvas.drawRoundRect(child.getLeft(), child.getTop(), child.getRight(),
+                                child.getBottom(), 12, 12, paint);
+                    }
+                }
+            }
+        };
+        recycler.addItemDecoration(decoration);
+    }
+
+    public void start(final StreamInfoItem item) {
+        if (actionMode == null) {
+            actionMode = ((AppCompatActivity) fragment.requireActivity())
+                    .startSupportActionMode(this);
+        }
+        if (actionMode != null && item != null) {
+            selection.toggle(item);
+        }
+        refresh();
+    }
+
+    public boolean toggleIfActive(final StreamInfoItem item) {
+        if (actionMode == null) {
+            return false;
+        }
+        selection.toggle(item);
+        refresh();
+        return true;
+    }
+
+    public void refresh() {
+        recycler.invalidateItemDecorations();
+        if (actionMode != null) {
+            actionMode.setTitle(fragment.getString(R.string.stream_selection_count,
+                    selection.itemsInDisplayOrder(items.get()).size()));
+            actionMode.invalidate();
+        }
+    }
+
+    public void finish() {
+        if (actionMode != null) {
+            actionMode.finish();
+        }
+    }
+
+    public void destroy() {
+        finish();
+        recycler.removeItemDecoration(decoration);
+        disposables.clear();
+    }
+
+    @Override
+    public boolean onCreateActionMode(final ActionMode mode, final Menu menu) {
+        menu.add(0, R.id.selection_all, 0, R.string.stream_select_all_loaded);
+        menu.add(0, R.id.selection_enqueue, 1, R.string.enqueue_stream);
+        menu.add(0, R.id.selection_playlist, 2, R.string.add_to_playlist);
+        menu.add(0, R.id.selection_download, 3, R.string.download);
+        return true;
+    }
+
+    @Override
+    public boolean onPrepareActionMode(final ActionMode mode, final Menu menu) {
+        final boolean anySelected = !selection.itemsInDisplayOrder(items.get()).isEmpty();
+        menu.findItem(R.id.selection_enqueue).setEnabled(anySelected);
+        menu.findItem(R.id.selection_playlist).setEnabled(anySelected);
+        menu.findItem(R.id.selection_download).setEnabled(anySelected);
+        return true;
+    }
+
+    @Override
+    public boolean onActionItemClicked(final ActionMode mode, final MenuItem action) {
+        if (action.getItemId() == R.id.selection_all) {
+            selection.selectAll(items.get());
+            refresh();
+            return true;
+        }
+        final List<StreamInfoItem> selected = selection.itemsInDisplayOrder(items.get());
+        if (selected.isEmpty()) {
+            return true;
+        }
+        if (action.getItemId() == R.id.selection_enqueue) {
+            NavigationHelper.enqueueOnPlayer(fragment.requireContext(),
+                    new SinglePlayQueue(selected, 0));
+        } else if (action.getItemId() == R.id.selection_playlist) {
+            disposables.add(PlaylistDialog.createCorrespondingDialog(fragment.requireContext(),
+                    selected.stream().map(StreamEntity::new).collect(Collectors.toList()),
+                    dialog -> dialog.show(fragment.getParentFragmentManager(), "PlaylistDialog")));
+        } else if (action.getItemId() == R.id.selection_download) {
+            BulkDownloadDialog.newInstance(selected.stream().map(BulkDownloadItem::from)
+                    .collect(Collectors.toList()))
+                    .show(fragment.getParentFragmentManager(), "BulkDownloadDialog");
+        } else {
+            return false;
+        }
+        mode.finish();
+        return true;
+    }
+
+    @Override
+    public void onDestroyActionMode(final ActionMode mode) {
+        actionMode = null;
+        selection.clear();
+        recycler.invalidateItemDecorations();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/dialog/InfoItemDialog.java
@@ -219,6 +219,11 @@ public final class InfoItemDialog {
             return this;
         }
 
+        public Builder addEntry(@NonNull final StreamDialogEntry entry) {
+            entries.add(entry);
+            return this;
+        }
+
         /**
          * Adds new entries. These are appended to the current entry list.
          * @param newEntries the entries to add

--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
@@ -651,7 +651,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     }
 
     private boolean isPlaylistListFiltered() {
-        return isContextualSearchActive() || !PlaylistCategories.ALL.equals(selectedCategory);
+        return !PlaylistCategories.allowsReordering(isContextualSearchActive(), selectedCategory);
     }
 
     private static String categoryKey(final PlaylistLocalItem playlist) {

--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
@@ -17,10 +17,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentManager;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.evernote.android.state.State;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -78,6 +81,9 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     private List<Pair<Long, LocalItem.LocalItemType>> deletedItems;
     private List<PlaylistLocalItem> completePlaylists = Collections.emptyList();
     private String contextualSearchQuery = "";
+    private PlaylistCategories categories = new PlaylistCategories();
+    @State
+    public String selectedCategory = PlaylistCategories.ALL;
 
     ///////////////////////////////////////////////////////////////////////////
     // Fragment LifeCycle - Creation
@@ -98,6 +104,13 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
         debounceSaver = new DebounceSaver(3000, this);
 
         deletedItems = new ArrayList<>();
+        try {
+            categories = PlaylistCategories.fromJson(PreferenceManager
+                    .getDefaultSharedPreferences(requireContext())
+                    .getString(PlaylistCategories.PREFERENCE_KEY, ""));
+        } catch (final com.grack.nanojson.JsonParserException error) {
+            Log.e("BookmarkFragment", "Could not read playlist categories", error);
+        }
     }
 
     @Nullable
@@ -127,8 +140,18 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     @Override
     protected void initViews(final View rootView, final Bundle savedInstanceState) {
         super.initViews(rootView, savedInstanceState);
+        if (!PlaylistCategories.ALL.equals(selectedCategory)
+                && !PlaylistCategories.UNCATEGORIZED.equals(selectedCategory)
+                && categories.name(selectedCategory) == null) {
+            selectedCategory = PlaylistCategories.ALL;
+        }
+        rootView.findViewById(R.id.playlist_category_filter)
+                .setOnClickListener(view -> chooseCategory(null));
+        rootView.findViewById(R.id.playlist_category_manage)
+                .setOnClickListener(view -> manageCategories());
+        updateCategoryLabel();
 
-        itemListAdapter.setUseItemHandle(!isContextualSearchActive());
+        itemListAdapter.setUseItemHandle(!isPlaylistListFiltered());
     }
 
     @Override
@@ -173,7 +196,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
             @Override
             public void drag(final LocalItem selectedItem,
                              final RecyclerView.ViewHolder viewHolder) {
-                if (!isContextualSearchActive() && itemTouchHelper != null) {
+                if (!isPlaylistListFiltered() && itemTouchHelper != null) {
                     itemTouchHelper.startDrag(viewHolder);
                 }
             }
@@ -302,12 +325,15 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
         }
 
         itemListAdapter.clearStreamItemList();
-        itemListAdapter.setUseItemHandle(!isContextualSearchActive());
-        setEmptyStateMessage(isContextualSearchActive()
+        itemListAdapter.setUseItemHandle(!isPlaylistListFiltered());
+        setEmptyStateMessage(isPlaylistListFiltered()
                 ? R.string.search_no_results : R.string.empty_list_subtitle);
 
         final List<PlaylistLocalItem> filteredPlaylists = ContextualSearchHelper.filter(
-                completePlaylists,
+                completePlaylists.stream()
+                        .filter(playlist -> categories.matches(categoryKey(playlist),
+                                selectedCategory))
+                        .collect(java.util.stream.Collectors.toList()),
                 contextualSearchQuery,
                 playlist -> new String[]{playlist.getOrderingName()});
 
@@ -327,7 +353,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     @Override
     public void setContextualSearchQuery(@NonNull final String query) {
         final String normalizedQuery = ContextualSearchHelper.normalizeQuery(query);
-        if (!isContextualSearchActive() && ContextualSearchHelper.isActive(normalizedQuery)) {
+        if (!isPlaylistListFiltered() && ContextualSearchHelper.isActive(normalizedQuery)) {
             captureCanonicalOrderFromAdapter();
             saveImmediate();
         }
@@ -340,7 +366,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     }
 
     private void captureCanonicalOrderFromAdapter() {
-        if (itemListAdapter == null) {
+        if (itemListAdapter == null || isPlaylistListFiltered()) {
             return;
         }
         final List<PlaylistLocalItem> displayedOrder = new ArrayList<>();
@@ -397,6 +423,15 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
             return;
         }
 
+        if (isPlaylistListFiltered()) {
+            disposables.add(localPlaylistManager.updatePlaylists(Collections.emptyList(),
+                            Collections.singletonList(item.getUid()))
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(() -> { }, throwable -> showError(new ErrorInfo(throwable,
+                            UserAction.REQUESTED_BOOKMARK, "Deleting categorized playlist"))));
+            return;
+        }
+
         itemListAdapter.removeItem(item);
 
         if (item instanceof PlaylistMetadataEntry) {
@@ -434,7 +469,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
 
     @Override
     public void saveImmediate() {
-        if (itemListAdapter == null || isContextualSearchActive()) {
+        if (itemListAdapter == null || isPlaylistListFiltered()) {
             return;
         }
 
@@ -519,7 +554,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
                                   @NonNull final RecyclerView.ViewHolder target) {
 
                 // Allow swap LocalBookmarkPlaylistItemHolder and RemoteBookmarkPlaylistItemHolder.
-                if (isContextualSearchActive() || itemListAdapter == null
+                if (isPlaylistListFiltered() || itemListAdapter == null
                         || source.getItemViewType() != target.getItemViewType()
                         && !(
                         (
@@ -566,19 +601,29 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     ///////////////////////////////////////////////////////////////////////////
 
     private void showRemoteDeleteDialog(final PlaylistRemoteEntity item) {
-        showDeleteDialog(item.getOrderingName(), item);
+        new MaterialAlertDialogBuilder(requireContext())
+                .setItems(new String[]{getString(R.string.playlist_move_to_category),
+                    getString(R.string.delete)}, (dialog, which) -> {
+                    if (which == 0) {
+                        chooseCategory(item);
+                    } else {
+                        showDeleteDialog(item.getOrderingName(), item);
+                    }
+                }).show();
     }
 
     private void showLocalDialog(final PlaylistMetadataEntry selectedItem) {
         final String rename = getString(R.string.rename);
         final String delete = getString(R.string.delete);
         final String unsetThumbnail = getString(R.string.unset_playlist_thumbnail);
+        final String moveToCategory = getString(R.string.playlist_move_to_category);
         final boolean isThumbnailPermanent = localPlaylistManager
                 .getIsPlaylistThumbnailPermanent(selectedItem.getUid());
 
         final ArrayList<String> items = new ArrayList<>();
         items.add(rename);
         items.add(delete);
+        items.add(moveToCategory);
         if (isThumbnailPermanent) {
             items.add(unsetThumbnail);
         }
@@ -588,6 +633,8 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
                 showRenameDialog(selectedItem);
             } else if (items.get(index).equals(delete)) {
                 showDeleteDialog(selectedItem.getOrderingName(), selectedItem);
+            } else if (items.get(index).equals(moveToCategory)) {
+                chooseCategory(selectedItem);
             } else if (isThumbnailPermanent && items.get(index).equals(unsetThumbnail)) {
                 final long thumbnailStreamId = localPlaylistManager
                         .getAutomaticPlaylistThumbnailStreamId(selectedItem.getUid());
@@ -601,6 +648,155 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
         new AlertDialog.Builder(activity)
                 .setItems(items.toArray(new String[0]), action)
                 .show();
+    }
+
+    private boolean isPlaylistListFiltered() {
+        return isContextualSearchActive() || !PlaylistCategories.ALL.equals(selectedCategory);
+    }
+
+    private static String categoryKey(final PlaylistLocalItem playlist) {
+        if (playlist instanceof PlaylistRemoteEntity) {
+            final PlaylistRemoteEntity remote = (PlaylistRemoteEntity) playlist;
+            return "remote:" + remote.getServiceId() + ":" + remote.getUrl();
+        }
+        return "local:" + playlist.getUid();
+    }
+
+    private void updateCategoryLabel() {
+        if (getView() == null) {
+            return;
+        }
+        final MaterialButton button = getView().findViewById(R.id.playlist_category_filter);
+        button.setText(PlaylistCategories.ALL.equals(selectedCategory)
+                ? getString(R.string.playlist_categories_all)
+                : PlaylistCategories.UNCATEGORIZED.equals(selectedCategory)
+                ? getString(R.string.playlist_uncategorized) : categories.name(selectedCategory));
+    }
+
+    private void setCategoryFilter(final String id) {
+        if (!isPlaylistListFiltered()) {
+            captureCanonicalOrderFromAdapter();
+            saveImmediate();
+        }
+        selectedCategory = id;
+        updateCategoryLabel();
+        showFilteredPlaylists();
+    }
+
+    private void saveCategories() {
+        PreferenceManager.getDefaultSharedPreferences(requireContext()).edit()
+                .putString(PlaylistCategories.PREFERENCE_KEY, categories.toJson()).apply();
+        updateCategoryLabel();
+        showFilteredPlaylists();
+    }
+
+    private void chooseCategory(@Nullable final PlaylistLocalItem playlist) {
+        if (!isPlaylistListFiltered()) {
+            captureCanonicalOrderFromAdapter();
+            saveImmediate();
+        }
+        final List<String> ids = new ArrayList<>();
+        final List<String> labels = new ArrayList<>();
+        if (playlist == null) {
+            ids.add(PlaylistCategories.ALL);
+            labels.add(getString(R.string.playlist_categories_all));
+        }
+        ids.add(PlaylistCategories.UNCATEGORIZED);
+        labels.add(getString(R.string.playlist_uncategorized));
+        for (final String id : categories.ids()) {
+            ids.add(id);
+            labels.add(categories.name(id));
+        }
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.playlist_categories)
+                .setItems(labels.toArray(new String[0]), (dialog, which) -> {
+                    if (playlist == null) {
+                        setCategoryFilter(ids.get(which));
+                    } else {
+                        categories.assign(categoryKey(playlist), ids.get(which));
+                        saveCategories();
+                    }
+                })
+                .setPositiveButton(R.string.playlist_category_create,
+                        (dialog, which) -> editCategory(null, playlist))
+                .setNegativeButton(R.string.cancel, null).show();
+    }
+
+    private void manageCategories() {
+        if (!isPlaylistListFiltered()) {
+            captureCanonicalOrderFromAdapter();
+            saveImmediate();
+        }
+        final List<String> ids = categories.ids();
+        final String[] names = ids.stream().map(categories::name).toArray(String[]::new);
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.playlist_categories)
+                .setItems(names, (dialog, which) -> {
+                    final String id = ids.get(which);
+                    new MaterialAlertDialogBuilder(requireContext())
+                            .setTitle(categories.name(id))
+                            .setItems(new String[]{getString(R.string.rename),
+                                getString(R.string.delete)}, (actionDialog, action) -> {
+                                if (action == 0) {
+                                    editCategory(id, null);
+                                } else {
+                                    deleteCategory(id);
+                                }
+                            }).show();
+                })
+                .setPositiveButton(R.string.playlist_category_create,
+                        (dialog, which) -> editCategory(null, null))
+                .setNegativeButton(R.string.cancel, null).show();
+    }
+
+    private void editCategory(@Nullable final String id,
+                              @Nullable final PlaylistLocalItem playlist) {
+        final DialogEditTextBinding input = DialogEditTextBinding.inflate(getLayoutInflater());
+        input.dialogEditText.setHint(R.string.name);
+        input.dialogEditText.setInputType(InputType.TYPE_CLASS_TEXT
+                | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        if (id != null) {
+            input.dialogEditText.setText(categories.name(id));
+        }
+        final AlertDialog dialog = new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(id == null ? R.string.playlist_category_create : R.string.rename)
+                .setView(input.getRoot())
+                .setPositiveButton(R.string.ok, null)
+                .setNegativeButton(R.string.cancel, null).create();
+        dialog.setOnShowListener(ignored -> dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+                .setOnClickListener(view -> {
+                    try {
+                        final String name = input.dialogEditText.getText().toString();
+                        if (id == null) {
+                            final String created = categories.create(name);
+                            if (playlist != null) {
+                                categories.assign(categoryKey(playlist), created);
+                            }
+                        } else {
+                            categories.rename(id, name);
+                        }
+                        saveCategories();
+                        dialog.dismiss();
+                    } catch (final IllegalArgumentException error) {
+                        input.dialogEditText.setError(
+                                getString(R.string.playlist_category_name_error));
+                    }
+                }));
+        dialog.show();
+    }
+
+    private void deleteCategory(final String id) {
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(categories.name(id))
+                .setMessage(R.string.playlist_category_delete_message)
+                .setPositiveButton(R.string.delete, (dialog, which) -> {
+                    categories.delete(id);
+                    if (id.equals(selectedCategory)) {
+                        selectedCategory = PlaylistCategories.ALL;
+                    }
+                    saveCategories();
+                })
+                .setNegativeButton(R.string.cancel, null).show();
     }
 
     private void showRenameDialog(final PlaylistMetadataEntry selectedItem) {

--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/PlaylistCategories.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/PlaylistCategories.java
@@ -1,0 +1,110 @@
+package org.schabi.newpipe.local.bookmark;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonParserException;
+import com.grack.nanojson.JsonWriter;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/** Local organization metadata stored with full-backup preferences. */
+public final class PlaylistCategories {
+    public static final String PREFERENCE_KEY = "playlist_categories_v1";
+    public static final String ALL = "*";
+    public static final String UNCATEGORIZED = "";
+    private final Map<String, String> names = new LinkedHashMap<>();
+    private final Map<String, String> memberships = new LinkedHashMap<>();
+
+    public static PlaylistCategories fromJson(final String json) throws JsonParserException {
+        final PlaylistCategories result = new PlaylistCategories();
+        if (json == null || json.isEmpty()) {
+            return result;
+        }
+        final JsonObject root = JsonParser.object().from(json);
+        for (final Object entry : root.getArray("categories")) {
+            if (entry instanceof JsonObject) {
+                final JsonObject category = (JsonObject) entry;
+                final String id = category.getString("id");
+                final String name = category.getString("name");
+                if (id != null && !id.isEmpty() && !ALL.equals(id)
+                        && name != null && !name.trim().isEmpty()) {
+                    result.names.put(id, name);
+                }
+            }
+        }
+        root.getObject("memberships").forEach((key, value) -> {
+            if (value instanceof String && result.names.containsKey(value)) {
+                result.memberships.put(key, (String) value);
+            }
+        });
+        return result;
+    }
+
+    public String toJson() {
+        final JsonArray categories = new JsonArray();
+        names.forEach((id, name) -> {
+            final JsonObject category = new JsonObject();
+            category.put("id", id);
+            category.put("name", name);
+            categories.add(category);
+        });
+        final JsonObject root = new JsonObject();
+        root.put("categories", categories);
+        final JsonObject assignments = new JsonObject();
+        memberships.forEach(assignments::put);
+        root.put("memberships", assignments);
+        return JsonWriter.string(root);
+    }
+
+    public List<String> ids() {
+        final List<String> ids = new ArrayList<>(names.keySet());
+        ids.sort(Comparator.comparing(names::get, String.CASE_INSENSITIVE_ORDER));
+        return ids;
+    }
+
+    public String name(final String id) {
+        return names.get(id);
+    }
+
+    public String create(final String name) {
+        final String id = UUID.randomUUID().toString();
+        rename(id, name);
+        return id;
+    }
+
+    public void rename(final String id, final String name) {
+        final String trimmed = name.trim();
+        if (trimmed.isEmpty() || trimmed.length() > 80 || names.entrySet().stream()
+                .anyMatch(entry -> !entry.getKey().equals(id)
+                        && entry.getValue().equalsIgnoreCase(trimmed))) {
+            throw new IllegalArgumentException("Choose a unique name of 1 to 80 characters");
+        }
+        names.put(id, trimmed);
+    }
+
+    public void delete(final String id) {
+        names.remove(id);
+        memberships.values().removeIf(id::equals);
+    }
+
+    public void assign(final String playlistKey, final String categoryId) {
+        if (UNCATEGORIZED.equals(categoryId)) {
+            memberships.remove(playlistKey);
+        } else if (names.containsKey(categoryId)) {
+            memberships.put(playlistKey, categoryId);
+        } else {
+            throw new IllegalArgumentException("Unknown playlist category");
+        }
+    }
+
+    public boolean matches(final String playlistKey, final String categoryId) {
+        return ALL.equals(categoryId) || categoryId.equals(
+                memberships.getOrDefault(playlistKey, UNCATEGORIZED));
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/PlaylistCategories.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/PlaylistCategories.java
@@ -21,6 +21,10 @@ public final class PlaylistCategories {
     private final Map<String, String> names = new LinkedHashMap<>();
     private final Map<String, String> memberships = new LinkedHashMap<>();
 
+    public static boolean allowsReordering(final boolean searchActive, final String categoryId) {
+        return !searchActive && ALL.equals(categoryId);
+    }
+
     public static PlaylistCategories fromJson(final String json) throws JsonParserException {
         final PlaylistCategories result = new PlaylistCategories();
         if (json == null || json.isEmpty()) {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -75,6 +75,8 @@ import org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty
 import org.schabi.newpipe.fragments.BaseStateFragment
 import org.schabi.newpipe.info_list.ItemViewMode
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog
+import org.schabi.newpipe.info_list.dialog.StreamDialogEntry
+import org.schabi.newpipe.info_list.StreamSelectionController
 import org.schabi.newpipe.ktx.animate
 import org.schabi.newpipe.ktx.animateHideRecyclerViewAllowingScrolling
 import org.schabi.newpipe.ktx.slideUp
@@ -123,6 +125,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     var feedHeaderExpanded = true
 
     private lateinit var groupAdapter: GroupieAdapter
+    private var streamSelection: StreamSelectionController? = null
 
     private lateinit var onSettingsChangeListener: SharedPreferences.OnSharedPreferenceChangeListener
     private var updateListViewModeOnResume = false
@@ -178,6 +181,24 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
             setOnItemClickListener(listenerStreamItem)
             setOnItemLongClickListener(listenerStreamItem)
         }
+        streamSelection = StreamSelectionController(
+            this,
+            feedBinding.itemsList,
+            {
+                (0 until groupAdapter.itemCount).mapNotNull { position ->
+                    (groupAdapter.getItem(position) as? StreamItem)
+                        ?.streamWithState?.stream?.toStreamInfoItem()
+                }
+            },
+            { position ->
+                if (position in 0 until groupAdapter.itemCount) {
+                    (groupAdapter.getItem(position) as? StreamItem)
+                        ?.streamWithState?.stream?.toStreamInfoItem()
+                } else {
+                    null
+                }
+            }
+        )
 
         val restoreFeedHeaderExpanded = feedHeaderExpanded
         feedBinding.feedHeader.addOnOffsetChangedListener(feedHeaderOffsetListener)
@@ -390,6 +411,8 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
     }
 
     override fun onDestroyView() {
+        streamSelection?.destroy()
+        streamSelection = null
         PreferenceManager.getDefaultSharedPreferences(requireContext())
             .unregisterOnSharedPreferenceChangeListener(onSettingsChangeListener)
 
@@ -503,13 +526,19 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         val activity: Activity? = getActivity()
         if (context == null || context.resources == null || activity == null) return
 
-        InfoItemDialog.Builder(activity, context, this, item).create().show()
+        InfoItemDialog.Builder(activity, context, this, item)
+            .addEntry(StreamDialogEntry(R.string.stream_select) { _, selected ->
+                streamSelection?.start(selected)
+            }).create().show()
     }
 
     private val listenerStreamItem = object : OnItemClickListener, OnItemLongClickListener {
         override fun onItemClick(item: Item<*>, view: View) {
             if (item is StreamItem && !isRefreshing) {
                 val stream = item.streamWithState.stream
+                if (streamSelection?.toggleIfActive(stream.toStreamInfoItem()) == true) {
+                    return
+                }
                 if (stream.requiresMembership) {
                     MembersOnlyContentHelper.showExplanation(requireContext())
                     return
@@ -539,6 +568,12 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
 
         override fun onItemLongClick(item: Item<*>, view: View): Boolean {
             if (item is StreamItem && !isRefreshing) {
+                if (streamSelection?.toggleIfActive(
+                        item.streamWithState.stream.toStreamInfoItem()
+                    ) == true
+                ) {
+                    return true
+                }
                 showInfoItemDialog(item.streamWithState.stream.toStreamInfoItem())
                 return true
             }
@@ -649,6 +684,7 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         val oldOldestSubscriptionUpdate = oldestSubscriptionUpdate
 
         groupAdapter.updateAsync(displayedItems, false) {
+            streamSelection?.refresh()
             if (restoreListState) {
                 oldOldestSubscriptionUpdate?.run {
                     highlightNewItemsAfter(oldOldestSubscriptionUpdate)

--- a/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/FeedFragment.kt
@@ -74,9 +74,9 @@ import org.schabi.newpipe.extractor.stream.StreamInfoItem
 import org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty
 import org.schabi.newpipe.fragments.BaseStateFragment
 import org.schabi.newpipe.info_list.ItemViewMode
+import org.schabi.newpipe.info_list.StreamSelectionController
 import org.schabi.newpipe.info_list.dialog.InfoItemDialog
 import org.schabi.newpipe.info_list.dialog.StreamDialogEntry
-import org.schabi.newpipe.info_list.StreamSelectionController
 import org.schabi.newpipe.ktx.animate
 import org.schabi.newpipe.ktx.animateHideRecyclerViewAllowingScrolling
 import org.schabi.newpipe.ktx.slideUp
@@ -527,9 +527,11 @@ class FeedFragment : BaseStateFragment<FeedState>(), ContextualSearchable {
         if (context == null || context.resources == null || activity == null) return
 
         InfoItemDialog.Builder(activity, context, this, item)
-            .addEntry(StreamDialogEntry(R.string.stream_select) { _, selected ->
-                streamSelection?.start(selected)
-            }).create().show()
+            .addEntry(
+                StreamDialogEntry(R.string.stream_select) { _, selected ->
+                    streamSelection?.start(selected)
+                }
+            ).create().show()
     }
 
     private val listenerStreamItem = object : OnItemClickListener, OnItemLongClickListener {

--- a/app/src/main/java/org/schabi/newpipe/player/equalizer/AudioDynamicsProcessor.java
+++ b/app/src/main/java/org/schabi/newpipe/player/equalizer/AudioDynamicsProcessor.java
@@ -1,0 +1,116 @@
+package org.schabi.newpipe.player.equalizer;
+
+import androidx.media3.common.C;
+import androidx.media3.common.audio.BaseAudioProcessor;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.function.BooleanSupplier;
+
+/** Adaptive RMS leveling and a stereo-linked compressor for decoded audio. */
+public final class AudioDynamicsProcessor extends BaseAudioProcessor {
+    public static final String NORMALIZATION_KEY = "audio_loudness_normalization";
+    public static final String COMPRESSION_KEY = "audio_dynamic_compression";
+    private static final double TARGET_RMS = 0.126; // approximately -18 dBFS
+    private static final double NOISE_FLOOR = 0.00316; // -50 dBFS
+    private static final double PEAK_CEILING = 0.98;
+
+    private final BooleanSupplier normalize;
+    private final BooleanSupplier compress;
+    private double meanSquare;
+    private double normalizationGain = 1.0;
+    private double compressionGain = 1.0;
+    private double rmsSmoothing;
+    private double gainAttack;
+    private double gainRelease;
+    private double compressorAttack;
+    private double compressorRelease;
+
+    public AudioDynamicsProcessor(final BooleanSupplier normalize,
+                                   final BooleanSupplier compress) {
+        this.normalize = normalize;
+        this.compress = compress;
+    }
+
+    @Override
+    protected AudioFormat onConfigure(final AudioFormat format) {
+        if (format.encoding != C.ENCODING_PCM_16BIT) {
+            return AudioFormat.NOT_SET;
+        }
+        rmsSmoothing = coefficient(format.sampleRate, 0.4);
+        gainAttack = coefficient(format.sampleRate, 0.2);
+        gainRelease = coefficient(format.sampleRate, 3.0);
+        compressorAttack = coefficient(format.sampleRate, 0.005);
+        compressorRelease = coefficient(format.sampleRate, 0.15);
+        return format;
+    }
+
+    private static double coefficient(final int sampleRate, final double seconds) {
+        return Math.exp(-1.0 / (sampleRate * seconds));
+    }
+
+    @Override
+    protected void onFlush() {
+        meanSquare = 0.0;
+        normalizationGain = 1.0;
+        compressionGain = 1.0;
+    }
+
+    @Override
+    public void queueInput(final ByteBuffer input) {
+        if (!input.hasRemaining()) {
+            return;
+        }
+        final boolean normalizationEnabled = normalize.getAsBoolean();
+        final boolean compressionEnabled = compress.getAsBoolean();
+        final ByteBuffer output = replaceOutputBuffer(input.remaining())
+                .order(ByteOrder.LITTLE_ENDIAN);
+        if (!normalizationEnabled && !compressionEnabled) {
+            output.put(input).flip();
+            onFlush();
+            return;
+        }
+        final ByteBuffer samples = input.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        final int channels = inputAudioFormat.channelCount;
+        final int frameBytes = channels * 2;
+        while (samples.remaining() >= frameBytes) {
+            final int start = samples.position();
+            double sumSquares = 0.0;
+            double peak = 0.0;
+            for (int channel = 0; channel < channels; channel++) {
+                final double sample = samples.getShort() / 32768.0;
+                sumSquares += sample * sample;
+                peak = Math.max(peak, Math.abs(sample));
+            }
+            meanSquare = rmsSmoothing * meanSquare
+                    + (1.0 - rmsSmoothing) * sumSquares / channels;
+            final double rms = Math.sqrt(meanSquare);
+            final double targetGain = normalizationEnabled && rms > NOISE_FLOOR
+                    ? Math.max(0.25, Math.min(4.0, TARGET_RMS / rms)) : 1.0;
+            final double smoothing = targetGain < normalizationGain ? gainAttack : gainRelease;
+            normalizationGain = smoothing * normalizationGain
+                    + (1.0 - smoothing) * targetGain;
+            final double levelGain = normalizationEnabled ? normalizationGain : 1.0;
+            final double leveledPeak = peak * levelGain;
+            // A 4:1 ratio above -18 dBFS, shared by all channels to preserve stereo balance.
+            final double targetCompression = compressionEnabled && leveledPeak > TARGET_RMS
+                    ? Math.pow(TARGET_RMS / leveledPeak, 0.75) : 1.0;
+            final double compressionSmoothing = targetCompression < compressionGain
+                    ? compressorAttack : compressorRelease;
+            compressionGain = compressionSmoothing * compressionGain
+                    + (1.0 - compressionSmoothing) * targetCompression;
+            double gain = levelGain * (compressionEnabled ? compressionGain : 1.0);
+            if (peak > 0) {
+                gain = Math.min(gain, PEAK_CEILING / peak);
+            }
+            samples.position(start);
+            for (int channel = 0; channel < channels; channel++) {
+                output.putShort((short) Math.round(samples.getShort() * gain));
+            }
+        }
+        // Media3 supplies complete PCM frames. Preserve unexpected trailing bytes safely.
+        output.put(samples);
+        input.position(input.limit());
+        output.flip();
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/gesture/MainPlayerGestureListener.kt
@@ -64,6 +64,10 @@ class MainPlayerGestureListener(
     private var twoFingerStartTranslationY = 0f
 
     override fun onTouch(v: View, event: MotionEvent): Boolean {
+        if (playerUi.isTouchLocked) {
+            v.parent?.requestDisallowInterceptTouchEvent(true)
+            return true
+        }
         if (handleTwoFingerGesture(v, event)) {
             return true
         }

--- a/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/CustomRenderersFactory.java
@@ -5,6 +5,7 @@ import android.os.Handler;
 import android.os.Looper;
 
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
 
 import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.Renderer;
@@ -17,6 +18,7 @@ import androidx.media3.exoplayer.text.TextRenderer;
 import androidx.media3.exoplayer.video.VideoRendererEventListener;
 
 import org.schabi.newpipe.player.visualizer.VisualizerAudioProcessor;
+import org.schabi.newpipe.player.equalizer.AudioDynamicsProcessor;
 
 import java.util.ArrayList;
 
@@ -33,6 +35,7 @@ import java.util.ArrayList;
 public final class CustomRenderersFactory extends DefaultRenderersFactory {
     private final boolean useCustomVideoRenderer;
     private final VisualizerAudioProcessor visualizerAudioProcessor;
+    private final AudioDynamicsProcessor audioDynamicsProcessor;
 
     public CustomRenderersFactory(final Context context) {
         this(context, true, new VisualizerAudioProcessor());
@@ -51,6 +54,11 @@ public final class CustomRenderersFactory extends DefaultRenderersFactory {
         super(context);
         this.useCustomVideoRenderer = useCustomVideoRenderer;
         this.visualizerAudioProcessor = visualizerAudioProcessor;
+        final android.content.SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        audioDynamicsProcessor = new AudioDynamicsProcessor(
+                () -> preferences.getBoolean(AudioDynamicsProcessor.NORMALIZATION_KEY, false),
+                () -> preferences.getBoolean(AudioDynamicsProcessor.COMPRESSION_KEY, false));
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -102,9 +110,11 @@ public final class CustomRenderersFactory extends DefaultRenderersFactory {
                                        final boolean enableFloatOutput,
                                        final boolean enableAudioOutputPlaybackParams) {
         return new DefaultAudioSink.Builder(context)
-                .setEnableFloatOutput(enableFloatOutput)
+                // Custom processors use the PCM16 path, including live preference changes.
+                .setEnableFloatOutput(false)
                 .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
-                .setAudioProcessors(new AudioProcessor[] {visualizerAudioProcessor})
+                .setAudioProcessors(new AudioProcessor[] {
+                    audioDynamicsProcessor, visualizerAudioProcessor})
                 .build();
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -101,6 +101,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     private static final int DETAIL_TITLE_TEXT_SIZE_TABLET = 15; // sp
 
     private boolean isFullscreen = false;
+    private boolean touchLocked;
     private boolean isVerticalVideo = false;
     private boolean fragmentIsVisible = false;
 
@@ -124,6 +125,8 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     public MainPlayerUi(@NonNull final Player player,
                         @NonNull final PlayerBinding playerBinding) {
         super(player, playerBinding);
+        binding.touchLockButton.setOnClickListener(view -> setTouchLocked(true));
+        binding.touchUnlockButton.setOnClickListener(view -> setTouchLocked(false));
     }
 
     /**
@@ -298,6 +301,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
     @Override
     public void destroy() {
+        setTouchLocked(false);
         super.destroy();
 
         // Exit from fullscreen when user closes the player via notification
@@ -322,6 +326,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
 
     @Override
     public void smoothStopForImmediateReusing() {
+        setTouchLocked(false);
         super.smoothStopForImmediateReusing();
         // Android TV will handle back button in case controls will be visible
         // (one more additional unneeded click while the player is hidden)
@@ -338,6 +343,7 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
     @Override
     protected void setupElementsVisibility() {
         super.setupElementsVisibility();
+        binding.touchLockButton.setVisibility(isFullscreen ? View.VISIBLE : View.GONE);
 
         closeItemsList();
         showHideKodiButton();
@@ -1011,6 +1017,37 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         }
         return super.onKeyDown(keyCode);
     }
+
+    public boolean isTouchLocked() {
+        return touchLocked;
+    }
+
+    private void setTouchLocked(final boolean locked) {
+        touchLocked = locked && isFullscreen;
+        binding.touchLockOverlay.setVisibility(touchLocked ? View.VISIBLE : View.GONE);
+        binding.playbackControlRoot.setImportantForAccessibility(touchLocked
+                ? View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                : View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+        if (touchLocked) {
+            closeItemsList();
+            hideControls(0, 0);
+            binding.touchUnlockButton.requestFocus();
+        }
+    }
+
+    @Override
+    public void showControls(final long duration) {
+        if (!touchLocked) {
+            super.showControls(duration);
+        }
+    }
+
+    @Override
+    public void showControlsThenHide() {
+        if (!touchLocked) {
+            super.showControlsThenHide();
+        }
+    }
     //endregion
 
 
@@ -1072,6 +1109,10 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
         }
 
         isFullscreen = fullscreen;
+        if (!fullscreen) {
+            setTouchLocked(false);
+        }
+        binding.touchLockButton.setVisibility(fullscreen ? View.VISIBLE : View.GONE);
         if (isFullscreen) {
             // Android needs tens milliseconds to send new insets but a user is able to see
             // how controls changes it's position from `0` to `nav bar height` padding.

--- a/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
+++ b/app/src/main/java/org/schabi/newpipe/player/ui/MainPlayerUi.java
@@ -126,7 +126,10 @@ public final class MainPlayerUi extends VideoPlayerUi implements View.OnLayoutCh
                         @NonNull final PlayerBinding playerBinding) {
         super(player, playerBinding);
         binding.touchLockButton.setOnClickListener(view -> setTouchLocked(true));
-        binding.touchUnlockButton.setOnClickListener(view -> setTouchLocked(false));
+        binding.touchUnlockButton.setOnClickListener(view -> {
+            setTouchLocked(false);
+            showControlsThenHide();
+        });
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -32,6 +32,7 @@ import org.schabi.newpipe.settings.export.BackupFileLocator;
 import org.schabi.newpipe.settings.export.ImportExportManager;
 import org.schabi.newpipe.settings.export.NewPipeCompatibleExportManager;
 import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager;
+import org.schabi.newpipe.settings.export.ScheduledBackupWorker;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -79,6 +80,23 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private SubscriptionsImportExportHelper importExportHelper;
     private NewPipeDataMigrationManager migrationManager;
     private NewPipeCompatibleExportManager compatibleExportManager;
+    private final ActivityResultLauncher<Uri> requestBackupDirectory =
+            registerForActivityResult(new ActivityResultContracts.OpenDocumentTree(), uri -> {
+                if (uri == null) {
+                    return;
+                }
+                try {
+                    requireContext().getContentResolver().takePersistableUriPermission(uri,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                    | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                    defaultPreferences.edit()
+                            .putString(ScheduledBackupWorker.DIRECTORY_KEY, uri.toString()).apply();
+                    ScheduledBackupWorker.schedule(requireContext());
+                    updateAutomaticBackupSummary();
+                } catch (final SecurityException error) {
+                    showErrorSnackbar(error, "Selecting automatic backup folder");
+                }
+            });
 
 
     @Override
@@ -97,6 +115,25 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         importExportDataPathKey = getString(R.string.import_export_data_path);
 
         addPreferencesFromResourceRegistry();
+        requirePreference(R.string.automatic_backup_directory_key)
+                .setOnPreferenceClickListener(preference -> {
+                    requestBackupDirectory.launch(null);
+                    return true;
+                });
+        requirePreference(R.string.automatic_backup_interval_key)
+                .setOnPreferenceChangeListener((preference, value) -> {
+                    if (!"off".equals(value) && defaultPreferences.getString(
+                            ScheduledBackupWorker.DIRECTORY_KEY, "").isEmpty()) {
+                        Toast.makeText(requireContext(), R.string.automatic_backup_choose_folder,
+                                Toast.LENGTH_LONG).show();
+                        requestBackupDirectory.launch(null);
+                        return false;
+                    }
+                    defaultPreferences.edit().putString(ScheduledBackupWorker.INTERVAL_KEY,
+                            (String) value).apply();
+                    ScheduledBackupWorker.schedule(requireContext());
+                    return true;
+                });
 
         final Preference importDataPreference = requirePreference(R.string.import_data);
         importDataPreference.setOnPreferenceClickListener((Preference p) -> {
@@ -190,6 +227,27 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
             return true;
         });
 
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateAutomaticBackupSummary();
+    }
+
+    private void updateAutomaticBackupSummary() {
+        final Preference directory = requirePreference(R.string.automatic_backup_directory_key);
+        final String uri = defaultPreferences.getString(ScheduledBackupWorker.DIRECTORY_KEY, "");
+        directory.setSummary(uri.isEmpty() ? getString(R.string.automatic_backup_choose_folder)
+                : Uri.decode(uri));
+        final Preference status = requirePreference(R.string.automatic_backup_status_key);
+        final long timestamp = defaultPreferences.getLong(
+                ScheduledBackupWorker.LAST_SUCCESS_KEY, 0);
+        status.setSummary(defaultPreferences.getBoolean(ScheduledBackupWorker.FAILED_KEY, false)
+                ? getString(R.string.automatic_backup_failed)
+                : timestamp == 0 ? getString(R.string.automatic_backup_waiting)
+                : getString(R.string.automatic_backup_last_success,
+                        java.text.DateFormat.getDateTimeInstance().format(new Date(timestamp))));
     }
 
     private void requestExportPathResult(final ActivityResult result) {

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -80,6 +80,14 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     private SubscriptionsImportExportHelper importExportHelper;
     private NewPipeDataMigrationManager migrationManager;
     private NewPipeCompatibleExportManager compatibleExportManager;
+    private final SharedPreferences.OnSharedPreferenceChangeListener backupStatusListener =
+            (preferences, key) -> {
+                if (isAdded() && getView() != null
+                        && (ScheduledBackupWorker.LAST_SUCCESS_KEY.equals(key)
+                        || ScheduledBackupWorker.FAILED_KEY.equals(key))) {
+                    updateAutomaticBackupSummary();
+                }
+            };
     private final ActivityResultLauncher<Uri> requestBackupDirectory =
             registerForActivityResult(new ActivityResultContracts.OpenDocumentTree(), uri -> {
                 if (uri == null) {
@@ -117,7 +125,8 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         addPreferencesFromResourceRegistry();
         requirePreference(R.string.automatic_backup_directory_key)
                 .setOnPreferenceClickListener(preference -> {
-                    requestBackupDirectory.launch(null);
+                    NoFileManagerSafeGuard.launchSafe(requestBackupDirectory,
+                            null, TAG, requireContext());
                     return true;
                 });
         requirePreference(R.string.automatic_backup_interval_key)
@@ -126,7 +135,8 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                             ScheduledBackupWorker.DIRECTORY_KEY, "").isEmpty()) {
                         Toast.makeText(requireContext(), R.string.automatic_backup_choose_folder,
                                 Toast.LENGTH_LONG).show();
-                        requestBackupDirectory.launch(null);
+                        NoFileManagerSafeGuard.launchSafe(requestBackupDirectory,
+                                null, TAG, requireContext());
                         return false;
                     }
                     defaultPreferences.edit().putString(ScheduledBackupWorker.INTERVAL_KEY,
@@ -232,7 +242,14 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
     @Override
     public void onResume() {
         super.onResume();
+        defaultPreferences.registerOnSharedPreferenceChangeListener(backupStatusListener);
         updateAutomaticBackupSummary();
+    }
+
+    @Override
+    public void onPause() {
+        defaultPreferences.unregisterOnSharedPreferenceChangeListener(backupStatusListener);
+        super.onPause();
     }
 
     private void updateAutomaticBackupSummary() {

--- a/app/src/main/java/org/schabi/newpipe/settings/WizeStreamDefaultPreferences.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/WizeStreamDefaultPreferences.kt
@@ -7,6 +7,7 @@ import com.grack.nanojson.JsonArray
 import com.grack.nanojson.JsonParser
 import java.io.InputStream
 import org.schabi.newpipe.R
+import org.schabi.newpipe.local.bookmark.PlaylistCategories
 
 /**
  * Applies the canonical WizeStream default SharedPreferences snapshot.
@@ -53,6 +54,8 @@ object WizeStreamDefaultPreferences {
         clearFirst: Boolean = false
     ) {
         val jsonObject = JsonParser.`object`().from(input)
+        // Categories describe the library, so resetting playback/UI settings must retain them.
+        val categories = preferences.getString(PlaylistCategories.PREFERENCE_KEY, null)
         val editor = preferences.edit()
         if (clearFirst) {
             editor.clear()
@@ -60,6 +63,9 @@ object WizeStreamDefaultPreferences {
 
         for ((key, value) in jsonObject) {
             putValue(editor, key, value)
+        }
+        if (clearFirst && categories != null) {
+            editor.putString(PlaylistCategories.PREFERENCE_KEY, categories)
         }
         editor.putBoolean(DEFAULTS_APPLIED_KEY, true)
 

--- a/app/src/main/java/org/schabi/newpipe/settings/export/DatabaseSnapshot.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/DatabaseSnapshot.java
@@ -1,0 +1,88 @@
+package org.schabi.newpipe.settings.export;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Copies a transactional view, including WAL content, without closing the live database. */
+public final class DatabaseSnapshot {
+    private DatabaseSnapshot() {
+    }
+
+    public static void create(final SupportSQLiteDatabase source, final File destination) {
+        source.beginTransactionNonExclusive();
+        try (SQLiteDatabase target = SQLiteDatabase.openOrCreateDatabase(destination, null)) {
+            target.beginTransaction();
+            try {
+                final List<String> tables = new ArrayList<>();
+                try (Cursor schema = source.query("SELECT name, sql FROM sqlite_master"
+                        + " WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")) {
+                    while (schema.moveToNext()) {
+                        target.execSQL(schema.getString(1));
+                        tables.add(schema.getString(0));
+                    }
+                }
+                for (final String table : tables) {
+                    copyTable(source, target, table);
+                }
+                // AUTOINCREMENT sequences can exceed the largest surviving row ID.
+                try (Cursor sequence = source.query("SELECT name FROM sqlite_master"
+                        + " WHERE name = 'sqlite_sequence'")) {
+                    if (sequence.moveToFirst()) {
+                        target.execSQL("DELETE FROM sqlite_sequence");
+                        copyTable(source, target, "sqlite_sequence");
+                    }
+                }
+                try (Cursor schema = source.query("SELECT sql FROM sqlite_master"
+                        + " WHERE type IN ('index', 'trigger', 'view') AND sql IS NOT NULL")) {
+                    while (schema.moveToNext()) {
+                        target.execSQL(schema.getString(0));
+                    }
+                }
+                target.setVersion(source.getVersion());
+                target.setTransactionSuccessful();
+            } finally {
+                target.endTransaction();
+            }
+        } finally {
+            source.endTransaction();
+        }
+    }
+
+    private static void copyTable(final SupportSQLiteDatabase source,
+                                  final SQLiteDatabase target, final String table) {
+        final String quoted = "\"" + table.replace("\"", "\"\"") + "\"";
+        try (Cursor rows = source.query("SELECT * FROM " + quoted)) {
+            final String placeholders = String.join(",",
+                    java.util.Collections.nCopies(rows.getColumnCount(), "?"));
+            final String insert = "INSERT INTO " + quoted + " VALUES (" + placeholders + ")";
+            while (rows.moveToNext()) {
+                final Object[] values = new Object[rows.getColumnCount()];
+                for (int column = 0; column < values.length; column++) {
+                    switch (rows.getType(column)) {
+                        case Cursor.FIELD_TYPE_INTEGER:
+                            values[column] = rows.getLong(column);
+                            break;
+                        case Cursor.FIELD_TYPE_FLOAT:
+                            values[column] = rows.getDouble(column);
+                            break;
+                        case Cursor.FIELD_TYPE_BLOB:
+                            values[column] = rows.getBlob(column);
+                            break;
+                        case Cursor.FIELD_TYPE_STRING:
+                            values[column] = rows.getString(column);
+                            break;
+                        default:
+                            values[column] = null;
+                    }
+                }
+                target.execSQL(insert, values);
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/export/DatabaseSnapshot.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/DatabaseSnapshot.java
@@ -21,7 +21,8 @@ public final class DatabaseSnapshot {
             try {
                 final List<String> tables = new ArrayList<>();
                 try (Cursor schema = source.query("SELECT name, sql FROM sqlite_master"
-                        + " WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")) {
+                        + " WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+                        + " AND name != 'android_metadata'")) {
                     while (schema.moveToNext()) {
                         target.execSQL(schema.getString(1));
                         tables.add(schema.getString(0));

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ImportExportManager.kt
@@ -70,13 +70,18 @@ class ImportExportManager(private val fileLocator: BackupFileLocator) {
      * It also creates the file.
      */
     @Throws(Exception::class)
-    fun exportDatabase(preferences: SharedPreferences, file: StoredFileHelper) {
+    @JvmOverloads
+    fun exportDatabase(
+        preferences: SharedPreferences,
+        file: StoredFileHelper,
+        database: Path = fileLocator.db
+    ) {
         // truncate the file before writing to it, otherwise if the new content is smaller than the
         // previous file size, the file will retain part of the previous content and be corrupted
         ZipOutputStream(SharpOutputStream(file.openAndTruncateStream()).buffered()).use { outZip ->
             // add the database
             val name = BackupFileLocator.FILE_NAME_DB
-            ZipHelper.addFileToZip(outZip, name, fileLocator.db)
+            ZipHelper.addFileToZip(outZip, name, database)
 
             // add the JSON preferences; legacy serialized preferences are still supported when
             // importing old backups, but new backups avoid writing that vulnerable format.

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ScheduledBackupWorker.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ScheduledBackupWorker.java
@@ -1,0 +1,139 @@
+package org.schabi.newpipe.settings.export;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.documentfile.provider.DocumentFile;
+import androidx.preference.PreferenceManager;
+import androidx.work.Constraints;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import org.schabi.newpipe.NewPipeDatabase;
+import org.schabi.newpipe.streams.io.StoredFileHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public final class ScheduledBackupWorker extends Worker {
+    public static final String INTERVAL_KEY = "automatic_backup_interval";
+    public static final String DIRECTORY_KEY = "automatic_backup_directory";
+    public static final String LAST_SUCCESS_KEY = "automatic_backup_last_success";
+    public static final String FAILED_KEY = "automatic_backup_failed";
+    private static final String WORK_NAME = "automatic-backup";
+    private static final int RETAINED_BACKUPS = 7;
+
+    public ScheduledBackupWorker(@NonNull final Context context,
+                                 @NonNull final WorkerParameters parameters) {
+        super(context, parameters);
+    }
+
+    public static int intervalDays(final String value) {
+        return "daily".equals(value) ? 1 : "weekly".equals(value) ? 7 : 0;
+    }
+
+    public static boolean isManagedBackup(final String name) {
+        return name != null && name.matches("WizeStreamAuto-\\d{8}_\\d{9}\\.zip");
+    }
+
+    public static void schedule(final Context context) {
+        final SharedPreferences preferences = PreferenceManager
+                .getDefaultSharedPreferences(context);
+        final int days = intervalDays(preferences.getString(INTERVAL_KEY, "off"));
+        final WorkManager workManager = WorkManager.getInstance(context);
+        if (days == 0 || preferences.getString(DIRECTORY_KEY, "").isEmpty()) {
+            workManager.cancelUniqueWork(WORK_NAME);
+            return;
+        }
+        final PeriodicWorkRequest request =
+                new PeriodicWorkRequest.Builder(ScheduledBackupWorker.class, days, TimeUnit.DAYS)
+                        .setConstraints(new Constraints.Builder()
+                                .setRequiresBatteryNotLow(true)
+                                .setRequiresStorageNotLow(true).build())
+                        .build();
+        workManager.enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE,
+                request);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        final Context context = getApplicationContext();
+        final SharedPreferences preferences = PreferenceManager
+                .getDefaultSharedPreferences(context);
+        if (intervalDays(preferences.getString(INTERVAL_KEY, "off")) == 0) {
+            return Result.success();
+        }
+        File snapshot = null;
+        DocumentFile output = null;
+        try {
+            final Uri uri = Uri.parse(preferences.getString(DIRECTORY_KEY, ""));
+            final DocumentFile directory = DocumentFile.fromTreeUri(context, uri);
+            if (directory == null || !directory.canWrite()) {
+                throw new IOException("The backup folder is no longer writable");
+            }
+            snapshot = File.createTempFile("automatic-backup-", ".db", context.getCacheDir());
+            DatabaseSnapshot.create(NewPipeDatabase.getInstance(context)
+                    .getOpenHelper().getWritableDatabase(), snapshot);
+            if (isStopped()) {
+                return Result.success();
+            }
+            final String name = "WizeStreamAuto-"
+                    + new SimpleDateFormat("yyyyMMdd_HHmmssSSS", Locale.US).format(new Date())
+                    + ".zip";
+            output = directory.createFile("application/zip", name);
+            if (output == null) {
+                throw new IOException("Could not create the backup file");
+            }
+            new ImportExportManager(new BackupFileLocator(context)).exportDatabase(preferences,
+                    new StoredFileHelper(context, output.getUri(), "application/zip"),
+                    snapshot.toPath());
+            // Keep the new backup even if an unavailable provider prevents retention cleanup.
+            output = null;
+            preferences.edit().putLong(LAST_SUCCESS_KEY, System.currentTimeMillis())
+                    .putBoolean(FAILED_KEY, false).apply();
+            pruneBackups(directory);
+            return Result.success();
+        } catch (final Exception error) {
+            preferences.edit().putBoolean(FAILED_KEY, true).apply();
+            return getRunAttemptCount() < 2 ? Result.retry() : Result.failure();
+        } finally {
+            if (output != null) {
+                try {
+                    output.delete();
+                } catch (final RuntimeException ignored) {
+                    // A revoked provider permission must not escape the worker's failure result.
+                }
+            }
+            if (snapshot != null) {
+                android.database.sqlite.SQLiteDatabase.deleteDatabase(snapshot);
+            }
+        }
+    }
+
+    private static void pruneBackups(final DocumentFile directory) {
+        try {
+            final DocumentFile[] backups = Arrays.stream(directory.listFiles())
+                    .filter(file -> file.isFile() && isManagedBackup(file.getName()))
+                    .sorted(Comparator.comparing(DocumentFile::getName).reversed())
+                    .toArray(DocumentFile[]::new);
+            for (int i = RETAINED_BACKUPS; i < backups.length; i++) {
+                backups[i].delete();
+            }
+        } catch (final RuntimeException ignored) {
+            // A successful backup must not be retried just because cleanup failed.
+        }
+    }
+
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/export/ScheduledBackupWorker.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/ScheduledBackupWorker.java
@@ -122,7 +122,7 @@ public final class ScheduledBackupWorker extends Worker {
         }
     }
 
-    private static void pruneBackups(final DocumentFile directory) {
+    static void pruneBackups(final DocumentFile directory) {
         try {
             final DocumentFile[] backups = Arrays.stream(directory.listFiles())
                     .filter(file -> file.isFile() && isManagedBackup(file.getName()))

--- a/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ExtractorHelper.java
@@ -46,6 +46,7 @@ import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
 import org.schabi.newpipe.extractor.channel.ChannelTabInfo;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
+import org.schabi.newpipe.extractor.comments.CommentSortOrder;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.kiosk.KioskInfo;
@@ -390,10 +391,19 @@ public final class ExtractorHelper {
     public static Single<CommentsInfo> getCommentsInfo(final int serviceId,
                                                        final String url,
                                                        final boolean forceLoad) {
+        return getCommentsInfo(serviceId, url, forceLoad, CommentSortOrder.TOP);
+    }
+
+    public static Single<CommentsInfo> getCommentsInfo(final int serviceId,
+                                                       final String url,
+                                                       final boolean forceLoad,
+                                                       final CommentSortOrder sortOrder) {
         checkServiceId(serviceId);
-        return checkCache(forceLoad, serviceId, url, InfoCache.Type.COMMENTS,
+        final String cacheKey = sortOrder == CommentSortOrder.TOP ? url
+                : url + "#comments-sort=" + sortOrder.name();
+        return checkCache(forceLoad, serviceId, cacheKey, InfoCache.Type.COMMENTS,
                 Single.fromCallable(() ->
-                        CommentsInfo.getInfo(NewPipe.getService(serviceId), url)));
+                        CommentsInfo.getInfo(NewPipe.getService(serviceId), url, sortOrder)));
     }
 
     public static Single<InfoItemsPage<CommentsInfoItem>> getMoreCommentItems(

--- a/app/src/main/java/org/schabi/newpipe/views/TouchLockOverlay.java
+++ b/app/src/main/java/org/schabi/newpipe/views/TouchLockOverlay.java
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/** Shields playback gestures while allowing the child unlock button to receive clicks. */
+public final class TouchLockOverlay extends FrameLayout {
+    public TouchLockOverlay(@NonNull final Context context, @Nullable final AttributeSet attrs) {
+        super(context, attrs);
+        setClickable(true);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(final MotionEvent event) {
+        if (getParent() != null) {
+            getParent().requestDisallowInterceptTouchEvent(true);
+        }
+        super.dispatchTouchEvent(event);
+        return true;
+    }
+}

--- a/app/src/main/res/drawable/ic_touch_lock.xml
+++ b/app/src/main/res/drawable/ic_touch_lock.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M18,8h-1V6a5,5 0,0 0,-10 0v2H6a2,2 0,0 0,-2 2v10a2,2 0,0 0,2 2h12a2,2 0,0 0,2 -2V10a2,2 0,0 0,-2 -2zM9,6a3,3 0,0 1,6 0v2H9zM13,16.7V19h-2v-2.3a2,2 0,1 1,2 0z" />
+</vector>

--- a/app/src/main/res/layout/fragment_bookmarks.xml
+++ b/app/src/main/res/layout/fragment_bookmarks.xml
@@ -5,8 +5,30 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <LinearLayout
+        android:id="@+id/playlist_category_controls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="16dp">
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/playlist_category_filter"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/playlist_categories_all" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/playlist_category_manage"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/playlist_categories" />
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/items_list"
+        android:layout_below="@id/playlist_category_controls"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"

--- a/app/src/main/res/layout/fragment_comments.xml
+++ b/app/src/main/res/layout/fragment_comments.xml
@@ -1,11 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/comment_sort"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        app:singleSelection="true"
+        app:selectionRequired="true">
+        <com.google.android.material.chip.Chip
+            android:id="@+id/comments_top"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/comments_sort_top" />
+        <com.google.android.material.chip.Chip
+            android:id="@+id/comments_newest"
+            style="@style/Widget.Material3.Chip.Filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/comments_sort_newest" />
+    </com.google.android.material.chip.ChipGroup>
+
     <org.schabi.newpipe.views.NewPipeRecyclerView
         android:id="@+id/items_list"
+        android:layout_below="@id/comment_sort"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -437,6 +437,17 @@
                             app:tint="@color/white" />
 
                         <androidx.appcompat.widget.AppCompatImageButton
+                            android:id="@+id/touchLockButton"
+                            android:layout_width="48dp"
+                            android:layout_height="48dp"
+                            android:background="?attr/selectableItemBackgroundBorderless"
+                            android:contentDescription="@string/player_touch_lock"
+                            android:padding="@dimen/player_main_icon_buttons_padding"
+                            android:src="@drawable/ic_touch_lock"
+                            android:visibility="gone"
+                            app:tint="@color/white" />
+
+                        <androidx.appcompat.widget.AppCompatImageButton
                             android:id="@+id/listenModeButton"
                             android:layout_width="48dp"
                             android:layout_height="48dp"
@@ -991,4 +1002,19 @@
         android:alpha="0"
         android:visibility="invisible" /> <!-- Required for the first appearance fading correctly -->
 
+    <org.schabi.newpipe.views.TouchLockOverlay
+        android:id="@+id/touchLockOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/touchUnlockButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical|end"
+            android:layout_margin="32dp"
+            android:minHeight="48dp"
+            android:text="@string/player_touch_unlock"
+            app:icon="@drawable/ic_touch_lock" />
+    </org.schabi.newpipe.views.TouchLockOverlay>
 </RelativeLayout>

--- a/app/src/main/res/values/mobile_features.xml
+++ b/app/src/main/res/values/mobile_features.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="automatic_backup_directory_key" translatable="false">automatic_backup_directory</string>
+    <string name="automatic_backup_interval_key" translatable="false">automatic_backup_interval</string>
+    <string name="automatic_backup_status_key" translatable="false">automatic_backup_status</string>
+    <string name="automatic_backup_title">Automatic backups</string>
+    <string name="automatic_backup_folder">Backup folder</string>
+    <string name="automatic_backup_choose_folder">Choose a folder before enabling automatic backups</string>
+    <string name="automatic_backup_frequency">Backup frequency</string>
+    <string name="automatic_backup_retention">Keep the latest 7 automatic backups</string>
+    <string name="automatic_backup_waiting">No automatic backup yet. Android schedules backups when battery and storage allow.</string>
+    <string name="automatic_backup_failed">The last backup failed. Check the folder permission and available space.</string>
+    <string name="automatic_backup_last_success">Last successful backup: %1$s</string>
+    <string-array name="automatic_backup_intervals">
+        <item>Off</item>
+        <item>Daily</item>
+        <item>Weekly</item>
+    </string-array>
+    <string-array name="automatic_backup_interval_values" translatable="false">
+        <item>off</item>
+        <item>daily</item>
+        <item>weekly</item>
+    </string-array>
+    <string name="player_touch_lock">Lock touch controls</string>
+    <string name="player_touch_unlock">Unlock</string>
+    <string name="audio_loudness_normalization">Loudness normalization</string>
+    <string name="audio_loudness_normalization_summary">Gradually level quiet and loud audio during playback</string>
+    <string name="audio_dynamic_compression">Dynamic range compression</string>
+    <string name="audio_dynamic_compression_summary">Reduce loud peaks for more comfortable listening</string>
+    <string name="comments_sort_top">Top</string>
+    <string name="comments_sort_newest">Newest</string>
+    <string name="stream_select">Select</string>
+    <string name="stream_select_all_loaded">Select all loaded videos</string>
+    <string name="stream_selection_count">%1$d selected</string>
+    <item name="selection_all" type="id" />
+    <item name="selection_enqueue" type="id" />
+    <item name="selection_playlist" type="id" />
+    <item name="selection_download" type="id" />
+    <string name="playlist_categories">Categories</string>
+    <string name="playlist_categories_all">All playlists</string>
+    <string name="playlist_uncategorized">Uncategorized</string>
+    <string name="playlist_move_to_category">Move to category</string>
+    <string name="playlist_category_create">New category</string>
+    <string name="playlist_category_name_error">Choose a unique name of 1 to 80 characters</string>
+    <string name="playlist_category_delete_message">Delete this category? Its playlists will move to Uncategorized.</string>
+</resources>

--- a/app/src/main/res/xml/backup_restore_settings.xml
+++ b/app/src/main/res/xml/backup_restore_settings.xml
@@ -37,6 +37,28 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <PreferenceCategory
+        android:title="@string/automatic_backup_title"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:key="@string/automatic_backup_directory_key"
+            android:title="@string/automatic_backup_folder"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="@string/automatic_backup_interval_key"
+            android:title="@string/automatic_backup_frequency"
+            android:defaultValue="off"
+            android:entries="@array/automatic_backup_intervals"
+            android:entryValues="@array/automatic_backup_interval_values"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="@string/automatic_backup_status_key"
+            android:title="@string/automatic_backup_retention"
+            app:selectable="false"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
     <Preference
         android:key="@string/reset_settings"
         android:title="@string/reset_settings_title"

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -91,21 +91,21 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false">
 
-    <SwitchPreferenceCompat
-        android:key="audio_loudness_normalization"
-        android:title="@string/audio_loudness_normalization"
-        android:summary="@string/audio_loudness_normalization_summary"
-        android:defaultValue="false"
-        app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:key="audio_loudness_normalization"
+            android:title="@string/audio_loudness_normalization"
+            android:summary="@string/audio_loudness_normalization_summary"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false" />
 
-    <SwitchPreferenceCompat
-        android:key="audio_dynamic_compression"
-        android:title="@string/audio_dynamic_compression"
-        android:summary="@string/audio_dynamic_compression_summary"
-        android:defaultValue="false"
-        app:iconSpaceReserved="false" />
+        <SwitchPreferenceCompat
+            android:key="audio_dynamic_compression"
+            android:title="@string/audio_dynamic_compression"
+            android:summary="@string/audio_dynamic_compression_summary"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false" />
 
-    <Preference
+        <Preference
             android:key="@string/equalizer_settings_key"
             android:summary="@string/equalizer_settings_summary_disabled"
             android:title="@string/equalizer"

--- a/app/src/main/res/xml/video_audio_settings.xml
+++ b/app/src/main/res/xml/video_audio_settings.xml
@@ -91,7 +91,21 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false">
 
-        <Preference
+    <SwitchPreferenceCompat
+        android:key="audio_loudness_normalization"
+        android:title="@string/audio_loudness_normalization"
+        android:summary="@string/audio_loudness_normalization_summary"
+        android:defaultValue="false"
+        app:iconSpaceReserved="false" />
+
+    <SwitchPreferenceCompat
+        android:key="audio_dynamic_compression"
+        android:title="@string/audio_dynamic_compression"
+        android:summary="@string/audio_dynamic_compression_summary"
+        android:defaultValue="false"
+        app:iconSpaceReserved="false" />
+
+    <Preference
             android:key="@string/equalizer_settings_key"
             android:summary="@string/equalizer_settings_summary_disabled"
             android:title="@string/equalizer"

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSortTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSortTest.java
@@ -1,0 +1,38 @@
+package org.schabi.newpipe.extractor.services.youtube.extractors;
+
+import com.grack.nanojson.JsonObject;
+import com.grack.nanojson.JsonParser;
+
+import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.comments.CommentSortOrder;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class YoutubeCommentSortTest {
+    @Test
+    void choosesTheRequestedServerContinuationRegardlessOfTranslatedTitle() throws Exception {
+        final JsonObject response = JsonParser.object().from("""
+                {"onResponseReceivedEndpoints":[{}, {"reloadContinuationItemsCommand":{
+                  "continuationItems":[{}, {"commentsHeaderRenderer":{"sortMenu":{
+                    "sortFilterSubMenuRenderer":{"subMenuItems":[
+                      {"title":"Principales","serviceEndpoint":{
+                        "continuationCommand":{"token":"top-token"}}},
+                      {"title":"Recientes","serviceEndpoint":{
+                        "continuationCommand":{"token":"newest-token"}}}
+                    ]}
+                  }}}]
+                }}]}
+                """);
+        assertEquals("top-token", YoutubeCommentSort.continuation(response, CommentSortOrder.TOP));
+        assertEquals("newest-token",
+                YoutubeCommentSort.continuation(response, CommentSortOrder.NEWEST));
+    }
+
+    @Test
+    void unavailableSortDoesNotSilentlyReturnTheDefaultOrder() {
+        assertThrows(ParsingException.class,
+                () -> YoutubeCommentSort.continuation(new JsonObject(), CommentSortOrder.NEWEST));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/info_list/StreamSelectionTest.java
+++ b/app/src/test/java/org/schabi/newpipe/info_list/StreamSelectionTest.java
@@ -1,0 +1,41 @@
+package org.schabi.newpipe.info_list;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.schabi.newpipe.extractor.stream.StreamInfoItem;
+import org.schabi.newpipe.extractor.stream.StreamType;
+
+import java.util.List;
+
+public class StreamSelectionTest {
+    private static StreamInfoItem item(final int service, final String url) {
+        return new StreamInfoItem(service, url, "Title", StreamType.VIDEO_STREAM);
+    }
+
+    @Test
+    public void selectionUsesServiceAndUrlInsteadOfObjectIdentity() {
+        final StreamSelection selection = new StreamSelection();
+        selection.toggle(item(0, "url"));
+        assertTrue(selection.contains(item(0, "url")));
+        assertFalse(selection.contains(item(1, "url")));
+        selection.toggle(item(0, "url"));
+        assertFalse(selection.contains(item(0, "url")));
+    }
+
+    @Test
+    public void actionsUseDisplayOrderAndIgnoreRemovedOrDuplicateRows() {
+        final StreamInfoItem first = item(0, "first");
+        final StreamInfoItem second = item(0, "second");
+        final StreamSelection selection = new StreamSelection();
+        selection.toggle(second);
+        selection.toggle(first);
+        selection.toggle(item(0, "removed"));
+        assertEquals(List.of(first, second),
+                selection.itemsInDisplayOrder(List.of(first, second, item(0, "first"))));
+        selection.clear();
+        assertTrue(selection.itemsInDisplayOrder(List.of(first, second)).isEmpty());
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/bookmark/PlaylistCategoriesTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/bookmark/PlaylistCategoriesTest.java
@@ -1,0 +1,55 @@
+package org.schabi.newpipe.local.bookmark;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PlaylistCategoriesTest {
+    @Test
+    public void roundTripPreservesLocalAndRemoteMemberships() throws Exception {
+        final PlaylistCategories categories = new PlaylistCategories();
+        final String music = categories.create(" Music ");
+        categories.assign("local:42", music);
+        categories.assign("remote:0:https://example.com/list", music);
+        final PlaylistCategories restored = PlaylistCategories.fromJson(categories.toJson());
+        assertEquals("Music", restored.name(music));
+        assertTrue(restored.matches("local:42", music));
+        assertTrue(restored.matches("remote:0:https://example.com/list", music));
+        assertFalse(restored.matches("local:42", PlaylistCategories.UNCATEGORIZED));
+        assertTrue(restored.matches("local:43", PlaylistCategories.UNCATEGORIZED));
+    }
+
+    @Test
+    public void movingAndRenamingKeepMembershipUnambiguous() {
+        final PlaylistCategories categories = new PlaylistCategories();
+        final String first = categories.create("First");
+        final String second = categories.create("Second");
+        categories.assign("local:1", first);
+        categories.assign("local:1", second);
+        categories.rename(second, "Renamed");
+        assertFalse(categories.matches("local:1", first));
+        assertTrue(categories.matches("local:1", second));
+        assertTrue(categories.matches("local:1", PlaylistCategories.ALL));
+    }
+
+    @Test
+    public void deletingCategoryReturnsMembersToUncategorized() {
+        final PlaylistCategories categories = new PlaylistCategories();
+        final String category = categories.create("Temporary");
+        categories.assign("local:1", category);
+        categories.delete(category);
+        assertTrue(categories.ids().isEmpty());
+        assertTrue(categories.matches("local:1", PlaylistCategories.UNCATEGORIZED));
+    }
+
+    @Test
+    public void namesMustBeUniqueAndNonempty() {
+        final PlaylistCategories categories = new PlaylistCategories();
+        categories.create("Music");
+        assertThrows(IllegalArgumentException.class, () -> categories.create(" music "));
+        assertThrows(IllegalArgumentException.class, () -> categories.create("  "));
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/local/search/ContextualSearchIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.schabi.newpipe.local.bookmark.PlaylistCategories;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,14 +49,12 @@ public class ContextualSearchIntegrationTest {
     }
 
     @Test
-    public void bookmarkFilteringProtectsCanonicalOrdering() throws Exception {
-        final String source = read(
-                "org/schabi/newpipe/local/bookmark/BookmarkFragment.java");
-
-        assertTrue(source.contains("captureCanonicalOrderFromAdapter();"));
-        assertTrue(source.contains(
-                "itemListAdapter.setUseItemHandle(!isContextualSearchActive())"));
-        assertTrue(source.contains("itemListAdapter == null || isContextualSearchActive()"));
+    public void bookmarkFilteringProtectsCanonicalOrdering() {
+        assertTrue(PlaylistCategories.allowsReordering(false, PlaylistCategories.ALL));
+        assertFalse(PlaylistCategories.allowsReordering(true, PlaylistCategories.ALL));
+        assertFalse(PlaylistCategories.allowsReordering(false, "a-category"));
+        assertFalse(PlaylistCategories.allowsReordering(true, "a-category"));
+        assertFalse(PlaylistCategories.allowsReordering(false, PlaylistCategories.UNCATEGORIZED));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/player/equalizer/AudioDynamicsProcessorTest.java
+++ b/app/src/test/java/org/schabi/newpipe/player/equalizer/AudioDynamicsProcessorTest.java
@@ -1,0 +1,88 @@
+package org.schabi.newpipe.player.equalizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import androidx.media3.common.C;
+import androidx.media3.common.audio.AudioProcessor;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class AudioDynamicsProcessorTest {
+    private static AudioDynamicsProcessor processor(final boolean normalization,
+                                                     final boolean compression) throws Exception {
+        final AudioDynamicsProcessor processor =
+                new AudioDynamicsProcessor(() -> normalization, () -> compression);
+        processor.configure(new AudioProcessor.AudioFormat(48000, 2, C.ENCODING_PCM_16BIT));
+        processor.flush();
+        return processor;
+    }
+
+    private static ByteBuffer render(final AudioDynamicsProcessor processor,
+                                      final short left, final short right, final int seconds) {
+        final ByteBuffer input = ByteBuffer.allocateDirect(48000 * seconds * 4)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        while (input.hasRemaining()) {
+            input.putShort(left).putShort(right);
+        }
+        input.flip();
+        processor.queueInput(input);
+        assertEquals(0, input.remaining());
+        return processor.getOutput().order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    @Test
+    public void disabledProcessingIsBitExact() throws Exception {
+        final ByteBuffer output = render(processor(false, false), Short.MIN_VALUE,
+                Short.MAX_VALUE, 1);
+        while (output.hasRemaining()) {
+            assertEquals(Short.MIN_VALUE, output.getShort());
+            assertEquals(Short.MAX_VALUE, output.getShort());
+        }
+    }
+
+    @Test
+    public void silenceStaysSilentAndEmptyBuffersAreAccepted() throws Exception {
+        final AudioDynamicsProcessor processor = processor(true, true);
+        processor.queueInput(AudioProcessor.EMPTY_BUFFER);
+        assertEquals(0, processor.getOutput().remaining());
+        final ByteBuffer output = render(processor, (short) 0, (short) 0, 1);
+        while (output.hasRemaining()) {
+            assertEquals(0, output.getShort());
+        }
+    }
+
+    @Test
+    public void normalizationRaisesQuietAndReducesLoudAudio() throws Exception {
+        final ByteBuffer quiet = render(processor(true, false), (short) 1500, (short) 1500, 10);
+        final ByteBuffer loud = render(processor(true, false), (short) 16000, (short) 16000, 10);
+        assertTrue(quiet.getShort(quiet.limit() - 2) > 3500);
+        assertTrue(loud.getShort(loud.limit() - 2) < 5000);
+    }
+
+    @Test
+    public void compressionPreservesChannelBalance() throws Exception {
+        final ByteBuffer output = render(processor(false, true), (short) 24000,
+                (short) -12000, 2);
+        final short left = output.getShort(output.limit() - 4);
+        final short right = output.getShort(output.limit() - 2);
+        assertTrue(left > 0 && left < 10000);
+        assertEquals(left, -2 * right, 2.0);
+    }
+
+    @Test
+    public void abruptPeaksCannotOverflowAfterQuietAudio() throws Exception {
+        final AudioDynamicsProcessor processor = processor(true, false);
+        render(processor, (short) 1000, (short) 1000, 10);
+        final ByteBuffer output = render(processor, Short.MAX_VALUE, Short.MIN_VALUE, 1);
+        while (output.hasRemaining()) {
+            final short left = output.getShort();
+            final short right = output.getShort();
+            assertTrue(left > 0 && left <= 32113);
+            assertTrue(right < 0 && right >= -32113);
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/settings/WizeStreamDefaultPreferencesTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/WizeStreamDefaultPreferencesTest.kt
@@ -83,6 +83,20 @@ class WizeStreamDefaultPreferencesTest {
     }
 
     @Test
+    fun `resetting settings retains playlist organization`() {
+        val key = org.schabi.newpipe.local.bookmark.PlaylistCategories.PREFERENCE_KEY
+        val categories = "{\"categories\":[],\"memberships\":{}}"
+        `when`(preferences.getString(key, null)).thenReturn(categories)
+        WizeStreamDefaultPreferences.applyDefaults(
+            "{}".byteInputStream(),
+            preferences,
+            clearFirst = true
+        )
+        verify(editor).clear()
+        verify(editor).putString(key, categories)
+    }
+
+    @Test
     fun `bundled WizeStream defaults include accepted baseline values`() {
         val defaultsPath = listOf(
             Path.of("src/main/res/raw/wizestream_default_preferences.json"),

--- a/app/src/test/java/org/schabi/newpipe/settings/export/ScheduledBackupPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/settings/export/ScheduledBackupPolicyTest.java
@@ -3,6 +3,12 @@ package org.schabi.newpipe.settings.export;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.documentfile.provider.DocumentFile;
 
 import org.junit.Test;
 
@@ -22,5 +28,29 @@ public class ScheduledBackupPolicyTest {
         assertFalse(ScheduledBackupWorker.isManagedBackup("WizeStreamData-20260912_120030.zip"));
         assertFalse(ScheduledBackupWorker.isManagedBackup("WizeStreamAuto-important.zip"));
         assertFalse(ScheduledBackupWorker.isManagedBackup(null));
+    }
+
+    @Test
+    public void retentionDeletesOnlyOlderManagedBackups() {
+        final DocumentFile directory = mock(DocumentFile.class);
+        final DocumentFile[] files = new DocumentFile[10];
+        for (int index = 0; index < 9; index++) {
+            files[index] = mock(DocumentFile.class);
+            when(files[index].isFile()).thenReturn(true);
+            when(files[index].getName())
+                    .thenReturn("WizeStreamAuto-20260912_12000000" + index + ".zip");
+        }
+        files[9] = mock(DocumentFile.class);
+        when(files[9].isFile()).thenReturn(true);
+        when(files[9].getName()).thenReturn("WizeStreamData-manual-backup.zip");
+        when(directory.listFiles()).thenReturn(files);
+
+        ScheduledBackupWorker.pruneBackups(directory);
+
+        verify(files[0]).delete();
+        verify(files[1]).delete();
+        for (int index = 2; index < files.length; index++) {
+            verify(files[index], never()).delete();
+        }
     }
 }

--- a/app/src/test/java/org/schabi/newpipe/settings/export/ScheduledBackupPolicyTest.java
+++ b/app/src/test/java/org/schabi/newpipe/settings/export/ScheduledBackupPolicyTest.java
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.settings.export;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ScheduledBackupPolicyTest {
+    @Test
+    public void unsupportedIntervalsDisableScheduling() {
+        assertEquals(0, ScheduledBackupWorker.intervalDays(null));
+        assertEquals(0, ScheduledBackupWorker.intervalDays("off"));
+        assertEquals(0, ScheduledBackupWorker.intervalDays("unknown"));
+        assertEquals(1, ScheduledBackupWorker.intervalDays("daily"));
+        assertEquals(7, ScheduledBackupWorker.intervalDays("weekly"));
+    }
+
+    @Test
+    public void retentionRecognizesOnlyAutomaticBackupFiles() {
+        assertTrue(ScheduledBackupWorker.isManagedBackup("WizeStreamAuto-20260912_120030123.zip"));
+        assertFalse(ScheduledBackupWorker.isManagedBackup("WizeStreamData-20260912_120030.zip"));
+        assertFalse(ScheduledBackupWorker.isManagedBackup("WizeStreamAuto-important.zip"));
+        assertFalse(ScheduledBackupWorker.isManagedBackup(null));
+    }
+}


### PR DESCRIPTION
- Implement features: automatic backups, fullscreen touch lock, content multi-select, playlist categories, audio normalization/compression, and comment sorting.
- Schedule daily or weekly full backups to a user-selected folder, snapshot the live database transactionally, display backup status, and retain seven automatic backups while protecting manual exports.
- Add a fullscreen touch shield with an explicit Unlock control; exiting fullscreen clears the lock.
- Add Select to search, channel, and feed context menus, with bulk enqueue, add-to-playlist, and download actions in display order.
- Organize local and bookmarked online playlists into categories with create, rename, move, and delete actions. Categories are local to the device, included in full backups, and preserved when resetting settings. Filtering cannot rewrite hidden playlist ordering.
- Add optional adaptive loudness normalization and stereo-linked dynamic range compression to built-in decoded-audio playback. Both default to off.
- Add YouTube Top/Newest comment ordering using server continuations, independent caches, and pagination; unsupported services retain their existing behavior.
- Add behavioral tests for snapshot integrity, retention, touch shielding, selection identity/order, category persistence, audio processing, and comment continuations. Replace the affected source-text ordering assertion with behavioral policy coverage.
- Document feature locations and behavior in README.md.
- Validation passed on commit 7812d5ec3de36bf3343518938fce20cf47594dcc: debug APK assembly, Android lint, Checkstyle, ktlint, JVM tests, and the source-inspection-test gate. Local whitespace and XML parsing checks also passed.
- Android instrumentation passed: 106 tests on API 23 and 108 tests on API 35. [Successful CI run](https://github.com/wizdom13/WizeStream/actions/runs/34712767390).
- [Download the debug APK artifact](https://github.com/wizdom13/WizeStream/actions/runs/34712767390/artifacts/10303469601).
- Manual device QA remains for touch lock across rotations and themes, selection accessibility, storage providers, and listening quality. The local environment could not download the Android toolchain, so build and device validation ran in repository CI.