### PR TITLE
Keep bookmark layouts consistent with display settings and theme

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/local/LocalItemListAdapterTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/LocalItemListAdapterTest.kt
@@ -1,20 +1,32 @@
 package org.schabi.newpipe.local
 
+import android.view.ContextThemeWrapper
+import android.view.MotionEvent
 import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.schabi.newpipe.R
 import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.LocalItem
+import org.schabi.newpipe.database.playlist.PlaylistMetadataEntry
 import org.schabi.newpipe.database.playlist.PlaylistStreamEntry
+import org.schabi.newpipe.database.playlist.model.PlaylistRemoteEntity
 import org.schabi.newpipe.database.stream.model.StreamEntity
 import org.schabi.newpipe.extractor.stream.StreamType
+import org.schabi.newpipe.info_list.ItemViewMode
 import org.schabi.newpipe.testUtil.TestDatabase
+import org.schabi.newpipe.util.OnClickGesture
 
 @RunWith(AndroidJUnit4::class)
 class LocalItemListAdapterTest {
@@ -53,6 +65,113 @@ class LocalItemListAdapterTest {
 
             adapter.insertItemAt(1, duplicate)
             assertEquals(listOf(first, duplicate), adapter.itemsList)
+        }
+    }
+
+    @Test
+    fun bookmarksFollowViewModeAndKeepItWhenDragHandlesAreDisabled() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val context = ContextThemeWrapper(instrumentation.targetContext, R.style.LightTheme)
+            val adapter = LocalItemListAdapter(context)
+            adapter.setUseItemHandle(true)
+            adapter.addItems(
+                listOf(
+                    PlaylistMetadataEntry(1, "Wisso", null, 0, false, null, 4),
+                    PlaylistRemoteEntity(
+                        serviceId = 0,
+                        orderingName = "Remote playlist",
+                        url = "https://example.com/playlist",
+                        thumbnailUrl = null,
+                        uploader = "Uploader",
+                        streamCount = 4
+                    )
+                )
+            )
+            var selected: LocalItem? = null
+            var dragCount = 0
+            adapter.setSelectedListener(object : OnClickGesture<LocalItem> {
+                override fun selected(selectedItem: LocalItem) {
+                    selected = selectedItem
+                }
+
+                override fun drag(selectedItem: LocalItem, viewHolder: RecyclerView.ViewHolder) {
+                    dragCount++
+                }
+            })
+            val viewTypes = mutableSetOf<Int>()
+            for (mode in listOf(ItemViewMode.LIST, ItemViewMode.CARD, ItemViewMode.GRID)) {
+                adapter.setItemViewMode(mode)
+                for (position in 0..1) {
+                    val type = adapter.getItemViewType(position)
+                    viewTypes.add(type)
+                    val holder = adapter.createViewHolder(FrameLayout(context), type)
+                    val handle = holder.itemView.findViewById<View>(R.id.itemHandle)
+                    val thumbnail = holder.itemView.findViewById<View>(R.id.itemThumbnailContainer)
+                    val title = holder.itemView.findViewById<TextView>(R.id.itemTitleView)
+                    var thumbnailWidth = 0
+                    var thumbnailHeight = 0
+                    for (enabled in listOf(true, false, true)) {
+                        adapter.setItemHandleEnabled(enabled)
+                        assertEquals(type, adapter.getItemViewType(position))
+                        adapter.bindViewHolder(holder, position)
+                        val widthDp = if (mode == ItemViewMode.GRID) 180 else 400
+                        val width = (widthDp * context.resources.displayMetrics.density).toInt()
+                        holder.itemView.measure(
+                            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+                        )
+                        holder.itemView.layout(0, 0, width, holder.itemView.measuredHeight)
+                        assertTrue(thumbnail.width > 0)
+                        assertTrue(thumbnail.height > 0)
+                        if (mode == ItemViewMode.LIST) {
+                            assertTrue(title.left >= thumbnail.right)
+                            assertTrue(title.top < thumbnail.bottom)
+                        } else {
+                            assertTrue(title.top >= thumbnail.bottom)
+                            assertEquals(16.0 / 9.0, thumbnail.width.toDouble() / thumbnail.height, 0.05)
+                        }
+                        if (thumbnailWidth != 0) {
+                            assertEquals(thumbnailWidth, thumbnail.width)
+                            assertEquals(thumbnailHeight, thumbnail.height)
+                        }
+                        thumbnailWidth = thumbnail.width
+                        thumbnailHeight = thumbnail.height
+                        assertEquals(if (enabled) View.VISIBLE else View.GONE, handle.visibility)
+                        assertEquals(enabled, handle.isEnabled)
+                        assertTrue(title.text.isNotEmpty())
+                        holder.itemView.performClick()
+                        assertSame(adapter.itemsList[position], selected)
+                        val previousDragCount = dragCount
+                        val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 1f, 1f, 0)
+                        try {
+                            handle.dispatchTouchEvent(event)
+                        } finally {
+                            event.recycle()
+                        }
+                        assertEquals(previousDragCount + if (enabled) 1 else 0, dragCount)
+                    }
+                }
+            }
+            assertEquals(6, viewTypes.size)
+        }
+    }
+
+    @Test
+    fun ordinaryPlaylistCardsDoNotExposeBookmarkDragHandles() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.runOnMainSync {
+            val context = ContextThemeWrapper(instrumentation.targetContext, R.style.LightTheme)
+            val adapter = LocalItemListAdapter(context)
+            adapter.addItems(listOf(PlaylistMetadataEntry(1, "Playlist", null, 0, false, null, 4)))
+            for (mode in listOf(ItemViewMode.CARD, ItemViewMode.GRID)) {
+                adapter.setItemViewMode(mode)
+                val holder = adapter.createViewHolder(FrameLayout(context), adapter.getItemViewType(0))
+                adapter.bindViewHolder(holder, 0)
+                val handle = holder.itemView.findViewById<View>(R.id.itemHandle)
+                assertEquals(View.GONE, handle.visibility)
+                assertFalse(handle.hasOnClickListeners())
+            }
         }
     }
 

--- a/app/src/androidTest/java/org/schabi/newpipe/local/LocalItemListAdapterTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/local/LocalItemListAdapterTest.kt
@@ -129,6 +129,7 @@ class LocalItemListAdapterTest {
                             assertTrue(title.top < thumbnail.bottom)
                         } else {
                             assertTrue(title.top >= thumbnail.bottom)
+                            assertEquals(width - holder.itemView.paddingLeft - holder.itemView.paddingRight, thumbnail.width)
                             assertEquals(16.0 / 9.0, thumbnail.width.toDouble() / thumbnail.height, 0.05)
                         }
                         if (thumbnailWidth != 0) {

--- a/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
@@ -259,7 +259,11 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
         this.useItemHandle = useItemHandle;
     }
 
-    /** Controls dragging without changing the bookmark row layout. Rebind after updating. */
+    /**
+     * Controls dragging without changing the bookmark layout. Rebind after updating.
+     *
+     * @param enabled whether bookmark drag handles should be visible and enabled
+     */
     public void setItemHandleEnabled(final boolean enabled) {
         itemHandleEnabled = enabled;
     }

--- a/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
+++ b/app/src/main/java/org/schabi/newpipe/local/LocalItemListAdapter.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.schabi.newpipe.R;
 import org.schabi.newpipe.database.LocalItem;
 import org.schabi.newpipe.database.stream.model.StreamStateEntity;
 import org.schabi.newpipe.info_list.ItemViewMode;
@@ -78,11 +79,15 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
     private static final int LOCAL_PLAYLIST_GRID_HOLDER_TYPE = 0x2001;
     private static final int LOCAL_PLAYLIST_CARD_HOLDER_TYPE = 0x2002;
     private static final int LOCAL_BOOKMARK_PLAYLIST_HOLDER_TYPE = 0x2003;
+    private static final int LOCAL_BOOKMARK_PLAYLIST_CARD_HOLDER_TYPE = 0x2004;
+    private static final int LOCAL_BOOKMARK_PLAYLIST_GRID_HOLDER_TYPE = 0x2005;
 
     private static final int REMOTE_PLAYLIST_HOLDER_TYPE = 0x3000;
     private static final int REMOTE_PLAYLIST_GRID_HOLDER_TYPE = 0x3001;
     private static final int REMOTE_PLAYLIST_CARD_HOLDER_TYPE = 0x3002;
     private static final int REMOTE_BOOKMARK_PLAYLIST_HOLDER_TYPE = 0x3003;
+    private static final int REMOTE_BOOKMARK_PLAYLIST_CARD_HOLDER_TYPE = 0x3004;
+    private static final int REMOTE_BOOKMARK_PLAYLIST_GRID_HOLDER_TYPE = 0x3005;
 
     private final LocalItemBuilder localItemBuilder;
     private final ArrayList<LocalItem> localItems;
@@ -94,6 +99,7 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
     private View footer = null;
     private ItemViewMode itemViewMode = ItemViewMode.LIST;
     private boolean useItemHandle = false;
+    private boolean itemHandleEnabled = true;
 
     public LocalItemListAdapter(final Context context) {
         recordManager = new HistoryRecordManager(context);
@@ -253,6 +259,11 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
         this.useItemHandle = useItemHandle;
     }
 
+    /** Controls dragging without changing the bookmark row layout. Rebind after updating. */
+    public void setItemHandleEnabled(final boolean enabled) {
+        itemHandleEnabled = enabled;
+    }
+
     public void setHeaderSupplier(@Nullable final Supplier<View> headerSupplier) {
         final boolean changed = headerSupplier != this.headerSupplier;
         this.headerSupplier = headerSupplier;
@@ -339,7 +350,11 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
         switch (item.getLocalItemType()) {
             case PLAYLIST_LOCAL_ITEM:
                 if (useItemHandle) {
-                    return LOCAL_BOOKMARK_PLAYLIST_HOLDER_TYPE;
+                    return switch (itemViewMode) {
+                        case CARD -> LOCAL_BOOKMARK_PLAYLIST_CARD_HOLDER_TYPE;
+                        case GRID -> LOCAL_BOOKMARK_PLAYLIST_GRID_HOLDER_TYPE;
+                        default -> LOCAL_BOOKMARK_PLAYLIST_HOLDER_TYPE;
+                    };
                 } else if (itemViewMode == ItemViewMode.CARD) {
                     return LOCAL_PLAYLIST_CARD_HOLDER_TYPE;
                 } else if (itemViewMode == ItemViewMode.GRID) {
@@ -349,7 +364,11 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
                 }
             case PLAYLIST_REMOTE_ITEM:
                 if (useItemHandle) {
-                    return REMOTE_BOOKMARK_PLAYLIST_HOLDER_TYPE;
+                    return switch (itemViewMode) {
+                        case CARD -> REMOTE_BOOKMARK_PLAYLIST_CARD_HOLDER_TYPE;
+                        case GRID -> REMOTE_BOOKMARK_PLAYLIST_GRID_HOLDER_TYPE;
+                        default -> REMOTE_BOOKMARK_PLAYLIST_HOLDER_TYPE;
+                    };
                 } else if (itemViewMode == ItemViewMode.CARD) {
                     return REMOTE_PLAYLIST_CARD_HOLDER_TYPE;
                 } else if (itemViewMode == ItemViewMode.GRID) {
@@ -401,6 +420,12 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
                 return new LocalPlaylistCardItemHolder(localItemBuilder, parent);
             case LOCAL_BOOKMARK_PLAYLIST_HOLDER_TYPE:
                 return new LocalBookmarkPlaylistItemHolder(localItemBuilder, parent);
+            case LOCAL_BOOKMARK_PLAYLIST_CARD_HOLDER_TYPE:
+                return new LocalBookmarkPlaylistItemHolder(localItemBuilder,
+                        R.layout.list_playlist_card_item, parent);
+            case LOCAL_BOOKMARK_PLAYLIST_GRID_HOLDER_TYPE:
+                return new LocalBookmarkPlaylistItemHolder(localItemBuilder,
+                        R.layout.list_playlist_grid_item, parent);
             case REMOTE_PLAYLIST_HOLDER_TYPE:
                 return new RemotePlaylistItemHolder(localItemBuilder, parent);
             case REMOTE_PLAYLIST_GRID_HOLDER_TYPE:
@@ -409,6 +434,12 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
                 return new RemotePlaylistCardItemHolder(localItemBuilder, parent);
             case REMOTE_BOOKMARK_PLAYLIST_HOLDER_TYPE:
                 return new RemoteBookmarkPlaylistItemHolder(localItemBuilder, parent);
+            case REMOTE_BOOKMARK_PLAYLIST_CARD_HOLDER_TYPE:
+                return new RemoteBookmarkPlaylistItemHolder(localItemBuilder,
+                        R.layout.list_playlist_card_item, parent);
+            case REMOTE_BOOKMARK_PLAYLIST_GRID_HOLDER_TYPE:
+                return new RemoteBookmarkPlaylistItemHolder(localItemBuilder,
+                        R.layout.list_playlist_grid_item, parent);
             case STREAM_PLAYLIST_HOLDER_TYPE:
                 return new LocalPlaylistStreamItemHolder(localItemBuilder, parent);
             case STREAM_PLAYLIST_GRID_HOLDER_TYPE:
@@ -444,6 +475,12 @@ public class LocalItemListAdapter extends RecyclerView.Adapter<RecyclerView.View
 
             ((LocalItemHolder) holder)
                     .updateFromItem(localItems.get(position), recordManager, dateTimeFormatter);
+            if (holder instanceof LocalBookmarkPlaylistItemHolder
+                    || holder instanceof RemoteBookmarkPlaylistItemHolder) {
+                final View handle = holder.itemView.findViewById(R.id.itemHandle);
+                handle.setEnabled(itemHandleEnabled);
+                handle.setVisibility(itemHandleEnabled ? View.VISIBLE : View.GONE);
+            }
         } else if (holder instanceof HeaderFooterHolder && position == 0 && hasHeader()) {
             ((HeaderFooterHolder) holder).view = headerSupplier.get();
         } else if (holder instanceof HeaderFooterHolder && position == sizeConsideringHeader()

--- a/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/local/bookmark/BookmarkFragment.java
@@ -1,7 +1,6 @@
 package org.schabi.newpipe.local.bookmark;
 
 import static org.schabi.newpipe.local.bookmark.MergedPlaylistManager.getMergedOrderedPlaylists;
-import static org.schabi.newpipe.util.ThemeHelper.shouldUseGridLayout;
 
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -18,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
+import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -151,7 +151,8 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
                 .setOnClickListener(view -> manageCategories());
         updateCategoryLabel();
 
-        itemListAdapter.setUseItemHandle(!isPlaylistListFiltered());
+        itemListAdapter.setUseItemHandle(true);
+        itemListAdapter.setItemHandleEnabled(!isPlaylistListFiltered());
     }
 
     @Override
@@ -325,7 +326,7 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
         }
 
         itemListAdapter.clearStreamItemList();
-        itemListAdapter.setUseItemHandle(!isPlaylistListFiltered());
+        itemListAdapter.setItemHandleEnabled(!isPlaylistListFiltered());
         setEmptyStateMessage(isPlaylistListFiltered()
                 ? R.string.search_no_results : R.string.empty_list_subtitle);
 
@@ -530,11 +531,19 @@ public final class BookmarkFragment extends BaseLocalListFragment<List<PlaylistL
     }
 
     private ItemTouchHelper.SimpleCallback getItemTouchCallback() {
-        int directions = ItemTouchHelper.UP | ItemTouchHelper.DOWN;
-        if (shouldUseGridLayout(requireContext())) {
-            directions |= ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT;
-        }
-        return new ItemTouchHelper.SimpleCallback(directions, ItemTouchHelper.ACTION_STATE_IDLE) {
+        return new ItemTouchHelper.SimpleCallback(ItemTouchHelper.UP | ItemTouchHelper.DOWN,
+                ItemTouchHelper.ACTION_STATE_IDLE) {
+            @Override
+            public int getDragDirs(@NonNull final RecyclerView recyclerView,
+                                   @NonNull final RecyclerView.ViewHolder viewHolder) {
+                if (isPlaylistListFiltered()) {
+                    return 0;
+                }
+                final int directions = ItemTouchHelper.UP | ItemTouchHelper.DOWN;
+                return recyclerView.getLayoutManager() instanceof GridLayoutManager
+                        ? directions | ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT : directions;
+            }
+
             @Override
             public int interpolateOutOfBoundsScroll(@NonNull final RecyclerView recyclerView,
                                                     final int viewSize,

--- a/app/src/main/java/org/schabi/newpipe/local/holder/LocalBookmarkPlaylistItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/LocalBookmarkPlaylistItemHolder.java
@@ -20,8 +20,8 @@ public class LocalBookmarkPlaylistItemHolder extends LocalPlaylistItemHolder {
         this(infoItemBuilder, R.layout.list_playlist_bookmark_item, parent);
     }
 
-    LocalBookmarkPlaylistItemHolder(final LocalItemBuilder infoItemBuilder, final int layoutId,
-                                    final ViewGroup parent) {
+    public LocalBookmarkPlaylistItemHolder(final LocalItemBuilder infoItemBuilder,
+                                           final int layoutId, final ViewGroup parent) {
         super(infoItemBuilder, layoutId, parent);
         itemHandleView = itemView.findViewById(R.id.itemHandle);
     }

--- a/app/src/main/java/org/schabi/newpipe/local/holder/RemoteBookmarkPlaylistItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/local/holder/RemoteBookmarkPlaylistItemHolder.java
@@ -20,8 +20,8 @@ public class RemoteBookmarkPlaylistItemHolder extends RemotePlaylistItemHolder {
         this(infoItemBuilder, R.layout.list_playlist_bookmark_item, parent);
     }
 
-    RemoteBookmarkPlaylistItemHolder(final LocalItemBuilder infoItemBuilder, final int layoutId,
-                                     final ViewGroup parent) {
+    public RemoteBookmarkPlaylistItemHolder(final LocalItemBuilder infoItemBuilder,
+                                            final int layoutId, final ViewGroup parent) {
         super(infoItemBuilder, layoutId, parent);
         itemHandleView = itemView.findViewById(R.id.itemHandle);
     }

--- a/app/src/main/res/layout/fragment_bookmarks.xml
+++ b/app/src/main/res/layout/fragment_bookmarks.xml
@@ -3,21 +3,32 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
 
     <LinearLayout
         android:id="@+id/playlist_category_controls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingHorizontal="16dp">
+        android:paddingHorizontal="@dimen/margin_normal"
+        android:paddingVertical="@dimen/spacing_micro">
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/playlist_category_filter"
-            style="@style/Widget.Material3.Button.TextButton"
+            style="@style/Widget.Material3.Button.TonalButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_small"
             android:layout_weight="1"
-            android:text="@string/playlist_categories_all" />
+            android:ellipsize="end"
+            android:gravity="start|center_vertical"
+            android:maxLines="1"
+            android:text="@string/playlist_categories_all"
+            app:icon="@drawable/ic_arrow_drop_down"
+            app:iconGravity="end" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/playlist_category_manage"
             style="@style/Widget.Material3.Button.TextButton"

--- a/app/src/main/res/layout/list_playlist_bookmark_item.xml
+++ b/app/src/main/res/layout/list_playlist_bookmark_item.xml
@@ -10,52 +10,50 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <ImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="90dp"
         android:layout_height="50dp"
         android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginRight="@dimen/video_item_search_image_right_margin"
-        android:scaleType="centerCrop"
-        android:src="@drawable/placeholder_thumbnail_playlist"
-        tools:ignore="RtlHardcoded" />
+        android:layout_marginEnd="@dimen/margin_small">
 
-    <org.schabi.newpipe.views.NewPipeTextView
-        android:id="@+id/itemStreamCountView"
-        android:layout_width="45dp"
-        android:layout_height="match_parent"
-        android:layout_alignTop="@id/itemThumbnailView"
-        android:layout_alignRight="@id/itemThumbnailView"
-        android:layout_alignBottom="@id/itemThumbnailView"
-        android:background="@color/info_list_playlist_stream_count_badge_background_color"
-        android:gravity="center"
-        android:paddingTop="4dp"
-        android:paddingBottom="6dp"
-        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-        android:textColor="@color/info_list_thumbnail_badge_text_color"
-        android:textSize="@dimen/video_item_search_duration_text_size"
-        android:textStyle="bold"
-        app:drawableTint="@color/info_list_thumbnail_badge_text_color"
-        app:drawableTopCompat="@drawable/ic_playlist_play"
-        tools:ignore="RtlHardcoded"
-        tools:text="3141" />
+        <ImageView
+            android:id="@+id/itemThumbnailView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            android:src="@drawable/placeholder_thumbnail_playlist" />
+
+        <org.schabi.newpipe.views.NewPipeTextView
+            android:id="@+id/itemStreamCountView"
+            android:layout_width="45dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="end"
+            android:background="@color/info_list_playlist_stream_count_badge_background_color"
+            android:gravity="center"
+            android:paddingTop="4dp"
+            android:paddingBottom="6dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="@color/info_list_thumbnail_badge_text_color"
+            android:textSize="@dimen/video_item_search_duration_text_size"
+            android:textStyle="bold"
+            app:drawableTint="@color/info_list_thumbnail_badge_text_color"
+            app:drawableTopCompat="@drawable/ic_playlist_play"
+            tools:text="4" />
+
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
 
     <ImageView
         android:id="@+id/itemHandle"
-        android:layout_width="wrap_content"
-        android:layout_height="55dp"
-        android:layout_alignParentRight="true"
-        android:layout_gravity="center_vertical"
-        android:layout_alignTop="@id/itemTitleView"
-        android:layout_alignBottom="@id/itemUploaderView"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
         android:contentDescription="@string/detail_drag_description"
-        android:paddingLeft="@dimen/video_item_search_image_right_margin"
         android:scaleType="center"
         app:srcCompat="@drawable/ic_drag_handle"
-        app:tint="?attr/colorOnSurfaceVariant"
-        tools:ignore="RtlHardcoded,RtlSymmetry" />
+        app:tint="?attr/colorOnSurfaceVariant" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemTitleView"
@@ -63,29 +61,26 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_toStartOf="@id/itemHandle"
-        android:layout_toLeftOf="@id/itemHandle"
-        android:layout_toRightOf="@+id/itemThumbnailView"
+        android:layout_toEndOf="@id/itemThumbnailContainer"
         android:ellipsize="end"
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/video_item_search_title_text_size"
-        tools:ignore="RtlHardcoded"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique vitae sem vitae blanditLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsum" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemUploaderView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/itemTitleView"
-        android:layout_toLeftOf="@id/itemHandle"
-        android:layout_toRightOf="@+id/itemThumbnailView"
+        android:layout_below="@id/itemTitleView"
+        android:layout_toStartOf="@id/itemHandle"
+        android:layout_toEndOf="@id/itemThumbnailContainer"
         android:ellipsize="end"
         android:lines="1"
         android:textAppearance="@style/TextAppearance.Material3.BodySmall"
         android:textColor="?attr/colorOnSurfaceVariant"
         android:textSize="@dimen/video_item_search_uploader_text_size"
-        tools:ignore="RtlHardcoded"
         tools:text="Uploader really long lorem ipsum dolor sit amet consectetur" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/list_playlist_card_item.xml
+++ b/app/src/main/res/layout/list_playlist_card_item.xml
@@ -6,75 +6,105 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
-    android:paddingTop="@dimen/margin_small"
-    android:paddingBottom="@dimen/spacing_micro"
+    android:layout_marginHorizontal="@dimen/stream_card_horizontal_margin"
+    android:paddingTop="@dimen/channel_item_grid_padding"
+    android:paddingBottom="@dimen/channel_item_grid_padding"
     android:clickable="true"
     android:focusable="true">
 
-    <ImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="fitStart"
-        android:src="@drawable/placeholder_thumbnail_playlist"
         app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="RtlHardcoded" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <View
-        android:id="@+id/videoCountOverlay"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@color/info_list_playlist_stream_count_badge_background_color"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
-        app:layout_constraintWidth_percent="0.35" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-    <org.schabi.newpipe.views.NewPipeTextView
-        android:id="@+id/itemStreamCountView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-        android:textColor="@color/info_list_thumbnail_badge_text_color"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@id/playIcon"
-        app:layout_constraintEnd_toEndOf="@id/videoCountOverlay"
-        app:layout_constraintStart_toStartOf="@id/videoCountOverlay"
-        app:layout_constraintTop_toTopOf="@id/videoCountOverlay"
-        app:layout_constraintVertical_chainStyle="packed"
-        tools:text="314159" />
+            <ImageView
+                android:id="@+id/itemThumbnailView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/placeholder_thumbnail_playlist"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="RtlHardcoded" />
 
-    <!--    playIcon includes 8dp start margin to give center aligned look
-            when placed next to the video count -->
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/playIcon"
-        android:layout_width="@dimen/player_main_buttons_min_width"
-        android:layout_height="@dimen/player_main_buttons_min_width"
-        android:layout_marginStart="8dp"
-        android:src="@drawable/ic_playlist_play"
-        android:tint="@color/info_list_thumbnail_badge_text_color"
-        app:layout_constraintBottom_toBottomOf="@id/videoCountOverlay"
-        app:layout_constraintEnd_toEndOf="@id/videoCountOverlay"
-        app:layout_constraintStart_toStartOf="@id/videoCountOverlay"
-        app:layout_constraintTop_toBottomOf="@id/itemStreamCountView" />
+            <View
+                android:id="@+id/videoCountOverlay"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="@color/info_list_playlist_stream_count_badge_background_color"
+                app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
+                app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+                app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+                app:layout_constraintWidth_percent="0.35" />
+
+            <org.schabi.newpipe.views.NewPipeTextView
+                android:id="@+id/itemStreamCountView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="@color/info_list_thumbnail_badge_text_color"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@id/playIcon"
+                app:layout_constraintEnd_toEndOf="@id/videoCountOverlay"
+                app:layout_constraintStart_toStartOf="@id/videoCountOverlay"
+                app:layout_constraintTop_toTopOf="@id/videoCountOverlay"
+                app:layout_constraintVertical_chainStyle="packed"
+                tools:text="314159" />
+
+            <!--    playIcon includes 8dp start margin to give center aligned look
+                    when placed next to the video count -->
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/playIcon"
+                android:layout_width="@dimen/player_main_buttons_min_width"
+                android:layout_height="@dimen/player_main_buttons_min_width"
+                android:layout_marginStart="8dp"
+                android:src="@drawable/ic_playlist_play"
+                android:tint="@color/info_list_thumbnail_badge_text_color"
+                app:layout_constraintBottom_toBottomOf="@id/videoCountOverlay"
+                app:layout_constraintEnd_toEndOf="@id/videoCountOverlay"
+                app:layout_constraintStart_toStartOf="@id/videoCountOverlay"
+                app:layout_constraintTop_toBottomOf="@id/itemStreamCountView" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
+
+    <ImageView
+        android:id="@+id/itemHandle"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="@string/detail_drag_description"
+        android:scaleType="center"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
+        app:srcCompat="@drawable/ic_drag_handle"
+        app:tint="?attr/colorOnSurfaceVariant" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemTitleView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_small"
-        android:layout_marginTop="@dimen/spacing_nano"
+        android:layout_marginTop="@dimen/margin_small"
         android:layout_marginEnd="@dimen/margin_small"
         android:ellipsize="end"
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
         android:textColor="?attr/colorOnSurface"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/itemHandle"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
         tools:ignore="RtlHardcoded"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc tristique vitae sem vitae blanditLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsumLorem ipsum" />
 

--- a/app/src/main/res/layout/list_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_playlist_grid_item.xml
@@ -10,49 +10,78 @@
     android:focusable="true"
     android:padding="@dimen/video_item_search_padding">
 
-    <ImageView
-        android:id="@+id/itemThumbnailView"
+    <org.schabi.newpipe.views.RoundedThumbnailContainer
+        android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scaleType="fitCenter"
-        android:src="@drawable/placeholder_thumbnail_playlist"
-        app:layout_constraintDimensionRatio="H,16:9"
+        app:layout_constraintDimensionRatio="16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <org.schabi.newpipe.views.NewPipeTextView
-        android:id="@+id/itemStreamCountView"
-        android:layout_width="@dimen/playlist_item_thumbnail_stream_count_width"
-        android:layout_height="0dp"
-        android:background="@color/info_list_playlist_stream_count_badge_background_color"
-        android:drawableTop="@drawable/ic_playlist_play"
-        android:drawableTint="@color/info_list_thumbnail_badge_text_color"
-        android:gravity="center"
-        android:paddingTop="16dp"
-        android:paddingBottom="14dp"
-        android:textAppearance="@style/TextAppearance.Material3.BodySmall"
-        android:textColor="@color/info_list_thumbnail_badge_text_color"
-        android:textSize="@dimen/video_item_search_duration_text_size"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
-        tools:text="314159" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ImageView
+                android:id="@+id/itemThumbnailView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/placeholder_thumbnail_playlist"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <org.schabi.newpipe.views.NewPipeTextView
+                android:id="@+id/itemStreamCountView"
+                android:layout_width="@dimen/playlist_item_thumbnail_stream_count_width"
+                android:layout_height="0dp"
+                android:background="@color/info_list_playlist_stream_count_badge_background_color"
+                android:drawableTop="@drawable/ic_playlist_play"
+                android:drawableTint="@color/info_list_thumbnail_badge_text_color"
+                android:gravity="center"
+                android:paddingTop="16dp"
+                android:paddingBottom="14dp"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="@color/info_list_thumbnail_badge_text_color"
+                android:textSize="@dimen/video_item_search_duration_text_size"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@id/itemThumbnailView"
+                app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
+                app:layout_constraintTop_toTopOf="@id/itemThumbnailView"
+                tools:text="314159" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </org.schabi.newpipe.views.RoundedThumbnailContainer>
+
+    <ImageView
+        android:id="@+id/itemHandle"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="@string/detail_drag_description"
+        android:scaleType="center"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
+        app:srcCompat="@drawable/ic_drag_handle"
+        app:tint="?attr/colorOnSurfaceVariant" />
 
     <org.schabi.newpipe.views.NewPipeTextView
         android:id="@+id/itemTitleView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
+        android:layout_marginTop="@dimen/margin_small"
         android:ellipsize="end"
         android:maxLines="2"
         android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/video_item_search_title_text_size"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
-        app:layout_constraintTop_toBottomOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toStartOf="@id/itemHandle"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
+        app:layout_constraintTop_toBottomOf="@id/itemThumbnailContainer"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit" />
 
     <org.schabi.newpipe.views.NewPipeTextView
@@ -64,8 +93,8 @@
         android:textColor="?attr/colorOnSurfaceVariant"
         android:textSize="@dimen/video_item_search_uploader_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/itemThumbnailView"
-        app:layout_constraintStart_toStartOf="@id/itemThumbnailView"
+        app:layout_constraintEnd_toStartOf="@id/itemHandle"
+        app:layout_constraintStart_toStartOf="@id/itemThumbnailContainer"
         app:layout_constraintTop_toBottomOf="@id/itemTitleView"
         tools:text="Uploader" />
 

--- a/app/src/main/res/layout/list_playlist_grid_item.xml
+++ b/app/src/main/res/layout/list_playlist_grid_item.xml
@@ -14,7 +14,7 @@
         android:id="@+id/itemThumbnailContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintDimensionRatio="16:9"
+        app:layout_constraintDimensionRatio="H,16:9"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">

--- a/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
+++ b/app/src/test/java/org/schabi/newpipe/util/TabletGridConfigurationTest.java
@@ -82,15 +82,6 @@ public class TabletGridConfigurationTest {
                             + "            android:layout_width=\"match_parent\"\n"
                             + "            android:layout_height=\"match_parent\""));
         }
-
-        final String playlist = read(
-                "app/src/main/res/layout/list_playlist_grid_item.xml");
-        assertTrue(playlist.contains(
-                "android:id=\"@+id/itemThumbnailView\"\n"
-                        + "        android:layout_width=\"0dp\"\n"
-                        + "        android:layout_height=\"0dp\""));
-        assertTrue(playlist.contains(
-                "app:layout_constraintDimensionRatio=\"H,16:9\""));
     }
 
     private String read(final String relativePath) throws Exception {


### PR DESCRIPTION
- Fix the layout jump between All playlists and category/search results: both now follow the List, Card, or Grid setting.
- Separate bookmark layout selection from drag availability. All playlists retains reorder handles in each mode; category/search results hide and disable them, preserving the full playlist order.
- Use the active Material surface for Bookmarks, a tonal category dropdown, and rounded playlist thumbnails with theme-consistent spacing. The text beside/below the thumbnail remains the playlist title.
- Update `LocalItemListAdapter.java`, `BookmarkFragment.java`, both bookmark holder classes, `fragment_bookmarks.xml`, the bookmark/card/grid playlist layouts, `LocalItemListAdapterTest.kt`, and `TabletGridConfigurationTest.java`.
- Add Android regression coverage for local and remote playlists across all three view modes, stable thumbnail geometry while filtering, restored drag handling, playlist clicks, and hidden handles outside Bookmarks.
- Replace the obsolete playlist XML-string assertion with Android checks of actual thumbnail width and 16:9 aspect ratio.
- Validation passed in [CI run 34716983561](https://github.com/wizdom13/WizeStream/actions/runs/34716983561): Checkstyle, ktlint, debug APK build, Android lint, JVM tests, 108 Android 6 tests, and 110 Android 15 tests. Local XML parsing, `git diff --check`, and the source-inspection test gate also pass.
- Device visual verification is still needed for the supplied theme, Dark/Black/manual palettes, RTL, rotation, and long category names.