### PR TITLE
Remember comment sorting and handle refreshed sort menus

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSort.java
+++ b/app/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSort.java
@@ -18,7 +18,8 @@ final class YoutubeCommentSort {
                 continue;
             }
             final JsonObject command = ((JsonObject) endpoint).getObject(
-                    "reloadContinuationItemsCommand");
+                    "reloadContinuationItemsCommand",
+                    ((JsonObject) endpoint).getObject("appendContinuationItemsAction"));
             for (final Object item : command.getArray("continuationItems")) {
                 if (!(item instanceof JsonObject)) {
                     continue;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -10,6 +10,9 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.preference.PreferenceManager;
+
+import com.google.android.material.chip.ChipGroup;
 
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.error.UserAction;
@@ -17,7 +20,6 @@ import org.schabi.newpipe.extractor.ListExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsInfo;
 import org.schabi.newpipe.extractor.comments.CommentSortOrder;
 import org.schabi.newpipe.extractor.ServiceList;
-import com.google.android.material.chip.ChipGroup;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.info_list.ItemViewMode;
@@ -29,6 +31,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 
 public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, CommentsInfo> {
+    private static final String SORT_PREFERENCE = "comment_sort_newest";
     private final CompositeDisposable disposables = new CompositeDisposable();
 
     private TextView emptyStateDesc;
@@ -56,13 +59,17 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
         super.initViews(rootView, savedInstanceState);
 
         emptyStateDesc = rootView.findViewById(R.id.empty_state_desc);
-        if (savedInstanceState != null) {
-            sortOrder = savedInstanceState.getBoolean("comments_newest", false)
-                    ? CommentSortOrder.NEWEST : CommentSortOrder.TOP;
-        }
+        final boolean supportsSorting = serviceId == ServiceList.YouTube.getServiceId();
+        final boolean newest = savedInstanceState != null
+                ? savedInstanceState.getBoolean("comments_newest", false)
+                : PreferenceManager.getDefaultSharedPreferences(requireContext())
+                        .getBoolean(SORT_PREFERENCE, false);
+        sortOrder = supportsSorting
+                ? currentInfo != null ? currentInfo.getSortOrder()
+                        : newest ? CommentSortOrder.NEWEST : CommentSortOrder.TOP
+                : CommentSortOrder.TOP;
         final ChipGroup sorting = rootView.findViewById(R.id.comment_sort);
-        sorting.setVisibility(serviceId == ServiceList.YouTube.getServiceId()
-                ? View.VISIBLE : View.GONE);
+        sorting.setVisibility(supportsSorting ? View.VISIBLE : View.GONE);
         sorting.check(sortOrder == CommentSortOrder.NEWEST
                 ? R.id.comments_newest : R.id.comments_top);
         sorting.setOnCheckedStateChangeListener((group, checkedIds) -> {
@@ -70,6 +77,8 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
                     ? CommentSortOrder.NEWEST : CommentSortOrder.TOP;
             if (sortOrder != selected) {
                 sortOrder = selected;
+                PreferenceManager.getDefaultSharedPreferences(requireContext()).edit()
+                        .putBoolean(SORT_PREFERENCE, selected == CommentSortOrder.NEWEST).apply();
                 currentNextPage = null;
                 startLoading(true);
             }

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
-    private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
+    private static final boolean SAMSUNG = "samsung".equals(Build.MANUFACTURER);
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -53,38 +53,38 @@ public final class DeviceUtils {
      * <p>Board: HiSilicon Hi3798MV200</p>
      */
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("Hi3798MV200");
+            && "Hi3798MV200".equals(Build.DEVICE);
     /**
      * <p>Zephir TS43UHD-2.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+            && "cvt_mt5886_eu_1g".equals(Build.DEVICE);
     /**
      * Hilife TV.
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
-            && Build.DEVICE.equals("RealtekATV");
+            && "RealtekATV".equals(Build.DEVICE);
     /**
      * <p>Phillips 4K (O)LED TV.</p>
      * Supports custom ROMs with different API levels
      */
     private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
-            && Build.DEVICE.equals("PH7M_EU_5596");
+            && "PH7M_EU_5596".equals(Build.DEVICE);
     /**
      * <p>Philips QM16XE.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
-            && Build.DEVICE.equals("QM16XE_U");
+            && "QM16XE_U".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH1.</p>
      * <p>Processor: MT5895</p>
      * <p>Blacklist reason: fullscreen crash / stuttering</p>
      */
     private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH1");
+            && "BRAVIA_VH1".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH2.</p>
      * <p>Blacklist reason: fullscreen crash; this includes model A90J as reported in
@@ -92,14 +92,14 @@ public final class DeviceUtils {
      * #9023</a></p>
      */
     private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH2");
+            && "BRAVIA_VH2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 2.</p>
      * Uses a MediaTek MT5891 (MT5596) SoC.
      * @see <a href="https://github.com/CiNcH83/bravia_atv2">
      *     https://github.com/CiNcH83/bravia_atv2</a>
      */
-    private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
+    private static final boolean BRAVIA_ATV2 = "BRAVIA_ATV2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 3 4K.</p>
      * <p>Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.</p>
@@ -107,19 +107,19 @@ public final class DeviceUtils {
      * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
      *     https://browser.geekbench.com/v4/cpu/9101105</a>
      */
-    private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
+    private static final boolean BRAVIA_ATV3_4K = "BRAVIA_ATV3_4K".equals(Build.DEVICE);
     /**
      * <p>Panasonic 4KTV-JUP.</p>
      * <p>Blacklist reason: fullscreen crash</p>
      */
-    private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
+    private static final boolean TX_50JXW834 = "TX_50JXW834".equals(Build.DEVICE);
     /**
      * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
      * <p>Blacklist reason: black screen; reported at
      * <a href="https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769">
      *     #10122</a></p>
      */
-    private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    private static final boolean HMB9213NW = "HMB9213NW".equals(Build.DEVICE);
     // endregion
 
     private DeviceUtils() {

--- a/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSortTest.java
+++ b/app/src/test/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentSortTest.java
@@ -2,6 +2,7 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
+import com.grack.nanojson.JsonWriter;
 
 import org.junit.jupiter.api.Test;
 import org.schabi.newpipe.extractor.comments.CommentSortOrder;
@@ -28,6 +29,10 @@ class YoutubeCommentSortTest {
         assertEquals("top-token", YoutubeCommentSort.continuation(response, CommentSortOrder.TOP));
         assertEquals("newest-token",
                 YoutubeCommentSort.continuation(response, CommentSortOrder.NEWEST));
+        final JsonObject appendResponse = JsonParser.object().from(JsonWriter.string(response)
+                .replace("reloadContinuationItemsCommand", "appendContinuationItemsAction"));
+        assertEquals("newest-token",
+                YoutubeCommentSort.continuation(appendResponse, CommentSortOrder.NEWEST));
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
@@ -88,9 +88,15 @@ public class VideoDetailBackPressTest {
 
     @After
     public void tearDown() {
-        playerHelper.close();
-        deviceUtils.close();
-        log.close();
+        if (playerHelper != null) {
+            playerHelper.close();
+        }
+        if (deviceUtils != null) {
+            deviceUtils.close();
+        }
+        if (log != null) {
+            log.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
- Remember the existing YouTube Top/Newest comment sort selection across visits and restore it consistently.
- Handle YouTube comment-sort headers returned through either continuation response shape.
- Fix Android Build stub initialization and cleanup in the fullscreen regression tests so the existing test suite can run.
- Validated: source-inspection gate, debug build, lint, JVM tests, and Android tests on API 23 and 35 all passed.