### PR TITLE
Add opt-in automatic channel downloads

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/download/AutomaticDownloadHistoryTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/download/AutomaticDownloadHistoryTest.kt
@@ -1,0 +1,29 @@
+package org.schabi.newpipe.download
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutomaticDownloadHistoryTest {
+    @Test
+    fun receiptsSurviveReopeningAndRemainIsolatedByChannel() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val name = "automatic-downloads-test-${System.nanoTime()}.db"
+        try {
+            AutomaticDownloadHistory(context, name).use {
+                it.add(1, "stream")
+                it.add(1, "stream")
+                it.add(1, "")
+            }
+            AutomaticDownloadHistory(context, name).use {
+                assertTrue(it.contains(1, "stream"))
+                assertTrue(it.contains(1, ""))
+                assertFalse(it.contains(2, "stream"))
+            }
+        } finally {
+            context.deleteDatabase(name)
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/App.kt
+++ b/app/src/main/java/org/schabi/newpipe/App.kt
@@ -114,6 +114,7 @@ open class App :
         BridgeStateSaverInitializer.init(this)
         StateSaver.init(this)
         initNotificationChannels()
+        org.schabi.newpipe.download.AutomaticDownloads.initialize(this)
 
         ServiceHelper.initServices(this)
 

--- a/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadHistory.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadHistory.kt
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.download
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+
+/** Device-local receipts survive restarts and do not grow an in-memory preference set. */
+internal class AutomaticDownloadHistory(context: Context, name: String = "automatic-downloads.db") : SQLiteOpenHelper(context, name, null, 1) {
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL("CREATE TABLE receipts (channel INTEGER NOT NULL, source TEXT NOT NULL, PRIMARY KEY(channel, source))")
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+
+    fun contains(channel: Long, source: String): Boolean = readableDatabase.rawQuery(
+        "SELECT 1 FROM receipts WHERE channel=? AND source=?", arrayOf(channel.toString(), source)
+    ).use { it.moveToFirst() }
+
+    fun add(channel: Long, source: String) {
+        writableDatabase.insertWithOnConflict("receipts", null, ContentValues().apply {
+            put("channel", channel)
+            put("source", source)
+        }, SQLiteDatabase.CONFLICT_IGNORE)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadHistory.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadHistory.kt
@@ -4,9 +4,10 @@ import android.content.ContentValues
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
+import java.io.Closeable
 
 /** Device-local receipts survive restarts and do not grow an in-memory preference set. */
-internal class AutomaticDownloadHistory(context: Context, name: String = "automatic-downloads.db") : SQLiteOpenHelper(context, name, null, 1) {
+internal class AutomaticDownloadHistory(context: Context, name: String = "automatic-downloads.db") : SQLiteOpenHelper(context, name, null, 1), Closeable {
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL("CREATE TABLE receipts (channel INTEGER NOT NULL, source TEXT NOT NULL, PRIMARY KEY(channel, source))")
     }
@@ -14,13 +15,19 @@ internal class AutomaticDownloadHistory(context: Context, name: String = "automa
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
 
     fun contains(channel: Long, source: String): Boolean = readableDatabase.rawQuery(
-        "SELECT 1 FROM receipts WHERE channel=? AND source=?", arrayOf(channel.toString(), source)
+        "SELECT 1 FROM receipts WHERE channel=? AND source=?",
+        arrayOf(channel.toString(), source)
     ).use { it.moveToFirst() }
 
     fun add(channel: Long, source: String) {
-        writableDatabase.insertWithOnConflict("receipts", null, ContentValues().apply {
-            put("channel", channel)
-            put("source", source)
-        }, SQLiteDatabase.CONFLICT_IGNORE)
+        writableDatabase.insertWithOnConflict(
+            "receipts",
+            null,
+            ContentValues().apply {
+                put("channel", channel)
+                put("source", source)
+            },
+            SQLiteDatabase.CONFLICT_IGNORE
+        )
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadWorker.kt
@@ -51,7 +51,9 @@ class AutomaticDownloadWorker(context: Context, parameters: WorkerParameters) : 
                 binder.set(service as DownloadManagerService.DownloadManagerBinder)
                 connected.countDown()
             }
-            override fun onServiceDisconnected(name: ComponentName) { binder.set(null) }
+            override fun onServiceDisconnected(name: ComponentName) {
+                binder.set(null)
+            }
         }
         if (!context.bindService(Intent(context, DownloadManagerService::class.java), connection, Context.BIND_AUTO_CREATE)) throw IOException("Download service unavailable")
         try {

--- a/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloadWorker.kt
@@ -1,0 +1,115 @@
+package org.schabi.newpipe.download
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.preference.PreferenceManager
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.rxjava3.RxWorker
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.schabi.newpipe.R
+import org.schabi.newpipe.local.feed.service.FeedLoadManager
+import org.schabi.newpipe.local.subscription.SubscriptionManager
+import org.schabi.newpipe.settings.NewPipeSettings
+import org.schabi.newpipe.util.ExtractorHelper
+import org.schabi.newpipe.util.StreamTypeUtil
+import us.shandian.giga.service.DownloadManagerService
+
+class AutomaticDownloadWorker(context: Context, parameters: WorkerParameters) : RxWorker(context, parameters) {
+    private val feed = FeedLoadManager(context)
+
+    override fun createWork(): Single<Result> = Single.fromCallable {
+        val context = applicationContext
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        if (!preferences.getBoolean(AutomaticDownloads.ENABLED, false)) return@fromCallable Result.success()
+        val subscriptions = SubscriptionManager(context).subscriptionTable().getAllDirect().associateBy { it.uid }
+        val rules = AutomaticDownloads.rules(context).filter { rule ->
+            subscriptions[rule.uid]?.let { it.url == rule.url && it.serviceId == rule.serviceId } == true
+        }
+        if (rules.isEmpty()) return@fromCallable Result.success()
+        val notification = NotificationCompat.Builder(context, context.getString(R.string.notification_channel_id))
+            .setSmallIcon(R.drawable.ic_wizestream_triangle_white).setContentTitle(context.getString(R.string.automatic_downloads))
+            .setOngoing(true).setProgress(0, 0, true).build()
+        setForegroundAsync(ForegroundInfo(0xAD01, notification, if (Build.VERSION.SDK_INT >= 29) ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC else 0)).get()
+        val result = feed.startLoading(ignoreOutdatedThreshold = true, onlySubscriptions = rules.map { it.uid }.toSet()).blockingGet()
+        val connected = CountDownLatch(1)
+        val binder = AtomicReference<DownloadManagerService.DownloadManagerBinder>()
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName, service: IBinder) {
+                binder.set(service as DownloadManagerService.DownloadManagerBinder)
+                connected.countDown()
+            }
+            override fun onServiceDisconnected(name: ComponentName) { binder.set(null) }
+        }
+        if (!context.bindService(Intent(context, DownloadManagerService::class.java), connection, Context.BIND_AUTO_CREATE)) throw IOException("Download service unavailable")
+        try {
+            if (!connected.await(15, TimeUnit.SECONDS)) throw IOException("Download service timed out")
+            val service = binder.get() ?: throw IOException("Download service disconnected")
+            if (service.askForSavePath()) throw IOException(context.getString(R.string.bulk_download_ask_path_error))
+            var failed = result.any { it.isOnError }
+            var totalQueued = 0
+            AutomaticDownloadHistory(context).use { history ->
+                result.mapNotNull { it.value }.forEach { update ->
+                    val rule = rules.firstOrNull { it.uid == update.uid } ?: return@forEach
+                    val initialized = history.contains(rule.uid, "")
+                    val candidates = update.streams.distinctBy { it.url }.filter { stream ->
+                        val live = StreamTypeUtil.isLiveStream(stream.streamType)
+                        val selected = AutomaticDownloadPolicy.shouldDownload(stream.uploadDate?.date()?.timeInMillis, rule.since, initialized, history.contains(rule.uid, stream.url), live)
+                        if (!initialized && !selected && !live) history.add(rule.uid, stream.url)
+                        selected
+                    }
+                    history.add(rule.uid, "")
+                    var queued = 0
+                    for (stream in candidates) {
+                        if (queued >= 3 || totalQueued >= 20 || isStopped || !preferences.getBoolean(AutomaticDownloads.ENABLED, false)) break
+                        if (AutomaticDownloads.rules(context).none { it.uid == rule.uid }) break
+                        val kind = if (rule.audio) 'a' else 'v'
+                        if (service.downloadManager.hasMissionForSource(stream.url, kind)) {
+                            history.add(rule.uid, stream.url)
+                            continue
+                        }
+                        try {
+                            val directory = if (rule.audio) service.mainStorageAudio else service.mainStorageVideo
+                            if (directory == null || directory.isDirect == NewPipeSettings.useStorageAccessFramework(context) || directory.isInvalidSafStorage || !directory.canWrite()) throw IOException(context.getString(R.string.bulk_download_folder_error))
+                            val info = ExtractorHelper.getStreamInfo(rule.serviceId, stream.url, false).blockingGet()
+                            if (StreamTypeUtil.isLiveStream(info.streamType) || isStopped) continue
+                            BulkDownloadMissionFactory.enqueue(context, directory, info, if (rule.audio) BulkDownloadMissionFactory.MediaType.AUDIO else BulkDownloadMissionFactory.MediaType.VIDEO, preferences.getInt(context.getString(R.string.default_download_threads), 3), 1, 1, false, preferences.getBoolean(AutomaticDownloads.WIFI_ONLY, true))
+                            history.add(rule.uid, stream.url)
+                            queued++
+                            totalQueued++
+                        } catch (exception: Exception) {
+                            Log.w("AutomaticDownloads", "Unable to enqueue a new channel upload", exception)
+                            failed = true
+                        }
+                    }
+                }
+            }
+            preferences.edit().putString("automatic_download_status", context.getString(if (failed) R.string.automatic_download_partial_status else R.string.automatic_download_success_status, totalQueued)).apply()
+            if (failed) Result.retry() else Result.success()
+        } finally {
+            context.unbindService(connection)
+        }
+    }.subscribeOn(Schedulers.io()).doOnDispose { feed.cancel() }.onErrorReturn { error ->
+        Log.w("AutomaticDownloads", "Automatic download check failed", error)
+        PreferenceManager.getDefaultSharedPreferences(applicationContext).edit()
+            .putString("automatic_download_status", error.message ?: applicationContext.getString(R.string.general_error)).apply()
+        Result.retry()
+    }
+
+    override fun onStopped() {
+        feed.cancel()
+        super.onStopped()
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloads.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloads.kt
@@ -1,0 +1,92 @@
+package org.schabi.newpipe.download
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import java.util.concurrent.TimeUnit
+import org.json.JSONObject
+import org.schabi.newpipe.R
+
+internal data class AutomaticDownloadRule(val uid: Long, val serviceId: Int, val url: String, val name: String, val audio: Boolean, val since: Long)
+
+object AutomaticDownloads {
+    const val ENABLED = "automatic_downloads_enabled"
+    const val WIFI_ONLY = "automatic_downloads_wifi_only"
+    private const val WORK = "automatic-channel-downloads"
+
+    internal fun rules(context: Context): List<AutomaticDownloadRule> = context.getSharedPreferences(WORK, Context.MODE_PRIVATE).all.mapNotNull { (key, value) ->
+        runCatching {
+            val data = JSONObject(value as String)
+            AutomaticDownloadRule(key.toLong(), data.getInt("service"), data.getString("url"), data.getString("name"), data.getBoolean("audio"), data.getLong("since"))
+        }.getOrNull()
+    }
+
+    @JvmStatic
+    fun initialize(context: Context) {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val manager = WorkManager.getInstance(context)
+        if (!preferences.getBoolean(ENABLED, false) || rules(context).isEmpty()) {
+            manager.cancelUniqueWork(WORK)
+            return
+        }
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(if (preferences.getBoolean(WIFI_ONLY, true)) NetworkType.UNMETERED else NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .setRequiresStorageNotLow(true)
+            .build()
+        manager.enqueueUniquePeriodicWork(
+            WORK, ExistingPeriodicWorkPolicy.UPDATE,
+            PeriodicWorkRequestBuilder<AutomaticDownloadWorker>(1, TimeUnit.HOURS).setConstraints(constraints).build()
+        )
+    }
+
+    @JvmStatic
+    fun configure(context: Context, uid: Long, serviceId: Int, url: String, name: String) {
+        val current = rules(context).firstOrNull { it.uid == uid }
+        val options = arrayOf(context.getString(R.string.automatic_download_off), context.getString(R.string.audio), context.getString(R.string.video))
+        MaterialAlertDialogBuilder(context).setTitle(context.getString(R.string.automatic_download_channel_title, name))
+            .setSingleChoiceItems(options, if (current == null) 0 else if (current.audio) 1 else 2) { dialog, index ->
+                val editor = context.getSharedPreferences(WORK, Context.MODE_PRIVATE).edit()
+                if (index == 0) {
+                    editor.remove(uid.toString())
+                } else {
+                    editor.putString(uid.toString(), JSONObject().put("service", serviceId).put("url", url).put("name", name)
+                        .put("audio", index == 1).put("since", current?.since ?: System.currentTimeMillis()).toString())
+                    PreferenceManager.getDefaultSharedPreferences(context).edit().putBoolean(ENABLED, true).apply()
+                }
+                editor.apply()
+                initialize(context)
+                dialog.dismiss()
+            }.setNegativeButton(R.string.cancel, null).show()
+    }
+
+    @JvmStatic
+    fun manage(context: Context) {
+        val configured = rules(context)
+        val builder = MaterialAlertDialogBuilder(context).setTitle(R.string.automatic_download_channels)
+        if (configured.isEmpty()) {
+            builder.setMessage(R.string.automatic_download_instructions).setPositiveButton(R.string.ok, null)
+        } else {
+            builder.setItems(configured.map { it.name }.toTypedArray()) { _, index ->
+                val rule = configured[index]
+                configure(context, rule.uid, rule.serviceId, rule.url, rule.name)
+            }.setNegativeButton(R.string.cancel, null)
+        }
+        builder.show()
+    }
+}
+
+internal object AutomaticDownloadPolicy {
+    fun shouldDownload(publishedAt: Long?, enabledAt: Long, initialized: Boolean, seen: Boolean, live: Boolean): Boolean {
+        if (seen || live) return false
+        // The first check establishes a baseline rather than downloading a channel's archive.
+        if (!initialized) return publishedAt != null && publishedAt >= enabledAt
+        // Some feeds report only the date, so allow the enabling day after baseline creation.
+        return publishedAt == null || publishedAt >= enabledAt - TimeUnit.DAYS.toMillis(1)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloads.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/AutomaticDownloads.kt
@@ -40,7 +40,8 @@ object AutomaticDownloads {
             .setRequiresStorageNotLow(true)
             .build()
         manager.enqueueUniquePeriodicWork(
-            WORK, ExistingPeriodicWorkPolicy.UPDATE,
+            WORK,
+            ExistingPeriodicWorkPolicy.UPDATE,
             PeriodicWorkRequestBuilder<AutomaticDownloadWorker>(1, TimeUnit.HOURS).setConstraints(constraints).build()
         )
     }
@@ -48,15 +49,23 @@ object AutomaticDownloads {
     @JvmStatic
     fun configure(context: Context, uid: Long, serviceId: Int, url: String, name: String) {
         val current = rules(context).firstOrNull { it.uid == uid }
+        val selected = when {
+            current == null -> 0
+            current.audio -> 1
+            else -> 2
+        }
         val options = arrayOf(context.getString(R.string.automatic_download_off), context.getString(R.string.audio), context.getString(R.string.video))
         MaterialAlertDialogBuilder(context).setTitle(context.getString(R.string.automatic_download_channel_title, name))
-            .setSingleChoiceItems(options, if (current == null) 0 else if (current.audio) 1 else 2) { dialog, index ->
+            .setSingleChoiceItems(options, selected) { dialog, index ->
                 val editor = context.getSharedPreferences(WORK, Context.MODE_PRIVATE).edit()
                 if (index == 0) {
                     editor.remove(uid.toString())
                 } else {
-                    editor.putString(uid.toString(), JSONObject().put("service", serviceId).put("url", url).put("name", name)
-                        .put("audio", index == 1).put("since", current?.since ?: System.currentTimeMillis()).toString())
+                    editor.putString(
+                        uid.toString(),
+                        JSONObject().put("service", serviceId).put("url", url).put("name", name)
+                            .put("audio", index == 1).put("since", current?.since ?: System.currentTimeMillis()).toString()
+                    )
                     PreferenceManager.getDefaultSharedPreferences(context).edit().putBoolean(ENABLED, true).apply()
                 }
                 editor.apply()

--- a/app/src/main/java/org/schabi/newpipe/download/BulkDownloadMissionFactory.java
+++ b/app/src/main/java/org/schabi/newpipe/download/BulkDownloadMissionFactory.java
@@ -43,6 +43,16 @@ final class BulkDownloadMissionFactory {
                         final int position,
                         final int total,
                         final boolean addNumberPrefix) {
+        enqueue(context, directory, info, mediaType, threads, position, total,
+                addNumberPrefix, null);
+    }
+
+    static void enqueue(@NonNull final Context context,
+                        @NonNull final StoredDirectoryHelper directory,
+                        @NonNull final StreamInfo info,
+                        @NonNull final MediaType mediaType,
+                        final int threads, final int position, final int total,
+                        final boolean addNumberPrefix, final Boolean automaticWifiOnly) {
         final MissionSelection selection = mediaType == MediaType.AUDIO
                 ? selectAudio(context, info) : selectVideo(context, info);
 
@@ -71,7 +81,7 @@ final class BulkDownloadMissionFactory {
 
         DownloadManagerService.startMission(context, urls, storage, selection.kind, threads,
                 info, selection.postprocessingName, selection.postprocessingArguments,
-                0, recoveryInfo);
+                0, recoveryInfo, automaticWifiOnly);
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -113,6 +113,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
     private MenuItem menuRssButton;
     private MenuItem menuNotifyButton;
     private MenuItem menuNotificationKeywordsButton;
+    private MenuItem menuAutomaticDownloadsButton;
     private SubscriptionEntity channelSubscription;
 
     public static ChannelFragment getInstance(final int serviceId, final String url,
@@ -189,6 +190,7 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                 menuNotifyButton = menu.findItem(R.id.menu_item_notify);
                 menuNotificationKeywordsButton =
                         menu.findItem(R.id.menu_item_notification_keywords);
+                menuAutomaticDownloadsButton = menu.findItem(R.id.menu_item_automatic_downloads);
                 updateRssButton();
                 updateNotifyButton(channelSubscription);
             }
@@ -202,6 +204,12 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
                     setNotify(value);
                 } else if (itemId == R.id.menu_item_notification_keywords) {
                     showNotificationConfigDialog();
+                } else if (itemId == R.id.menu_item_automatic_downloads) {
+                    if (channelSubscription != null && currentInfo != null) {
+                        org.schabi.newpipe.download.AutomaticDownloads.configure(requireContext(),
+                                channelSubscription.getUid(), currentInfo.getServiceId(),
+                                currentInfo.getUrl(), currentInfo.getName());
+                    }
                 } else if (itemId == R.id.action_settings) {
                     NavigationHelper.openSettings(requireContext());
                 } else if (itemId == R.id.menu_item_rss) {
@@ -503,6 +511,9 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
 
         menuNotifyButton.setVisible(subscription != null);
         menuNotificationKeywordsButton.setVisible(subscription != null);
+        if (menuAutomaticDownloadsButton != null) {
+            menuAutomaticDownloadsButton.setVisible(subscription != null);
+        }
     }
 
     private void showNotificationConfigDialog() {

--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -66,7 +66,8 @@ class FeedLoadManager(private val context: Context) {
     fun startLoading(
         groupId: Long = FeedGroupEntity.GROUP_ALL_ID,
         ignoreOutdatedThreshold: Boolean = false,
-        scope: FeedScope? = null
+        scope: FeedScope? = null,
+        onlySubscriptions: Set<Long>? = null
     ): Single<List<Notification<FeedUpdateInfo>>> {
         feedScope = scope
         val defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -114,6 +115,7 @@ class FeedLoadManager(private val context: Context) {
 
         return outdatedSubscriptions
             .take(1)
+            .map { subscriptions -> subscriptions.filter { onlySubscriptions == null || it.uid in onlySubscriptions } }
             .doOnNext {
                 currentProgress.set(0)
                 maxProgress.set(it.size)

--- a/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/DownloadSettingsFragment.java
@@ -39,6 +39,16 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
     private Preference prefStorageAsk;
 
     private Context ctx;
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        final Preference status = findPreference("automatic_download_status");
+        if (status != null) {
+            status.setSummary(defaultPreferences.getString("automatic_download_status",
+                    getString(R.string.automatic_download_waiting_status)));
+        }
+    }
     private final ActivityResultLauncher<Intent> requestDownloadVideoPathLauncher =
             registerForActivityResult(
                     new StartActivityForResult(), this::requestDownloadVideoPathResult);
@@ -79,6 +89,15 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
             updatePathPickers(!(boolean) value);
             return true;
         });
+        for (final String key : new String[]{
+                org.schabi.newpipe.download.AutomaticDownloads.ENABLED,
+                org.schabi.newpipe.download.AutomaticDownloads.WIFI_ONLY}) {
+            findPreference(key).setOnPreferenceChangeListener((preference, value) -> {
+                new android.os.Handler(android.os.Looper.getMainLooper()).post(() ->
+                        org.schabi.newpipe.download.AutomaticDownloads.initialize(ctx));
+                return true;
+            });
+        }
     }
 
     @Override
@@ -167,6 +186,11 @@ public class DownloadSettingsFragment extends BasePreferenceFragment {
         }
 
         final String key = preference.getKey();
+
+        if ("automatic_download_channels".equals(key)) {
+            org.schabi.newpipe.download.AutomaticDownloads.manage(requireContext());
+            return true;
+        }
 
         if (key.equals(storageUseSafPreference)) {
             if (!NewPipeSettings.useStorageAccessFramework(ctx)) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
-    private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
+    private static final boolean SAMSUNG = "samsung".equals(Build.MANUFACTURER);
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -53,38 +53,38 @@ public final class DeviceUtils {
      * <p>Board: HiSilicon Hi3798MV200</p>
      */
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("Hi3798MV200");
+            && "Hi3798MV200".equals(Build.DEVICE);
     /**
      * <p>Zephir TS43UHD-2.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+            && "cvt_mt5886_eu_1g".equals(Build.DEVICE);
     /**
      * Hilife TV.
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
-            && Build.DEVICE.equals("RealtekATV");
+            && "RealtekATV".equals(Build.DEVICE);
     /**
      * <p>Phillips 4K (O)LED TV.</p>
      * Supports custom ROMs with different API levels
      */
     private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
-            && Build.DEVICE.equals("PH7M_EU_5596");
+            && "PH7M_EU_5596".equals(Build.DEVICE);
     /**
      * <p>Philips QM16XE.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
-            && Build.DEVICE.equals("QM16XE_U");
+            && "QM16XE_U".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH1.</p>
      * <p>Processor: MT5895</p>
      * <p>Blacklist reason: fullscreen crash / stuttering</p>
      */
     private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH1");
+            && "BRAVIA_VH1".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH2.</p>
      * <p>Blacklist reason: fullscreen crash; this includes model A90J as reported in
@@ -92,14 +92,14 @@ public final class DeviceUtils {
      * #9023</a></p>
      */
     private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH2");
+            && "BRAVIA_VH2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 2.</p>
      * Uses a MediaTek MT5891 (MT5596) SoC.
      * @see <a href="https://github.com/CiNcH83/bravia_atv2">
      *     https://github.com/CiNcH83/bravia_atv2</a>
      */
-    private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
+    private static final boolean BRAVIA_ATV2 = "BRAVIA_ATV2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 3 4K.</p>
      * <p>Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.</p>
@@ -107,19 +107,19 @@ public final class DeviceUtils {
      * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
      *     https://browser.geekbench.com/v4/cpu/9101105</a>
      */
-    private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
+    private static final boolean BRAVIA_ATV3_4K = "BRAVIA_ATV3_4K".equals(Build.DEVICE);
     /**
      * <p>Panasonic 4KTV-JUP.</p>
      * <p>Blacklist reason: fullscreen crash</p>
      */
-    private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
+    private static final boolean TX_50JXW834 = "TX_50JXW834".equals(Build.DEVICE);
     /**
      * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
      * <p>Blacklist reason: black screen; reported at
      * <a href="https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769">
      *     #10122</a></p>
      */
-    private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    private static final boolean HMB9213NW = "HMB9213NW".equals(Build.DEVICE);
     // endregion
 
     private DeviceUtils() {

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -87,6 +87,7 @@ public class DownloadMission extends Mission {
      * 3: hold
      */
     public volatile int psState;
+    public boolean requiresUnmeteredNetwork;
 
     /**
      * the post-processing algorithm instance

--- a/app/src/main/java/us/shandian/giga/service/DownloadManager.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManager.java
@@ -268,7 +268,7 @@ public class DownloadManager {
 
             boolean start = !mPrefQueueLimit || getRunningMissionsCount() < 1;
 
-            if (canDownloadInCurrentNetwork() && start) {
+            if (canDownloadInCurrentNetwork(mission) && start) {
                 mission.start();
             }
         }
@@ -276,9 +276,21 @@ public class DownloadManager {
 
 
     public void resumeMission(DownloadMission mission) {
-        if (!mission.running) {
+        if (!mission.running && (!mission.requiresUnmeteredNetwork
+                || canDownloadInCurrentNetwork(mission))) {
             mission.start();
         }
+    }
+
+    public synchronized boolean hasMissionForSource(final String source, final char kind) {
+        for (final DownloadMission mission : mMissionsPending) {
+            if (kind == mission.kind && source.equals(mission.source)) return true;
+        }
+        for (final FinishedMission mission : mMissionsFinished) {
+            if (kind == mission.kind && source.equals(mission.source)
+                    && mission.storage != null && mission.storage.existsAsFile()) return true;
+        }
+        return false;
     }
 
     public void pauseMission(DownloadMission mission) {
@@ -470,7 +482,8 @@ public class DownloadManager {
 
             boolean flag = false;
             for (DownloadMission mission : mMissionsPending) {
-                if (mission.running || !mission.enqueued || mission.isFinished())
+                if (mission.running || !mission.enqueued || mission.isFinished()
+                        || !canDownloadInCurrentNetwork(mission))
                     continue;
 
                 resumeMission(mission);
@@ -506,6 +519,11 @@ public class DownloadManager {
         return !(mPrefMeteredDownloads && mLastNetworkStatus == NetworkState.MeteredOperating);
     }
 
+    private boolean canDownloadInCurrentNetwork(final DownloadMission mission) {
+        return canDownloadInCurrentNetwork() && !(mission.requiresUnmeteredNetwork
+                && mLastNetworkStatus == NetworkState.MeteredOperating);
+    }
+
     void handleConnectivityState(NetworkState currentStatus, boolean updateOnly) {
         if (currentStatus == mLastNetworkStatus) return;
 
@@ -516,15 +534,13 @@ public class DownloadManager {
             return;// don't touch anything without the user interaction
         }
 
-        boolean isMetered = mPrefMeteredDownloads && mLastNetworkStatus == NetworkState.MeteredOperating;
-
         synchronized (this) {
             for (DownloadMission mission : mMissionsPending) {
                 if (mission.isCorrupt() || mission.isPsRunning()) continue;
-
-                if (mission.running && isMetered) {
+                if (mission.running && !canDownloadInCurrentNetwork(mission)) {
                     mission.pause();
-                } else if (!mission.running && !isMetered && mission.enqueued) {
+                } else if (!mission.running && canDownloadInCurrentNetwork(mission)
+                        && mission.enqueued) {
                     mission.start();
                     if (mPrefQueueLimit) break;
                 }

--- a/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
@@ -364,8 +364,19 @@ public class DownloadManagerService extends Service {
                                     char kind, int threads, StreamInfo streamInfo, String psName,
                                     String[] psArgs, long nearLength,
                                     ArrayList<MissionRecoveryInfo> recoveryInfo) {
+        startMission(context, urls, storage, kind, threads, streamInfo, psName, psArgs,
+                nearLength, recoveryInfo, null);
+    }
+
+    public static void startMission(Context context, String[] urls, StoredFileHelper storage,
+                                    char kind, int threads, StreamInfo streamInfo, String psName,
+                                    String[] psArgs, long nearLength,
+                                    ArrayList<MissionRecoveryInfo> recoveryInfo,
+                                    Boolean automaticWifiOnly) {
         final Intent intent = new Intent(context, DownloadManagerService.class)
                 .setAction(Intent.ACTION_RUN)
+                .putExtra("automatic_download", automaticWifiOnly != null)
+                .putExtra("automatic_wifi_only", Boolean.TRUE.equals(automaticWifiOnly))
                 .putExtra(EXTRA_URLS, urls)
                 .putExtra(EXTRA_KIND, kind)
                 .putExtra(EXTRA_THREADS, threads)
@@ -410,6 +421,12 @@ public class DownloadManagerService extends Service {
             ps = Postprocessing.getAlgorithm(psName, psArgs, streamInfo);
 
         final DownloadMission mission = new DownloadMission(urls, storage, kind, ps);
+        if (intent.getBooleanExtra("automatic_download", false)
+                && mManager.hasMissionForSource(streamInfo.getUrl(), kind)) {
+            storage.delete();
+            return;
+        }
+        mission.requiresUnmeteredNetwork = intent.getBooleanExtra("automatic_wifi_only", false);
         mission.threadCount = threads;
         mission.source = streamInfo.getUrl();
         mission.nearLength = nearLength;

--- a/app/src/main/res/menu/menu_channel.xml
+++ b/app/src/main/res/menu/menu_channel.xml
@@ -53,4 +53,9 @@
         android:orderInCategory="4"
         android:title="@string/open_in_browser"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/menu_item_automatic_downloads"
+        android:title="@string/automatic_downloads"
+        android:visible="false"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/automatic_download_strings.xml
+++ b/app/src/main/res/values/automatic_download_strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="automatic_downloads">Automatic channel downloads</string>
+    <string name="automatic_download_channel_title">Download new uploads: %1$s</string>
+    <string name="automatic_download_channels">Manage automatic downloads</string>
+    <string name="automatic_download_instructions">Subscribe to a channel, then choose Automatic channel downloads in its menu. New uploads are checked hourly, with up to 3 per channel and 20 total per check. Uses your default download quality and saved folders. Existing uploads are skipped; failed downloads can be retried from Downloads.</string>
+    <string name="automatic_download_wifi_only">Use unmetered networks only</string>
+    <string name="automatic_download_off">Off</string>
+    <string name="automatic_download_success_status">Last check: queued %1$d downloads.</string>
+    <string name="automatic_download_partial_status">Last check: queued %1$d downloads. Some items could not be queued and will be checked again.</string>
+    <string name="automatic_download_waiting_status">Waiting for the next scheduled check.</string>
+    <string name="automatic_download_status_title">Last automatic download check</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,4 +1605,14 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
+    <string name="automatic_downloads">Automatic channel downloads</string>
+    <string name="automatic_download_channel_title">Download new uploads: %1$s</string>
+    <string name="automatic_download_channels">Manage automatic downloads</string>
+    <string name="automatic_download_instructions">Subscribe to a channel, then choose Automatic channel downloads in its menu. New uploads are checked hourly, with up to 3 per channel and 20 total per check. Uses your default download quality and saved folders. Existing uploads are skipped; failed downloads can be retried from Downloads.</string>
+    <string name="automatic_download_wifi_only">Use unmetered networks only</string>
+    <string name="automatic_download_off">Off</string>
+    <string name="automatic_download_success_status">Last check: queued %1$d downloads.</string>
+    <string name="automatic_download_partial_status">Last check: queued %1$d downloads. Some items could not be queued and will be checked again.</string>
+    <string name="automatic_download_waiting_status">Waiting for the next scheduled check.</string>
+    <string name="automatic_download_status_title">Last automatic download check</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,14 +1605,4 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
-    <string name="automatic_downloads">Automatic channel downloads</string>
-    <string name="automatic_download_channel_title">Download new uploads: %1$s</string>
-    <string name="automatic_download_channels">Manage automatic downloads</string>
-    <string name="automatic_download_instructions">Subscribe to a channel, then choose Automatic channel downloads in its menu. New uploads are checked hourly, with up to 3 per channel and 20 total per check. Uses your default download quality and saved folders. Existing uploads are skipped; failed downloads can be retried from Downloads.</string>
-    <string name="automatic_download_wifi_only">Use unmetered networks only</string>
-    <string name="automatic_download_off">Off</string>
-    <string name="automatic_download_success_status">Last check: queued %1$d downloads.</string>
-    <string name="automatic_download_partial_status">Last check: queued %1$d downloads. Some items could not be queued and will be checked again.</string>
-    <string name="automatic_download_waiting_status">Waiting for the next scheduled check.</string>
-    <string name="automatic_download_status_title">Last automatic download check</string>
 </resources>

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -79,4 +79,22 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <PreferenceCategory android:title="@string/automatic_downloads" app:iconSpaceReserved="false">
+        <SwitchPreferenceCompat
+            android:key="automatic_downloads_enabled"
+            android:defaultValue="false"
+            android:title="@string/automatic_downloads"
+            android:summary="@string/automatic_download_instructions"
+            app:iconSpaceReserved="false" app:singleLineTitle="false" />
+        <SwitchPreferenceCompat
+            android:key="automatic_downloads_wifi_only"
+            android:defaultValue="true"
+            android:title="@string/automatic_download_wifi_only"
+            app:iconSpaceReserved="false" />
+        <Preference android:key="automatic_download_channels"
+            android:title="@string/automatic_download_channels" app:iconSpaceReserved="false" />
+        <Preference android:key="automatic_download_status"
+            android:title="@string/automatic_download_status_title"
+            android:selectable="false" app:iconSpaceReserved="false" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/test/java/org/schabi/newpipe/download/AutomaticDownloadPolicyTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/AutomaticDownloadPolicyTest.kt
@@ -1,0 +1,31 @@
+package org.schabi.newpipe.download
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutomaticDownloadPolicyTest {
+    @Test
+    fun enablingDoesNotDownloadTheChannelArchive() {
+        assertFalse(AutomaticDownloadPolicy.shouldDownload(10, 20, false, false, false))
+        assertFalse(AutomaticDownloadPolicy.shouldDownload(null, 20, false, false, false))
+        assertTrue(AutomaticDownloadPolicy.shouldDownload(30, 20, false, false, false))
+    }
+
+    @Test
+    fun newUndatedUploadsAreAcceptedAfterTheBaseline() {
+        assertTrue(AutomaticDownloadPolicy.shouldDownload(null, 20, true, false, false))
+        assertFalse(AutomaticDownloadPolicy.shouldDownload(null, 20, true, true, false))
+    }
+
+    @Test
+    fun liveStreamsWaitUntilAnArchivedCopyIsAvailable() {
+        assertFalse(AutomaticDownloadPolicy.shouldDownload(30, 20, true, false, true))
+        assertTrue(AutomaticDownloadPolicy.shouldDownload(30, 20, true, false, false))
+    }
+
+    @Test
+    fun oldUploadsReappearingInAFeedAreNotBackfilled() {
+        assertFalse(AutomaticDownloadPolicy.shouldDownload(1, 200_000_000, true, false, false))
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
@@ -88,9 +88,15 @@ public class VideoDetailBackPressTest {
 
     @After
     public void tearDown() {
-        playerHelper.close();
-        deviceUtils.close();
-        log.close();
+        if (playerHelper != null) {
+            playerHelper.close();
+        }
+        if (deviceUtils != null) {
+            deviceUtils.close();
+        }
+        if (log != null) {
+            log.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
- Add per-subscribed-channel Off/Audio/Video download choices and global controls in Download settings.
- Check for new uploads hourly with WorkManager, establish a baseline instead of downloading the channel archive, and persist duplicate receipts.
- Default to unmetered networks and enforce that restriction throughout queued downloads; require usable saved download folders.
- Limit each check to three uploads per channel and twenty total; expose the last check status in settings.
- Validated: source-inspection gate, debug build, lint, JVM tests, and Android tests on API 23 and 35 all passed, including receipt persistence.
- Verified clean local merges with the other five feature branches. Scheduled execution under real-device battery and network conditions still needs device QA.