### PR TITLE
Personalize discovery topics and visibility

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
@@ -18,6 +18,9 @@ import org.schabi.newpipe.database.stream.StreamStatisticsEntry
 @Dao
 abstract class StreamHistoryDAO : BasicDAO<StreamHistoryEntity> {
 
+    @Query("SELECT DISTINCT service_id || ':' || url FROM streams INNER JOIN stream_history ON uid = stream_id")
+    abstract fun discoveryWatchedKeys(): List<String>
+
     @Query("SELECT * FROM stream_history")
     abstract override fun getAll(): Flowable<List<StreamHistoryEntity>>
 

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
@@ -204,7 +204,7 @@ public abstract class BaseListInfoFragment<I extends InfoItem, L extends ListInf
         super.handleNextItems(result);
 
         currentNextPage = result.getNextPage();
-        infoListAdapter.addInfoItemList(result.getItems());
+        infoListAdapter.addInfoItemList(getDisplayItems(result.getItems()));
 
         showListFooter(hasMoreItems());
 
@@ -217,6 +217,11 @@ public abstract class BaseListInfoFragment<I extends InfoItem, L extends ListInf
     @Override
     protected boolean hasMoreItems() {
         return Page.isValid(currentNextPage);
+    }
+
+    /** Produces display items without modifying cached extractor results. */
+    protected List<I> getDisplayItems(final List<I> items) {
+        return items;
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -232,7 +237,7 @@ public abstract class BaseListInfoFragment<I extends InfoItem, L extends ListInf
 
         if (infoListAdapter.getItemsList().isEmpty()) {
             if (!result.getRelatedItems().isEmpty()) {
-                infoListAdapter.addInfoItemList(result.getRelatedItems());
+                infoListAdapter.addInfoItemList(getDisplayItems(result.getRelatedItems()));
             }
             if (!infoListAdapter.getItemsList().isEmpty()) {
                 showListFooter(hasMoreItems());

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListInfoFragment.java
@@ -219,7 +219,11 @@ public abstract class BaseListInfoFragment<I extends InfoItem, L extends ListInf
         return Page.isValid(currentNextPage);
     }
 
-    /** Produces display items without modifying cached extractor results. */
+    /**
+     * Produces display items without modifying cached extractor results.
+     * @param items original items from the extractor
+     * @return items to display
+     */
     protected List<I> getDisplayItems(final List<I> items) {
         return items;
     }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/DiscoveryPersonalization.kt
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/DiscoveryPersonalization.kt
@@ -1,0 +1,113 @@
+package org.schabi.newpipe.fragments.list.kiosk
+
+import android.content.Context
+import android.text.InputType
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.preference.PreferenceManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import java.util.Locale
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.R
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamType
+
+internal data class DiscoveryRules(
+    val interests: List<String> = emptyList(),
+    val hidden: List<String> = emptyList(),
+    val hideWatched: Boolean = false,
+    val hideShorts: Boolean = false,
+    val hideLive: Boolean = false
+) {
+    fun apply(items: List<StreamInfoItem>, watched: Set<String>): List<StreamInfoItem> = items.filter { item ->
+        val text = "${item.name} ${item.uploaderName}".lowercase(Locale.ROOT)
+        hidden.none { text.contains(it) } &&
+            (!hideWatched || "${item.serviceId}:${item.url}" !in watched) &&
+            (!hideShorts || !item.isShortFormContent) &&
+            (!hideLive || item.streamType !in setOf(StreamType.LIVE_STREAM, StreamType.AUDIO_LIVE_STREAM))
+    }.sortedByDescending { item ->
+        val text = "${item.name} ${item.uploaderName}".lowercase(Locale.ROOT)
+        interests.count { text.contains(it) }
+    }
+}
+
+class DiscoveryPersonalization private constructor(private val rules: DiscoveryRules, private val watched: Set<String>) {
+    fun apply(items: List<StreamInfoItem>): List<StreamInfoItem> = rules.apply(items, watched)
+
+    companion object {
+        private const val PREFIX = "discovery_"
+
+        private fun terms(text: String): List<String> = text.split(',', '\n').map { it.trim().lowercase(Locale.ROOT) }.filter { it.isNotEmpty() }.distinct().take(100)
+
+        private fun rules(context: Context): DiscoveryRules {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            return DiscoveryRules(
+                terms(prefs.getString(PREFIX + "interests", "").orEmpty()),
+                terms(prefs.getString(PREFIX + "hidden", "").orEmpty()),
+                prefs.getBoolean(PREFIX + "watched", false),
+                prefs.getBoolean(PREFIX + "shorts", false),
+                prefs.getBoolean(PREFIX + "live", false)
+            )
+        }
+
+        /** Call on an IO scheduler: history is consulted only when requested. */
+        @JvmStatic
+        fun load(context: Context): DiscoveryPersonalization {
+            val rules = rules(context)
+            val watched = if (rules.hideWatched) {
+                NewPipeDatabase.getInstance(context).streamHistoryDAO().discoveryWatchedKeys().toSet()
+            } else {
+                emptySet()
+            }
+            return DiscoveryPersonalization(rules, watched)
+        }
+
+        @JvmStatic
+        fun configure(context: Context, onChanged: Runnable) {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val padding = (24 * context.resources.displayMetrics.density).toInt()
+            val content = LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(padding, padding / 2, padding, 0)
+                addView(TextView(context).apply { setText(R.string.discovery_personalize_help) })
+            }
+            fun field(key: String, label: Int): EditText {
+                content.addView(TextView(context).apply { setText(label) })
+                return EditText(context).apply {
+                    inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                    setText(prefs.getString(PREFIX + key, ""))
+                    maxLines = 4
+                    content.addView(this)
+                }
+            }
+            fun check(key: String, label: Int): CheckBox = CheckBox(context).apply {
+                setText(label)
+                isChecked = prefs.getBoolean(PREFIX + key, false)
+                content.addView(this)
+            }
+            val interests = field("interests", R.string.discovery_interests)
+            val hidden = field("hidden", R.string.discovery_hidden)
+            val watched = check("watched", R.string.discovery_hide_watched)
+            val shorts = check("shorts", R.string.discovery_hide_shorts)
+            val live = check("live", R.string.discovery_hide_live)
+            MaterialAlertDialogBuilder(context).setTitle(R.string.discovery_personalize)
+                .setView(ScrollView(context).apply { addView(content) })
+                .setPositiveButton(R.string.ok) { _, _ ->
+                    prefs.edit().putString(PREFIX + "interests", interests.text.toString().take(10000))
+                        .putString(PREFIX + "hidden", hidden.text.toString().take(10000))
+                        .putBoolean(PREFIX + "watched", watched.isChecked)
+                        .putBoolean(PREFIX + "shorts", shorts.isChecked)
+                        .putBoolean(PREFIX + "live", live.isChecked).apply()
+                    onChanged.run()
+                }.setNeutralButton(R.string.discovery_reset) { _, _ ->
+                    val editor = prefs.edit()
+                    listOf("interests", "hidden", "watched", "shorts", "live").forEach { editor.remove(PREFIX + it) }
+                    editor.apply()
+                    onChanged.run()
+                }.setNegativeButton(R.string.cancel, null).show()
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/kiosk/KioskFragment.java
@@ -36,6 +36,8 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.KioskTranslator;
 import org.schabi.newpipe.util.Localization;
 
+import java.util.List;
+
 import io.reactivex.rxjava3.core.Single;
 
 public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInfo> {
@@ -44,6 +46,8 @@ public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInf
     String kioskTranslatedName;
     @State
     ContentCountry contentCountry;
+
+    private DiscoveryPersonalization personalization;
 
     /*//////////////////////////////////////////////////////////////////////////
     // Views
@@ -92,7 +96,8 @@ public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInf
     @Override
     public void onResume() {
         super.onResume();
-        if (!Localization.getPreferredContentCountry(requireContext()).equals(contentCountry)) {
+        if (!Localization.getPreferredContentCountry(requireContext()).equals(contentCountry)
+                || (currentInfo != null && personalization == null && !isLoading.get())) {
             reloadContent();
         }
         if (useAsFrontPage && activity != null) {
@@ -119,6 +124,10 @@ public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInf
     public void onCreateOptionsMenu(@NonNull final Menu menu,
                                     @NonNull final MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
+        menu.add(R.string.discovery_personalize).setOnMenuItemClickListener(item -> {
+            DiscoveryPersonalization.configure(requireContext(), this::reloadContent);
+            return true;
+        });
         final ActionBar supportActionBar = activity.getSupportActionBar();
         if (supportActionBar != null && useAsFrontPage) {
             supportActionBar.setDisplayHomeAsUpEnabled(false);
@@ -132,17 +141,26 @@ public class KioskFragment extends BaseListInfoFragment<StreamInfoItem, KioskInf
     @Override
     public Single<KioskInfo> loadResult(final boolean forceReload) {
         contentCountry = Localization.getPreferredContentCountry(requireContext());
-        return ExtractorHelper.getKioskInfo(serviceId, url, forceReload);
+        final android.content.Context context = requireContext().getApplicationContext();
+        return ExtractorHelper.getKioskInfo(serviceId, url, forceReload)
+                .doOnSuccess(info -> personalization = DiscoveryPersonalization.load(context));
     }
 
     @Override
     public Single<ListExtractor.InfoItemsPage<StreamInfoItem>> loadMoreItemsLogic() {
-        return ExtractorHelper.getMoreKioskItems(serviceId, url, currentNextPage);
+        final android.content.Context context = requireContext().getApplicationContext();
+        return ExtractorHelper.getMoreKioskItems(serviceId, url, currentNextPage)
+                .doOnSuccess(info -> personalization = DiscoveryPersonalization.load(context));
     }
 
     /*//////////////////////////////////////////////////////////////////////////
     // Contract
     //////////////////////////////////////////////////////////////////////////*/
+
+    @Override
+    protected List<StreamInfoItem> getDisplayItems(final List<StreamInfoItem> items) {
+        return personalization == null ? items : personalization.apply(items);
+    }
 
     @Override
     public void handleResult(@NonNull final KioskInfo result) {

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
-    private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
+    private static final boolean SAMSUNG = "samsung".equals(Build.MANUFACTURER);
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -53,38 +53,38 @@ public final class DeviceUtils {
      * <p>Board: HiSilicon Hi3798MV200</p>
      */
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("Hi3798MV200");
+            && "Hi3798MV200".equals(Build.DEVICE);
     /**
      * <p>Zephir TS43UHD-2.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+            && "cvt_mt5886_eu_1g".equals(Build.DEVICE);
     /**
      * Hilife TV.
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
-            && Build.DEVICE.equals("RealtekATV");
+            && "RealtekATV".equals(Build.DEVICE);
     /**
      * <p>Phillips 4K (O)LED TV.</p>
      * Supports custom ROMs with different API levels
      */
     private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
-            && Build.DEVICE.equals("PH7M_EU_5596");
+            && "PH7M_EU_5596".equals(Build.DEVICE);
     /**
      * <p>Philips QM16XE.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
-            && Build.DEVICE.equals("QM16XE_U");
+            && "QM16XE_U".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH1.</p>
      * <p>Processor: MT5895</p>
      * <p>Blacklist reason: fullscreen crash / stuttering</p>
      */
     private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH1");
+            && "BRAVIA_VH1".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH2.</p>
      * <p>Blacklist reason: fullscreen crash; this includes model A90J as reported in
@@ -92,14 +92,14 @@ public final class DeviceUtils {
      * #9023</a></p>
      */
     private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH2");
+            && "BRAVIA_VH2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 2.</p>
      * Uses a MediaTek MT5891 (MT5596) SoC.
      * @see <a href="https://github.com/CiNcH83/bravia_atv2">
      *     https://github.com/CiNcH83/bravia_atv2</a>
      */
-    private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
+    private static final boolean BRAVIA_ATV2 = "BRAVIA_ATV2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 3 4K.</p>
      * <p>Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.</p>
@@ -107,19 +107,19 @@ public final class DeviceUtils {
      * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
      *     https://browser.geekbench.com/v4/cpu/9101105</a>
      */
-    private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
+    private static final boolean BRAVIA_ATV3_4K = "BRAVIA_ATV3_4K".equals(Build.DEVICE);
     /**
      * <p>Panasonic 4KTV-JUP.</p>
      * <p>Blacklist reason: fullscreen crash</p>
      */
-    private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
+    private static final boolean TX_50JXW834 = "TX_50JXW834".equals(Build.DEVICE);
     /**
      * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
      * <p>Blacklist reason: black screen; reported at
      * <a href="https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769">
      *     #10122</a></p>
      */
-    private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    private static final boolean HMB9213NW = "HMB9213NW".equals(Build.DEVICE);
     // endregion
 
     private DeviceUtils() {

--- a/app/src/main/res/values/discovery_personalization_strings.xml
+++ b/app/src/main/res/values/discovery_personalization_strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="discovery_personalize">Personalize discovery</string>
+    <string name="discovery_personalize_help">Prioritize topics within each page of this service’s discovery feed. Separate keywords with commas. These preferences apply to discovery pages only.</string>
+    <string name="discovery_interests">Preferred topics or channels</string>
+    <string name="discovery_hidden">Hidden keywords or channels</string>
+    <string name="discovery_hide_watched">Hide watched videos</string>
+    <string name="discovery_hide_shorts">Hide Shorts</string>
+    <string name="discovery_hide_live">Hide live streams</string>
+    <string name="discovery_reset">Reset preferences</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,4 +1605,12 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
+    <string name="discovery_personalize">Personalize discovery</string>
+    <string name="discovery_personalize_help">Prioritize topics within each page of this service’s discovery feed. Separate keywords with commas. These preferences apply to discovery pages only.</string>
+    <string name="discovery_interests">Preferred topics or channels</string>
+    <string name="discovery_hidden">Hidden keywords or channels</string>
+    <string name="discovery_hide_watched">Hide watched videos</string>
+    <string name="discovery_hide_shorts">Hide Shorts</string>
+    <string name="discovery_hide_live">Hide live streams</string>
+    <string name="discovery_reset">Reset preferences</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,12 +1605,4 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
-    <string name="discovery_personalize">Personalize discovery</string>
-    <string name="discovery_personalize_help">Prioritize topics within each page of this service’s discovery feed. Separate keywords with commas. These preferences apply to discovery pages only.</string>
-    <string name="discovery_interests">Preferred topics or channels</string>
-    <string name="discovery_hidden">Hidden keywords or channels</string>
-    <string name="discovery_hide_watched">Hide watched videos</string>
-    <string name="discovery_hide_shorts">Hide Shorts</string>
-    <string name="discovery_hide_live">Hide live streams</string>
-    <string name="discovery_reset">Reset preferences</string>
 </resources>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
@@ -88,9 +88,15 @@ public class VideoDetailBackPressTest {
 
     @After
     public void tearDown() {
-        playerHelper.close();
-        deviceUtils.close();
-        log.close();
+        if (playerHelper != null) {
+            playerHelper.close();
+        }
+        if (deviceUtils != null) {
+            deviceUtils.close();
+        }
+        if (log != null) {
+            log.close();
+        }
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/fragments/list/kiosk/DiscoveryPersonalizationTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/fragments/list/kiosk/DiscoveryPersonalizationTest.kt
@@ -1,0 +1,34 @@
+package org.schabi.newpipe.fragments.list.kiosk
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamType
+
+class DiscoveryPersonalizationTest {
+    private fun item(title: String, url: String = title): StreamInfoItem = StreamInfoItem(0, url, title, StreamType.VIDEO_STREAM)
+
+    @Test
+    fun interestsPrioritizeMatchesWithoutMutatingSourceOrDiscardingOtherTopics() {
+        val original = listOf(item("Music"), item("Space science"), item("News"), item("Science today"))
+        val result = DiscoveryRules(interests = listOf("science")).apply(original, emptySet())
+        assertEquals(listOf("Space science", "Science today", "Music", "News"), result.map { it.name })
+        assertEquals("Music", original.first().name)
+        assertEquals(original, DiscoveryRules().apply(original, emptySet()))
+    }
+
+    @Test
+    fun hiddenTermsMatchChannelsAndAllVisibilityControlsCompose() {
+        val items = listOf(
+            item("Blocked channel").apply { uploaderName = "Spam" },
+            item("Short").apply { isShortFormContent = true },
+            StreamInfoItem(0, "live", "Live", StreamType.LIVE_STREAM),
+            item("Watched", "watched"),
+            item("Keep")
+        )
+        val result = DiscoveryRules(hidden = listOf("spam"), hideWatched = true, hideShorts = true, hideLive = true)
+            .apply(items, setOf("0:watched"))
+        assertEquals(listOf("Keep"), result.map { it.name })
+        assertEquals(5, items.size)
+    }
+}


### PR DESCRIPTION
- Add discovery preferences for preferred topics and channels, hidden keywords, watched videos, Shorts, and live streams.
- Apply stable ordering within each fetched page without modifying cached extractor results; reset restores the original feed.
- Add behavioral tests for ranking, filtering, and preserving source data.
- Validated: source-inspection gate, debug build, lint, JVM tests, and Android tests on API 23 and 35 all passed.
- Verified clean local merges with the other five feature branches.