### PR TITLE
Automatically play available downloaded copies

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/download/DownloadedCopyLookupTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/download/DownloadedCopyLookupTest.kt
@@ -1,0 +1,62 @@
+package org.schabi.newpipe.download
+
+import android.content.Context
+import android.net.Uri
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.schabi.newpipe.extractor.stream.StreamInfo
+import org.schabi.newpipe.extractor.stream.StreamType
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+import org.schabi.newpipe.streams.io.StoredFileHelper
+import us.shandian.giga.get.FinishedMission
+import us.shandian.giga.get.sqlite.FinishedMissionStore
+
+class DownloadedCopyLookupTest {
+    @Test
+    fun completeCopyKeepsRemoteIdentityAndMissingOrDisabledCopiesAreSkipped() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val file = File.createTempFile("copy-lookup", ".m4a", context.cacheDir).apply { writeBytes(ByteArray(32) { 1 }) }
+        val source = "https://www.youtube.com/watch?v=abcdefghijk"
+        val queueItem = PlayQueueItem(StreamInfo(0, "abcdefghijk", source, "Saved").apply {
+            duration = 1
+            streamType = StreamType.AUDIO_STREAM
+        })
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val enabled = prefs.getBoolean(DownloadedCopyRepository.PREFERENCE, true)
+        val store = FinishedMissionStore(context)
+        val mission = FinishedMission().apply {
+            this.source = source
+            storage = StoredFileHelper(context, null, Uri.fromFile(file), "")
+            kind = 'a'
+            length = file.length()
+            timestamp = System.currentTimeMillis()
+            syncId = "copy-lookup-test"
+            displayName = file.name
+            mimeType = "audio/mp4"
+        }
+        try {
+            prefs.edit().putBoolean(DownloadedCopyRepository.PREFERENCE, true).commit()
+            store.addFinishedMission(mission)
+            val copy = DownloadedCopyRepository.find(context, 0, source, "Saved", true, queueItem)
+            assertNotNull(copy)
+            assertEquals(source, copy!!.url)
+            assertEquals(Uri.fromFile(file).toString(), copy.copyUri)
+            assertNull(DownloadedCopyRepository.find(context, 0, source, "Saved", false, queueItem))
+            prefs.edit().putBoolean(DownloadedCopyRepository.PREFERENCE, false).commit()
+            assertNull(DownloadedCopyRepository.find(context, 0, source, "Saved", true, queueItem))
+            prefs.edit().putBoolean(DownloadedCopyRepository.PREFERENCE, true).commit()
+            file.delete()
+            assertNull(DownloadedCopyRepository.find(context, 0, source, "Saved", true, queueItem))
+        } finally {
+            store.deleteMission(mission)
+            store.close()
+            prefs.edit().putBoolean(DownloadedCopyRepository.PREFERENCE, enabled).commit()
+            file.delete()
+        }
+    }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/download/DownloadedCopyLookupTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/download/DownloadedCopyLookupTest.kt
@@ -22,10 +22,12 @@ class DownloadedCopyLookupTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val file = File.createTempFile("copy-lookup", ".m4a", context.cacheDir).apply { writeBytes(ByteArray(32) { 1 }) }
         val source = "https://www.youtube.com/watch?v=abcdefghijk"
-        val queueItem = PlayQueueItem(StreamInfo(0, "abcdefghijk", source, "Saved").apply {
-            duration = 1
-            streamType = StreamType.AUDIO_STREAM
-        })
+        val queueItem = PlayQueueItem(
+            StreamInfo(0, "abcdefghijk", source, "Saved").apply {
+                duration = 1
+                streamType = StreamType.AUDIO_STREAM
+            }
+        )
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         val enabled = prefs.getBoolean(DownloadedCopyRepository.PREFERENCE, true)
         val store = FinishedMissionStore(context)

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadedCopyRepository.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadedCopyRepository.kt
@@ -40,9 +40,7 @@ object DownloadedCopyRepository {
     }
 
     @JvmStatic
-    fun reject(info: DownloadedStreamInfo) {
-        rejectedCopies.add(info.copyUri)
-    }
+    fun reject(info: DownloadedStreamInfo): Boolean = rejectedCopies.add(info.copyUri)
 
     @JvmStatic
     fun find(context: Context, service: Int, url: String, title: String?, audioOnly: Boolean, item: PlayQueueItem? = null): DownloadedStreamInfo? {

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadedCopyRepository.kt
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadedCopyRepository.kt
@@ -1,0 +1,99 @@
+package org.schabi.newpipe.download
+
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import androidx.preference.PreferenceManager
+import io.reactivex.rxjava3.core.Single
+import java.net.URI
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+import org.schabi.newpipe.R
+import org.schabi.newpipe.extractor.MediaFormat
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory
+import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.Description
+import org.schabi.newpipe.extractor.stream.StreamInfo
+import org.schabi.newpipe.extractor.stream.StreamType
+import org.schabi.newpipe.extractor.stream.VideoStream
+import org.schabi.newpipe.player.playqueue.PlayQueueItem
+import us.shandian.giga.get.FinishedMission
+import us.shandian.giga.get.sqlite.FinishedMissionStore
+
+/** Keeps the service URL as identity while using a verified local file as the media source. */
+class DownloadedStreamInfo(val copyUri: String, service: Int, sourceUrl: String, title: String) : StreamInfo(service, sourceUrl, sourceUrl, title)
+
+object DownloadedCopyRepository {
+    const val PREFERENCE = "prefer_downloaded_copies"
+    private val rejectedCopies = ConcurrentHashMap.newKeySet<String>()
+
+    internal fun sameSource(serviceId: Int, requested: String, downloaded: String): Boolean {
+        if (downloaded.contains("wizestream-segments=")) return false
+        return runCatching {
+            if (serviceId == ServiceList.YouTube.serviceId) {
+                val factory = YoutubeStreamLinkHandlerFactory.getInstance()
+                factory.getId(requested) == factory.getId(downloaded)
+            } else {
+                URI(requested).normalize() == URI(downloaded).normalize()
+            }
+        }.getOrDefault(false)
+    }
+
+    @JvmStatic
+    fun reject(info: DownloadedStreamInfo) {
+        rejectedCopies.add(info.copyUri)
+    }
+
+    @JvmStatic
+    fun find(context: Context, service: Int, url: String, title: String?, audioOnly: Boolean, item: PlayQueueItem? = null): DownloadedStreamInfo? {
+        if (!PreferenceManager.getDefaultSharedPreferences(context).getBoolean(PREFERENCE, true)) return null
+        return runCatching {
+            val store = FinishedMissionStore(context)
+            try {
+                store.loadFinishedMissions().asSequence()
+                    .filter { (it.kind == 'v' || audioOnly && it.kind == 'a') && sameSource(service, url, it.source.orEmpty()) }
+                    .sortedBy { if (audioOnly && it.kind == 'a') 0 else 1 }
+                    .mapNotNull { mission -> openCopy(context, mission, service, url, title, item) }
+                    .firstOrNull()
+            } finally {
+                store.close()
+            }
+        }.getOrNull()
+    }
+
+    private fun openCopy(context: Context, mission: FinishedMission, service: Int, url: String, title: String?, item: PlayQueueItem?): DownloadedStreamInfo? = runCatching {
+        val storage = mission.storage ?: return@runCatching null
+        val uri = storage.uri.toString()
+        if (uri in rejectedCopies || mission.length <= 0 || !storage.existsAsFile() || storage.length() < mission.length) return@runCatching null
+        storage.stream.use { if (it.read() < 0) return@runCatching null }
+        val info = DownloadedStreamInfo(uri, service, url, title?.takeIf { it.isNotBlank() } ?: mission.displayName.orEmpty())
+        info.streamType = if (mission.kind == 'v') StreamType.VIDEO_STREAM else StreamType.AUDIO_STREAM
+        info.uploaderName = item?.uploader.orEmpty()
+        info.uploaderUrl = item?.uploaderUrl.orEmpty()
+        info.thumbnails = item?.thumbnails.orEmpty()
+        info.duration = item?.duration?.takeIf { it > 0 } ?: readDuration(context, storage.uri)
+        info.description = Description(context.getString(R.string.playing_downloaded_copy), Description.PLAIN_TEXT)
+        val format = MediaFormat.getFromMimeType(mission.mimeType.orEmpty()) ?: MediaFormat.getFromSuffix(mission.displayName.orEmpty().substringAfterLast('.'))
+        if (mission.kind == 'v') {
+            info.videoStreams = listOf(VideoStream.Builder().setId("downloaded").setContent(uri, true).setIsVideoOnly(false).setResolution("").setMediaFormat(format).build())
+        } else {
+            info.audioStreams = listOf(AudioStream.Builder().setId("downloaded").setContent(uri, true).setAverageBitrate(0).setMediaFormat(format).build())
+        }
+        info
+    }.getOrNull()
+
+    private fun readDuration(context: Context, uri: android.net.Uri): Long {
+        val reader = MediaMetadataRetriever()
+        return try {
+            reader.setDataSource(context, uri)
+            (reader.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0) / 1000
+        } finally {
+            reader.release()
+        }
+    }
+
+    @JvmStatic
+    fun streamInfoOrNetwork(context: Context, service: Int, url: String, title: String?, network: Single<StreamInfo>): Single<StreamInfo> = Single.fromCallable {
+        Optional.ofNullable(find(context, service, url, title, false))
+    }.flatMap { local -> if (local.isPresent) Single.just<StreamInfo>(local.get()) else network }
+}

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -1340,7 +1340,9 @@ public final class VideoDetailFragment
 
     private void runWorker(final boolean forceLoad, final boolean addToBackStack) {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
-        currentWorker = ExtractorHelper.getStreamInfo(serviceId, url, forceLoad)
+        currentWorker = org.schabi.newpipe.download.DownloadedCopyRepository.streamInfoOrNetwork(
+                        requireContext(), serviceId, url, title,
+                        ExtractorHelper.getStreamInfo(serviceId, url, forceLoad))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {

--- a/app/src/main/java/org/schabi/newpipe/player/Player.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.kt
@@ -547,6 +547,8 @@ class Player(
 
     override fun sourceOfLocal(item: PlayQueueItem): MediaSource? = streamController.sourceOfLocal(item)
 
+    override fun sourceOfDownloaded(item: PlayQueueItem): MediaSource? = streamController.sourceOfDownloaded(item)
+
     fun disablePreloadingOfCurrentTrack() = streamController.disablePreloadingOfCurrentTrack()
 
     val selectedVideoStream: Optional<VideoStream>

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerErrorController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerErrorController.kt
@@ -47,9 +47,9 @@ internal class PlayerErrorController(
         Log.e(Player.TAG, "ExoPlayer - onPlayerError() called with:", error)
 
         player.saveStreamProgressState()
-        val downloaded = player.currentStreamInfo.orElse(null) as? org.schabi.newpipe.download.DownloadedStreamInfo
-        if (downloaded != null) {
-            org.schabi.newpipe.download.DownloadedCopyRepository.reject(downloaded)
+        val downloaded = org.schabi.newpipe.player.mediaitem.MediaItemTag.from(player.exoPlayer.currentMediaItem)
+            .flatMap { it.maybeStreamInfo }.orElse(null) as? org.schabi.newpipe.download.DownloadedStreamInfo
+        if (downloaded != null && org.schabi.newpipe.download.DownloadedCopyRepository.reject(downloaded)) {
             player.setRecovery()
             player.reloadPlayQueueManager()
             return

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerErrorController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerErrorController.kt
@@ -47,6 +47,13 @@ internal class PlayerErrorController(
         Log.e(Player.TAG, "ExoPlayer - onPlayerError() called with:", error)
 
         player.saveStreamProgressState()
+        val downloaded = player.currentStreamInfo.orElse(null) as? org.schabi.newpipe.download.DownloadedStreamInfo
+        if (downloaded != null) {
+            org.schabi.newpipe.download.DownloadedCopyRepository.reject(downloaded)
+            player.setRecovery()
+            player.reloadPlayQueueManager()
+            return
+        }
         if (tryRecoverFromYouTubeMediaUrlFailure(error)) {
             return
         }

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerStreamController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerStreamController.kt
@@ -27,6 +27,9 @@ internal class PlayerStreamController(
     private val loadController: LoadController
 ) {
     fun sourceOf(info: StreamInfo): MediaSource? {
+        if (info is org.schabi.newpipe.download.DownloadedStreamInfo) {
+            return downloadedSource(info)
+        }
         if (player.audioPlayerSelected()) {
             return audioResolver.resolve(info)
         }
@@ -52,6 +55,17 @@ internal class PlayerStreamController(
         return dataSource.progressiveMediaSourceFactory
             .createMediaSource(LocalMediaItemTag.of(item).asMediaItem())
     }
+
+    fun sourceOfDownloaded(item: PlayQueueItem): MediaSource? {
+        val info = org.schabi.newpipe.download.DownloadedCopyRepository.find(
+            context, item.serviceId, item.url, item.title,
+            player.audioPlayerSelected() || player.isAudioOnly, item
+        ) ?: return null
+        return downloadedSource(info)
+    }
+
+    private fun downloadedSource(info: org.schabi.newpipe.download.DownloadedStreamInfo): MediaSource = dataSource.progressiveMediaSourceFactory
+        .createMediaSource(org.schabi.newpipe.player.mediaitem.StreamInfoTag.of(info).asMediaItem().buildUpon().setUri(info.copyUri).build())
 
     fun disablePreloadingOfCurrentTrack() {
         loadController.disablePreloadingOfCurrentTrack()

--- a/app/src/main/java/org/schabi/newpipe/player/PlayerStreamController.kt
+++ b/app/src/main/java/org/schabi/newpipe/player/PlayerStreamController.kt
@@ -58,8 +58,12 @@ internal class PlayerStreamController(
 
     fun sourceOfDownloaded(item: PlayQueueItem): MediaSource? {
         val info = org.schabi.newpipe.download.DownloadedCopyRepository.find(
-            context, item.serviceId, item.url, item.title,
-            player.audioPlayerSelected() || player.isAudioOnly, item
+            context,
+            item.serviceId,
+            item.url,
+            item.title,
+            player.audioPlayerSelected() || player.isAudioOnly,
+            item
         ) ?: return null
         return downloadedSource(info)
     }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/MediaSourceManager.java
@@ -434,6 +434,24 @@ public class MediaSourceManager {
                             new MediaSourceResolutionException(
                                     "Unable to open local media: " + throwable.getMessage())));
         }
+        return Single.fromCallable(() -> Optional.ofNullable(
+                        playbackListener.sourceOfDownloaded(stream)))
+                .subscribeOn(Schedulers.io())
+                .onErrorReturnItem(Optional.empty())
+                .flatMap(source -> {
+                    if (source.isPresent()) {
+                        final Optional<MediaItemTag> tag =
+                                MediaItemTag.from(source.get().getMediaItem());
+                        if (tag.isPresent()) {
+                            return Single.<ManagedMediaSource>just(new LoadedMediaSource(
+                                    source.get(), tag.get(), stream, Long.MAX_VALUE));
+                        }
+                    }
+                    return getRemoteMediaSource(stream);
+                });
+    }
+
+    private Single<ManagedMediaSource> getRemoteMediaSource(@NonNull final PlayQueueItem stream) {
         return stream.getStream()
                 .map(streamInfo -> Optional
                         .ofNullable(playbackListener.sourceOf(stream, streamInfo))

--- a/app/src/main/java/org/schabi/newpipe/player/playback/PlaybackListener.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/PlaybackListener.java
@@ -79,6 +79,16 @@ public interface PlaybackListener {
     MediaSource sourceOfLocal(PlayQueueItem item);
 
     /**
+     * Finds a completed download for a remote item before invoking its online extractor.
+     * @param item the requested stream
+     * @return a playable local copy, or {@code null} to use the network
+     */
+    @Nullable
+    default MediaSource sourceOfDownloaded(final PlayQueueItem item) {
+        return null;
+    }
+
+    /**
      * Called when the play queue can no longer be played or used.
      * Currently, this means the play queue is empty and complete.
      * Signals to the listener that it should shutdown.

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
-    private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
+    private static final boolean SAMSUNG = "samsung".equals(Build.MANUFACTURER);
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -53,38 +53,38 @@ public final class DeviceUtils {
      * <p>Board: HiSilicon Hi3798MV200</p>
      */
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("Hi3798MV200");
+            && "Hi3798MV200".equals(Build.DEVICE);
     /**
      * <p>Zephir TS43UHD-2.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+            && "cvt_mt5886_eu_1g".equals(Build.DEVICE);
     /**
      * Hilife TV.
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
-            && Build.DEVICE.equals("RealtekATV");
+            && "RealtekATV".equals(Build.DEVICE);
     /**
      * <p>Phillips 4K (O)LED TV.</p>
      * Supports custom ROMs with different API levels
      */
     private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
-            && Build.DEVICE.equals("PH7M_EU_5596");
+            && "PH7M_EU_5596".equals(Build.DEVICE);
     /**
      * <p>Philips QM16XE.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
-            && Build.DEVICE.equals("QM16XE_U");
+            && "QM16XE_U".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH1.</p>
      * <p>Processor: MT5895</p>
      * <p>Blacklist reason: fullscreen crash / stuttering</p>
      */
     private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH1");
+            && "BRAVIA_VH1".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH2.</p>
      * <p>Blacklist reason: fullscreen crash; this includes model A90J as reported in
@@ -92,14 +92,14 @@ public final class DeviceUtils {
      * #9023</a></p>
      */
     private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH2");
+            && "BRAVIA_VH2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 2.</p>
      * Uses a MediaTek MT5891 (MT5596) SoC.
      * @see <a href="https://github.com/CiNcH83/bravia_atv2">
      *     https://github.com/CiNcH83/bravia_atv2</a>
      */
-    private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
+    private static final boolean BRAVIA_ATV2 = "BRAVIA_ATV2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 3 4K.</p>
      * <p>Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.</p>
@@ -107,19 +107,19 @@ public final class DeviceUtils {
      * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
      *     https://browser.geekbench.com/v4/cpu/9101105</a>
      */
-    private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
+    private static final boolean BRAVIA_ATV3_4K = "BRAVIA_ATV3_4K".equals(Build.DEVICE);
     /**
      * <p>Panasonic 4KTV-JUP.</p>
      * <p>Blacklist reason: fullscreen crash</p>
      */
-    private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
+    private static final boolean TX_50JXW834 = "TX_50JXW834".equals(Build.DEVICE);
     /**
      * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
      * <p>Blacklist reason: black screen; reported at
      * <a href="https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769">
      *     #10122</a></p>
      */
-    private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    private static final boolean HMB9213NW = "HMB9213NW".equals(Build.DEVICE);
     // endregion
 
     private DeviceUtils() {

--- a/app/src/main/res/values/downloaded_copy_strings.xml
+++ b/app/src/main/res/values/downloaded_copy_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="prefer_downloaded_copies_title">Use downloaded copies automatically</string>
+    <string name="prefer_downloaded_copies_summary">Play complete downloaded files without fetching the stream online. Missing or unreadable files fall back to streaming. Turn off to use online quality and audio-track choices.</string>
+    <string name="playing_downloaded_copy">Playing a downloaded copy. Original stream details may be unavailable offline.</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,4 +1605,7 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
+    <string name="prefer_downloaded_copies_title">Use downloaded copies automatically</string>
+    <string name="prefer_downloaded_copies_summary">Play complete downloaded files without fetching the stream online. Missing or unreadable files fall back to streaming. Turn off to use online quality and audio-track choices.</string>
+    <string name="playing_downloaded_copy">Playing a downloaded copy. Original stream details may be unavailable offline.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,7 +1605,4 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
-    <string name="prefer_downloaded_copies_title">Use downloaded copies automatically</string>
-    <string name="prefer_downloaded_copies_summary">Play complete downloaded files without fetching the stream online. Missing or unreadable files fall back to streaming. Turn off to use online quality and audio-track choices.</string>
-    <string name="playing_downloaded_copy">Playing a downloaded copy. Original stream details may be unavailable offline.</string>
 </resources>

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -9,7 +9,6 @@
         android:summary="@string/prefer_downloaded_copies_summary"
         app:singleLineTitle="false" app:iconSpaceReserved="false" />
 
-
     <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/downloads_storage_ask"
@@ -85,6 +84,5 @@
         android:title="@string/enable_queue_limit"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
-
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -2,6 +2,13 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/settings_category_downloads_title">
+    <SwitchPreferenceCompat
+        android:key="prefer_downloaded_copies"
+        android:defaultValue="true"
+        android:title="@string/prefer_downloaded_copies_title"
+        android:summary="@string/prefer_downloaded_copies_summary"
+        app:singleLineTitle="false" app:iconSpaceReserved="false" />
+
 
     <SwitchPreferenceCompat
         android:defaultValue="false"
@@ -79,10 +86,5 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
-    <SwitchPreferenceCompat
-        android:key="prefer_downloaded_copies"
-        android:defaultValue="true"
-        android:title="@string/prefer_downloaded_copies_title"
-        android:summary="@string/prefer_downloaded_copies_summary"
-        app:singleLineTitle="false" app:iconSpaceReserved="false" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/download_settings.xml
+++ b/app/src/main/res/xml/download_settings.xml
@@ -79,4 +79,10 @@
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:key="prefer_downloaded_copies"
+        android:defaultValue="true"
+        android:title="@string/prefer_downloaded_copies_title"
+        android:summary="@string/prefer_downloaded_copies_summary"
+        app:singleLineTitle="false" app:iconSpaceReserved="false" />
 </PreferenceScreen>

--- a/app/src/test/java/org/schabi/newpipe/download/DownloadedCopyRepositoryTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/download/DownloadedCopyRepositoryTest.kt
@@ -1,0 +1,30 @@
+package org.schabi.newpipe.download
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadedCopyRepositoryTest {
+    @Test
+    fun matchesYouTubeAliasesAndIgnoresPlaybackPosition() {
+        assertTrue(DownloadedCopyRepository.sameSource(0, "https://youtu.be/dQw4w9WgXcQ?t=20", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+        assertTrue(DownloadedCopyRepository.sameSource(0, "https://www.youtube.com/shorts/dQw4w9WgXcQ", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun neverSubstitutesPartialExportsForCompleteStreams() {
+        assertFalse(DownloadedCopyRepository.sameSource(0, "https://youtu.be/dQw4w9WgXcQ", "https://www.youtube.com/watch?v=dQw4w9WgXcQ#wizestream-segments=1000:2000"))
+    }
+
+    @Test
+    fun rejectsDifferentVideosAndLookalikeHosts() {
+        assertFalse(DownloadedCopyRepository.sameSource(0, "https://youtu.be/dQw4w9WgXcQ", "https://www.youtube.com/watch?v=abcdefghijk"))
+        assertFalse(DownloadedCopyRepository.sameSource(0, "https://youtu.be/dQw4w9WgXcQ", "https://youtube.example/watch?v=dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun keepsNonYouTubeQueryIdentitiesDistinct() {
+        assertFalse(DownloadedCopyRepository.sameSource(99, "https://example.com/video?id=1", "https://example.com/video?id=2"))
+        assertTrue(DownloadedCopyRepository.sameSource(99, "https://example.com/video?id=1", "https://example.com/video?id=1"))
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
@@ -88,9 +88,15 @@ public class VideoDetailBackPressTest {
 
     @After
     public void tearDown() {
-        playerHelper.close();
-        deviceUtils.close();
-        log.close();
+        if (playerHelper != null) {
+            playerHelper.close();
+        }
+        if (deviceUtils != null) {
+            deviceUtils.close();
+        }
+        if (log != null) {
+            log.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
- Prefer complete, readable downloads before remote extraction and playback, including opening a video while offline.
- Keep the original service URL and history identity; exclude partial segment exports and fall back to streaming when a local copy cannot play.
- Add a Download setting to disable this behavior and bound recovery so a rejected copy cannot cause a retry loop.
- Add source-matching tests and Android tests for saved-file lookup, media type matching, missing files, and the disabled setting.
- Validated: source-inspection gate, debug build, lint, JVM tests, and Android tests on API 23 and 35 all passed.
- Verified clean local merges with the other five feature branches. Offline playback and storage-provider behavior on a physical device still need QA.