### PR TITLE
Import Google Takeout playlists, subscriptions and history

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/export/TakeoutImporterTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/export/TakeoutImporterTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.schabi.newpipe.database.AppDatabase
 
@@ -24,6 +25,23 @@ class TakeoutImporterTest {
             assertEquals(listOf(second.url, first.url), db.playlistStreamDAO().getOrderedStreamsDirect(playlist.uid).map { it.url })
             assertEquals(1700000000123, db.streamHistoryDAO().getAllDirect().single().accessDate.toInstant().toEpochMilli())
             assertEquals(1, journaled)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun failedHistoryWriteRollsBackPlaylistsAndStreamsAsWell() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        try {
+            val video = TakeoutVideo("https://www.youtube.com/watch?v=abcdefghijk", "First")
+            val data = TakeoutData(listOf(TakeoutPlaylist("Learning", listOf(video))), listOf(TakeoutWatch(video, 1700000000123)), 0)
+            val importer = TakeoutImporter(db) { _, _, _ -> throw IllegalStateException("Simulated storage failure") }
+            assertThrows(IllegalStateException::class.java) { importer.import(data) }
+            assertEquals(0, db.playlistDAO().getAllDirect().size)
+            assertEquals(0, db.streamHistoryDAO().getAllDirect().size)
+            assertEquals(0, db.streamDAO().getAll().blockingFirst().size)
         } finally {
             db.close()
         }

--- a/app/src/androidTest/java/org/schabi/newpipe/settings/export/TakeoutImporterTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/export/TakeoutImporterTest.kt
@@ -1,0 +1,31 @@
+package org.schabi.newpipe.settings.export
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.schabi.newpipe.database.AppDatabase
+
+class TakeoutImporterTest {
+    @Test
+    fun repeatedImportsPreservePlaylistOrderAndWatchDatesWithoutDuplicates() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        try {
+            val first = TakeoutVideo("https://www.youtube.com/watch?v=abcdefghijk", "First")
+            val second = TakeoutVideo("https://www.youtube.com/watch?v=lmnopqrstuv", "Second")
+            val data = TakeoutData(listOf(TakeoutPlaylist("Learning", listOf(second, first))), listOf(TakeoutWatch(first, 1700000000123)), 0)
+            var journaled = 0
+            val importer = TakeoutImporter(db) { _, _, _ -> journaled++ }
+            assertEquals(TakeoutImportResult(1, 2, 1, 0), importer.import(data))
+            assertEquals(TakeoutImportResult(0, 0, 0, 3), importer.import(data))
+            val playlist = db.playlistDAO().getAllDirect().single()
+            assertEquals(listOf(second.url, first.url), db.playlistStreamDAO().getOrderedStreamsDirect(playlist.uid).map { it.url })
+            assertEquals(1700000000123, db.streamHistoryDAO().getAllDirect().single().accessDate.toInstant().toEpochMilli())
+            assertEquals(1, journaled)
+        } finally {
+            db.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/org/schabi/newpipe/settings/export/TakeoutImporterTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/export/TakeoutImporterTest.kt
@@ -48,6 +48,7 @@ class TakeoutImporterTest {
             db.close()
         }
     }
+
     @Test
     fun preservesEmptyAndSameNamedPlaylistsRepeatedVideosAndExistingChannelSettings() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -118,5 +119,4 @@ class TakeoutImporterTest {
             db.close()
         }
     }
-
 }

--- a/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
@@ -19,9 +19,6 @@ import org.schabi.newpipe.database.stream.StreamStatisticsEntry
 @Dao
 abstract class StreamHistoryDAO : BasicDAO<StreamHistoryEntity> {
 
-    @Query("SELECT EXISTS(SELECT 1 FROM stream_history WHERE stream_id = :streamId AND access_date = :date)")
-    abstract fun hasTakeoutEvent(streamId: Long, date: OffsetDateTime): Boolean
-
     @Query("SELECT * FROM stream_history")
     abstract override fun getAll(): Flowable<List<StreamHistoryEntity>>
 
@@ -65,4 +62,7 @@ abstract class StreamHistoryDAO : BasicDAO<StreamHistoryEntity> {
         """
     )
     abstract fun getStatistics(): Flowable<MutableList<StreamStatisticsEntry>>
+    @Query("SELECT EXISTS(SELECT 1 FROM stream_history WHERE stream_id = :streamId AND access_date = :date)")
+    abstract fun hasTakeoutEvent(streamId: Long, date: OffsetDateTime): Boolean
+
 }

--- a/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
@@ -10,6 +10,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.RewriteQueriesToDropUnusedColumns
 import io.reactivex.rxjava3.core.Flowable
+import java.time.OffsetDateTime
 import org.schabi.newpipe.database.BasicDAO
 import org.schabi.newpipe.database.history.model.StreamHistoryEntity
 import org.schabi.newpipe.database.history.model.StreamHistoryEntry
@@ -17,6 +18,9 @@ import org.schabi.newpipe.database.stream.StreamStatisticsEntry
 
 @Dao
 abstract class StreamHistoryDAO : BasicDAO<StreamHistoryEntity> {
+
+    @Query("SELECT EXISTS(SELECT 1 FROM stream_history WHERE stream_id = :streamId AND access_date = :date)")
+    abstract fun hasTakeoutEvent(streamId: Long, date: OffsetDateTime): Boolean
 
     @Query("SELECT * FROM stream_history")
     abstract override fun getAll(): Flowable<List<StreamHistoryEntity>>

--- a/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
+++ b/app/src/main/java/org/schabi/newpipe/database/history/dao/StreamHistoryDAO.kt
@@ -62,7 +62,7 @@ abstract class StreamHistoryDAO : BasicDAO<StreamHistoryEntity> {
         """
     )
     abstract fun getStatistics(): Flowable<MutableList<StreamStatisticsEntry>>
+
     @Query("SELECT EXISTS(SELECT 1 FROM stream_history WHERE stream_id = :streamId AND access_date = :date)")
     abstract fun hasTakeoutEvent(streamId: Long, date: OffsetDateTime): Boolean
-
 }

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -33,6 +33,7 @@ import org.schabi.newpipe.settings.export.ImportExportManager;
 import org.schabi.newpipe.settings.export.NewPipeCompatibleExportManager;
 import org.schabi.newpipe.settings.export.NewPipeDataMigrationManager;
 import org.schabi.newpipe.settings.export.ScheduledBackupWorker;
+import org.schabi.newpipe.settings.export.TakeoutImportWorker;
 import org.schabi.newpipe.streams.io.NoFileManagerSafeGuard;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 import org.schabi.newpipe.util.NavigationHelper;
@@ -63,6 +64,21 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
 
     private final SimpleDateFormat exportDateFormat =
             new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US);
+    private final ActivityResultLauncher<String[]> requestTakeoutImport =
+            registerForActivityResult(new ActivityResultContracts.OpenDocument(), uri -> {
+                if (uri == null) {
+                    return;
+                }
+                try {
+                    requireContext().getContentResolver().takePersistableUriPermission(uri,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    TakeoutImportWorker.enqueue(requireContext(), uri);
+                    Toast.makeText(requireContext(), R.string.takeout_import_queued,
+                            Toast.LENGTH_LONG).show();
+                } catch (final Exception error) {
+                    showErrorSnackbar(error, "Opening Takeout export");
+                }
+            });
     private ImportExportManager manager;
     private String importExportDataPathKey;
     private final ActivityResultLauncher<Intent> requestImportPathLauncher =
@@ -123,6 +139,27 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         importExportDataPathKey = getString(R.string.import_export_data_path);
 
         addPreferencesFromResourceRegistry();
+        requirePreference(R.string.takeout_import_key).setOnPreferenceClickListener(preference -> {
+            new MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.takeout_import_title)
+                    .setMessage(R.string.takeout_import_help)
+                    .setPositiveButton(R.string.ok, (dialog, which) ->
+                            NoFileManagerSafeGuard.launchSafe(requestTakeoutImport,
+                                    new String[]{"*/*"}, TAG, requireContext()))
+                    .setNegativeButton(R.string.cancel, null).show();
+            return true;
+        });
+        androidx.work.WorkManager.getInstance(requireContext())
+                .getWorkInfosForUniqueWorkLiveData("takeout-import").observe(this, work -> {
+                    if (isAdded() && !work.isEmpty()) {
+                        final boolean pending = work.stream()
+                                .anyMatch(info -> !info.getState().isFinished());
+                        requirePreference(R.string.takeout_import_status_key).setSummary(pending
+                                ? getString(R.string.takeout_import_queued)
+                                : defaultPreferences.getString(TakeoutImportWorker.STATUS,
+                                        getString(R.string.takeout_import_idle)));
+                    }
+                });
         requirePreference(R.string.automatic_backup_directory_key)
                 .setOnPreferenceClickListener(preference -> {
                     NoFileManagerSafeGuard.launchSafe(requestBackupDirectory,
@@ -244,6 +281,9 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
         super.onResume();
         defaultPreferences.registerOnSharedPreferenceChangeListener(backupStatusListener);
         updateAutomaticBackupSummary();
+        requirePreference(R.string.takeout_import_status_key).setSummary(
+                defaultPreferences.getString(TakeoutImportWorker.STATUS,
+                        getString(R.string.takeout_import_idle)));
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutImportWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutImportWorker.kt
@@ -1,0 +1,86 @@
+package org.schabi.newpipe.settings.export
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.preference.PreferenceManager
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import org.schabi.newpipe.NewPipeDatabase
+import org.schabi.newpipe.R
+import org.schabi.newpipe.sync.HistorySyncRecorder
+import org.schabi.newpipe.sync.RoomPlaylistSyncStore
+
+class TakeoutImportWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+    override fun doWork(): Result {
+        val context = applicationContext
+        val file = File.createTempFile("takeout-", ".import", context.cacheDir)
+        return try {
+            val uri = Uri.parse(requireNotNull(inputData.getString("uri")))
+            val name = context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use {
+                if (it.moveToFirst()) it.getString(0) else "takeout.zip"
+            } ?: "takeout.zip"
+            requireNotNull(context.contentResolver.openInputStream(uri)).use { input ->
+                file.outputStream().use { output ->
+                    val buffer = ByteArray(8192)
+                    var total = 0L
+                    while (true) {
+                        check(!isStopped) { "Import cancelled" }
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        total += count
+                        require(total <= 256L * 1024 * 1024) { "Select a Takeout export under 256 MiB, without uploaded video files." }
+                        output.write(buffer, 0, count)
+                    }
+                }
+            }
+            val data = TakeoutParser.parse(file, name)
+            val history = HistorySyncRecorder.get(context)
+            val result = TakeoutImporter(NewPipeDatabase.getInstance(context), history::recordWatchEvent).import(data)
+            RoomPlaylistSyncStore.get(context).reconcileLocalPlaylists()
+            status(context.getString(R.string.takeout_import_result, result.playlists, result.videos, result.watches, result.skipped))
+            Result.success()
+        } catch (error: Exception) {
+            status(context.getString(R.string.takeout_import_error, error.localizedMessage ?: error.javaClass.simpleName))
+            Result.failure()
+        } finally {
+            file.delete()
+        }
+    }
+
+    private fun status(message: String) {
+        PreferenceManager.getDefaultSharedPreferences(applicationContext).edit().putString(STATUS, message).apply()
+    }
+
+    companion object {
+        const val STATUS = "takeout_import_status"
+        private const val WORK = "takeout-import"
+
+        @JvmStatic
+        fun enqueue(context: Context, uri: Uri) {
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK,
+                ExistingWorkPolicy.KEEP,
+                OneTimeWorkRequestBuilder<TakeoutImportWorker>().setInputData(workDataOf("uri" to uri.toString())).build()
+            )
+        }
+    }
+}
+
+internal fun InputStream.readTakeoutBytes(limit: Int): ByteArray {
+    val output = ByteArrayOutputStream()
+    val buffer = ByteArray(8192)
+    while (output.size() <= limit) {
+        val count = read(buffer, 0, minOf(buffer.size, limit + 1 - output.size()))
+        if (count < 0) break
+        output.write(buffer, 0, count)
+    }
+    return output.toByteArray()
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutImportWorker.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutImportWorker.kt
@@ -54,8 +54,13 @@ class TakeoutImportWorker(context: Context, params: WorkerParameters) : Worker(c
             status(
                 context.getString(
                     R.string.takeout_import_result,
-                    result.playlists, result.videos, result.watches, result.skipped,
-                    result.bookmarks, result.subscriptions, result.searches
+                    result.playlists,
+                    result.videos,
+                    result.watches,
+                    result.skipped,
+                    result.bookmarks,
+                    result.subscriptions,
+                    result.searches
                 )
             )
             Result.success()

--- a/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutImporter.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutImporter.kt
@@ -1,0 +1,64 @@
+package org.schabi.newpipe.settings.export
+
+import java.time.Instant
+import java.time.ZoneOffset
+import org.schabi.newpipe.database.AppDatabase
+import org.schabi.newpipe.database.history.model.StreamHistoryEntity
+import org.schabi.newpipe.database.playlist.model.PlaylistEntity
+import org.schabi.newpipe.database.playlist.model.PlaylistStreamEntity
+import org.schabi.newpipe.database.stream.model.StreamEntity
+import org.schabi.newpipe.extractor.stream.StreamType
+
+internal data class TakeoutImportResult(val playlists: Int, val videos: Int, val watches: Int, val skipped: Int)
+
+internal class TakeoutImporter(private val database: AppDatabase, private val recordWatch: (Long, Long, Long) -> Unit) {
+    fun import(data: TakeoutData): TakeoutImportResult {
+        var playlists = 0
+        var videos = 0
+        var watches = 0
+        var skipped = data.skipped
+        database.runInTransaction {
+            fun stream(video: TakeoutVideo): Long = database.streamDAO().getStreamDirect(0, video.url)?.uid ?: database.streamDAO().insert(
+                StreamEntity(serviceId = 0, url = video.url, title = video.title, streamType = StreamType.VIDEO_STREAM, duration = -1, uploader = "")
+            )
+            val existing = database.playlistDAO().getAllDirect().associateBy { it.name }.toMutableMap()
+            for (playlist in data.playlists) {
+                check(!Thread.currentThread().isInterrupted) { "Import cancelled" }
+                val name = "${playlist.name.take(200)} (Takeout)"
+                var target = existing[name]
+                val old = target?.let { database.playlistStreamDAO().getOrderedStreamsDirect(it.uid) }.orEmpty()
+                val seen = old.map { it.url }.toMutableSet()
+                var index = old.size
+                for (video in playlist.videos) {
+                    if (!seen.add(video.url)) {
+                        skipped++
+                        continue
+                    }
+                    val streamId = stream(video)
+                    if (target == null) {
+                        target = PlaylistEntity(name = name, isThumbnailPermanent = false, thumbnailStreamId = streamId, displayIndex = -1)
+                        target.uid = database.playlistDAO().insert(target)
+                        existing[name] = target
+                        playlists++
+                    }
+                    database.playlistStreamDAO().insert(PlaylistStreamEntity(target.uid, streamId, index++))
+                    videos++
+                }
+            }
+            for (watch in data.history) {
+                check(!Thread.currentThread().isInterrupted) { "Import cancelled" }
+                val streamId = stream(watch.video)
+                val date = Instant.ofEpochMilli(watch.timestamp).atOffset(ZoneOffset.UTC)
+                if (database.streamHistoryDAO().hasTakeoutEvent(streamId, date)) {
+                    skipped++
+                } else {
+                    // Initialize and journal before materializing, as normal playback does.
+                    recordWatch(streamId, watch.timestamp, 1)
+                    database.streamHistoryDAO().insert(StreamHistoryEntity(streamId, date, 1))
+                    watches++
+                }
+            }
+        }
+        return TakeoutImportResult(playlists, videos, watches, skipped)
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutParser.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutParser.kt
@@ -53,6 +53,7 @@ internal object TakeoutParser {
                     }
                     playlists.add(TakeoutPlaylist(playlistName?.takeIf { it.isNotBlank() } ?: name.substringAfterLast('/').removeSuffix(".csv").removeSuffix("-videos"), videos))
                 }
+
                 "json" -> {
                     for (entry in JsonParser.array().from(text)) {
                         val row = entry as? JsonObject ?: continue
@@ -61,6 +62,7 @@ internal object TakeoutParser {
                         if (video != null && time != null) history.add(TakeoutWatch(video, time)) else skipped++
                     }
                 }
+
                 "html" -> {
                     for (cell in Jsoup.parse(text).select("div.content-cell")) {
                         val link = cell.select("a[href]").firstOrNull { video(it.attr("href"), "") != null } ?: continue
@@ -102,7 +104,9 @@ internal object TakeoutParser {
     private fun htmlTime(value: String): Long? {
         val text = value.trim().replace('\u202f', ' ').replace('\u00a0', ' ')
         return runCatching { Instant.parse(text).toEpochMilli() }.getOrNull() ?: listOf(
-            "MMM d, uuuu, h:mm:ss a z", "MMM d, uuuu, HH:mm:ss z", "d MMM uuuu, HH:mm:ss z"
+            "MMM d, uuuu, h:mm:ss a z",
+            "MMM d, uuuu, HH:mm:ss z",
+            "d MMM uuuu, HH:mm:ss z"
         ).firstNotNullOfOrNull { pattern ->
             runCatching { ZonedDateTime.parse(text, DateTimeFormatter.ofPattern(pattern, Locale.US)).toInstant().toEpochMilli() }.getOrNull()
         }
@@ -122,12 +126,15 @@ internal object TakeoutParser {
                     value.append('"')
                     i++
                 }
+
                 char == '"' -> quoted = !quoted
+
                 char == ',' && !quoted -> {
                     row.add(value.toString())
                     require(row.size <= 1000) { "Too many CSV columns." }
                     value.setLength(0)
                 }
+
                 (char == '\n' || char == '\r') && !quoted -> {
                     row.add(value.toString())
                     rows.add(row)
@@ -136,6 +143,7 @@ internal object TakeoutParser {
                     value.setLength(0)
                     if (char == '\r' && i < text.length && text[i] == '\n') i++
                 }
+
                 else -> value.append(char)
             }
         }

--- a/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutParser.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/TakeoutParser.kt
@@ -1,0 +1,149 @@
+package org.schabi.newpipe.settings.export
+
+import com.grack.nanojson.JsonObject
+import com.grack.nanojson.JsonParser
+import java.io.File
+import java.io.InputStream
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.zip.ZipFile
+import org.jsoup.Jsoup
+import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeStreamLinkHandlerFactory
+
+internal data class TakeoutVideo(val url: String, val title: String)
+internal data class TakeoutWatch(val video: TakeoutVideo, val timestamp: Long)
+internal data class TakeoutPlaylist(val name: String, val videos: List<TakeoutVideo>)
+internal data class TakeoutData(val playlists: List<TakeoutPlaylist>, val history: List<TakeoutWatch>, val skipped: Int)
+
+internal object TakeoutParser {
+    private const val MAX_FILE = 32 * 1024 * 1024
+    private const val MAX_TOTAL = 64 * 1024 * 1024
+    private const val MAX_RECORDS = 100000
+
+    fun parse(file: File, name: String): TakeoutData {
+        val playlists = mutableListOf<TakeoutPlaylist>()
+        val history = mutableListOf<TakeoutWatch>()
+        var skipped = 0
+        var bytes = 0
+        fun read(name: String, input: InputStream) {
+            val data = input.readTakeoutBytes(MAX_FILE)
+            require(data.size <= MAX_FILE) { "Takeout file exceeds 32 MiB; select a smaller export." }
+            bytes += data.size
+            require(bytes <= MAX_TOTAL) { "Selected Takeout data exceeds 64 MiB." }
+            val text = data.toString(Charsets.UTF_8).removePrefix("\uFEFF")
+            when (name.substringAfterLast('.').lowercase(Locale.ROOT)) {
+                "csv" -> {
+                    val rows = csv(text)
+                    val headerIndex = rows.indexOfFirst { row -> row.any { it.trim().equals("Video ID", true) || it.trim().equals("Video Id", true) } }
+                    if (headerIndex < 0) return
+                    val header = rows[headerIndex].map { it.trim().lowercase(Locale.ROOT) }
+                    val idColumn = header.indexOf("video id")
+                    val titleColumn = header.indexOf("title")
+                    val videos = rows.drop(headerIndex + 1).filter { it.any(String::isNotBlank) }.mapNotNull { row ->
+                        video(row.getOrNull(idColumn).orEmpty(), row.getOrNull(titleColumn).orEmpty()).also { if (it == null) skipped++ }
+                    }
+                    val titleHeader = rows.take(headerIndex).indexOfFirst { row -> row.any { it.equals("Playlist Title", true) || it.equals("Title", true) } }
+                    val playlistName = if (titleHeader >= 0) {
+                        val column = rows[titleHeader].indexOfFirst { it.equals("Playlist Title", true) || it.equals("Title", true) }
+                        rows.getOrNull(titleHeader + 1)?.getOrNull(column)
+                    } else {
+                        null
+                    }
+                    playlists.add(TakeoutPlaylist(playlistName?.takeIf { it.isNotBlank() } ?: name.substringAfterLast('/').removeSuffix(".csv").removeSuffix("-videos"), videos))
+                }
+                "json" -> {
+                    for (entry in JsonParser.array().from(text)) {
+                        val row = entry as? JsonObject ?: continue
+                        val video = video(row.getString("titleUrl", ""), row.getString("title", "").removePrefix("Watched "))
+                        val time = runCatching { Instant.parse(row.getString("time", "")).toEpochMilli() }.getOrNull()
+                        if (video != null && time != null) history.add(TakeoutWatch(video, time)) else skipped++
+                    }
+                }
+                "html" -> {
+                    for (cell in Jsoup.parse(text).select("div.content-cell")) {
+                        val link = cell.select("a[href]").firstOrNull { video(it.attr("href"), "") != null } ?: continue
+                        val video = video(link.attr("href"), link.text()) ?: continue
+                        val time = cell.wholeText().lines().mapNotNull(::htmlTime).firstOrNull()
+                        if (time != null) history.add(TakeoutWatch(video, time)) else skipped++
+                    }
+                }
+            }
+            require(history.size + playlists.sumOf { it.videos.size } <= MAX_RECORDS) { "Takeout export exceeds 100,000 records." }
+        }
+        val zip = file.inputStream().use { it.read() == 'P'.code && it.read() == 'K'.code }
+        if (zip) {
+            ZipFile(file).use { archive ->
+                val entries = archive.entries()
+                var count = 0
+                while (entries.hasMoreElements()) {
+                    val entry = entries.nextElement()
+                    require(++count <= 10000) { "Too many files in Takeout archive." }
+                    val path = entry.name.lowercase(Locale.ROOT)
+                    val playlist = path.endsWith(".csv") && (path.contains("/playlists/") || path.endsWith("-videos.csv"))
+                    val watch = path.endsWith("watch-history.json") || path.endsWith("watch-history.html")
+                    if (!entry.isDirectory && (playlist || watch)) archive.getInputStream(entry).use { read(entry.name, it) }
+                }
+            }
+        } else {
+            file.inputStream().use { read(name, it) }
+        }
+        require(playlists.isNotEmpty() || history.isNotEmpty()) { "No supported playlists or watch history found. Select playlist CSV, watch-history JSON/HTML, or a Takeout ZIP. Export history as JSON for reliable dates." }
+        return TakeoutData(playlists, history, skipped)
+    }
+
+    private fun video(value: String, title: String): TakeoutVideo? = runCatching {
+        val factory = YoutubeStreamLinkHandlerFactory.getInstance()
+        val id = if (value.matches(Regex("[A-Za-z0-9_-]{11}"))) value else factory.getId(value)
+        TakeoutVideo(factory.getUrl(id), title.ifBlank { id }.take(1000))
+    }.getOrNull()
+
+    private fun htmlTime(value: String): Long? {
+        val text = value.trim().replace('\u202f', ' ').replace('\u00a0', ' ')
+        return runCatching { Instant.parse(text).toEpochMilli() }.getOrNull() ?: listOf(
+            "MMM d, uuuu, h:mm:ss a z", "MMM d, uuuu, HH:mm:ss z", "d MMM uuuu, HH:mm:ss z"
+        ).firstNotNullOfOrNull { pattern ->
+            runCatching { ZonedDateTime.parse(text, DateTimeFormatter.ofPattern(pattern, Locale.US)).toInstant().toEpochMilli() }.getOrNull()
+        }
+    }
+
+    /** RFC 4180 quoted fields, embedded newlines, doubled quotes, CRLF and empty columns. */
+    internal fun csv(text: String): List<List<String>> {
+        val rows = mutableListOf<List<String>>()
+        var row = mutableListOf<String>()
+        val value = StringBuilder()
+        var quoted = false
+        var i = 0
+        while (i < text.length) {
+            val char = text[i++]
+            when {
+                char == '"' && quoted && i < text.length && text[i] == '"' -> {
+                    value.append('"')
+                    i++
+                }
+                char == '"' -> quoted = !quoted
+                char == ',' && !quoted -> {
+                    row.add(value.toString())
+                    require(row.size <= 1000) { "Too many CSV columns." }
+                    value.setLength(0)
+                }
+                (char == '\n' || char == '\r') && !quoted -> {
+                    row.add(value.toString())
+                    rows.add(row)
+                    require(rows.size <= MAX_RECORDS + 100) { "Too many CSV rows." }
+                    row = mutableListOf()
+                    value.setLength(0)
+                    if (char == '\r' && i < text.length && text[i] == '\n') i++
+                }
+                else -> value.append(char)
+            }
+        }
+        require(!quoted) { "Unclosed quoted CSV field." }
+        if (row.isNotEmpty() || value.isNotEmpty()) {
+            row.add(value.toString())
+            rows.add(row)
+        }
+        return rows
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
 public final class DeviceUtils {
 
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
-    private static final boolean SAMSUNG = Build.MANUFACTURER.equals("samsung");
+    private static final boolean SAMSUNG = "samsung".equals(Build.MANUFACTURER);
     private static Boolean isTV = null;
     private static Boolean isFireTV = null;
 
@@ -53,38 +53,38 @@ public final class DeviceUtils {
      * <p>Board: HiSilicon Hi3798MV200</p>
      */
     private static final boolean HI3798MV200 = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("Hi3798MV200");
+            && "Hi3798MV200".equals(Build.DEVICE);
     /**
      * <p>Zephir TS43UHD-2.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean CVT_MT5886_EU_1G = Build.VERSION.SDK_INT == 24
-            && Build.DEVICE.equals("cvt_mt5886_eu_1g");
+            && "cvt_mt5886_eu_1g".equals(Build.DEVICE);
     /**
      * Hilife TV.
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean REALTEKATV = Build.VERSION.SDK_INT == 25
-            && Build.DEVICE.equals("RealtekATV");
+            && "RealtekATV".equals(Build.DEVICE);
     /**
      * <p>Phillips 4K (O)LED TV.</p>
      * Supports custom ROMs with different API levels
      */
     private static final boolean PH7M_EU_5596 = Build.VERSION.SDK_INT >= 26
-            && Build.DEVICE.equals("PH7M_EU_5596");
+            && "PH7M_EU_5596".equals(Build.DEVICE);
     /**
      * <p>Philips QM16XE.</p>
      * <p>Blacklist reason: black screen</p>
      */
     private static final boolean QM16XE_U = Build.VERSION.SDK_INT == 23
-            && Build.DEVICE.equals("QM16XE_U");
+            && "QM16XE_U".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH1.</p>
      * <p>Processor: MT5895</p>
      * <p>Blacklist reason: fullscreen crash / stuttering</p>
      */
     private static final boolean BRAVIA_VH1 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH1");
+            && "BRAVIA_VH1".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia VH2.</p>
      * <p>Blacklist reason: fullscreen crash; this includes model A90J as reported in
@@ -92,14 +92,14 @@ public final class DeviceUtils {
      * #9023</a></p>
      */
     private static final boolean BRAVIA_VH2 = Build.VERSION.SDK_INT == 29
-            && Build.DEVICE.equals("BRAVIA_VH2");
+            && "BRAVIA_VH2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 2.</p>
      * Uses a MediaTek MT5891 (MT5596) SoC.
      * @see <a href="https://github.com/CiNcH83/bravia_atv2">
      *     https://github.com/CiNcH83/bravia_atv2</a>
      */
-    private static final boolean BRAVIA_ATV2 = Build.DEVICE.equals("BRAVIA_ATV2");
+    private static final boolean BRAVIA_ATV2 = "BRAVIA_ATV2".equals(Build.DEVICE);
     /**
      * <p>Sony Bravia Android TV platform 3 4K.</p>
      * <p>Uses ARM MT5891 and a {@link #BRAVIA_ATV2} motherboard.</p>
@@ -107,19 +107,19 @@ public final class DeviceUtils {
      * @see <a href="https://browser.geekbench.com/v4/cpu/9101105">
      *     https://browser.geekbench.com/v4/cpu/9101105</a>
      */
-    private static final boolean BRAVIA_ATV3_4K = Build.DEVICE.equals("BRAVIA_ATV3_4K");
+    private static final boolean BRAVIA_ATV3_4K = "BRAVIA_ATV3_4K".equals(Build.DEVICE);
     /**
      * <p>Panasonic 4KTV-JUP.</p>
      * <p>Blacklist reason: fullscreen crash</p>
      */
-    private static final boolean TX_50JXW834 = Build.DEVICE.equals("TX_50JXW834");
+    private static final boolean TX_50JXW834 = "TX_50JXW834".equals(Build.DEVICE);
     /**
      * <p>Bouygtel4K / Bouygues Telecom Bbox 4K.</p>
      * <p>Blacklist reason: black screen; reported at
      * <a href="https://github.com/TeamNewPipe/NewPipe/pull/10122#issuecomment-1638475769">
      *     #10122</a></p>
      */
-    private static final boolean HMB9213NW = Build.DEVICE.equals("HMB9213NW");
+    private static final boolean HMB9213NW = "HMB9213NW".equals(Build.DEVICE);
     // endregion
 
     private DeviceUtils() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,18 +1605,4 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
-    <string name="takeout_import_key" translatable="false">takeout_import</string>
-    <string name="takeout_import_status_key" translatable="false">takeout_import_status_preference</string>
-    <string name="takeout_import_title">Import Google Takeout</string>
-    <string name="takeout_import_summary">Add YouTube playlists and watch history from ZIP, CSV, JSON or HTML</string>
-    <string name="takeout_import_help">Select a Takeout ZIP containing YouTube playlists and history, an extracted playlist CSV, or watch-history JSON/HTML. Choose JSON when exporting history for reliable dates.
-
-Playlists are added with a (Takeout) suffix. Re-imports append missing videos to matching playlists and skip duplicate watch events. Existing data is kept. Video titles may be unavailable in playlist exports.
-
-Import runs on this device. Select an export under 256 MiB without uploaded video files.</string>
-    <string name="takeout_import_status_title">Last Takeout import</string>
-    <string name="takeout_import_idle">No import completed yet</string>
-    <string name="takeout_import_queued">Takeout import queued or running. Progress is shown in Backup and restore settings.</string>
-    <string name="takeout_import_result">Added %1$d playlists, %2$d playlist videos and %3$d watch events. Skipped %4$d duplicate or unavailable entries.</string>
-    <string name="takeout_import_error">Takeout import could not finish: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1605,4 +1605,18 @@
     <string name="search_button_behavior_summary">Choose whether Search filters the current tab first or opens search for the current service</string>
     <string name="search_button_behavior_current_tab">Search current tab</string>
     <string name="search_button_behavior_current_service">Search current service</string>
+    <string name="takeout_import_key" translatable="false">takeout_import</string>
+    <string name="takeout_import_status_key" translatable="false">takeout_import_status_preference</string>
+    <string name="takeout_import_title">Import Google Takeout</string>
+    <string name="takeout_import_summary">Add YouTube playlists and watch history from ZIP, CSV, JSON or HTML</string>
+    <string name="takeout_import_help">Select a Takeout ZIP containing YouTube playlists and history, an extracted playlist CSV, or watch-history JSON/HTML. Choose JSON when exporting history for reliable dates.
+
+Playlists are added with a (Takeout) suffix. Re-imports append missing videos to matching playlists and skip duplicate watch events. Existing data is kept. Video titles may be unavailable in playlist exports.
+
+Import runs on this device. Select an export under 256 MiB without uploaded video files.</string>
+    <string name="takeout_import_status_title">Last Takeout import</string>
+    <string name="takeout_import_idle">No import completed yet</string>
+    <string name="takeout_import_queued">Takeout import queued or running. Progress is shown in Backup and restore settings.</string>
+    <string name="takeout_import_result">Added %1$d playlists, %2$d playlist videos and %3$d watch events. Skipped %4$d duplicate or unavailable entries.</string>
+    <string name="takeout_import_error">Takeout import could not finish: %1$s</string>
 </resources>

--- a/app/src/main/res/values/takeout_import_strings.xml
+++ b/app/src/main/res/values/takeout_import_strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="takeout_import_key" translatable="false">takeout_import</string>
+    <string name="takeout_import_status_key" translatable="false">takeout_import_status_preference</string>
+    <string name="takeout_import_title">Import Google Takeout</string>
+    <string name="takeout_import_summary">Add YouTube playlists and watch history from ZIP, CSV, JSON or HTML</string>
+    <string name="takeout_import_help">Select a Takeout ZIP containing YouTube playlists and history, an extracted playlist CSV, or watch-history JSON/HTML. Choose JSON when exporting history for reliable dates.
+
+Playlists are added with a (Takeout) suffix. Re-imports append missing videos to matching playlists and skip duplicate watch events. Existing data is kept. Video titles may be unavailable in playlist exports.
+
+Import runs on this device. Select an export under 256 MiB without uploaded video files.</string>
+    <string name="takeout_import_status_title">Last Takeout import</string>
+    <string name="takeout_import_idle">No import completed yet</string>
+    <string name="takeout_import_queued">Takeout import queued or running. Progress is shown in Backup and restore settings.</string>
+    <string name="takeout_import_result">Added %1$d playlists, %2$d playlist videos and %3$d watch events. Skipped %4$d duplicate or unavailable entries.</string>
+    <string name="takeout_import_error">Takeout import could not finish: %1$s</string>
+</resources>

--- a/app/src/main/res/xml/backup_restore_settings.xml
+++ b/app/src/main/res/xml/backup_restore_settings.xml
@@ -79,4 +79,15 @@
         android:summary="@string/import_subscriptions_summary"
         app:singleLineTitle="false"
         app:iconSpaceReserved="false" />
+    <Preference
+        android:key="@string/takeout_import_key"
+        android:title="@string/takeout_import_title"
+        android:summary="@string/takeout_import_summary"
+        app:iconSpaceReserved="false" />
+    <Preference
+        android:key="@string/takeout_import_status_key"
+        android:title="@string/takeout_import_status_title"
+        android:summary="@string/takeout_import_idle"
+        app:selectable="false"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>

--- a/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
+++ b/app/src/test/java/org/schabi/newpipe/fragments/detail/VideoDetailBackPressTest.java
@@ -88,9 +88,15 @@ public class VideoDetailBackPressTest {
 
     @After
     public void tearDown() {
-        playerHelper.close();
-        deviceUtils.close();
-        log.close();
+        if (playerHelper != null) {
+            playerHelper.close();
+        }
+        if (deviceUtils != null) {
+            deviceUtils.close();
+        }
+        if (log != null) {
+            log.close();
+        }
     }
 
     @Test

--- a/app/src/test/java/org/schabi/newpipe/settings/export/TakeoutParserTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/export/TakeoutParserTest.kt
@@ -1,0 +1,54 @@
+package org.schabi.newpipe.settings.export
+
+import java.io.File
+import java.time.Instant
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class TakeoutParserTest {
+    @Test
+    fun zipCombinesPlaylistOrderAndHistoryWhileIgnoringOtherProducts() {
+        val file = File.createTempFile("takeout-test", ".zip")
+        try {
+            ZipOutputStream(file.outputStream()).use { zip ->
+                fun entry(name: String, text: String) {
+                    zip.putNextEntry(ZipEntry(name))
+                    zip.write(text.toByteArray())
+                    zip.closeEntry()
+                }
+                entry("Takeout/YouTube and YouTube Music/playlists/Science-videos.csv", "\uFEFFVideo ID,Time Added\r\nabcdefghijk,2024-01-01\r\nlmnopqrstuv,2024-01-02\r\n")
+                entry("Takeout/YouTube and YouTube Music/history/watch-history.json", """[{"title":"Watched Science","titleUrl":"https://www.youtube.com/watch?v=abcdefghijk","time":"2024-02-03T04:05:06.123Z"},{"title":"Deleted video","time":"2024-02-03T00:00:00Z"}]""")
+                entry("Takeout/My Activity/Search/search-history.json", "invalid ignored file")
+            }
+            val result = TakeoutParser.parse(file, "takeout.zip")
+            assertEquals("Science", result.playlists.single().name)
+            assertEquals(listOf("abcdefghijk", "lmnopqrstuv"), result.playlists.single().videos.map { it.title })
+            assertEquals(Instant.parse("2024-02-03T04:05:06.123Z").toEpochMilli(), result.history.single().timestamp)
+            assertEquals("Science", result.history.single().video.title)
+            assertEquals(1, result.skipped)
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun csvSupportsQuotedMetadataAndRejectsBrokenQuotes() {
+        assertEquals(listOf(listOf("a,b", "two\nlines", "say \"hi\"")), TakeoutParser.csv("\"a,b\",\"two\nlines\",\"say \"\"hi\"\"\""))
+        assertThrows(IllegalArgumentException::class.java) { TakeoutParser.csv("\"unclosed") }
+    }
+
+    @Test
+    fun htmlPreservesUtcDatesAndSkipsUnknownLocalizedDates() {
+        val file = File.createTempFile("watch-history", ".html")
+        try {
+            file.writeText("""<div class="content-cell">Watched <a href="https://www.youtube.com/watch?v=abcdefghijk">Science</a><br>Feb 3, 2024, 4:05:06 AM UTC</div>""")
+            val result = TakeoutParser.parse(file, "watch-history.html")
+            assertEquals(Instant.parse("2024-02-03T04:05:06Z").toEpochMilli(), result.history.single().timestamp)
+        } finally {
+            file.delete()
+        }
+    }
+}

--- a/app/src/test/java/org/schabi/newpipe/settings/export/TakeoutParserTest.kt
+++ b/app/src/test/java/org/schabi/newpipe/settings/export/TakeoutParserTest.kt
@@ -51,6 +51,7 @@ class TakeoutParserTest {
             file.delete()
         }
     }
+
     @Test
     fun zipPreservesSeparateMetadataEmptyPlaylistsSubscriptionsAndSearches() {
         val file = File.createTempFile("takeout-data", ".zip")
@@ -108,5 +109,4 @@ class TakeoutParserTest {
             file.delete()
         }
     }
-
 }


### PR DESCRIPTION
- Add Google Takeout import in Backup and restore for YouTube ZIP archives, playlist/subscription CSV files, and watch/search-history JSON or HTML.
- Preserve playlist names, ordered and repeated videos, empty playlists, and original playlist links when metadata supplies them. Save supplied links as bookmarks alongside editable local copies.
- Import subscriptions without overwriting existing channel settings, and preserve the original times of watch and search events. Journal new subscriptions and history for sync.
- Re-imports append missing video occurrences and skip matching history/subscription entries. Keep distinct same-named playlists in the same export separate, and append after existing playlist positions without overwriting entries.
- Process selected files on-device with bounded archive/file sizes, cancel checks, a database transaction, and persistent import results. Show counts for playlists, videos, bookmarks, subscriptions, watches, searches and skipped entries.
- Add parser fixtures for separate/embedded playlist metadata, empty playlists, subscription CSV, search JSON/HTML, Unicode queries and ignored non-YouTube data. Add Android tests for repeat imports, preserved channel settings, sparse playlist positions and transactional rollback.
- Validation passed: whitespace/source-inspection checks plus GitHub CI build, lint, JVM tests, and Android instrumentation tests on API 23 and 35. Confirmed the Takeout changes merge cleanly with the NewPipe export fix in #535. Local Gradle execution was unavailable because the distribution download is blocked in this environment.