### PR TITLE
Preserve playlists, channel groups and search history in NewPipe exports

### DIFF
--- a/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeCompatibleExportManagerTest.kt
+++ b/app/src/androidTest/java/org/schabi/newpipe/settings/NewPipeCompatibleExportManagerTest.kt
@@ -103,6 +103,66 @@ class NewPipeCompatibleExportManagerTest {
     }
 
     @Test
+    fun preservesPlaylistsGroupsAndSearchesWithOnlyCompatibleReferences() {
+        SQLiteDatabase.openDatabase(sourcePath.toString(), null, SQLiteDatabase.OPEN_READWRITE).use { source ->
+            source.execSQL(
+                "INSERT INTO streams VALUES " +
+                    "(40, 0, 'https://example.com/thumbnail', 'Thumbnail', 'VIDEO_STREAM', 60, " +
+                    "'Uploader', NULL, NULL, NULL, NULL, NULL, 0, 'REMOTE')"
+            )
+            source.execSQL(
+                "INSERT INTO playlists VALUES " +
+                    "(1, 'Mixed', 1, 20, 4), (2, 'Empty', 1, 999, 2), " +
+                    "(3, 'Device only', 1, 20, 1), (4, 'Custom thumbnail', 1, 40, 3)"
+            )
+            source.execSQL(
+                "INSERT INTO playlist_stream_join VALUES " +
+                    "(1, 30, 4), (1, 20, 7), (1, 10, 9), (1, 10, 11), (3, 20, 0)"
+            )
+            source.execSQL(
+                "INSERT INTO remote_playlists VALUES " +
+                    "(6, 0, 'Remote playlist', 'https://example.com/playlist', 'https://example.com/image', 'Owner', 17, 2), " +
+                    "(7, 5, 'Unsupported playlist', 'https://example.com/unsupported', NULL, NULL, 18, 1)"
+            )
+            source.execSQL("INSERT INTO feed_group VALUES (11, 'News', 8, 3), (12, 'Empty group', 999, 2)")
+            source.execSQL("INSERT INTO feed_group_subscription_join VALUES (11, 1), (11, 2)")
+            source.execSQL("INSERT INTO search_history VALUES (1000, 0, 'space', 1), (2000, 0, 'space', 2), (3000, 4, 'music', 3), (4000, 5, 'unsupported', 4)")
+        }
+        val result = NewPipeCompatibleExportManager(sourcePath, context.cacheDir.toPath()).createDatabase(destinationPath)
+        assertEquals(4, result.localPlaylists)
+        assertEquals(1, result.remotePlaylists)
+        assertEquals(3, result.playlistItems)
+        assertEquals(2, result.channelGroups)
+        assertEquals(1, result.groupMemberships)
+        assertEquals(3, result.searchItems)
+        assertEquals(8, result.skippedItems)
+        migrationTestHelper.runMigrationsAndValidate(PORTABLE_DATABASE_NAME, 9, true).close()
+        SQLiteDatabase.openDatabase(destinationPath.toString(), null, SQLiteDatabase.OPEN_READONLY).use { database ->
+            assertEquals("30,10,10", database.singleString("SELECT group_concat(stream_id) FROM (SELECT stream_id FROM playlist_stream_join WHERE playlist_id=1 ORDER BY join_index)"))
+            assertEquals(30, database.singleInt("SELECT thumbnail_stream_id FROM playlists WHERE uid=1"))
+            assertEquals(0, database.singleInt("SELECT is_thumbnail_permanent FROM playlists WHERE uid=1"))
+            assertEquals(-1, database.singleInt("SELECT thumbnail_stream_id FROM playlists WHERE uid=2"))
+            assertEquals(-1, database.singleInt("SELECT thumbnail_stream_id FROM playlists WHERE uid=3"))
+            assertEquals(40, database.singleInt("SELECT thumbnail_stream_id FROM playlists WHERE uid=4"))
+            assertEquals(1, database.singleInt("SELECT is_thumbnail_permanent FROM playlists WHERE uid=4"))
+            assertEquals(3, database.singleInt("SELECT COUNT(*) FROM streams"))
+            assertEquals(17, database.singleInt("SELECT display_index FROM remote_playlists WHERE uid=6"))
+            assertEquals("Owner", database.singleString("SELECT uploader FROM remote_playlists WHERE uid=6"))
+            assertEquals(8, database.singleInt("SELECT icon_id FROM feed_group WHERE uid=11"))
+            assertEquals(0, database.singleInt("SELECT icon_id FROM feed_group WHERE uid=12"))
+            assertEquals(1, database.singleInt("SELECT subscription_id FROM feed_group_subscription_join WHERE group_id=11"))
+            assertEquals("1000,2000", database.singleString("SELECT group_concat(creation_date) FROM (SELECT creation_date FROM search_history WHERE search='space' ORDER BY creation_date)"))
+            assertEquals("ok", database.singleString("PRAGMA quick_check"))
+            database.rawQuery("PRAGMA foreign_key_check", null).use { assertFalse(it.moveToFirst()) }
+        }
+        SQLiteDatabase.openDatabase(sourcePath.toString(), null, SQLiteDatabase.OPEN_READONLY).use { source ->
+            assertEquals(5, source.singleInt("SELECT COUNT(*) FROM playlist_stream_join"))
+            assertEquals(2, source.singleInt("SELECT COUNT(*) FROM feed_group_subscription_join"))
+            assertEquals(4, source.singleInt("SELECT COUNT(*) FROM search_history"))
+        }
+    }
+
+    @Test
     fun archiveContainsOnlyThePortableNewPipeDatabase() {
         archivePath.toFile().createNewFile()
         val file = StoredFileHelper(
@@ -165,6 +225,12 @@ class NewPipeCompatibleExportManagerTest {
                     "stream_id INTEGER PRIMARY KEY, progress_time INTEGER NOT NULL)"
             )
             database.execSQL("INSERT INTO stream_state VALUES (10, 30000), (20, 15000)")
+            database.execSQL("CREATE TABLE playlists (uid INTEGER PRIMARY KEY, name TEXT, is_thumbnail_permanent INTEGER NOT NULL, thumbnail_stream_id INTEGER NOT NULL, display_index INTEGER NOT NULL)")
+            database.execSQL("CREATE TABLE playlist_stream_join (playlist_id INTEGER NOT NULL, stream_id INTEGER NOT NULL, join_index INTEGER NOT NULL)")
+            database.execSQL("CREATE TABLE remote_playlists (uid INTEGER PRIMARY KEY, service_id INTEGER NOT NULL, name TEXT, url TEXT, thumbnail_url TEXT, uploader TEXT, display_index INTEGER NOT NULL, stream_count INTEGER)")
+            database.execSQL("CREATE TABLE feed_group (uid INTEGER PRIMARY KEY, name TEXT NOT NULL, icon_id INTEGER NOT NULL, sort_order INTEGER NOT NULL)")
+            database.execSQL("CREATE TABLE feed_group_subscription_join (group_id INTEGER NOT NULL, subscription_id INTEGER NOT NULL)")
+            database.execSQL("CREATE TABLE search_history (creation_date INTEGER, service_id INTEGER NOT NULL, search TEXT, id INTEGER PRIMARY KEY)")
         }
     }
 

--- a/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BackupRestoreSettingsFragment.java
@@ -548,7 +548,13 @@ public class BackupRestoreSettingsFragment extends BasePreferenceFragment {
                                         exportResult.getSubscriptions(),
                                         exportResult.getHistoryItems(),
                                         exportResult.getProgressItems(),
-                                        exportResult.getSkippedItems()))
+                                        exportResult.getSkippedItems(),
+                                        exportResult.getLocalPlaylists(),
+                                        exportResult.getRemotePlaylists(),
+                                        exportResult.getPlaylistItems(),
+                                        exportResult.getChannelGroups(),
+                                        exportResult.getGroupMemberships(),
+                                        exportResult.getSearchItems()))
                                 .setPositiveButton(R.string.ok, null)
                                 .show();
                     });

--- a/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeCompatibleExportManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/settings/export/NewPipeCompatibleExportManager.kt
@@ -26,7 +26,13 @@ class NewPipeCompatibleExportManager internal constructor(
         val subscriptions: Int,
         val historyItems: Int,
         val progressItems: Int,
-        val skippedItems: Int
+        val skippedItems: Int,
+        val localPlaylists: Int,
+        val remotePlaylists: Int,
+        val playlistItems: Int,
+        val channelGroups: Int,
+        val groupMemberships: Int,
+        val searchItems: Int
     )
 
     /**
@@ -114,7 +120,17 @@ class NewPipeCompatibleExportManager internal constructor(
                 skippedItems =
                     destination.rowCount("wizestream_source.subscriptions") - subscriptions +
                         destination.rowCount("wizestream_source.stream_history") - historyItems +
-                        destination.rowCount("wizestream_source.stream_state") - progressItems
+                        destination.rowCount("wizestream_source.stream_state") - progressItems +
+                        destination.skippedRows("remote_playlists") +
+                        destination.skippedRows("playlist_stream_join") +
+                        destination.skippedRows("feed_group_subscription_join") +
+                        destination.skippedRows("search_history"),
+                localPlaylists = destination.rowCount("playlists"),
+                remotePlaylists = destination.rowCount("remote_playlists"),
+                playlistItems = destination.rowCount("playlist_stream_join"),
+                channelGroups = destination.rowCount("feed_group"),
+                groupMemberships = destination.rowCount("feed_group_subscription_join"),
+                searchItems = destination.rowCount("search_history")
             )
         } finally {
             if (sourceAttached) {
@@ -148,7 +164,12 @@ class NewPipeCompatibleExportManager internal constructor(
                 "(EXISTS (SELECT 1 FROM wizestream_source.stream_history h " +
                 "WHERE h.stream_id = s.uid) OR " +
                 "EXISTS (SELECT 1 FROM wizestream_source.stream_state st " +
-                "WHERE st.stream_id = s.uid))"
+                "WHERE st.stream_id = s.uid) OR " +
+                "EXISTS (SELECT 1 FROM wizestream_source.playlist_stream_join j " +
+                "INNER JOIN wizestream_source.playlists p ON p.uid = j.playlist_id " +
+                "WHERE j.stream_id = s.uid) OR " +
+                "EXISTS (SELECT 1 FROM wizestream_source.playlists p " +
+                "WHERE p.thumbnail_stream_id = s.uid))"
         )
         database.execSQL(
             "INSERT INTO stream_history (stream_id, access_date, repeat_count) " +
@@ -161,6 +182,57 @@ class NewPipeCompatibleExportManager internal constructor(
                 "SELECT st.stream_id, st.progress_time " +
                 "FROM wizestream_source.stream_state st " +
                 "INNER JOIN streams s ON s.uid = st.stream_id"
+        )
+        copyPlaylists(database)
+        copyGroupsAndSearches(database)
+    }
+
+    private fun copyPlaylists(database: SQLiteDatabase) {
+        database.execSQL(
+            "INSERT INTO playlists " +
+                "(uid, name, is_thumbnail_permanent, thumbnail_stream_id, display_index) " +
+                "SELECT p.uid, p.name, " +
+                "CASE WHEN EXISTS (SELECT 1 FROM streams s WHERE s.uid = p.thumbnail_stream_id) " +
+                "THEN p.is_thumbnail_permanent ELSE 0 END, " +
+                "COALESCE((SELECT s.uid FROM streams s WHERE s.uid = p.thumbnail_stream_id), " +
+                "(SELECT j.stream_id FROM wizestream_source.playlist_stream_join j " +
+                "INNER JOIN streams s ON s.uid = j.stream_id WHERE j.playlist_id = p.uid " +
+                "ORDER BY j.join_index LIMIT 1), -1), p.display_index " +
+                "FROM wizestream_source.playlists p"
+        )
+        database.execSQL(
+            "INSERT INTO playlist_stream_join (playlist_id, stream_id, join_index) " +
+                "SELECT j.playlist_id, j.stream_id, j.join_index " +
+                "FROM wizestream_source.playlist_stream_join j " +
+                "INNER JOIN playlists p ON p.uid = j.playlist_id " +
+                "INNER JOIN streams s ON s.uid = j.stream_id"
+        )
+        database.execSQL(
+            "INSERT INTO remote_playlists " +
+                "(uid, service_id, name, url, thumbnail_url, uploader, display_index, stream_count) " +
+                "SELECT uid, service_id, name, url, thumbnail_url, uploader, " +
+                "display_index, stream_count FROM wizestream_source.remote_playlists " +
+                "WHERE service_id BETWEEN $NEWPIPE_FIRST_SERVICE_ID AND $NEWPIPE_LAST_SERVICE_ID"
+        )
+    }
+
+    private fun copyGroupsAndSearches(database: SQLiteDatabase) {
+        database.execSQL(
+            "INSERT INTO feed_group (uid, name, icon_id, sort_order) " +
+                "SELECT uid, name, CASE WHEN icon_id BETWEEN 0 AND $NEWPIPE_LAST_GROUP_ICON " +
+                "THEN icon_id ELSE 0 END, sort_order FROM wizestream_source.feed_group"
+        )
+        database.execSQL(
+            "INSERT INTO feed_group_subscription_join (group_id, subscription_id) " +
+                "SELECT j.group_id, j.subscription_id " +
+                "FROM wizestream_source.feed_group_subscription_join j " +
+                "INNER JOIN feed_group g ON g.uid = j.group_id " +
+                "INNER JOIN subscriptions s ON s.uid = j.subscription_id"
+        )
+        database.execSQL(
+            "INSERT INTO search_history (id, creation_date, service_id, search) " +
+                "SELECT id, creation_date, service_id, search FROM wizestream_source.search_history " +
+                "WHERE service_id BETWEEN $NEWPIPE_FIRST_SERVICE_ID AND $NEWPIPE_LAST_SERVICE_ID"
         )
     }
 
@@ -189,6 +261,8 @@ class NewPipeCompatibleExportManager internal constructor(
         }
     }
 
+    private fun SQLiteDatabase.skippedRows(table: String): Int = rowCount("wizestream_source.$table") - rowCount(table)
+
     private fun SQLiteDatabase.rowCount(table: String): Int = rawQuery(
         "SELECT COUNT(*) FROM $table",
         null
@@ -202,6 +276,7 @@ class NewPipeCompatibleExportManager internal constructor(
         const val NEWPIPE_IDENTITY_HASH = "7591e8039faa74d8c0517dc867af9d3e"
         const val NEWPIPE_FIRST_SERVICE_ID = 0
         const val NEWPIPE_LAST_SERVICE_ID = 4
+        const val NEWPIPE_LAST_GROUP_ICON = 38
 
         val REQUIRED_NEWPIPE_TABLES = setOf(
             "subscriptions",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -509,9 +509,9 @@
     <string name="export_data_title">Export full backup</string>
     <string name="export_compatible_data_key" translatable="false">export_compatible_data</string>
     <string name="export_compatible_data_title">Export for NewPipe</string>
-    <string name="export_compatible_data_summary">Create a NewPipe-compatible ZIP containing subscriptions, watch history, and playback positions. WizeStream settings and app-specific data are excluded.</string>
+    <string name="export_compatible_data_summary">Create a NewPipe-compatible ZIP containing subscriptions and channel groups, local and bookmarked playlists, watch and search history, and playback positions. WizeStream settings and app-specific data are excluded.</string>
     <string name="export_compatible_data_complete_title">NewPipe backup exported</string>
-    <string name="export_compatible_data_complete_message">Exported %1$d subscriptions, %2$d history items, and %3$d playback positions. Skipped %4$d records that NewPipe cannot use. Import this ZIP using NewPipe’s backup restore screen.</string>
+    <string name="export_compatible_data_complete_message">Exported %1$d subscriptions, %8$d channel groups with %9$d memberships, %5$d local playlists with %7$d videos, %6$d bookmarked playlists, %2$d watched items, %10$d searches, and %3$d playback positions. Skipped %4$d records that NewPipe cannot use. Import this ZIP using NewPipe’s backup restore screen.</string>
     <string name="clear_cookie_title">Clear reCAPTCHA cookies</string>
     <string name="recaptcha_cookies_cleared">reCAPTCHA cookies have been cleared</string>
     <string name="import_data_summary">Restore subscriptions, playlists, app settings, SponsorBlock settings, and local data from a ZIP backup.</string>


### PR DESCRIPTION
- Fixes #531: NewPipe-compatible backups created empty playlist, channel-group, and search-history tables, silently omitting that data during restore.
- Export local and bookmarked playlists, ordered playlist entries (including repeated videos), empty playlists, channel groups and their supported subscriptions, and timestamped search history.
- Include streams used only by playlists or custom thumbnails; fall back to a compatible thumbnail and group icon where necessary.
- Keep the source database unchanged and omit local files and unsupported services. Report counts for each exported category and skipped records.
- Add Android regression coverage that opens the export with the NewPipe schema, checks ordered entries and foreign keys, and verifies source data is unchanged.
- Validation passed: whitespace/source-inspection checks plus GitHub CI build, lint, JVM tests, and Android instrumentation tests on API 23 and 35. Local Gradle execution was unavailable because the distribution download is blocked in this environment.